### PR TITLE
Clarified handling of multiple vector sets

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -811,7 +811,7 @@ Accept:
            </pre>
 <p class="figure">Figure 8</p>
 <h1 id="rfc.section.11.3"><a href="#rfc.section.11.3">11.3.</a> Vector Set Download Request</h1>
-<p id="rfc.section.11.3.p.1">After registration, the server provides a list of vector sets to the client, each identified by a VS-ID.  The client will download, process, and upload test results for each vector set. Note that the client shall upload complete test results for each processed vector set, i.e. containing a result for every test case in the vector set.  </p>
+<p id="rfc.section.11.3.p.1">After registration, the server provides a list of vector sets to the client, each identified by a VS-ID.  The client shall download, process, and upload test results for each vector set, one at a time. Note that the client shall upload complete test results for each processed vector set, i.e. containing a result for every test case in the vector set.  </p>
 <p id="rfc.section.11.3.p.2">This message is used to download a vector set from the server for a particular VS-ID.</p>
 <div id="rfc.figure.9"/>
 <div id="xml_json5"/>

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -660,11 +660,11 @@ Internet-Draft              Abbreviated Title               January 2017
 11.3.  Vector Set Download Request
 
    After registration, the server provides a list of vector sets to the
-   client, each identified by a VS-ID.  The client will download,
-   process, and upload test results for each vector set.  Note that the
-   client shall upload complete test results for each processed vector
-   set, i.e. containing a result for every test case in the vector set.
-
+   client, each identified by a VS-ID.  The client shall download,
+   process, and upload test results for each vector set, one at a time.
+   Note that the client shall upload complete test results for each
+   processed vector set, i.e. containing a result for every test case in
+   the vector set.
 
 
 

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -474,7 +474,7 @@ Accept:
      <section title="Vector Set Download Request">
 	 <t>
 	     After registration, the server provides a list of vector sets to the client, each identified
-	     by a VS-ID.  The client will download, process, and upload test results for each vector set. Note that the client shall upload 
+	     by a VS-ID.  The client shall download, process, and upload test results for each vector set, one at a time. Note that the client shall upload 
 	     complete test results for each processed vector set, i.e. containing a result for every test case in the vector set.
 	 </t>
 	 <t> This message is used to download a vector set from the server for a particular VS-ID.</t>


### PR DESCRIPTION
Clarified the expected download/upload behavior in sessions containing multiple vectors sets. The client is expected to download/upload one vector set a time.

In one possible implementation, the client may download one vector set, process and upload the results before proceeding to the next vector set, no particular order.

Alternatively, the client may download each vector set in a session, one at a time, process them in any order, then upload each result one a
time, no particular order.

This implies that the server shall be capable of validating a particular vector set even when other vector sets in a particular session have not
yet been generated and downloaded by the client.