### PR TITLE
Protocol date fix

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -850,7 +850,12 @@ Accept:
 "algorithms" : [
          {
 "algorithm" : "AES-GCM",
-"direction" : "encrypt,decrypt",
+"prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                {"algorithm" : "DRBG", "valValue" : "123456"}],
+"direction": [
+    "encrypt",
+    "decrypt"
+],
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
 "keyLen" : [

--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -418,7 +418,7 @@
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.2" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-7" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-2-16" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -439,10 +439,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">july 2016</td>
+  <td class="right">February 16, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: January 2, 2017</td>
+  <td class="left">Expires: August 20, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -463,11 +463,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on January 2, 2017.</p>
+<p>This Internet-Draft will expire on August 20, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2016 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   

--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -413,12 +413,12 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.2" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016" />
+  <meta name="dct.issued" scheme="ISO8601" content="2016-7" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -439,10 +439,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">2016</td>
+  <td class="right">july 2016</td>
 </tr>
 <tr>
-  <td class="left">Expires: August 14, 2017</td>
+  <td class="left">Expires: January 2, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -463,7 +463,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on August 14, 2017.</p>
+<p>This Internet-Draft will expire on January 2, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -850,12 +850,7 @@ Accept:
 "algorithms" : [
          {
 "algorithm" : "AES-GCM",
-"prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                {"algorithm" : "DRBG", "valValue" : "123456"}],
-"direction": [
-    "encrypt",
-    "decrypt"
-],
+"direction" : "encrypt,decrypt",
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
 "keyLen" : [

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                                      2016
-Expires: August 14, 2017
+Intended status: Informational                                 july 2016
+Expires: January 2, 2017
 
 
               Automated Cryptographic Validation Protocol
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 14, 2017.
+   This Internet-Draft will expire on January 2, 2017.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Fussell                  Expires August 14, 2017                [Page 1]
+Fussell                  Expires January 2, 2017                [Page 1]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
 Table of Contents
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Fussell                  Expires August 14, 2017                [Page 2]
+Fussell                  Expires January 2, 2017                [Page 2]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    with a validation authority.  This document describes how ACVP is
@@ -165,9 +165,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 3]
+Fussell                  Expires January 2, 2017                [Page 3]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    detailed conformance criteria, such as those in FIPS-140.  Instead,
@@ -221,9 +221,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 4]
+Fussell                  Expires January 2, 2017                [Page 4]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
 2.3.  Terminology
@@ -277,9 +277,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 5]
+Fussell                  Expires January 2, 2017                [Page 5]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
       encrypt/decrypt, generate keys, signatures, perform varifications
@@ -333,9 +333,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 6]
+Fussell                  Expires January 2, 2017                [Page 6]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
                              Protocol Layering
@@ -389,9 +389,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 7]
+Fussell                  Expires January 2, 2017                [Page 7]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    +--------------------------+-------------+-----------+--------------+
@@ -445,9 +445,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 8]
+Fussell                  Expires January 2, 2017                [Page 8]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    discussed here, but should be agreed upon between the client and
@@ -501,9 +501,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017                [Page 9]
+Fussell                  Expires January 2, 2017                [Page 9]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
 10.2.  Known Answer Test (KAT) Exchange
@@ -557,9 +557,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 10]
+Fussell                  Expires January 2, 2017               [Page 10]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    The first four claims are required, however "pkey" is an optional
@@ -613,9 +613,9 @@ each message.
 
 
 
-Fussell                  Expires August 14, 2017               [Page 11]
+Fussell                  Expires January 2, 2017               [Page 11]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
       desires the answers to the vectors as well, indicate with "yes",
@@ -669,20 +669,15 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 12]
+Fussell                  Expires January 2, 2017               [Page 12]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    "algorithms" : [
             {
    "algorithm" : "AES-GCM",
-   "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                   {"algorithm" : "DRBG", "valValue" : "123456"}],
-   "direction": [
-       "encrypt",
-       "decrypt"
-   ],
+   "direction" : "encrypt,decrypt",
    "ivGen" : "internal",
    "ivGenMode" : "8.2.1",
    "keyLen" : [
@@ -716,20 +711,6 @@ Internet-Draft              Abbreviated Title                       2016
    implementation specific for value add.  Follow on versions could
    include protocol information.
 
-
-
-
-
-
-
-
-
-
-Fussell                  Expires August 14, 2017               [Page 13]
-
-Internet-Draft              Abbreviated Title                       2016
-
-
 200 OK Response:
 {
 "version" : "0.2",
@@ -741,6 +722,13 @@ Internet-Draft              Abbreviated Title                       2016
 }
 
                                  Figure 8
+
+
+
+Fussell                  Expires January 2, 2017               [Page 13]
+
+Internet-Draft              Abbreviated Title                  july 2016
+
 
 11.3.  Vector Set Download Request
 
@@ -781,9 +769,21 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 14]
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 2, 2017               [Page 14]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    200 OK Response:
@@ -837,9 +837,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 15]
+Fussell                  Expires January 2, 2017               [Page 15]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    HTTP 1.1 200 OK
@@ -893,9 +893,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 16]
+Fussell                  Expires January 2, 2017               [Page 16]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
 11.5.  Validation Results Request
