### PR TITLE
Explicitly forbid partial uploads

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -409,12 +409,12 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2.dev0 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.2" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-1-5" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -435,10 +435,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">2016</td>
+  <td class="right">January 5, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: July 7, 2017</td>
+  <td class="left">Expires: July 9, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -459,11 +459,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on July 7, 2017.</p>
+<p>This Internet-Draft will expire on July 9, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2016 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -811,7 +811,8 @@ Accept:
            </pre>
 <p class="figure">Figure 8</p>
 <h1 id="rfc.section.11.3"><a href="#rfc.section.11.3">11.3.</a> Vector Set Download Request</h1>
-<p id="rfc.section.11.3.p.1">After registration, the server provides a list of vector sets to the client, each identified by a VS-ID.  The client will download, process, and upload test results for each vector set.  This message is used to download a vector set from the server for a particular VS-ID.  </p>
+<p id="rfc.section.11.3.p.1">After registration, the server provides a list of vector sets to the client, each identified by a VS-ID.  The client will download, process, and upload test results for each vector set. Note that the client shall upload complete test results for each processed vector set, i.e. containing a result for every test case in the vector set.  </p>
+<p id="rfc.section.11.3.p.2">This message is used to download a vector set from the server for a particular VS-ID.</p>
 <div id="rfc.figure.9"/>
 <div id="xml_json5"/>
 <pre>
@@ -821,7 +822,7 @@ Host: www.my-acvpserver.com
 Authorization: Bearer JWT
             </pre>
 <p class="figure">Figure 9</p>
-<p id="rfc.section.11.3.p.2">The server will respond with the vector set associated with the vsId for the client to process</p>
+<p id="rfc.section.11.3.p.3">The server will respond with the vector set associated with the vsId for the client to process</p>
 <div id="rfc.figure.10"/>
 <div id="xml_json6"/>
 <pre>
@@ -860,7 +861,7 @@ Content-Length: &lt;length of results&gt;
 
             </pre>
 <p class="figure">Figure 10</p>
-<p id="rfc.section.11.3.p.3">If the server did not have had enough time to generate the vector set for a given test session, the server may reply: </p>
+<p id="rfc.section.11.3.p.4">If the server did not have had enough time to generate the vector set for a given test session, the server may reply: </p>
 <div id="rfc.figure.11"/>
 <div id="xml_json7"/>
 <pre>
@@ -875,7 +876,7 @@ Content-Length: &lt;length of results&gt;
 }
            </pre>
 <p class="figure">Figure 11</p>
-<p id="rfc.section.11.3.p.4">Where the retry value represents the number of seconds for the client to wait before retrying the request.  The server may set the retry value based on the current server load and expected processing time to generate the vector set.  </p>
+<p id="rfc.section.11.3.p.5">Where the retry value represents the number of seconds for the client to wait before retrying the request.  The server may set the retry value based on the current server load and expected processing time to generate the vector set.  </p>
 <h1 id="rfc.section.11.4"><a href="#rfc.section.11.4">11.4.</a> Test Results Request</h1>
 <p id="rfc.section.11.4.p.1">The client will send this request to learn the results for an individual vector set.</p>
 <div id="rfc.figure.12"/>

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                                      2016
-Expires: July 7, 2017
+Intended status: Informational                           January 5, 2017
+Expires: July 9, 2017
 
 
               Automated Cryptographic Validation Protocol
@@ -31,11 +31,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 7, 2017.
+   This Internet-Draft will expire on July 9, 2017.
 
 Copyright Notice
 
-   Copyright (c) 2016 IETF Trust and the persons identified as the
+   Copyright (c) 2017 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 1]
+Fussell                   Expires July 9, 2017                  [Page 1]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
 Table of Contents
@@ -83,16 +83,16 @@ Table of Contents
      11.2.  Product Registration with Capabilities . . . . . . . . .  10
      11.3.  Vector Set Download Request  . . . . . . . . . . . . . .  12
      11.4.  Test Results Request . . . . . . . . . . . . . . . . . .  14
-     11.5.  Optional Flows . . . . . . . . . . . . . . . . . . . . .  15
+     11.5.  Optional Flows . . . . . . . . . . . . . . . . . . . . .  16
    12. Vector Set Expiration . . . . . . . . . . . . . . . . . . . .  16
-     12.1.  Resending test responses . . . . . . . . . . . . . . . .  17
+     12.1.  Resending test responses . . . . . . . . . . . . . . . .  18
    13. Error Codes . . . . . . . . . . . . . . . . . . . . . . . . .  18
