### PR TITLE
typo corrections

### DIFF
--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -584,7 +584,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -207,14 +207,14 @@
 	  <c/><c/><c/><c/><c/>
 
 	  <c>genPQ</c>
-	  <c>Genrate P and Q method, one or both</c>
+	  <c>Generate P and Q method, one or both</c>
 	  <c>array</c>
 	  <c>Probable, Provable</c>
 	  <c>Yes</c>
 	  <c/><c/><c/><c/><c/>
 
 	  <c>genG</c>
-	  <c>Genrate G method, one or both</c>
+	  <c>Generate G method, one or both</c>
 	  <c>array</c>
 	  <c>Unverifiable, Canonical</c>
 	  <c>Yes</c>
@@ -442,7 +442,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -424,7 +424,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_hashmac.xml
+++ b/src/acvp_sub_hashmac.xml
@@ -520,7 +520,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kas_ecc.xml
+++ b/src/acvp_sub_kas_ecc.xml
@@ -190,7 +190,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -244,7 +244,7 @@
 	</section>
 
 	<section anchor="scheme_cap_ex" title="KAS ECC Scheme Capabilities JSON Values">
-	<t>All other schemem capability advertised is a self-contained JSON object using the following values.</t>
+	<t>All other scheme capability advertised is a self-contained JSON object using the following values.</t>
         <texttable anchor="scheme_caps_table" title="KAS ECC Capabilities JSON Values">
           <ttcol align="left">JSON Value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -406,7 +406,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>hmacMacLen</c>
-	  <c>HMAC Mac langth in bytes, gte 8</c>
+	  <c>HMAC Mac length in bytes, gte 8</c>
 	  <c>value</c>
 	  <c>8 or greater</c>	
           <c>Yes</c>
@@ -433,7 +433,7 @@
 	    <t><list style="symbols">
 		<t>Full Unified</t>
 		<t>Full MQV</t>
-		<t>Ephemiral Unified</t>
+		<t>Ephemeral Unified</t>
 		<t>One Pass Unified</t>
 		<t>One Pass MQV</t>
 		<t>One Pass DH</t>
@@ -577,13 +577,13 @@
 
           <c>kcRole</c>
 	  <c>Key confirmation roles supported</c>
-	  <c>provider and/or recepient</c>	
+	  <c>provider and/or recipient</c>	
           <c>Yes</c>
 	  <c/><c/><c/><c/>
 
           <c>kcType</c>
 	  <c>Key confirmation types supported</c>
-	  <c>unilaterl and/or bilateral</c>	
+	  <c>unilateral and/or bilateral</c>	
           <c>Yes</c>
 	  <c/><c/><c/><c/>
 
@@ -720,7 +720,7 @@
 		<c/><c/><c/><c/>
 
 		<c>oiLen</c>
-		<c>Length of the OtherInfo field</c>
+		<c>Length of the otherInfo field</c>
 		<c>value</c>
 		<c>Yes</c>
 		<c/><c/><c/><c/>
@@ -771,7 +771,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">
@@ -860,8 +860,8 @@
 			          "role" : ["initiator", "responder"],
 				  "kdf" : ["concatenation", "ASN1"],
 				  "keyConf" : "yes",
