### PR TITLE
Update acvp_protocol.html to fix inconsistent property names.

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -914,11 +914,11 @@ Status: 200 OK
 Content-Type: application/json
 Content-Length: &lt;length of results&gt;
 {
-  "acv_version": "0.2",
-  "vs_id": 1437,
+  "acvVersion": "0.2",
+  "vsId": 1437,
   "algorithm": "AES-GCM",
   "direction": "encrypt",
-  "test_groups": [
+  "testGroups": [
     {
       "keyLen": 128,
       "ivLen": 96,
@@ -953,7 +953,7 @@ Status: 200 OK
 Content-Type: application/json
 Content-Length: &lt;length of results&gt;
 {
-"vs_id": 1437,
+"vsId": 1437,
 "version" : 0.2,
 "retry" : 10
 }
@@ -965,7 +965,7 @@ Content-Length: &lt;length of results&gt;
 <div id="rfc.figure.12"/>
 <div id="xml_json8"/>
 <pre>
-   POST /validation/acvp/vectors?vs_id=1437 HTTP1.1
+   POST /validation/acvp/vectors?vsId=1437 HTTP1.1
    User Agent: acvp-client/0.2
    Host: www.my-acvpserver.com
    Authorization: Bearer JWT


### PR DESCRIPTION
A couple of our camel-cased property names that used to contain underscores need to be converted to camel-case for consistency.  There were still some instances of "vs_id" for example...