### PR TITLE
Correct Table 1 Formatting

### DIFF
--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -272,25 +272,25 @@ The following functions are outside the scope of this document:</t>
 	  <c>/register</c>
 	  <c>POST</c>	
 	  <c><xref target="reg_capex" /></c>
-	  <c/><c/><c/>
+	  <c/><c/><c/><c/>
 
 	  <c>Vector Set download request</c>
 	  <c>/vectors</c>
 	  <c>GET</c>
 	  <c><xref target="vector_dl" /></c>
-	  <c/><c/><c/>
+	  <c/><c/><c/><c/>
 		
 	  <c>Submit Vector Test Results</c>
 	  <c>/vectors</c>
 	  <c>POST</c>
 	  <c><xref target="vector_dl2" /></c>
-	  <c/><c/><c/>
+	  <c/><c/><c/><c/>
 	  	
 	  <c>Request Validation Results</c>
 	  <c>/results</c>
 	  <c>GET</c>	
 	  <c><xref target="results_req" /></c>
-	  <c/><c/><c/>
+	  <c/><c/><c/><c/>
 
 	  <c>Request server to cancel session</c>
 	  <c>/cancel</c>


### PR DESCRIPTION
Correct Table 1 formatting in the ACVP Protocol spec.  There were missing cell spacers in the last xml file update.