-				  "kcRole" : ["provider", "recepient"],
-				  "kcType" : ["unilaterl", "bilateral"],
+				  "kcRole" : ["provider", "recipient"],
+				  "kcType" : ["unilateral", "bilateral"],
 				  "parmSetEB" :
 				      { "spCurve" : "P-224",
 				        "sha" : [224],

--- a/src/acvp_sub_kas_fcc.xml
+++ b/src/acvp_sub_kas_fcc.xml
@@ -190,7 +190,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -219,7 +219,7 @@
 
 
 	<section anchor="scheme_cap_ex" title="KAS FCC Scheme Capabilities JSON Values">
-	<t>All other schemem capability advertised is a self-contained JSON object using the following values.</t>
+	<t>All other scheme capability advertised is a self-contained JSON object using the following values.</t>
         <texttable anchor="scheme_caps_table" title="KAS FCC Capabilities JSON Values">
           <ttcol align="left">JSON Value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -361,7 +361,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>hmacMacLen</c>
-	  <c>HMAC Mac langth in bytes, gte 8</c>
+	  <c>HMAC Mac length in bytes, gte 8</c>
 	  <c>value</c>
 	  <c>8 or greater</c>	
           <c>Yes</c>
@@ -506,13 +506,13 @@
 
           <c>kcRole</c>
 	  <c>Key confirmation roles supported</c>
-	  <c>provider and/or recepient</c>	
+	  <c>provider and/or recipient</c>	
           <c>Yes</c>
 	  <c/><c/><c/><c/>
 
           <c>kcType</c>
 	  <c>Key confirmation types supported</c>
-	  <c>unilaterl and/or bilateral</c>	
+	  <c>unilateral and/or bilateral</c>	
           <c>Yes</c>
 	  <c/><c/><c/><c/>
 
@@ -728,7 +728,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">
@@ -812,8 +812,8 @@
 			          "role" : ["initiator"],
 				  "kdf" : ["concatenation"],
 				  "keyConf" : "yes",
-				  "kcRole" : ["provider", "recepient"],
-				  "kcType" : ["unilaterl", "bilateral"],
+				  "kcRole" : ["provider", "recipient"],
+				  "kcType" : ["unilateral", "bilateral"],
 				  "parmSetFB" :
 				      { "sha" : [224],
 					"ccmKeySize" : [128],

--- a/src/acvp_sub_kdf108.xml
+++ b/src/acvp_sub_kdf108.xml
@@ -359,7 +359,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_ikev1.xml
+++ b/src/acvp_sub_kdf135_ikev1.xml
@@ -190,7 +190,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -418,7 +418,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_ikev2.xml
+++ b/src/acvp_sub_kdf135_ikev2.xml
@@ -189,7 +189,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -398,7 +398,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_snmp.xml
+++ b/src/acvp_sub_kdf135_snmp.xml
@@ -190,14 +190,14 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
 
           <c>engineID</c>
-	  <c>SNMP: Two engine IDs in hexidecimal, can be the same</c>
+	  <c>SNMP: Two engine IDs in hexadecimal, can be the same</c>
           <c>array</c>
           <c>0-0xF</c>
           <c>No</c>
@@ -281,7 +281,7 @@
 
 
 	  <c>engineID</c>
-	  <c>engine ID as hexidecimal string</c>
+	  <c>engine ID as hexadecimal string</c>
           <c>value</c>
           <c>No</c>
 	  <c/><c/><c/><c/>
@@ -324,7 +324,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_srtp.xml
+++ b/src/acvp_sub_kdf135_srtp.xml
@@ -190,7 +190,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -364,7 +364,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_ssh.xml
+++ b/src/acvp_sub_kdf135_ssh.xml
@@ -189,7 +189,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -361,7 +361,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_tls.xml
+++ b/src/acvp_sub_kdf135_tls.xml
@@ -190,7 +190,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -368,7 +368,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_tpm.xml
+++ b/src/acvp_sub_kdf135_tpm.xml
@@ -188,7 +188,7 @@
           <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -309,7 +309,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_kdf135_x963.xml
+++ b/src/acvp_sub_kdf135_x963.xml
@@ -190,7 +190,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>No</c>
@@ -356,7 +356,7 @@
 	</section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -799,7 +799,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">

--- a/src/acvp_sub_symmetric.xml
+++ b/src/acvp_sub_symmetric.xml
@@ -187,7 +187,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
-          <c>Prerequistie algorithm validations</c>
+          <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
           <c>Yes</c>
@@ -427,7 +427,7 @@
     </section>
 
     <section anchor="vector_responses" title="Test Vector Responses">
-	<t>After the ACVP client downloads and processes a vector set, it must send the resonse vectors
+	<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
 	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
 
 	<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">


### PR DESCRIPTION
Typo corrections in several src files.
- Note there were some typos in JSON options like `unilateral` and `recipient`. I'm assuming these were mistakes and corrected them.
- Did not update artifacts, looks like they haven't been updated for a few commits, is this something you'd like me to add to this PR?