-   14. Other Considerations  . . . . . . . . . . . . . . . . . . . .  18
-   15. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  18
-   16. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  18
-   17. Normative References  . . . . . . . . . . . . . . . . . . . .  18
-   Appendix A.  JSON Formatting Guidelines . . . . . . . . . . . . .  18
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  19
+   14. Other Considerations  . . . . . . . . . . . . . . . . . . . .  19
+   15. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  19
+   16. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  19
+   17. Normative References  . . . . . . . . . . . . . . . . . . . .  19
+   Appendix A.  JSON Formatting Guidelines . . . . . . . . . . . . .  19
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  20
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 2]
+Fussell                   Expires July 9, 2017                  [Page 2]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
 1.1.  Requirements Language
@@ -165,9 +165,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 3]
+Fussell                   Expires July 9, 2017                  [Page 3]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
    conflicting) conformance criteria.  ACVP does not define an interface
@@ -221,9 +221,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 4]
+Fussell                   Expires July 9, 2017                  [Page 4]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
 3.  Architecture
@@ -277,9 +277,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 5]
+Fussell                   Expires July 9, 2017                  [Page 5]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
    o  Crpyographic Module API - This is the interface to the crypto
@@ -333,9 +333,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 6]
+Fussell                   Expires July 9, 2017                  [Page 6]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
 5.  Security
@@ -389,9 +389,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 7]
+Fussell                   Expires July 9, 2017                  [Page 7]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
 10.1.  Product Registration/Capabilities Exchange
@@ -445,9 +445,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 8]
+Fussell                   Expires July 9, 2017                  [Page 8]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
    o  /validation/acvp/vectors
@@ -501,9 +501,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                  [Page 9]
+Fussell                   Expires July 9, 2017                  [Page 9]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
 POST /validation/acvp/register HTTP1.1
@@ -557,9 +557,9 @@ each message.
 
 
 
-Fussell                   Expires July 7, 2017                 [Page 10]
+Fussell                   Expires July 9, 2017                 [Page 10]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
       the "encryptAtRest" field or registering with "no" will indicate
@@ -613,9 +613,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                   Expires July 7, 2017                 [Page 11]
+Fussell                   Expires July 9, 2017                 [Page 11]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
 
    "tagLen" : [
@@ -661,18 +661,21 @@ Internet-Draft              Abbreviated Title                       2016
 
    After registration, the server provides a list of vector sets to the
    client, each identified by a VS-ID.  The client will download,
-   process, and upload test results for each vector set.  This message
-   is used to download a vector set from the server for a particular VS-
-   ID.
+   process, and upload test results for each vector set.  Note that the
+   client shall upload complete test results for each processed vector
+   set, i.e. containing a result for every test case in the vector set.
 
 
 
 
 
-Fussell                   Expires July 7, 2017                 [Page 12]
+Fussell                   Expires July 9, 2017                 [Page 12]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title               January 2017
 
+
+   This message is used to download a vector set from the server for a
+   particular VS-ID.
 
    GET /validation/acvp/ vectors?vsId=1437  HTTP1.1
    User Agent: acvp-client/0.2
@@ -720,15 +723,15 @@ Internet-Draft              Abbreviated Title                       2016
 
                                  Figure 10
 
+
+
+Fussell                   Expires July 9, 2017                 [Page 13]
+
+Internet-Draft              Abbreviated Title               January 2017
+
+
    If the server did not have had enough time to generate the vector set
    for a given test session, the server may reply:
-
-
-
-Fussell                   Expires July 7, 2017                 [Page 13]
-
-Internet-Draft              Abbreviated Title                       2016
-
 
    HTTP 1.1 200 OK
    Status: 200 OK
@@ -751,6 +754,37 @@ Internet-Draft              Abbreviated Title                       2016
 
    The client will send this request to learn the results for an
    individual vector set.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 14]
+
+Internet-Draft              Abbreviated Title               January 2017
+
 
 GET /validation/acvp/results?vsId=1437 HTTP1.1
 User Agent:
@@ -779,13 +813,6 @@ Content-Length: <length of results>
 
                                  Figure 12
 
-
-
-Fussell                   Expires July 7, 2017                 [Page 14]
-
-Internet-Draft              Abbreviated Title                       2016
-
-
    The results request is an optional flow since some clients may not
    require success/fail information.  Another possibility is to provide
    an out of band management session on the server may provide access to
@@ -806,6 +833,14 @@ Internet-Draft              Abbreviated Title                       2016
 
    o  PASSED indicates all test cases have been processed by the server
       and have passed.
+
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 15]
+
+Internet-Draft              Abbreviated Title               January 2017
+
 
    Result is defined for individual test cases:
 
@@ -830,18 +865,6 @@ Internet-Draft              Abbreviated Title                       2016
    traceability or debugging purposes it desires.  This may be important
    for those cases where there are test failures.
 