@@ -949,9 +949,9 @@ Content-Length: <length of results>
 
 
 
-Fussell                  Expires August 14, 2017               [Page 17]
+Fussell                  Expires January 2, 2017               [Page 17]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    o  EXPIRED indicates not all the test case responses were received
@@ -1005,9 +1005,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 18]
+Fussell                  Expires January 2, 2017               [Page 18]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    HTTP 1.1 200 OK
@@ -1061,9 +1061,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 19]
+Fussell                  Expires January 2, 2017               [Page 19]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
                    {
@@ -1117,9 +1117,9 @@ Internet-Draft              Abbreviated Title                       2016
 
 
 
-Fussell                  Expires August 14, 2017               [Page 20]
+Fussell                  Expires January 2, 2017               [Page 20]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    information.  A non-exhaustive list of JSON encoded error messages
@@ -1173,9 +1173,9 @@ Appendix A.  JSON Formatting Guidelines
 
 
 
-Fussell                  Expires August 14, 2017               [Page 21]
+Fussell                  Expires January 2, 2017               [Page 21]
 
-Internet-Draft              Abbreviated Title                       2016
+Internet-Draft              Abbreviated Title                  july 2016
 
 
    strings or big numbers shall use double quotes at both ends.  Big
@@ -1229,4 +1229,4 @@ Author's Address
 
 
 
-Fussell                  Expires August 14, 2017               [Page 22]
+Fussell                  Expires January 2, 2017               [Page 22]

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -677,7 +677,12 @@ Internet-Draft              Abbreviated Title                  july 2016
    "algorithms" : [
             {
    "algorithm" : "AES-GCM",
-   "direction" : "encrypt,decrypt",
+   "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                   {"algorithm" : "DRBG", "valValue" : "123456"}],
+   "direction": [
+       "encrypt",
+       "decrypt"
+   ],
    "ivGen" : "internal",
    "ivGenMode" : "8.2.1",
    "keyLen" : [
@@ -711,6 +716,20 @@ Internet-Draft              Abbreviated Title                  july 2016
    implementation specific for value add.  Follow on versions could
    include protocol information.
 
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 2, 2017               [Page 13]
+
+Internet-Draft              Abbreviated Title                  july 2016
+
+
 200 OK Response:
 {
 "version" : "0.2",
@@ -722,13 +741,6 @@ Internet-Draft              Abbreviated Title                  july 2016
 }
 
                                  Figure 8
-
-
-
-Fussell                  Expires January 2, 2017               [Page 13]
-
-Internet-Draft              Abbreviated Title                  july 2016
-
 
 11.3.  Vector Set Download Request
 
@@ -750,18 +762,6 @@ Internet-Draft              Abbreviated Title                  july 2016
    for the client to process.  The actual test group content contained
    in the response will vary depending on the specific sub-specification
    of the algorithm and testType being tested.
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                                 july 2016
-Expires: January 2, 2017
+Intended status: Informational                         February 16, 2017
+Expires: August 20, 2017
 
 
               Automated Cryptographic Validation Protocol
@@ -31,11 +31,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 2, 2017.
+   This Internet-Draft will expire on August 20, 2017.
 
 Copyright Notice
 
-   Copyright (c) 2016 IETF Trust and the persons identified as the
+   Copyright (c) 2017 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Fussell                  Expires January 2, 2017                [Page 1]
+Fussell                  Expires August 20, 2017                [Page 1]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
 Table of Contents
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Fussell                  Expires January 2, 2017                [Page 2]
+Fussell                  Expires August 20, 2017                [Page 2]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    with a validation authority.  This document describes how ACVP is
@@ -165,9 +165,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 3]
+Fussell                  Expires August 20, 2017                [Page 3]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    detailed conformance criteria, such as those in FIPS-140.  Instead,
@@ -221,9 +221,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 4]
+Fussell                  Expires August 20, 2017                [Page 4]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
 2.3.  Terminology
@@ -277,9 +277,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 5]
+Fussell                  Expires August 20, 2017                [Page 5]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
       encrypt/decrypt, generate keys, signatures, perform varifications
@@ -333,9 +333,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 6]
+Fussell                  Expires August 20, 2017                [Page 6]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
                              Protocol Layering
