### PR TITLE
Update other sub-specs with new uniqueness verbiage.

### DIFF
--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -796,7 +796,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInputPR" : "a0cdf5c1c670fd7b65a4f0a899e4"
                           },
                         {
-                          "tcIdd": "1816",
+                          "tcId": "1816",
                           "entropyInput" : "b8ab88b9c5fda8544b90a043684e",
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -509,18 +509,18 @@ the bit lengths the supported values shall be specified explicitly. </t>
 
 	</section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
-	    the JSON elements for each DRBG test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+	       that represents a single vector to be processed by the ACVP client.  The following table describes
+               the JSON elements for each test case.</t>
 	    <texttable anchor="vs_tc_table" title="DRBG Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
 
-		<c>testCaseId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>tcId</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 <c/>
@@ -610,8 +610,8 @@ the bit lengths the supported values shall be specified explicitly. </t>
           <c>array</c>
 	</texttable>
 	
-	  <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
+	  <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each DRBG test vector.</t>
 	    <texttable anchor="vs_tr_table" title="DRBG Test Case Results JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
@@ -619,8 +619,8 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
 
-		<c>testCaseId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>tcId</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/>
@@ -786,7 +786,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                       "type": "long",
                       "tests": [
                         {
-                          "testCaseId": "1815",
+                          "tcId": "1815",
                           "entropyInput":"78aac2cb444594e29dc97b0195b5",
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
@@ -796,7 +796,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInputPR" : "a0cdf5c1c670fd7b65a4f0a899e4"
                           },
                         {
-                          "testCaseIdd": "1816",
+                          "tcIdd": "1816",
                           "entropyInput" : "b8ab88b9c5fda8544b90a043684e",
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
@@ -831,7 +831,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                       "type": "long",
                       "tests": [
                         {
-                          "testCaseId": "2111",
+                          "tcId": "2111",
                           "entropyInput":"ee3392c5f3de6f3f8c4f28d852afacd2cbaa89ed48d1c5d4311662962aa70a98",
                           "nonce":"b991a820fac75fd02642ad8fa651eda4",
                           "persoString":"30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
@@ -841,7 +841,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInputPR" : "968ea185d1439fa2d67eb55ac93ba596b1ea679de7c6e44f80dc6f213455f1ed"
                           },
                         {
-                          "testCaseId": "2112",
+                          "tcId": "2112",
                           "entropyInput" : "a0ace75784b97224de2957e5f60dc85b25331fcf7901f37418d3c9de17ed4261",
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
@@ -875,7 +875,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                       "type": "long",
                       "tests": [
                         {
-                          "testCaseId": "2151",
+                          "tcId": "2151",
                           "entropyInput":"b37f442929f21306d8750a82fc6b362a574babd3ed60f19a35c37e469a5f14bf",
                           "nonce":"c3283de7bc8395b6acccbb5ea5fa96bb",
                           "persoString":"5674ab88573f76754c9c23251ced43004e4e0839b8238dc02738c52fd4f0c6d2",
@@ -885,7 +885,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInputPR" : "3ab094c46749b53452230b757e06a0e73ae98154fee23b219b2d2cb3799f3ddd"
                           },
                         {
-                          "testCaseId": "2152",
+                          "tcId": "2152",
                           "entropyInput" : "453ee7be8e0c38345bc5bd41b3fc966bee51865cbdefef8de88c2e2f98e0d89c",
                           "nonce": "caab6531ed1d096668e7d7e5bb8f306b",
                           "persoString" : "ff6f535e2b41be7c17d4cfc0f14868ab838b739e643d269d624a1a0637152d78",
@@ -910,11 +910,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
                     "vectorSetId": "1133",
                     "testResults": [
                         {
-                            "testCaseId": "1815",
+                            "tcId": "1815",
                             "returnedBits ": "4565e85447af7134775816588f1b0faf8b402a951db17753d01809d14724449d"
                         },
                         {
-                            "testCaseId": "1816",
+                            "tcId": "1816",
                             "returnedBits": "b67acc3b2231ec54344d5be2ee8fcac72e83651b8cf2ac2bc361171b882f0965"
                         }
                     ]
@@ -930,11 +930,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
                     "vectorSetId":  "1146",
                     "testResults": [
                         {
-                            "testCaseId": "2111",
+                            "tcId": "2111",
                             "returnedBits": "e42130fd1d920a2bcd177c0de0d5834c9b05a6ecdf3bc46e3733869f762dc2e7d97357934d8061db033670c3739369924b321216c30b3e45d9bc8c0bad61d8fdc03dffd70725e793ebfe98bc15358764402f4e2c71be4acfad898649b51c5d2625374a61be2b59833d2dfcc593eddcffbac79016b22a992ae6f5f82bae194e06"
                         },
                        {
-                            "testCaseId": "2112",
+                            "tcId": "2112",
                             "returnedBits": "495b2a0de6b5fc4545fdd5fec93362d1203b1dfef3528f7d852fb89ba1c45059bd52cb7a80176dd71c26108912be6f3c33d95d5cee92349ba6bf16db42c4c828729a9b4a5f53e60655df55f0e58753ad2785d53fc44fe98a5e214e8172554bd53047f38a67f8a5af11111e33dcc5e705824a78d661839994f3529cec5a83a9f0"
                        }
                     ]
@@ -949,11 +949,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
                     "vectorSetId": "1156",
                     "testResults": [
                         {
-                            "testCaseId": "2151",
+                            "tcId": "2151",
                             "returnedBits ": "3bcb4371e388a8c453f16fb48e46859b7cbd1b8307681083fb8c10e7a6ea77ff89f6ce2ab9efff8ea11e95117e577a139e5a2f99786282fefadf07c13d7ceb123d81f93d262ad84d9d1589ea6bb760a0cabd75285e29a11bb97a8ff3317d839639866195c3364c98f250ce97c974c06805821e66ce214333d275d8a01a6c69a7"
                         },
                        {
-                            "testCaseId": "2152",
+                            "tcId": "2152",
                             "returnedBits": "0302cb504af55d89d8aa03a05d5cd9969c0650e32c27d32dc5db991b95297885a593cb81ee2fbfea273f61830fa0d548c1d89ff1d8495a9fd4dee2c7ddc075620bec06d3641232b4433d229f2b4a791a11709fe3d6fe4f809f97d113bdaebe255223e6e5914296886861d28331ea702bf05f63a8fd62b97a845de43012ed4a55"
                        }
                     ]

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -357,9 +357,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DSA2 test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each DSA2 test vector.</t>
 	    <texttable anchor="vs_tc_table5" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -367,7 +367,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -369,9 +369,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each ECDSA2 test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each ECDSA2 test vector.</t>
 	    <texttable anchor="vs_tc_table5" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -379,7 +379,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_hashmac.xml
+++ b/src/acvp_sub_hashmac.xml
@@ -427,9 +427,9 @@
 
 	</section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each secure hash test vector.</t>
 	    <texttable anchor="vs_tc_table" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
@@ -438,7 +438,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>
@@ -470,7 +470,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kas_ecc.xml
+++ b/src/acvp_sub_kas_ecc.xml
@@ -595,9 +595,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each KAS ECC test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each KAS ECC test vector.</t>
 	    <texttable anchor="vs_tc_table5" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -605,7 +605,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kas_fcc.xml
+++ b/src/acvp_sub_kas_fcc.xml
@@ -542,9 +542,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each KAS FCC test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each KAS FCC test vector.</t>
 	    <texttable anchor="vs_tc_table5" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -552,7 +552,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf108.xml
+++ b/src/acvp_sub_kdf108.xml
@@ -331,9 +331,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-108 KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-108 KDF test vector.</t>
 	    <texttable anchor="vs_tc_table5" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -341,7 +341,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 

--- a/src/acvp_sub_kdf135_ikev1.xml
+++ b/src/acvp_sub_kdf135_ikev1.xml
@@ -359,9 +359,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each SP800-135 IKEv1 KDF test vector.</t>
 	    <texttable anchor="vs_tc_table1" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
@@ -370,7 +370,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_ikev2.xml
+++ b/src/acvp_sub_kdf135_ikev2.xml
@@ -343,9 +343,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each SP800-135 IKEv2 KDF test vector.</t>
 	    <texttable anchor="vs_tc_table1" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
@@ -354,7 +354,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_snmp.xml
+++ b/src/acvp_sub_kdf135_snmp.xml
@@ -300,9 +300,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 SNMP KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 SNMP KDF test vector.</t>
 	    <texttable anchor="vs_tc_table6" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -310,7 +310,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_srtp.xml
+++ b/src/acvp_sub_kdf135_srtp.xml
@@ -315,9 +315,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 SRTP KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 SRTP KDF test vector.</t>
 	    <texttable anchor="vs_tc_table5" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -325,7 +325,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_ssh.xml
+++ b/src/acvp_sub_kdf135_ssh.xml
@@ -323,9 +323,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 SSH KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 SSH KDF test vector.</t>
 	    <texttable anchor="vs_tc_table4" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -333,7 +333,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_tls.xml
+++ b/src/acvp_sub_kdf135_tls.xml
@@ -319,9 +319,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 TLS KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 TLS KDF test vector.</t>
 	    <texttable anchor="vs_tc_table7" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -329,7 +329,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_tpm.xml
+++ b/src/acvp_sub_kdf135_tpm.xml
@@ -272,9 +272,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 TPM KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each SP800-135 TPM KDF test vector.</t>
 	    <texttable anchor="vs_tc_table8" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -282,7 +282,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_kdf135_x963.xml
+++ b/src/acvp_sub_kdf135_x963.xml
@@ -326,9 +326,9 @@
 
           </section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client. The following table describes the JSON elements for each SP800-135 ANS X9.63 KDF test vector.</t>
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each SP800-135 ANS X9.63 KDF test vector.</t>
 	    <texttable anchor="vs_tc_table3" title="Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -336,7 +336,7 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>tcId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -661,7 +661,7 @@
 <c/>
 <c/>
 <c/>
-	  <c>vectorSetId</c>
+	  <c>vsId</c>
 	  <c>Unique numeric identifier for the vector set</c>
           <c>value</c>
 <c/>
@@ -732,9 +732,9 @@
 
 	</section>
 
-	<section title="Test Vectors JSON Schema" anchor="tvjs">
-	    <t>Each test group contains an array of one or more test vectors.  Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
+	<section title="Test Case JSON Schema" anchor="tvjs">
+	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
+		that represents a single test vector to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each DRBG test vector.</t>
 	    <texttable anchor="vs_tc_table" title="RSA Test Case JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
@@ -742,8 +742,8 @@
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
 
-		<c>testCaseId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>tcId</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/>
@@ -813,7 +813,7 @@
 <c/>
 		<c/>
 		<c/>
-	  <c>vectorSetId</c>
+	  <c>vsId</c>
 	  <c>Unique numeric identifier for the vector set</c>
           <c>value</c>
 <c/>
@@ -832,8 +832,8 @@
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
 
-		<c>testCaseId</c>
-		<c>Unique numeric identifier for the test case</c>
+		<c>tcId</c>
+		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
 		<c>value</c>
 		<c>No</c>
 		<c/>
@@ -1412,7 +1412,7 @@
     <artwork><![CDATA[
    {
      "version": "0.2",
-      "vectorSetId": "1133",
+      "vsId": "1133",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1421,12 +1421,12 @@
                  "randPQ" : "1",
                  "tests" : [
                     {
-                      "testCaseId" : "1145",
+                      "tcId" : "1145",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256"
                     },
                     {
-                      "testCaseId" : "1147",
+                      "tcId" : "1147",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256"
                     }
@@ -1438,22 +1438,22 @@
                  "randPQ" : "3",
                  "tests" : [
                     {
-                      "testCaseId" : "1111",
+                      "tcId" : "1111",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256"
                     },
                     {
-                      "testCaseId" : "1112",
+                      "tcId" : "1112",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-512"
                     },
                     {
-                      "testCaseId" : "1113",
+                      "tcId" : "1113",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256"
                     },
                     {
-                      "testCaseId" : "1114",
+                      "tcId" : "1114",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-512"
                     }
@@ -1466,22 +1466,22 @@
                  "primeTest" : "tblC2",
                  "tests" : [
                     {
-                      "testCaseId" : "1115",
+                      "tcId" : "1115",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256"
                     },
                     {
-                      "testCaseId" : "1116",
+                      "tcId" : "1116",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-512"
                     },
                     {
-                      "testCaseId" : "1117",
+                      "tcId" : "1117",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256"
                     },
                     {
-                      "testCaseId" : "1118",
+                      "tcId" : "1118",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-512"
                     }
@@ -1494,12 +1494,12 @@
                  "primeTest" : "tblC3",
                  "tests" : [
                     {
-                      "testCaseId" : "1135",
+                      "tcId" : "1135",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-512"
                     },
                     {
-                      "testCaseId" : "1137",
+                      "tcId" : "1137",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-512"
                     }
@@ -1512,45 +1512,45 @@
                  "primeTest" : "tblC2",
                  "tests" : [
                     {
-                      "testCaseId" : "1119",
+                      "tcId" : "1119",
                       "modRSA" : "2048",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
                       "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "testCaseId" : "1120",
+                      "tcId" : "1120",
                       "modRSA" : "2048",
                       "e" : "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000085a4cf",
                       "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5"
                     },
                     {
-                      "testCaseId" : "1121",
+                      "tcId" : "1121",
                       "modRSA" : "3072",
                       "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
                       "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     },
                     {
-                      "testCaseId" : "1122",
+                      "tcId" : "1122",
                       "modRSA" : "3072",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000054a7dd",
                       "pRand" : "0c5742407c0bac4f474edda6f92e42bd36ade552d947eb8bc5ac97c23efac563de8262ecc1e542cd489fcd33f3dcadcf900c8b0acd28abb1d25318c4f7dae3fa4b281c3b89a77d06db36115ff10496005b45fab68aa45e5f40296570ff97081007d907aa74b56f59841f6069900e14f5f2cf508b9094f3ee37aa4c0a43e38922dc3fce63d6d1e392d1a70da4e5ba7083188ca78693bb7e953352aeb76f3f5905613a10a04c791560717316e2a2c13bb4522aeb86680355bec7dda0b3674e10e9"
                     },
                     {
-                      "testCaseId" : "1129",
+                      "tcId" : "1129",
                       "modRSA" : "2048"
                     },
                     {
-                      "testCaseId" : "1130",
+                      "tcId" : "1130",
                       "modRSA" : "2048"
                     },
                     {
-                      "testCaseId" : "1131",
+                      "tcId" : "1131",
                       "modRSA" : 3072
                     },
                     {
-                      "testCaseId" : "1132",
+                      "tcId" : "1132",
                       "modRSA" : "3072"
                     }
                  ]
@@ -1562,27 +1562,27 @@
                  "primeTest" : "tblC3",
                  "tests" : [
                     {
-                      "testCaseId" : "1123",
+                      "tcId" : "1123",
                       "modRSA" : "2048",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037a7f1",
                       "pRand" : "ea4fe1b753e17f7a99a648c1d111d7599eda7ed85b14c974df5d3f1a39e9b3bc2ce3d4e9ab70a2d184c4ce56fbe18c97b09fd47bb39a470ef2bfa5217e1aa8493326dfd9cc9e73da683691cef7d6ded642bfb56c919f8f54ea08de9bffa2f155e8a3a6746302347fb2f581be2deb55b057c3ac371d867c710a03cb9c1d218223",
                       "qRand" : "c8435496e852f54eac36a1b8e29e5258ba383f3cd453293d98b9d565e72b03e44ead75ea341615062b504c3350b2404f53401f19b88b6a23bca4a19687300522489dbe3beab828e438b28b5a10e8c0da4b38162b458bb7f92804f1969fa3a1cd92f9b16b358047bcc1858e21ab787738cc311abd6bbdf138b352b26d206614cf"
                     },
                     {
-                      "testCaseId" : "1124",
+                      "tcId" : "1124",
                       "modRSA" : "2048",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000333f01",
                       "pRand" : "0456038077312d974418bbe2432387d97b55158496263213df19a9ff7f888cdcf3dbae9bba8cdd5d8b6799de99cfb37d1bad0173fc38540a0d0e098ebdf1718b92c9361880af2025382ffb20fc094eced508b097f455f357a2b35a562be410cf44f4c44d5bc4bf0b57b43af86cd7cf37aa9edffa6d23132b1eeece0f09691645"
                     },
                     {
-                      "testCaseId" : "1125",
+                      "tcId" : "1125",
                       "modRSA" : "3072",
                       "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fe8ed9",
                       "pRand" : "f26e1240a0a1b954430793b7b3e3bbf46b1cbc022e29444099c3edcbb66e9ecab3414c80275ca523ea269c085758582917e6cdb2b42f819011a9ddc1e1c25788c507e9dd8fb0bb3fb3d1103e6b0dff333394956aae41855584ec4119e4a3ab804764caa88db6d10c503402f3280aa573ef9066a2ca17a31aafe9bf0bcd412302505e6feb3fe7538bab064d415af979a32cc0b9e298d0b8bc7d1eb3f70e02004257c360bca9549a5bbedee3833ae23c8e65b430e8acb5035a7b410d55a2a5687b",
                       "qRand" : "a57a699bc759f6e71049eeef16011b2b1549cb8b27a822ac7e45178f3f80680390e1ee99f5f531f5e44a8b570aece9aa0682cff9202cff065a704972748c117e9be5439f93198406bd33c7dded7956e692b531ee7c92133a1e6884a2a48459f55551f406e840461ef18e4c613906186f1ce95a9ba63f4f7673dd552678fba5b0672ac921de31eb7213c14387dd2a7b47c0dbdc088cd8b16f3b552c3fa95631f79cad18a98dc86e22728aa533db8e767396d6eceddb525dceb0baa1cecd57734b"
                     },
                     {
-                      "testCaseId" : "1126",
+                      "tcId" : "1126",
                       "modRSA" : "3072",
                       "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000524781",
                       "pRand" : "aad0d971253463ae131e900189b1e978ca55c58dfa3797995f69e2ef147246402e78d3ad703f298943d6e02709289ab846deb65731cffa735239d787abfa6e26f0e295325efe9eab616422cdcbe391ce531bf5508b9d45cf5dc5bd2389c31cdf658cf1ac3ec714978da665d1867ac6846e629f3552172a8e2b879a2c4f326298d9c379cf97c1ddadfc0d8c4c112a0f6e48195131b756603b8052e2b25d010851749ea37cdbaa9490ea686546ee1688445673304d4df5024d834c9d9da965c7cb"
@@ -1599,7 +1599,7 @@
     <artwork><![CDATA[
    {
      "version": "0.2",
-      "vectorSetId": "1163",
+      "vsId": "1163",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1607,13 +1607,13 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "testCaseId" : "1165",
+                      "tcId" : "1165",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256",
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
-                      "testCaseId" : "1166",
+                      "tcId" : "1166",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
@@ -1625,13 +1625,13 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "testCaseId" : "1167",
+                      "tcId" : "1167",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
-                      "testCaseId" : "1168",
+                      "tcId" : "1168",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
@@ -1643,14 +1643,14 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "testCaseId" : "1169",
+                      "tcId" : "1169",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256",
                       "saltLen" : "20",
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
                     {
-                      "testCaseId" : "1170",
+                      "tcId" : "1170",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-512",
                       "saltLen" : "62",
@@ -1668,7 +1668,7 @@
     <artwork><![CDATA[
    {
      "version": "0.2",
-      "vectorSetId": "1173",
+      "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1676,7 +1676,7 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "testCaseId" : "1174",
+                      "tcId" : "1174",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
@@ -1685,7 +1685,7 @@
                       "s" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
                     },
                     {
-                      "testCaseId" : "1175",
+                      "tcId" : "1175",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
@@ -1700,7 +1700,7 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "testCaseId" : "1176",
+                      "tcId" : "1176",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
@@ -1709,7 +1709,7 @@
                       "s" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
                     },
                     {
-                      "testCaseId" : "1177",
+                      "tcId" : "1177",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
@@ -1724,7 +1724,7 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "testCaseId" : "1178",
+                      "tcId" : "1178",
                       "modRSA" : "2048",
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
@@ -1733,7 +1733,7 @@
                       "s" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
                     },
                     {
-                      "testCaseId" : "1179",
+                      "tcId" : "1179",
                       "modRSA" : "3072",
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
@@ -1758,7 +1758,7 @@
     <artwork><![CDATA[
    {
      "version": "0.2",
-      "vectorSetId": "1193",
+      "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1766,13 +1766,13 @@
                  "modRSA" : "2048",
                  "tests" : [
                     {
-                      "testCaseId" : "1194",
+                      "tcId" : "1194",
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
                     },
                     {
-                      "testCaseId" : "1195",
+                      "tcId" : "1195",
                       "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
                       "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
@@ -1791,7 +1791,7 @@
     <artwork><![CDATA[
    {
      "version": "0.2",
-      "vectorSetId": "1194",
+      "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1799,11 +1799,11 @@
                  "modRSA" : "2048",
                  "tests" : [
                     {
-                      "testCaseId" : "1195",
+                      "tcId" : "1195",
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc" 
                     },
                     {
-                      "testCaseId" : "1196",
+                      "tcId" : "1196",
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
                     }
                  ]
@@ -1823,10 +1823,10 @@
         <artwork><![CDATA[
                 {
                     "version": "0.2",
-                    "vectorSetId": "1133",
+                    "vsId": "1133",
                     "testResults": [
                     {
-                      "testCaseId" : "1111",
+                      "tcId" : "1111",
                       "e" : "10000021",
                       "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
                       "bitlen1" : "312",
@@ -1839,7 +1839,7 @@
                       "d" : "6b56ee657ebf6a54b35869b02f4e21d3ef0fb479a70309b522a95d955bf966385e770bd9e321bf95eca857ab36b5084ca6f7596255d11a4a49a1547d5b4306be33ff2ec560838565b6c45c6962ff4f8c64752f615c57fbed7d8b961a2e3fad976648feee6bf1d050c812badb0639188f9ff1e0faf4739b74c31ccb7fadd5c67ff4794ef7249b94abab145351aca47f8fe8e0628b7959f91f7eb06ff7a7a7e308365522c9ddc74c62c69662a9d0ee6b4223c66a4f102f4fbd436cab8723a9f416767ab85cd28ffbf5dc60cdf7a51648f3c57ad69d6b07bb77399bbf19c21ad01a9c782951782ac8a46ed8dac939442cbb280fbdc4056e68a5a7565e69c80c849"
                     },
                     {
-                      "testCaseId" : "1112",
+                      "tcId" : "1112",
                       "e" : "10000021",
                       "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
                       "bitlen1" : "320",
@@ -1852,7 +1852,7 @@
                       "d" : "a5fc5868f19c7644f10b81ca056953cd38fce6dbbbc29a38416b42e256ec02172977d14e3733ee01d92a83179c61bcb01264e0b3b00fe4039981518a81020d3cbbe48b862e7ad121c45551a7104d5db2a6de18d1b9009857cdce08cd5f2bcdb6292b8f45f130ee755667e3c06109c4ae2b1145e1d8f3d427d5d4059df0fad45b1805c031dcc9d37e6d85faccbb7ef8e6bbb4ec91dc9899e723a11d0eb516079b38f9d31c6ba9cbe728ae6d126240cccf13eb8188c76dd0612fb1a766bcc80d05a5c84367a8c2097e3a7f57d438da460a682e8517ad2a83ca472f5a1f2893b821c0cf0a29c7cd476af9fe2c62adeb2d3bced5fdeee547714ebe71f79adc4239"
                     },
                     {
-                      "testCaseId" : "1113",
+                      "tcId" : "1113",
                       "e" : "10000021",
                       "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
                       "bitlen1" : "448",
@@ -1865,7 +1865,7 @@
                       "d" : "43f10b697929aee4aebeed949a829ed4a816927f2b1ba427e4305ac7e61ac923f9cea977dbc7b1c9759cc327d48a8205cd04e9357d9c1c83be78461f04e0a6d8e4243320e53ba638a94bc74bc130b7fc9fdca9c6c06c2c78b1c6e6727891117129de8642f4b2e633c5e5c1c7f2d04b315d7869dc29bd7e05ad55348ef3519451e66af3fbcaa396f93ffe357649e87cf1039a9e31d07cf08d0b8c305d40eb1880fe7d7fa84a6658ae3776dd1557fbdab1306b4aa305071ffeaa8548a6f25e32442c292a0acfb095d8aa591894d5bd2d3d349219ff9ec008730065a46301972fced0754e519234da6fbe84e63690dfc0ad860b644f79c091d8e0cfd1ec570f66689f3e0d78ae2c2129db1d30250149e4838be51441cd30e01157374181e6a8cf7b5a62392598db88330e4e386dc2a312c428016a9d076d3b1066b2538799fd21bfa29ff74c978104a500d4953277748cf637aab62423325e38be21118c0dfa9c68a4391eb65ee0b7226dd2ddbc6d64387acef2f29ea42b198aff6bfca3930f93d5"
                     },
                     {
-                      "testCaseId" : "1114",
+                      "tcId" : "1114",
                       "e" : "10000021",
                       "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
                       "bitlen1" : "504",
@@ -1878,7 +1878,7 @@
                       "d" : "cf02aaaca392f5d21e80ac8e954ccc3eb738155b9ca03d96c1c7506b6593e97954e0b97eed739e6cd0eff08fe66e1584926d8d6ab9d6c686f99f758fec24627071a0f9164096b93c2693e296d2707f392ada019d010459b0783918f8f104423e2dfdcd418194144bde4b9fbbc766dc892bf9154803d41e8a295e2fd280592e4388dd78d792f96654da3268421553fa101f5e334b5149a6bd6857705ae9b5fbe4f80f2334fffec4a168a63c47d927d54e33571590f4450e005adb54c4a290f52141a7a502007a3508c6fad932f04e5b469cbab7228f69c34e89b5b4e7378fc82a9f1dd2132bceceb447dfd8a14679dd9df39194e4190b6d5fa79e2abe140abc4cc6cd428ed04c1bdb14cf51bd9133119138b1cee3bb1649bedb2e86c810010006e611237a901e3e404ca78c551253979c587a92440e11c2b742e87bea09a93fa2b1ed6cbf66907d3005a572b20055cc4870bce35d78b51f7b22ba37ff7f8af05dc2d0d6c743d95ac0a5e0eabf5be061991bb2fb505555589c5c5a0cd3b575d15"
                     },
                     {
-                      "testCaseId" : "1115",
+                      "tcId" : "1115",
                       "e" : "10000021",
                       "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
                       "bitlen1" : "232",
@@ -1900,7 +1900,7 @@
                       "d" : "bec8baec7da0634211ed76b770d9ef0834cfc689cb2a6d1c04a9c14d9ab249ebf5711147dde7a0120b521d8a0a2ba62fcedd767a8abde768e6bf1d12d5e88fd7f1a11d44684f6239512f976366236e270d39801eae4cab9109dc1746ffca0d868049551b7e27caa57d32ba0235dc8bf68a3955d562a283d31ac5f23342757e7918d85ffb654789ee39638543dbe76dea9ddbae3bb12c411b509923c101035ce53c7b642047bc91e3cbedb3f945f0cae1edad5a2c600db921722b4655742f8c10650cd1c868050d26c0caefff2dabf02a9841f1dff07e0094485e8965b06fd4ffb024a1d9a13ac241be9a2db0bcbfd656edcc5d1c945857a8ec3cd281d61f715"
                     },
                     {
-                      "testCaseId" : "1116",
+                      "tcId" : "1116",
                      "e" : "10000021",
                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
                      "bitlen1" : "272",
@@ -1922,7 +1922,7 @@
                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
-                      "testCaseId" : "1117",
+                      "tcId" : "1117",
                       "e" : "10000021",
                       "seed" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddbbc",
                       "bitlen1" : "512",
@@ -1944,7 +1944,7 @@
                      "d" : "4abd536c3f299e3c7365e496caedc45561ddc2a97d2d52f8c9e3eb1e7be52117e952ad9ee9768df7380ed09750d6c9bedf7d5da8ebe36046cb17f16e4f7cd88ced6279cceda200b17faa16b77000b53360c9e50bd5da91329a309bf422c716b7127b7331163987810ad08ca15b0580a97fe63bec434c72213f8527d939b02b60bd0902e97da8068d81354eedfa5d62067201a2b5b64c021022becda98b175bb57f4216211f22f11b28b5ce0021e87361e5c0f4e363f8f15123b1e7eb76cea6ecd065549925425f68fc80c8846d399205edbdf417d6554bb3eeaa58ef0e68be51a447c80438dcdff548203813d13e50f792e2aa106537d39198fde0a305446dfaf16de93e670600ce20a48ddb16ae196c43b4d1049c7c1c130c510b780e37591bee3bcf6c3d716f9acd305f81ab54675c95b7bef042f4c11ecae895d18c4fe1a986410e947b150deba89cf123fe11874304ae8922b61cae5c6b298cf20ea65cce98e94cb4849c85b813de46554ad6e0f0f844b679060855c02ae69b1806e55e21"
                     },
                     {
-                      "testCaseId" : "1118",
+                      "tcId" : "1118",
                       "e" : "10000021",
                       "seed" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b6e7",
                       "bitlen1" : "512",
@@ -1966,7 +1966,7 @@
                       "d" : "f5931b10bdb7e1c3dacdee6a16a951420423cebcd3d0465edb82663895892780f3a3fd25a6fb04e58cc566c8642cf3e86a1d406ef151e468d44b99f7827560aa68edcbb6fc52129fbf08cb448e15e9b50495e87d32557dad8cde1f5f3a2882131a3b94acc231850feee3533552c7efcc773d5943db12f06ec781923345ae0403f53420b093b7df9128176984b43022733bcd377076372b3d450f7e5542ae4984c852343edbf566af7d72a5fd66779d2e84c23f9a62d4af26cb0f634373b061ebc0f32d50fabc87450af7ada7eba7ea454c16da4958edee2916f30b809f58e10651fe4c4c494105b7da2b0dcd0dec0bf5e5ec81207aae8be43edbc9936b3e12f95a78185dab006ba41d4bbc5c1712664c91dd0875a8694697449f058ea070d24f1300adc95ef81928af0bf716fd204a33fc3b1e0cd662147a467d49d26d24bb523de98c7de6548a82c559e5ecba493c6b2bce2c20686fbf73ca8f10965f0cf0f2a773a269df48e8c514da5a3b77b55f86ecc1179f86dcb9ca1847598a4f8da1"
                     },
                     {
-                      "testCaseId" : "1135",
+                      "tcId" : "1135",
                       "e" : "10000021",
                       "bitlen1" : "224",
                       "xP1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d811",
@@ -1988,7 +1988,7 @@
                       "d" : "166bed3734b922f074460a0ae1a8fab231668de4a10daa969805338e6e738e9af173e2a5b0cb1cf132c40a0523dea617228cb7ec33779e86d91696a03218d1ee955f05fe9665d6416cca97600f89d30eed460a5638101137bb7e26a3f01ce9724e9570d372c593e6ff837b6eaabb0fc7698cb952a6122ba59f945d4e9b99a00b84dd150ecaa54ed35c280dc046b4af027beaec005a9768d23b38676d2a9d73e3b9c923d30c7e9ae8686815dda971de42fbf96872781231140d04e659c50a9e86bbd4cd9f5f5aa2df5e5e2ff7aa82ecebacb89a9931fa022a0982c42a304a0fad7e5da407be9e9b225664147a6837a05c43d704f4903a7a20f67a360bee822e21"
                     },
                     {
-                      "testCaseId" : "1137",
+                      "tcId" : "1137",
                       "e" : "10000021",
                       "bitlen1" : "320",
                       "xP1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077677",
@@ -2010,7 +2010,7 @@
                       "d" : "8c377a2f9817c497507f74c2d4d37c2093e5a204fe0bc04299c0337af153bf86022c2ad9f88d156b67263d21e0fff1fce1cf8e9affbf52bd83e33f38d7223b6aae31667b029188d939453b5cff019c1fc6ed87296f7897c2b3328bb888e1dd3b082e5b11272f7f8fc62473d701b35b342e4ac4f757c4b17924912dba913f17800f2a5dec389436b8d7288e6c44035d2aad9bba5bd1cfb8550fc3bdfd01c317ec222ea6f0cb90342367fdaa5b61513cdc3bea7a12bb44f1f07811a2c193b99615e89627164482248f474e89985ac1655df1054d93ec91f93b08c5ef077fad256cd042ac375cd536837b65489d62833c48fff221cb1092509e82fea082f0022151dbd9d2104314d10cef26fd4ea710898f42f956be2aa46756e5c436174e181f95e54ac8b6477baa5a32044678b3686d16df88e457bda4e0dddd94a24dbdb3ced4827392780cc96287fd6a46e82a5fb1daa0d372953c06ff6c2e1236926e0c11a367218a4291e6288e5cd1be03408770c5a667da57652eb46a9367369f732eb41"
                     },
                     {
-                      "testCaseId" : "1145",
+                      "tcId" : "1145",
                       "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
                       "e" : "10000021",
                       "p" : "f3ec667fe3c697769f89db44c48926f05285933f351ac5821458ea3414a1c62cf581e6cb702adc0323d7b86f6f013b471e24e4b25bbe731ecd023157a03656fb9a16fb7f6fcfa65020900822e8ce03bd967e38efd546ea30706698c7fa6d0f9e0316fe65d3195310e9baaaebcdd85e4a260341a90dd2c884f6e269e10647a2e9",
@@ -2019,7 +2019,7 @@
                       "d" : "8a19a9956ae2ccec6ca4fc0a5e56ab691c94b710dd668c00534bca4f5af84a568fee1bbbf36185747d11deac96faf66d13c08d97acfd29025d044630fdb2824c9435d8fa6ab7b6a349bf98ee86f5d1a7d6cf3956b43593c9a7b379fedcf2b78b1d4bcca082f0a9bbfeaa2a982a0cf16a1e812816bb9ede15edba51ffae5b65359e49b3c2e755fe32399614a35d45dd525709ae323b2828668be67c0c364d59925617f9583d399096d9f9cf085e29d011c78dc857e24376ebeeba688d72a2fbb1f8f09e92e7e606ff787fc9b395f6cac20c3ccb251bac325afdf1c3dbe75fce59753c7005bfd86957ba72172dc5a43b6192121e3cb97d0c43b9b63952bbe0d91"
                     },
                     {
-                      "testCaseId" : "1147",
+                      "tcId" : "1147",
                       "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
                       "e" : "10000021",
                       "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
@@ -2028,39 +2028,39 @@
                       "d" : "79815d367f924ba3509d3d4870cc729a82dc6dfb001e551baac15ff2ed77efdc6a00e628f29aabe062b5226a2e2689d26c82e8021958eda5fe0581f3bad0479942ec03bee965d79204c822d6c4e5cb82814419acd38a8779afae03b4a95ded204198bc2d68ee124cb5d2cbc68bc3621450168f55a9b9f2787b1cafb0328ceb9c0bc4e81d23bc155af9a172b18dac8f493f6753571b2f13cf56d7d93ac9d191dbfb7a2b6c6e795c2387722ee48d9bbf8fabd0fe58b3502a6a3173901057ae04bdd1f69cea58c38f9ac88c90427d8d3c60afd50dea9d98b669f8a052c7c26415885d70df8eb36fabd5d9fcde1a9cea5c4118f16af672fadb56f43e2fedf3b33ab4c0d6763b497d73164b778a1638af9c8e87e71cf64ed368c978179a2d7bfb2086ce8fd1ab6f3263603a71d0dc70fa5c56c6c0f233447bf4c93fb03c8e85ddbb204142e4414f0a1f35746c7f106931e25a1fe6a5f865b93d679ccd7742519b29803ed34ca40321c7e38fdeeed68195860b8157f14365a587ca58e1c5c7c46c9c1"
                     },
                     {
-                      "testCaseId" : "1119",
+                      "tcId" : "1119",
                       "primeResult" : "prime"
                     },
                    {
-                      "testCaseId" : "1120",
+                      "tcId" : "1120",
                       "primeResult" : "composite"
                    },
                    {
-                      "testCaseId" : "1121",
+                      "tcId" : "1121",
                        "primeResult" : "prime"
                    },
                    {
-                      "testCaseId" : "1122",
+                      "tcId" : "1122",
                       "primeResult" : "composite"
                    },
                    {
-                      "testCaseId" : "1123",
+                      "tcId" : "1123",
                       "primeResult" : "composite"
                    },
                    {
-                      "testCaseId" : "1124",
+                      "tcId" : "1124",
                       "primeResult" : "composite"
                    },
                    {
-                      "testCaseId" : "1125",
+                      "tcId" : "1125",
                       "primeResult" : "composite"
                    },
                    {
-                      "testCaseId" : "1126",
+                      "tcId" : "1126",
                       "primeResult" : "composite"
                    },
                    {
-                      "testCaseId" : "1129",
+                      "tcId" : "1129",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
                       "p" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "q" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275",
@@ -2068,7 +2068,7 @@
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "testCaseId" : "1130",
+                    "tcId" : "1130",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
@@ -2076,7 +2076,7 @@
                       "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
                    },
                    {
-                      "testCaseId" : "1131",
+                      "tcId" : "1131",
                       "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
@@ -2084,7 +2084,7 @@
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   },
                   {
-                      "testCaseId" : "1132",
+                      "tcId" : "1132",
                       "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
@@ -2102,16 +2102,16 @@
         <artwork><![CDATA[
                 {
                     "version": "0.2",
-                    "vectorSetId": "1163",
+                    "vsId": "1163",
                     "testResults": [
                     {
-                      "testCaseId" : "1165",
+                      "tcId" : "1165",
                       "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f3e7af",
                       "s" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
                     }
                     {
-                      "testCaseId" : "1166",
+                      "tcId" : "1166",
                       "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ebda09",
                       "s" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
@@ -2123,13 +2123,13 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "testCaseId" : "1167",
+                      "tcId" : "1167",
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "s" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
                     }
                     {
-                      "testCaseId" : "1168",
+                      "tcId" : "1168",
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
                       "s" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
@@ -2141,13 +2141,13 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "testCaseId" : "1169",
+                      "tcId" : "1169",
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "s" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
                     }
                     {
-                      "testCaseId" : "1170",
+                      "tcId" : "1170",
                       "e" : "1415a7",
                       "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
                       "s" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
@@ -2163,7 +2163,7 @@
         <artwork><![CDATA[
 {
      "version": "0.2",
-      "vectorSetId": "1173",
+      "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2171,11 +2171,11 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "testCaseId" : "1174",
+                      "tcId" : "1174",
                       "sigResult" : "fail"
                     },
                     {
-                      "testCaseId" : "1175",
+                      "tcId" : "1175",
                       "sigResult" : "fail"
                     }
                  ]
@@ -2185,11 +2185,11 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "testCaseId" : "1176",
+                      "tcId" : "1176",
                       "sigResult" : "pass"
                     },
                     {
-                      "testCaseId" : "1177",
+                      "tcId" : "1177",
                       "sigResult" : "fail"
                     }
                  ]
@@ -2199,11 +2199,11 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "testCaseId" : "1178",
+                      "tcId" : "1178",
                       "sigResult" : "fail"
                     },
                     {
-                      "testCaseId" : "1179",
+                      "tcId" : "1179",
                       "sigResult" : "fail"
                     }
                  ]
@@ -2222,7 +2222,7 @@
         <artwork><![CDATA[
 {
      "version": "0.2",
-      "vectorSetId": "1193",
+      "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2230,11 +2230,11 @@
                  "modRSA" : "2048",
                  "tests" : [
                     {
-                      "testCaseId" : "1194",
+                      "tcId" : "1194",
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "testCaseId" : "1195",
+                      "tcId" : "1195",
                       "s" : "fail"
                     }
                  ]
@@ -2250,7 +2250,7 @@
         <artwork><![CDATA[
 {
      "version": "0.2",
-      "vectorSetId": "1194",
+      "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2258,14 +2258,14 @@
                  "modRSA" : "2048",
                  "tests" : [
                     {
-                      "testCaseId" : "1195",
+                      "tcId" : "1195",
                       "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010001",
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "testCaseId" : "1196",
+                      "tcId" : "1196",
                       "s" : "fail"
                     }
                  ]


### PR DESCRIPTION
Propagate 47045cb332099ad96db6c4d43fb5b634fa11cabe to the other sub-specs.  Fixed inconsistent names in some of the sub-specs for vsId and tcID.