-
-
-
-
-
-
-
-Fussell                   Expires July 7, 2017                 [Page 15]
-
-Internet-Draft              Abbreviated Title                       2016
-
-
    POST /validation/acvp/cancel HTTP1.1
    User Agent: acvp-client/0.2
    Host: www.my-acvpserver.com
@@ -861,6 +884,19 @@ Internet-Draft              Abbreviated Title                       2016
    costs, need for artifacts, etc.  If the vector set has expired, the
    server will reply with an expired response when the client attempts
    to download the vector set:
+
+
+
+
+
+
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 16]
+
+Internet-Draft              Abbreviated Title               January 2017
+
 
    HTTP 1.1 200 OK
    Status: 200 OK
@@ -890,18 +926,33 @@ Internet-Draft              Abbreviated Title                       2016
    may change the expiration timestamp of a previously issued vector set
    to either extend or shorten its lifetime subject to server policy.
    The expiration timestamp must be in the 'expiry' JSON value, which is
-
-
-
-Fussell                   Expires July 7, 2017                 [Page 16]
-
-Internet-Draft              Abbreviated Title                       2016
-
-
    included in the JSON encoded vector set.  The expiry JSON value will
    be a string value of the UTC timestamp using form "YYYY-MM-DD
    HH:MM:SS".  The following figure shows a partial JSON encoded vector
    set that contains the expiry value.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 17]
+
+Internet-Draft              Abbreviated Title               January 2017
+
 
                    {
                      "acvVersion": "0.2",
@@ -943,17 +994,6 @@ Internet-Draft              Abbreviated Title                       2016
    the problem has been corrected in the DUT).  The resending of vector
    set responses must occur prior to expiry.
 
-
-
-
-
-
-
-Fussell                   Expires July 7, 2017                 [Page 17]
-
-Internet-Draft              Abbreviated Title                       2016
-
-
 13.  Error Codes
 
    Errors will follow HTTP[S] numbering scheme.  In addition errors as
@@ -961,6 +1001,14 @@ Internet-Draft              Abbreviated Title                       2016
    describes in detail the error and any associated troubleshooting
    information.  A non-exhaustive list of JSON encoded error messages
    are in Appendix 2.
+
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 18]
+
+Internet-Draft              Abbreviated Title               January 2017
+
 
 14.  Other Considerations
 
@@ -1002,14 +1050,6 @@ Appendix A.  JSON Formatting Guidelines
 
    Metadata assigned to the keyword may use any format which best
    reflects the information being represented including hyphens,
-
-
-
-Fussell                   Expires July 7, 2017                 [Page 18]
-
-Internet-Draft              Abbreviated Title                       2016
-
-
    underscores alternating case, numbers, etc.  However, brevity should
    be a major consideration, for example:
 
@@ -1018,6 +1058,14 @@ Internet-Draft              Abbreviated Title                       2016
    strings or big numbers shall use double quotes at both ends.  Big
    numbers require conversion from strings to whatever format is used by
    the DUT.  Numerical values of integer size or with decimal points may
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 19]
+
+Internet-Draft              Abbreviated Title               January 2017
+
+
    use quotations if those values are generally used as a string, for
    example the acvVersion would generally be used in displaying
    information not in any mathematical operations.  Something like
@@ -1061,4 +1109,12 @@ Author's Address
 
 
 
-Fussell                   Expires July 7, 2017                 [Page 19]
+
+
+
+
+
+
+
+
+Fussell                   Expires July 9, 2017                 [Page 20]

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -71,7 +71,7 @@
      </address>
    </author>
 
-   <date year="2016"/>
+   <date year="2017"/>
 
    <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
         in the current day for you. If only the current year is specified, xml2rfc will fill 
@@ -474,9 +474,10 @@ Accept:
      <section title="Vector Set Download Request">
 	 <t>
 	     After registration, the server provides a list of vector sets to the client, each identified
-	     by a VS-ID.  The client will download, process, and upload test results for each vector set.
-	     This message is used to download a vector set from the server for a particular VS-ID.
+	     by a VS-ID.  The client will download, process, and upload test results for each vector set. Note that the client shall upload 
+	     complete test results for each processed vector set, i.e. containing a result for every test case in the vector set.
 	 </t>
+	 <t> This message is used to download a vector set from the server for a particular VS-ID.</t>
 	 <figure align="center" anchor="xml_json5">
 	    <artwork align="left"><![CDATA[
 GET /validation/acvp/ vectors?vsId=1437  HTTP1.1


### PR DESCRIPTION
Added a note that explicitly forbids partial uploads of test results.
Addresses issue #8.