### PR TITLE
Fix poorly formatted tags

### DIFF
--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -425,14 +425,14 @@ Accept:
 "direction" : "encrypt,decrypt",
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
-"keyLens" : [
+"keyLen" : [
             128,
             256
              ],
 "tagLen" : [
             96
                ],
-"ivLens" : [
+"ivLen" : [
             96
                ],
 "ptLen" : [
@@ -504,11 +504,11 @@ Content-Length: <length of results>
   "direction": "encrypt",
   "test_groups": [
     {
-      "keylen": 128,
-      "ivlen": 96,
-      "ptlen": 0,
-      "aadlen": 128,
-      "taglen": 128,
+      "keyLen": 128,
+      "ivLen": 96,
+      "ptLen": 0,
+      "aadLen": 128,
+      "tagLen": 128,
       "tests": [
         {
           "tcId": 12340,
@@ -790,7 +790,7 @@ Big numbers require conversion from strings to whatever format is used by the DU
 Numerical values of integer size or with decimal points may use quotations if those
 values are generally used as a string, for example the acvVersion would generally be
 used in displaying information not in any mathematical operations.  Something like
-keyLen or ptLens values would be better used without quotes to avoid having to convert the
+keyLen or ptLen values would be better used without quotes to avoid having to convert the
 string to an integer for use in the code.
 
 </t>


### PR DESCRIPTION
This is a followup to #31 to remove some remaining typos: keylen, keyLens, ptlen, etc.