### PR TITLE
Added TLS/auth comments in Goals section

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -409,12 +409,12 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.2.dev0 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.2" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-12-22" />
+  <meta name="dct.issued" scheme="ISO8601" content="2016" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -435,10 +435,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">December 22, 2016</td>
+  <td class="right">2016</td>
 </tr>
 <tr>
-  <td class="left">Expires: June 25, 2017</td>
+  <td class="left">Expires: July 7, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -459,7 +459,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on June 25, 2017.</p>
+<p>This Internet-Draft will expire on July 7, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -546,6 +546,7 @@
   <li>Scalability</li>
   <li>Management interface</li>
 </ul>
+<p id="rfc.section.2.2.p.3">With that in mind there are several expectations when building a server used as a validation authority.  A validation authority shall use HTTPS, TLS 1.2 or greater and mutual authentication. Therefore a client that expects to be used with a validation authority shall have the same requirements.  A server, proxy or client developed for the purposes of internal organizational testing only may chose not to include some of those features.</p>
 <h1 id="rfc.section.2.3"><a href="#rfc.section.2.3">2.3.</a> Terminology</h1>
 <p id="rfc.section.2.3.p.1">TBD </p>
 <h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> Architecture</h1>

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                         December 22, 2016
-Expires: June 25, 2017
+Intended status: Informational                                      2016
+Expires: July 7, 2017
 
 
               Automated Cryptographic Validation Protocol
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 25, 2017.
+   This Internet-Draft will expire on July 7, 2017.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Fussell                   Expires June 25, 2017                 [Page 1]
+Fussell                   Expires July 7, 2017                  [Page 1]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
 Table of Contents
@@ -66,7 +66,7 @@ Table of Contents
      2.1.  Audience  . . . . . . . . . . . . . . . . . . . . . . . .   4
      2.2.  Goals . . . . . . . . . . . . . . . . . . . . . . . . . .   4
      2.3.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   4
-   3.  Architecture  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Architecture  . . . . . . . . . . . . . . . . . . . . . . . .   5
      3.1.  Server/Client Architecture  . . . . . . . . . . . . . . .   5
      3.2.  Server/Proxy Architecture . . . . . . . . . . . . . . . .   6
    4.  ACV Protocol  . . . . . . . . . . . . . . . . . . . . . . . .   6
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Fussell                   Expires June 25, 2017                 [Page 2]
+Fussell                   Expires July 7, 2017                  [Page 2]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
 1.1.  Requirements Language
@@ -165,9 +165,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                 [Page 3]
+Fussell                   Expires July 7, 2017                  [Page 3]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    conflicting) conformance criteria.  ACVP does not define an interface
@@ -204,27 +204,29 @@ Internet-Draft              Abbreviated Title              December 2016
 
    o  Management interface
 
+   With that in mind there are several expectations when building a
+   server used as a validation authority.  A validation authority shall
+   use HTTPS, TLS 1.2 or greater and mutual authentication.  Therefore a
+   client that expects to be used with a validation authority shall have
+   the same requirements.  A server, proxy or client developed for the
+   purposes of internal organizational testing only may chose not to
+   include some of those features.
+
 2.3.  Terminology
 
    TBD
 
-3.  Architecture
 
 
 
 
 
-
-
-
-
-
-
-
-Fussell                   Expires June 25, 2017                 [Page 4]
+Fussell                   Expires July 7, 2017                  [Page 4]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
+
+3.  Architecture
 
                         Server/Client Architecture
 
@@ -271,17 +273,17 @@ Internet-Draft              Abbreviated Title              December 2016
       encrypt/decrypt, generate keys, signatures, perform varifications
       and DRBG functions.
 
+
+
+
+
+Fussell                   Expires July 7, 2017                  [Page 5]
+
+Internet-Draft              Abbreviated Title                       2016
+
+
    o  Crpyographic Module API - This is the interface to the crypto
       module from the ACV Client.  This interface is environment