@@ -389,9 +389,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 7]
+Fussell                  Expires August 20, 2017                [Page 7]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    +--------------------------+-------------+-----------+--------------+
@@ -445,9 +445,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 8]
+Fussell                  Expires August 20, 2017                [Page 8]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    discussed here, but should be agreed upon between the client and
@@ -501,9 +501,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017                [Page 9]
+Fussell                  Expires August 20, 2017                [Page 9]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
 10.2.  Known Answer Test (KAT) Exchange
@@ -557,9 +557,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 10]
+Fussell                  Expires August 20, 2017               [Page 10]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    The first four claims are required, however "pkey" is an optional
@@ -613,9 +613,9 @@ each message.
 
 
 
-Fussell                  Expires January 2, 2017               [Page 11]
+Fussell                  Expires August 20, 2017               [Page 11]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
       desires the answers to the vectors as well, indicate with "yes",
@@ -669,9 +669,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 12]
+Fussell                  Expires August 20, 2017               [Page 12]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    "algorithms" : [
@@ -725,9 +725,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 13]
+Fussell                  Expires August 20, 2017               [Page 13]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
 200 OK Response:
@@ -781,9 +781,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 14]
+Fussell                  Expires August 20, 2017               [Page 14]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    200 OK Response:
@@ -837,9 +837,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 15]
+Fussell                  Expires August 20, 2017               [Page 15]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    HTTP 1.1 200 OK
@@ -893,9 +893,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 16]
+Fussell                  Expires August 20, 2017               [Page 16]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
 11.5.  Validation Results Request
@@ -949,9 +949,9 @@ Content-Length: <length of results>
 
 
 
-Fussell                  Expires January 2, 2017               [Page 17]
+Fussell                  Expires August 20, 2017               [Page 17]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    o  EXPIRED indicates not all the test case responses were received
@@ -1005,9 +1005,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 18]
+Fussell                  Expires August 20, 2017               [Page 18]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    HTTP 1.1 200 OK
@@ -1061,9 +1061,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 19]
+Fussell                  Expires August 20, 2017               [Page 19]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
                    {
@@ -1117,9 +1117,9 @@ Internet-Draft              Abbreviated Title                  july 2016
 
 
 
-Fussell                  Expires January 2, 2017               [Page 20]
+Fussell                  Expires August 20, 2017               [Page 20]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    information.  A non-exhaustive list of JSON encoded error messages
@@ -1173,9 +1173,9 @@ Appendix A.  JSON Formatting Guidelines
 
 
 
-Fussell                  Expires January 2, 2017               [Page 21]
+Fussell                  Expires August 20, 2017               [Page 21]
 
-Internet-Draft              Abbreviated Title                  july 2016
+Internet-Draft              Abbreviated Title              February 2017
 
 
    strings or big numbers shall use double quotes at both ends.  Big
@@ -1229,4 +1229,4 @@ Author's Address
 
 
 
-Fussell                  Expires January 2, 2017               [Page 22]
+Fussell                  Expires August 20, 2017               [Page 22]

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -71,7 +71,7 @@
      </address>
    </author>
 
-   <date month="july" year="2016"/>
+   <date year="2017"/>
 
    <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
         in the current day for you. If only the current year is specified, xml2rfc will fill 

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -71,7 +71,7 @@
      </address>
    </author>
 
-   <date year="2016"/>
+   <date month="july" year="2016"/>
 
    <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
         in the current day for you. If only the current year is specified, xml2rfc will fill 
@@ -471,12 +471,7 @@ Accept:
 "algorithms" : [
          {
 "algorithm" : "AES-GCM",
-"prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                {"algorithm" : "DRBG", "valValue" : "123456"}],
-"direction": [
-    "encrypt",
-    "decrypt"
-],
+"direction" : "encrypt,decrypt",
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
 "keyLen" : [

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -471,7 +471,12 @@ Accept:
 "algorithms" : [
          {
 "algorithm" : "AES-GCM",
-"direction" : "encrypt,decrypt",
+"prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                {"algorithm" : "DRBG", "valValue" : "123456"}],
+"direction": [
+    "encrypt",
+    "decrypt"
+],
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
 "keyLen" : [


### PR DESCRIPTION
Right now, acvp_protocol.xml only has the year specified for the date tag. For RFCs in the current year, this is automatically converted to a proper date format by XML2RFC. Now that 2016 is over, XML2RFC throws an error and does not parse the file. This adds a month to the date tag to allow XML2RFC to parse the file properly (and uploads the resulting files.)