-
-
-
-
-Fussell                   Expires June 25, 2017                 [Page 5]
-
-Internet-Draft              Abbreviated Title              December 2016
-
-
       specific and will vary depending on the API available on the
       crypto module.
 
@@ -331,11 +333,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-
-
-Fussell                   Expires June 25, 2017                 [Page 6]
+Fussell                   Expires July 7, 2017                  [Page 6]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
 5.  Security
@@ -389,9 +389,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                 [Page 7]
+Fussell                   Expires July 7, 2017                  [Page 7]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
 10.1.  Product Registration/Capabilities Exchange
@@ -445,9 +445,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                 [Page 8]
+Fussell                   Expires July 7, 2017                  [Page 8]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    o  /validation/acvp/vectors
@@ -501,9 +501,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                 [Page 9]
+Fussell                   Expires July 7, 2017                  [Page 9]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
 POST /validation/acvp/register HTTP1.1
@@ -557,9 +557,9 @@ each message.
 
 
 
-Fussell                   Expires June 25, 2017                [Page 10]
+Fussell                   Expires July 7, 2017                 [Page 10]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
       the "encryptAtRest" field or registering with "no" will indicate
@@ -613,9 +613,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                [Page 11]
+Fussell                   Expires July 7, 2017                 [Page 11]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    "tagLen" : [
@@ -669,9 +669,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                [Page 12]
+Fussell                   Expires July 7, 2017                 [Page 12]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    GET /validation/acvp/ vectors?vsId=1437  HTTP1.1
@@ -725,9 +725,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                [Page 13]
+Fussell                   Expires July 7, 2017                 [Page 13]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    HTTP 1.1 200 OK
@@ -781,9 +781,9 @@ Content-Length: <length of results>
 
 
 
-Fussell                   Expires June 25, 2017                [Page 14]
+Fussell                   Expires July 7, 2017                 [Page 14]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    The results request is an optional flow since some clients may not
@@ -837,9 +837,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                [Page 15]
+Fussell                   Expires July 7, 2017                 [Page 15]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    POST /validation/acvp/cancel HTTP1.1
@@ -893,9 +893,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                [Page 16]
+Fussell                   Expires July 7, 2017                 [Page 16]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    included in the JSON encoded vector set.  The expiry JSON value will
@@ -949,9 +949,9 @@ Internet-Draft              Abbreviated Title              December 2016
 
 
 
-Fussell                   Expires June 25, 2017                [Page 17]
+Fussell                   Expires July 7, 2017                 [Page 17]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
 13.  Error Codes
@@ -1005,9 +1005,9 @@ Appendix A.  JSON Formatting Guidelines
 
 
 
-Fussell                   Expires June 25, 2017                [Page 18]
+Fussell                   Expires July 7, 2017                 [Page 18]
 
-Internet-Draft              Abbreviated Title              December 2016
+Internet-Draft              Abbreviated Title                       2016
 
 
    underscores alternating case, numbers, etc.  However, brevity should
@@ -1061,4 +1061,4 @@ Author's Address
 
 
 
-Fussell                   Expires June 25, 2017                [Page 19]
+Fussell                   Expires July 7, 2017                 [Page 19]

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -150,6 +150,7 @@ The following functions are outside the scope of this document:</t>
 <t>	Scalability</t>
 <t>	Management interface</t>
 	   </list></t>
+	 <t>With that in mind there are several expectations when building a server used as a validation authority.  A validation authority shall use HTTPS, TLS 1.2 or greater and mutual authentication. Therefore a client that expects to be used with a validation authority shall have the same requirements.  A server, proxy or client developed for the purposes of internal organizational testing only may chose not to include some of those features.</t>
 	 </section>
 
         <section title="Terminology">


### PR DESCRIPTION
...to clarify requirements for a validation authority to use HTTPS, TLS 1.2 or gretaer and mutual authentication.