### PR TITLE
Fixed errors related to ranges of supported parameters

### DIFF
--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,7 +400,7 @@
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-12-27" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-3-13" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">December 27, 2016</td>
+  <td class="right">March 13, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: June 30, 2017</td>
+  <td class="left">Expires: September 14, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -445,11 +445,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on June 30, 2017.</p>
+<p>This Internet-Draft will expire on September 14, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2016 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -751,10 +751,10 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">entropyInputLen</td>
-      <td class="left">the bit length of the entropy input. See <a href="#caps_table">Table 3</a> notes below.</td>
-      <td class="left">value</td>
-      <td class="left">at least the maximum security strength supported by the mechanism/option, larger values are optional</td>
+      <td class="left">entropyInputRange</td>
+      <td class="left">the supported bit lengths of the entropy input. See <a href="#caps_table">Table 3</a> notes below.</td>
+      <td class="left">range</td>
+      <td class="left">min - at least the maximum security strength supported by the mechanism/option, max - larger values are optional, step - increment.</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -765,24 +765,10 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">nonceLen</td>
+      <td class="left">nonceLenRange</td>
       <td class="left">.See <a href="#caps_table">Table 3</a> notes below.</td>
-      <td class="left">value</td>
-      <td class="left">at least one half of the maximum security strength supported by the mechanism/option. Longer nonces are permitted.</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">persoStringLen</td>
-      <td class="left">.See <a href="#caps_table">Table 3</a> notes below.</td>
-      <td class="left">Array</td>
-      <td class="left">set to zero or the maximum security strength supported by the mechanism/option.</td>
+      <td class="left">range</td>
+      <td class="left">min - at least one half of the maximum security strength supported by the mechanism/option; max: - longer nonces are permitted, step - increment</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -793,10 +779,24 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">additionalInputLen</td>
+      <td class="left">persoStringLenRange</td>
       <td class="left">.See <a href="#caps_table">Table 3</a> notes below.</td>
-      <td class="left">Array</td>
-      <td class="left">set to zero or the maximum security strength supported by the mechanism/option.</td>
+      <td class="left">range</td>
+      <td class="left">min - the maximum security strength supported by the mechanism/option; max - largest supported length, step - increment to calculate all supported lengths. Set all to zero (0) if not supported.</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">additionalInputLenRange</td>
+      <td class="left">.See <a href="#caps_table">Table 3</a> notes below.</td>
+      <td class="left">range</td>
+      <td class="left">min - the maximum security strength supported by the mechanism/option; max - largest supported length, step - increment to calculate all supported lengths; set all to zero (0) if not supported.</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -821,8 +821,8 @@
 <p id="rfc.section.2.3.p.5">Note 4: For ctrDRBG implementations, at least one of the derivation function options shall be set depending on the one actually used or both</p>
 <p id="rfc.section.2.3.p.6">Note 5: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept.  The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, with the following exception: for ctrDRBG with no df, the bit length must equal the seed length.</p>
 <p id="rfc.section.2.3.p.7">Note 6: ctrDRBG with no derivation function (ctrDRBGWithoutDerFunc) does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half the maximum security strength supported by the mechanism/option.</p>
-<p id="rfc.section.2.3.p.8">Note 7: ACVP has two default bit length values for persoString: zero (0) and maximum supported supported security strength except in the case of ctrDRBGWithoutDerFunc, where the second personalization string length must be less than or equal to the seed length.  If the implementation only supports one personalization string length, then set both numbers equal to each other.  If the implementation does not use a persoString, set both numbers to 0 (zero). </p>
-<p id="rfc.section.2.3.p.9">Note 8: The addtionalInput configuration and restrictions are the same as those for the persoString.Similarly, for the default addtionalInput bit legths - same as those for persoString lengths.</p>
+<p id="rfc.section.2.3.p.8">Note 7: ACVP allows bit length values for persoString ranging from the maximum supported security strength except in the case of ctrDRBGWithoutDerFunc, where the second personalization string length must be less than or equal to the seed length.  If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0)..  If the implementation does not use a persoString, set all range parameters (min, max, step) to 0 (zero). </p>
+<p id="rfc.section.2.3.p.9">Note 8: The addtionalInput configuration and restrictions are the same as those for the persoString.</p>
 <h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
 <p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm, such as Hash_DRBG, etc.  This section describes the JSON schema for a test vector set used with DRBG algorithms.</p>
 <p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
@@ -963,8 +963,8 @@
     </tr>
     <tr>
       <td class="left">persoStringLen</td>
-      <td class="left">personalization string length</td>
-      <td class="left">value </td>
+      <td class="left">personalization string length; set to 0 (zero) if not used/supported</td>
+      <td class="left">value</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -975,8 +975,8 @@
     </tr>
     <tr>
       <td class="left">additonalInputLen</td>
-      <td class="left">additional input length</td>
-      <td class="left">value </td>
+      <td class="left">additional input length; set tp 0 (zero) if not used/supported</td>
+      <td class="left">value</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1224,10 +1224,18 @@
                 "prereqVals": [{"algorithm": "TDES", "valValue": "same"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"112",
-                "nonceLen":"56",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 112,
+                                "max": 256,
+                                "step" : 144},
+                "nonceLenRange": {"min" : 56,
+                                "max" : 56,
+                                "step" : 0},
+                "persoStringLenRange": {"min": 112,
+                                "max" : 112,
+                                "step" : 0},
+                "additionalInputLenRange":{ "min": 112,
+                                "max" : 112,
+                                "step" : 0},
                 "returnedBitsLen":"256"
             }
             </pre>
@@ -1240,10 +1248,18 @@
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"128",
-                "nonceLen":"64",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 128,
+                                "max": 256,
+                                "step" : 128},
+                "nonceLenRange": {"min" : 64,
+                                "max" : 64,
+                                "step" : 0},
+                "persoStringLenRange": {"min": 128,
+                                "max" : 128,
+                                "step" : 0},
+                "additionalInputLenRange":{ "min": 128,
+                                "max" : 128,
+                                "step" : 0},
                 "returnedBitsLen":"512"
             }
             </pre>
@@ -1255,10 +1271,18 @@
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"256",
-                "nonceLen":"128",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                 "entropyInputRange":{ "min": 256,
+                                "max": 512,
+                                "step" : 1},
+                "nonceLenRange": {"min" : 128,
+                                "max" : 256,
+                                 "step" : 128},
+                "persoStringLenRange": {"min": 256,
+                                 "max" : 512,
+                                 "step" : 1},
+              "additionalInputLenRange":{ "min": 256,
+                                 "max" : 512,
+                                 "step" : 1},
                 "returnedBitsLen":"1024"
             }
             </pre>
@@ -1270,10 +1294,18 @@
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "HMAC", "valValue": "9012"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"256",
-                "nonceLen":"128",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 256,
+                                 "max": 256,
+                                 "step" : 0},
+                "nonceLenRange": {"min" : 128,
+                                 "max" : 128,
+                                 "step" : 0},
+                "persoStringLenRange": {"min": 256,
+                                 "max" : 256,
+                                 "step" : 0},
+               "additionalInputLenRange":{ "min": 256,
+                                 "max" : 256,
+                                 "step" : 0},
                 "returnedBitsLen":"1024"
             }
             </pre>
@@ -1287,11 +1319,11 @@
                   "mode": "3KeyTDEA",
                   "derFunc":"yes",
                   "predResistance": "yes",
-                  "entropyInputLen":"128",
-                  "nonceLen":"64",
-                  "persoStringLen":"0",
-                  "additionalInputLen":"0",
-                  "returnedBitsLen":"512",                  
+                  "entropyInputLen":"112",
+                  "nonceLen":"56",
+                  "persoStringLen":"112",
+                  "additionalInputLen":"112",
+                  "returnedBitsLen":"256",                  
                   "testGroups": [
                     {
                       "type": "long",
@@ -1331,8 +1363,8 @@
                   "predResistance": "yes",
                   "entropyInputLen":"256",
                   "nonceLen":"128",
-                  "persoStringLen":"0",
-                  "additionalInputLen":"0",
+                  "persoStringLen":"256",
+                  "additionalInputLen":"256",
                   "returnedBitsLen":"1024",                  
                   "testGroups": [
                     {
@@ -1382,23 +1414,23 @@
                       "tests": [
                         {
                           "tcId": "2151",
-                          "entropyInput":"b37f442929f21306d8750a82fc6b362a574babd3ed60f19a35c37e469a5f14bf",
-                          "nonce":"c3283de7bc8395b6acccbb5ea5fa96bb",
-                          "persoString":"5674ab88573f76754c9c23251ced43004e4e0839b8238dc02738c52fd4f0c6d2",
-                          "additionalInput":"54b90323d3985459897b6743006bc0b573c2374512bd4af306e094c791b3fe83",
-                          "entropyInputPR": "c7825bcd4d93f29759e605a71cbd7d926ad7ea5cef223e0c18ef9f6fbd60ca59",
-                          "additionalInput" : "589b34ca088e88ebc0013ebe1371ba59981a7dc28a430f1878dbea58da48bbc8",
-                          "entropyInputPR" : "3ab094c46749b53452230b757e06a0e73ae98154fee23b219b2d2cb3799f3ddd"
+                          "entropyInput":"ae0a3acd541d0d582a8510f3028caa143fe1e5226a8469d40b979d3a0d1bbe69",
+                          "nonce":"786f03ad697332d74fad7a14604cee44",
+                          "persoString":"",
+                          "additionalInput":"",
+                          "entropyInputPR": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"
                           },
                         {
                           "tcId": "2152",
-                          "entropyInput" : "453ee7be8e0c38345bc5bd41b3fc966bee51865cbdefef8de88c2e2f98e0d89c",
-                          "nonce": "caab6531ed1d096668e7d7e5bb8f306b",
-                          "persoString" : "ff6f535e2b41be7c17d4cfc0f14868ab838b739e643d269d624a1a0637152d78",
-                          "additionalInput" : "725ae7b8d850fbfda11ec61ff42ce3b886cff4ab2adeffc2cb9bc23d5dc59db9",
-                          "entropyInputPR" : "6a126e70a096b6e7ac6a717a6becbe98e1dee0c2181c5353701fcead24b0fe4e",
-                          "additionalInput" : "ff3cd93f88072a2fc8cd0e4a4317a97b504f8fc6beb6753214455b12f0044dfc",
-                          "entropyInputPR" : "dba352082e876c90f5a1411670b47610d7c3b6116b00a1d0056702bb8fa3b78e"
+                          "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
+                          "nonce": "36dff124f908a95a022edf615618cd31",
+                          "persoString" : "",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "fff51d05b1349506c354a0e6ee01edcff21c509dff5cbb582c8fdc01d6e8bd5b"
                         }
                       ]
                     }
@@ -1449,11 +1481,11 @@
                     "testResults": [
                         {
                             "tcId": "2151",
-                            "returnedBits ": "3bcb4371e388a8c453f16fb48e46859b7cbd1b8307681083fb8c10e7a6ea77ff89f6ce2ab9efff8ea11e95117e577a139e5a2f99786282fefadf07c13d7ceb123d81f93d262ad84d9d1589ea6bb760a0cabd75285e29a11bb97a8ff3317d839639866195c3364c98f250ce97c974c06805821e66ce214333d275d8a01a6c69a7"
+                            "returnedBits ": "1af967534c670271e26c9b991ec975b78c84623853cd531368f5b2e81f015f97ffbb8cd4533d4354ed432fbdf8025f04786745fd006e173f34e6f01e136bd9b4db2b96919dfa12e8deecf7b7c72b1d329afa99c29e844b27ee34d468a4b20b5739c00ad405943aeb5084285468765190112c5e44756770479552f2f2913ed362"
                         },
                        {
                             "tcId": "2152",
-                            "returnedBits": "0302cb504af55d89d8aa03a05d5cd9969c0650e32c27d32dc5db991b95297885a593cb81ee2fbfea273f61830fa0d548c1d89ff1d8495a9fd4dee2c7ddc075620bec06d3641232b4433d229f2b4a791a11709fe3d6fe4f809f97d113bdaebe255223e6e5914296886861d28331ea702bf05f63a8fd62b97a845de43012ed4a55"
+                            "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
                        }
                     ]
                 }

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                         December 27, 2016
-Expires: June 30, 2017
+Intended status: Informational                            March 13, 2017
+Expires: September 14, 2017
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -32,11 +32,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 30, 2017.
+   This Internet-Draft will expire on September 14, 2017.
 
 Copyright Notice
 
-   Copyright (c) 2016 IETF Trust and the persons identified as the
+   Copyright (c) 2017 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 1]
+Vassilev               Expires September 14, 2017               [Page 1]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 Table of Contents
@@ -68,17 +68,17 @@ Table of Contents
      2.2.  Required Prerequisite Algorithms for DRBG Validations . .   4
      2.3.  Supported DRBG Algorithm Capabilities . . . . . . . . . .   4
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   8
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   8
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   9
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  11
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  11
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  12
-   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  12
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  14
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  16
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  18
+     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  10
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  12
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  13
+   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  13
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  16
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  18
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  20
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 2]
+Vassilev               Expires September 14, 2017               [Page 2]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
    values.  The specific details and restrictions on each of these input
@@ -165,9 +165,9 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 3]
+Vassilev               Expires September 14, 2017               [Page 3]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 2.2.  Required Prerequisite Algorithms for DRBG Validations
@@ -221,127 +221,159 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 4]
+Vassilev               Expires September 14, 2017               [Page 4]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
-   +----------------+------------+----------+---------------+----------+
-   | JSON Value     | Descriptio | JSON     | Valid Values  | Optional |
-   |                | n          | type     |               |          |
-   +----------------+------------+----------+---------------+----------+
-   | algorithm      | The DRBG   | value    | See Table 1   | No       |
-   |                | algorithm  |          |               |          |
-   |                | to be      |          |               |          |
-   |                | validated. |          |               |          |
-   |                |            |          |               |          |
-   | mode           | The        | value    | See Table 1   | No       |
-   |                | algorithm  |          |               |          |
-   |                | mode to be |          |               |          |
-   |                | validated  |          |               |          |
-   |                |            |          |               |          |
-   | derFuncEnabled | derivation | value    | yes, no       | Yes, app |
-   |                | function   |          |               | licable  |
-   |                | option     |          |               | to       |
-   |                |            |          |               | ctrDRBG  |
-   |                |            |          |               | only     |
-   |                |            |          |               |          |
-   | prereqVals     | The prereq | array of | array         | No       |
-   |                | uisite     | prereqAl |               |          |
-   |                | algorithm  | gVal     |               |          |
-   |                | validation | objects  |               |          |
-   |                | s          | - see    |               |          |
-   |                |            | Section  |               |          |
-   |                |            | 2.2      |               |          |
-   |                |            |          |               |          |
-   | predResistance | an impleme | value    | yes, no       | No       |
-   | Enabled        | ntation    |          |               |          |
-   |                | that can   |          |               |          |
-   |                | be used    |          |               |          |
-   |                | with       |          |               |          |
-   |                | prediction |          |               |          |
-   |                | resistance |          |               |          |
-   |                | . See      |          |               |          |
-   |                | Table 3    |          |               |          |
-   |                | notes      |          |               |          |
-   |                | below.     |          |               |          |
-   |                |            |          |               |          |
-   | reseedImplemen | Reseeding  | value    | yes, no       | No       |
-   | ted            | of the     |          |               |          |
-   |                | DRBG shall |          |               |          |
-   |                | be         |          |               |          |
-   |                | performed  |          |               |          |
-   |                | in         |          |               |          |
-   |                | accordance |          |               |          |
-   |                | with the s |          |               |          |
+   +-----------------+-----------+-----------+--------------+----------+
+   | JSON Value      | Descripti | JSON type | Valid Values | Optional |
+   |                 | on        |           |              |          |
+   +-----------------+-----------+-----------+--------------+----------+
+   | algorithm       | The DRBG  | value     | See Table 1  | No       |
+   |                 | algorithm |           |              |          |
+   |                 | to be val |           |              |          |
+   |                 | idated.   |           |              |          |
+   |                 |           |           |              |          |
+   | mode            | The       | value     | See Table 1  | No       |
+   |                 | algorithm |           |              |          |
+   |                 | mode to   |           |              |          |
+   |                 | be        |           |              |          |
+   |                 | validated |           |              |          |
+   |                 |           |           |              |          |
+   | derFuncEnabled  | derivatio | value     | yes, no      | Yes, app |
+   |                 | n         |           |              | licable  |
+   |                 | function  |           |              | to       |
+   |                 | option    |           |              | ctrDRBG  |
+   |                 |           |           |              | only     |
+   |                 |           |           |              |          |
+   | prereqVals      | The prere | array of  | array        | No       |
+   |                 | quisite   | prereqAlg |              |          |
+   |                 | algorithm | Val       |              |          |
+   |                 | validatio | objects - |              |          |
+   |                 | ns        | see       |              |          |
+   |                 |           | Section   |              |          |
+   |                 |           | 2.2       |              |          |
+   |                 |           |           |              |          |
+   | predResistanceE | an implem | value     | yes, no      | No       |
+   | nabled          | entation  |           |              |          |
+   |                 | that can  |           |              |          |
+   |                 | be used   |           |              |          |
+   |                 | with pred |           |              |          |
+   |                 | iction re |           |              |          |
+   |                 | sistance. |           |              |          |
+   |                 | See Table |           |              |          |
+   |                 | 3 notes   |           |              |          |
+   |                 | below.    |           |              |          |
+   |                 |           |           |              |          |
+   | reseedImplement | Reseeding | value     | yes, no      | No       |
+   | ed              | of the    |           |              |          |
+   |                 | DRBG      |           |              |          |
+   |                 | shall be  |           |              |          |
+   |                 | performed |           |              |          |
+   |                 | in accord |           |              |          |
+   |                 | ance with |           |              |          |
+   |                 | the speci |           |              |          |
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 5]
+Vassilev               Expires September 14, 2017               [Page 5]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
-   |                | pecificati |          |               |          |
-   |                | on for the |          |               |          |
-   |                | given DRBG |          |               |          |
-   |                | mechanism. |          |               |          |
-   |                | See Table  |          |               |          |
-   |                | 3 notes    |          |               |          |
-   |                | below.     |          |               |          |
-   |                |            |          |               |          |
-   | entropyInputLe | the bit    | value    | at least the  | No       |
-   | n              | length of  |          | maximum       |          |
-   |                | the        |          | security      |          |
-   |                | entropy    |          | strength      |          |
-   |                | input. See |          | supported by  |          |
-   |                | Table 3    |          | the mechanism |          |
-   |                | notes      |          | /option,      |          |
-   |                | below.     |          | larger values |          |
-   |                |            |          | are optional  |          |
-   |                |            |          |               |          |
-   | nonceLen       | .See Table | value    | at least one  | Yes      |
-   |                | 3 notes    |          | half of the   |          |
-   |                | below.     |          | maximum       |          |
-   |                |            |          | security      |          |
-   |                |            |          | strength      |          |
-   |                |            |          | supported by  |          |
-   |                |            |          | the mechanism |          |
-   |                |            |          | /option.      |          |
-   |                |            |          | Longer nonces |          |
-   |                |            |          | are           |          |
-   |                |            |          | permitted.    |          |
-   |                |            |          |               |          |
-   | persoStringLen | .See Table | Array    | set to zero   | No       |
-   |                | 3 notes    |          | or the        |          |
-   |                | below.     |          | maximum       |          |
-   |                |            |          | security      |          |
-   |                |            |          | strength      |          |
-   |                |            |          | supported by  |          |
-   |                |            |          | the mechanism |          |
-   |                |            |          | /option.      |          |
-   |                |            |          |               |          |
-   | additionalInpu | .See Table | Array    | set to zero   | No       |
-   | tLen           | 3 notes    |          | or the        |          |
-   |                | below.     |          | maximum       |          |
-   |                |            |          | security      |          |
-   |                |            |          | strength      |          |
-   |                |            |          | supported by  |          |
-   |                |            |          | the mechanism |          |
-   |                |            |          | /option.      |          |
-   |                |            |          |               |          |
+   |                 | fication  |           |              |          |
+   |                 | for the   |           |              |          |
+   |                 | given     |           |              |          |
+   |                 | DRBG mech |           |              |          |
+   |                 | anism.    |           |              |          |
+   |                 | See Table |           |              |          |
+   |                 | 3 notes   |           |              |          |
+   |                 | below.    |           |              |          |
+   |                 |           |           |              |          |
+   | entropyInputRan | the       | range     | min - at     | No       |
+   | ge              | supported |           | least the    |          |
+   |                 | bit       |           | maximum      |          |
+   |                 | lengths   |           | security     |          |
+   |                 | of the    |           | strength     |          |
+   |                 | entropy   |           | supported by |          |
+   |                 | input.    |           | the mechanis |          |
+   |                 | See Table |           | m/option,    |          |
+   |                 | 3 notes   |           | max - larger |          |
+   |                 | below.    |           | values are   |          |
+   |                 |           |           | optional,    |          |
+   |                 |           |           | step -       |          |
+   |                 |           |           | increment.   |          |
+   |                 |           |           |              |          |
+   | nonceLenRange   | .See      | range     | min - at     | No       |
+   |                 | Table 3   |           | least one    |          |
+   |                 | notes     |           | half of the  |          |
+   |                 | below.    |           | maximum      |          |
+   |                 |           |           | security     |          |
+   |                 |           |           | strength     |          |
+   |                 |           |           | supported by |          |
+   |                 |           |           | the mechanis |          |
+   |                 |           |           | m/option;    |          |
+   |                 |           |           | max: -       |          |
+   |                 |           |           | longer       |          |
+   |                 |           |           | nonces are   |          |
+   |                 |           |           | permitted,   |          |
+   |                 |           |           | step -       |          |
+   |                 |           |           | increment    |          |
+   |                 |           |           |              |          |
+   | persoStringLenR | .See      | range     | min - the    | No       |
+   | ange            | Table 3   |           | maximum      |          |
+   |                 | notes     |           | security     |          |
+   |                 | below.    |           | strength     |          |
+   |                 |           |           | supported by |          |
+   |                 |           |           | the mechanis |          |
+   |                 |           |           | m/option;    |          |
+   |                 |           |           | max -        |          |
+   |                 |           |           | largest      |          |
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 6]
+Vassilev               Expires September 14, 2017               [Page 6]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
-   | returnedBitsLe | .See Table | value    |               | No       |
-   | n              | 3 notes    |          |               |          |
-   |                | below.     |          |               |          |
-   +----------------+------------+----------+---------------+----------+
+   |                 |           |           | supported    |          |
+   |                 |           |           | length, step |          |
+   |                 |           |           | - increment  |          |
+   |                 |           |           | to calculate |          |
+   |                 |           |           | all          |          |
+   |                 |           |           | supported    |          |
+   |                 |           |           | lengths. Set |          |
+   |                 |           |           | all to zero  |          |
+   |                 |           |           | (0) if not   |          |
+   |                 |           |           | supported.   |          |
+   |                 |           |           |              |          |
+   | additionalInput | .See      | range     | min - the    | No       |
+   | LenRange        | Table 3   |           | maximum      |          |
+   |                 | notes     |           | security     |          |
+   |                 | below.    |           | strength     |          |
+   |                 |           |           | supported by |          |
+   |                 |           |           | the mechanis |          |
+   |                 |           |           | m/option;    |          |
+   |                 |           |           | max -        |          |
+   |                 |           |           | largest      |          |
+   |                 |           |           | supported    |          |
+   |                 |           |           | length, step |          |
+   |                 |           |           | - increment  |          |
+   |                 |           |           | to calculate |          |
+   |                 |           |           | all          |          |
+   |                 |           |           | supported    |          |
+   |                 |           |           | lengths; set |          |
+   |                 |           |           | all to zero  |          |
+   |                 |           |           | (0) if not   |          |
+   |                 |           |           | supported.   |          |
+   |                 |           |           |              |          |
+   | returnedBitsLen | .See      | value     |              | No       |
+   |                 | Table 3   |           |              |          |
+   |                 | notes     |           |              |          |
+   |                 | below.    |           |              |          |
+   +-----------------+-----------+-----------+--------------+----------+
 
              Table 3: DRBG Algorithm Capabilities JSON Values
 
@@ -354,6 +386,13 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
    Note 3: Implementations that can be used either way will have both
    flags set.
+
+
+
+Vassilev               Expires September 14, 2017               [Page 7]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    Note 4: For ctrDRBG implementations, at least one of the derivation
    function options shall be set depending on the one actually used or
@@ -371,28 +410,17 @@ Internet-Draft                DRBG Alg JSON                December 2016
    for this case.  The default nonce bit length is one-half the maximum
    security strength supported by the mechanism/option.
 
-   Note 7: ACVP has two default bit length values for persoString: zero
-   (0) and maximum supported supported security strength except in the
-   case of ctrDRBGWithoutDerFunc, where the second personalization
-   string length must be less than or equal to the seed length.  If the
-   implementation only supports one personalization string length, then
-   set both numbers equal to each other.  If the implementation does not
-   use a persoString, set both numbers to 0 (zero).
+   Note 7: ACVP allows bit length values for persoString ranging from
+   the maximum supported security strength except in the case of
+   ctrDRBGWithoutDerFunc, where the second personalization string length
+   must be less than or equal to the seed length.  If the implementation
+   only supports one personalization string length, then set only that
+   value as the range min and max and set the step to zero (0)..  If the
+   implementation does not use a persoString, set all range parameters
+   (min, max, step) to 0 (zero).
 
    Note 8: The addtionalInput configuration and restrictions are the
-   same as those for the persoString.Similarly, for the default
-   addtionalInput bit legths - same as those for persoString lengths.
-
-
-
-
-
-
-
-Vassilev                  Expires June 30, 2017                 [Page 7]
-
-Internet-Draft                DRBG Alg JSON                December 2016
-
+   same as those for the persoString.
 
 3.  Test Vectors
 
@@ -408,6 +436,19 @@ Internet-Draft                DRBG Alg JSON                December 2016
    contains meta data for the entire vector set as well as individual
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 14, 2017               [Page 8]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    +-------------+---------------------------------------------+-------+
    | JSON Value  | Description                                 | JSON  |
@@ -443,17 +484,27 @@ Internet-Draft                DRBG Alg JSON                December 2016
    following table describes the DRBG JSON elements of the Test Group
    JSON object.
 
-
-
-Vassilev                  Expires June 30, 2017                 [Page 8]
-
-Internet-Draft                DRBG Alg JSON                December 2016
-
-
    ACVP allows default bit lengths for the inputs to specific
    algorithms, typically communicated as numerical value zero (0).  If
    an implementation does not support one of the defaults, the bit
    lengths the supported values shall be specified explicitly.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 14, 2017               [Page 9]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    +-------------------+---------------------------+--------+----------+
    | JSON Value        | Description               | JSON   | Optional |
@@ -473,9 +524,12 @@ Internet-Draft                DRBG Alg JSON                December 2016
    | nonceLen          | nonce length              | value  | No       |
    |                   |                           |        |          |
    | persoStringLen    | personalization string    | value  | No       |
-   |                   | length                    |        |          |
+   |                   | length; set to 0 (zero)   |        |          |
+   |                   | if not used/supported     |        |          |
    |                   |                           |        |          |
-   | additonalInputLen | additional input length   | value  | No       |
+   | additonalInputLen | additional input length;  | value  | No       |
+   |                   | set tp 0 (zero) if not    |        |          |
+   |                   | used/supported            |        |          |
    |                   |                           |        |          |
    | returnedBitsLen   | returned bits length      | value  | No       |
    |                   |                           |        |          |
@@ -501,9 +555,11 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                 [Page 9]
+
+
+Vassilev               Expires September 14, 2017              [Page 10]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
    +---------------------+--------------------------+-------+----------+
@@ -557,9 +613,9 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 10]
+Vassilev               Expires September 14, 2017              [Page 11]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 4.  Test Vector Responses
@@ -613,9 +669,9 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 11]
+Vassilev               Expires September 14, 2017              [Page 12]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 6.  IANA Considerations
@@ -647,6 +703,33 @@ Appendix A.  Example DRBG Capabilities JSON Object
    The following is a example JSON object advertising support for
    ctrDRBG with 3KeyTDEA.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 14, 2017              [Page 13]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
             {
                 "algorithm": "ctrDRBG",
                 "mode": "3KeyTDEA",
@@ -654,25 +737,23 @@ Appendix A.  Example DRBG Capabilities JSON Object
                 "prereqVals": [{"algorithm": "TDES", "valValue": "same"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"112",
-                "nonceLen":"56",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 112,
+                                "max": 256,
+                                "step" : 144},
+                "nonceLenRange": {"min" : 56,
+                                "max" : 56,
+                                "step" : 0},
+                "persoStringLenRange": {"min": 112,
+                                "max" : 112,
+                                "step" : 0},
+                "additionalInputLenRange":{ "min": 112,
+                                "max" : 112,
+                                "step" : 0},
                 "returnedBitsLen":"256"
             }
 
    The following is a example JSON object advertising support for
    ctrDRBG with AES-128.
-
-
-
-
-
-
-Vassilev                  Expires June 30, 2017                [Page 12]
-
-Internet-Draft                DRBG Alg JSON                December 2016
-
 
             {
                 "algorithm": "ctrDRBG",
@@ -681,12 +762,29 @@ Internet-Draft                DRBG Alg JSON                December 2016
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"128",
-                "nonceLen":"64",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 128,
+                                "max": 256,
+                                "step" : 128},
+                "nonceLenRange": {"min" : 64,
+                                "max" : 64,
+                                "step" : 0},
+                "persoStringLenRange": {"min": 128,
+                                "max" : 128,
+                                "step" : 0},
+                "additionalInputLenRange":{ "min": 128,
+                                "max" : 128,
+                                "step" : 0},
                 "returnedBitsLen":"512"
             }
+
+
+
+
+
+Vassilev               Expires September 14, 2017              [Page 14]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    The following is a example JSON object advertising support for
    hashDRBG with AES-256.
@@ -697,10 +795,18 @@ Internet-Draft                DRBG Alg JSON                December 2016
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"256",
-                "nonceLen":"128",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                 "entropyInputRange":{ "min": 256,
+                                "max": 512,
+                                "step" : 1},
+                "nonceLenRange": {"min" : 128,
+                                "max" : 256,
+                                 "step" : 128},
+                "persoStringLenRange": {"min": 256,
+                                 "max" : 512,
+                                 "step" : 1},
+              "additionalInputLenRange":{ "min": 256,
+                                 "max" : 512,
+                                 "step" : 1},
                 "returnedBitsLen":"1024"
             }
 
@@ -713,21 +819,27 @@ Internet-Draft                DRBG Alg JSON                December 2016
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "HMAC", "valValue": "9012"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"256",
-                "nonceLen":"128",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 256,
+                                 "max": 256,
+                                 "step" : 0},
+                "nonceLenRange": {"min" : 128,
+                                 "max" : 128,
+                                 "step" : 0},
+                "persoStringLenRange": {"min": 256,
+                                 "max" : 256,
+                                 "step" : 0},
+               "additionalInputLenRange":{ "min": 256,
+                                 "max" : 256,
+                                 "step" : 0},
                 "returnedBitsLen":"1024"
             }
 
 
 
 
-
-
-Vassilev                  Expires June 30, 2017                [Page 13]
+Vassilev               Expires September 14, 2017              [Page 15]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 Appendix B.  Example Test Vectors JSON Object
@@ -742,11 +854,11 @@ Appendix B.  Example Test Vectors JSON Object
                   "mode": "3KeyTDEA",
                   "derFunc":"yes",
                   "predResistance": "yes",
-                  "entropyInputLen":"128",
-                  "nonceLen":"64",
-                  "persoStringLen":"0",
-                  "additionalInputLen":"0",
-                  "returnedBitsLen":"512",
+                  "entropyInputLen":"112",
+                  "nonceLen":"56",
+                  "persoStringLen":"112",
+                  "additionalInputLen":"112",
+                  "returnedBitsLen":"256",
                   "testGroups": [
                     {
                       "type": "long",
@@ -781,9 +893,9 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 14]
+Vassilev               Expires September 14, 2017              [Page 16]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
                 {
@@ -794,8 +906,8 @@ Internet-Draft                DRBG Alg JSON                December 2016
                   "predResistance": "yes",
                   "entropyInputLen":"256",
                   "nonceLen":"128",
-                  "persoStringLen":"0",
-                  "additionalInputLen":"0",
+                  "persoStringLen":"256",
+                  "additionalInputLen":"256",
                   "returnedBitsLen":"1024",
                   "testGroups": [
                     {
@@ -837,9 +949,9 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 15]
+Vassilev               Expires September 14, 2017              [Page 17]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
                 {
@@ -859,23 +971,23 @@ Internet-Draft                DRBG Alg JSON                December 2016
                       "tests": [
                         {
                           "tcId": "2151",
-                          "entropyInput":"b37f442929f21306d8750a82fc6b362a574babd3ed60f19a35c37e469a5f14bf",
-                          "nonce":"c3283de7bc8395b6acccbb5ea5fa96bb",
-                          "persoString":"5674ab88573f76754c9c23251ced43004e4e0839b8238dc02738c52fd4f0c6d2",
-                          "additionalInput":"54b90323d3985459897b6743006bc0b573c2374512bd4af306e094c791b3fe83",
-                          "entropyInputPR": "c7825bcd4d93f29759e605a71cbd7d926ad7ea5cef223e0c18ef9f6fbd60ca59",
-                          "additionalInput" : "589b34ca088e88ebc0013ebe1371ba59981a7dc28a430f1878dbea58da48bbc8",
-                          "entropyInputPR" : "3ab094c46749b53452230b757e06a0e73ae98154fee23b219b2d2cb3799f3ddd"
+                          "entropyInput":"ae0a3acd541d0d582a8510f3028caa143fe1e5226a8469d40b979d3a0d1bbe69",
+                          "nonce":"786f03ad697332d74fad7a14604cee44",
+                          "persoString":"",
+                          "additionalInput":"",
+                          "entropyInputPR": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"
                           },
                         {
                           "tcId": "2152",
-                          "entropyInput" : "453ee7be8e0c38345bc5bd41b3fc966bee51865cbdefef8de88c2e2f98e0d89c",
-                          "nonce": "caab6531ed1d096668e7d7e5bb8f306b",
-                          "persoString" : "ff6f535e2b41be7c17d4cfc0f14868ab838b739e643d269d624a1a0637152d78",
-                          "additionalInput" : "725ae7b8d850fbfda11ec61ff42ce3b886cff4ab2adeffc2cb9bc23d5dc59db9",
-                          "entropyInputPR" : "6a126e70a096b6e7ac6a717a6becbe98e1dee0c2181c5353701fcead24b0fe4e",
-                          "additionalInput" : "ff3cd93f88072a2fc8cd0e4a4317a97b504f8fc6beb6753214455b12f0044dfc",
-                          "entropyInputPR" : "dba352082e876c90f5a1411670b47610d7c3b6116b00a1d0056702bb8fa3b78e"
+                          "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
+                          "nonce": "36dff124f908a95a022edf615618cd31",
+                          "persoString" : "",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "fff51d05b1349506c354a0e6ee01edcff21c509dff5cbb582c8fdc01d6e8bd5b"
                         }
                       ]
                     }
@@ -893,9 +1005,9 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 16]
+Vassilev               Expires September 14, 2017              [Page 18]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
                 {
@@ -949,9 +1061,9 @@ Internet-Draft                DRBG Alg JSON                December 2016
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 17]
+Vassilev               Expires September 14, 2017              [Page 19]
 
-Internet-Draft                DRBG Alg JSON                December 2016
+Internet-Draft                DRBG Alg JSON                   March 2017
 
 
                 {
@@ -960,11 +1072,11 @@ Internet-Draft                DRBG Alg JSON                December 2016
                     "testResults": [
                         {
                             "tcId": "2151",
-                            "returnedBits ": "3bcb4371e388a8c453f16fb48e46859b7cbd1b8307681083fb8c10e7a6ea77ff89f6ce2ab9efff8ea11e95117e577a139e5a2f99786282fefadf07c13d7ceb123d81f93d262ad84d9d1589ea6bb760a0cabd75285e29a11bb97a8ff3317d839639866195c3364c98f250ce97c974c06805821e66ce214333d275d8a01a6c69a7"
+                            "returnedBits ": "1af967534c670271e26c9b991ec975b78c84623853cd531368f5b2e81f015f97ffbb8cd4533d4354ed432fbdf8025f04786745fd006e173f34e6f01e136bd9b4db2b96919dfa12e8deecf7b7c72b1d329afa99c29e844b27ee34d468a4b20b5739c00ad405943aeb5084285468765190112c5e44756770479552f2f2913ed362"
                         },
                        {
                             "tcId": "2152",
-                            "returnedBits": "0302cb504af55d89d8aa03a05d5cd9969c0650e32c27d32dc5db991b95297885a593cb81ee2fbfea273f61830fa0d548c1d89ff1d8495a9fd4dee2c7ddc075620bec06d3641232b4433d229f2b4a791a11709fe3d6fe4f809f97d113bdaebe255223e6e5914296886861d28331ea702bf05f63a8fd62b97a845de43012ed4a55"
+                            "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
                        }
                     ]
                 }
@@ -1005,4 +1117,4 @@ Author's Address
 
 
 
-Vassilev                  Expires June 30, 2017                [Page 18]
+Vassilev               Expires September 14, 2017              [Page 20]

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -69,7 +69,7 @@
       </address>
     </author>
 
-    <date month="December" year="2016"/>
+    <date month="March" year="2017"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -311,40 +311,40 @@
           <c/>
           <c/>
           <c/>
-          <c>entropyInputLen</c>
-         <c>the bit length of the entropy input. See <xref target="caps_table"/> notes below.</c>
-          <c>value</c>
-          <c>at least the maximum security strength supported by the mechanism/option, larger values are optional</c>
+          <c>entropyInputRange</c>
+         <c>the supported bit lengths of the entropy input. See <xref target="caps_table"/> notes below.</c>
+          <c>range</c>
+          <c>min - at least the maximum security strength supported by the mechanism/option, max - larger values are optional, step - increment.</c>
           <c>No</c>                    
           <c/>
           <c/>
           <c/>
           <c/>
           <c/>
-          <c>nonceLen</c>
+          <c>nonceLenRange</c>
          <c>.See <xref target="caps_table"/> notes below.</c>
-          <c>value</c>
-          <c>at least one half of the maximum security strength supported by the mechanism/option. Longer nonces are permitted.</c>
-          <c>Yes</c>
-          <c/>
-          <c/>
-          <c/>
-          <c/>
-          <c/>
-          <c>persoStringLen</c>
-         <c>.See <xref target="caps_table"/> notes below.</c>
-          <c>Array</c>
-          <c>set to zero or the maximum security strength supported by the mechanism/option.</c>
+          <c>range</c>
+          <c>min - at least one half of the maximum security strength supported by the mechanism/option; max: - longer nonces are permitted, step - increment</c>
           <c>No</c>
           <c/>
           <c/>
           <c/>
           <c/>
           <c/>
-          <c>additionalInputLen</c>
+          <c>persoStringLenRange</c>
          <c>.See <xref target="caps_table"/> notes below.</c>
-          <c>Array</c>
-          <c>set to zero or the maximum security strength supported by the mechanism/option.</c>
+          <c>range</c>
+          <c>min - the maximum security strength supported by the mechanism/option; max - largest supported length, step - increment to calculate all supported lengths. Set all to zero (0) if not supported.</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>additionalInputLenRange</c>
+         <c>.See <xref target="caps_table"/> notes below.</c>
+          <c>range</c>
+          <c>min - the maximum security strength supported by the mechanism/option; max - largest supported length, step - increment to calculate all supported lengths; set all to zero (0) if not supported.</c>
           <c>No</c>
           <c/>
           <c/>
@@ -368,12 +368,11 @@
           with the following exception: for ctrDRBG with no df, the bit length must equal the seed length.</t>
           <t>Note 6: ctrDRBG with no derivation function (ctrDRBGWithoutDerFunc) does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half
            the maximum security strength supported by the mechanism/option.</t>
-          <t>Note 7: ACVP has two default bit length values for persoString: zero (0) and maximum supported
+          <t>Note 7: ACVP allows bit length values for persoString ranging from the maximum 
            supported security strength except in the case of ctrDRBGWithoutDerFunc, where the second personalization string length must be less than or equal to the seed length. 
-          If the implementation only supports one personalization string length, then set both numbers equal to each other. 
-          If the implementation does not use a persoString, set both numbers to 0 (zero). </t>
-          <t>Note 8: The addtionalInput configuration and restrictions are the same as those for the persoString.Similarly, for the default addtionalInput bit legths - same as those for
-          persoString lengths.</t>
+          If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0).. 
+          If the implementation does not use a persoString, set all range parameters (min, max, step) to 0 (zero). </t>
+          <t>Note 8: The addtionalInput configuration and restrictions are the same as those for the persoString.</t>
           
    </section>
     </section>
@@ -481,16 +480,16 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c/>
 		<c/>
 		<c>persoStringLen</c>
-		<c>personalization string length</c>
-		<c>value </c>
+		<c>personalization string length; set to 0 (zero) if not used/supported</c>
+		<c>value</c>
 		<c>No</c>
 <c/>
 		<c/>
 		<c/>
 		<c/>
 		<c>additonalInputLen</c>
-		<c>additional input length</c>
-		<c>value </c>
+		<c>additional input length; set tp 0 (zero) if not used/supported</c>
+		<c>value</c>
 		<c>No</c>
 		<c/>
 		<c/>
@@ -705,10 +704,18 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 "prereqVals": [{"algorithm": "TDES", "valValue": "same"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"112",
-                "nonceLen":"56",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 112,
+                                "max": 256,
+                                "step" : 144},
+                "nonceLenRange": {"min" : 56,
+                                "max" : 56,
+                                "step" : 0},
+                "persoStringLenRange": {"min": 112,
+                                "max" : 112,
+                                "step" : 0},
+                "additionalInputLenRange":{ "min": 112,
+                                "max" : 112,
+                                "step" : 0},
                 "returnedBitsLen":"256"
             }
             ]]></artwork>
@@ -724,10 +731,18 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"128",
-                "nonceLen":"64",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 128,
+                                "max": 256,
+                                "step" : 128},
+                "nonceLenRange": {"min" : 64,
+                                "max" : 64,
+                                "step" : 0},
+                "persoStringLenRange": {"min": 128,
+                                "max" : 128,
+                                "step" : 0},
+                "additionalInputLenRange":{ "min": 128,
+                                "max" : 128,
+                                "step" : 0},
                 "returnedBitsLen":"512"
             }
             ]]></artwork>
@@ -741,10 +756,18 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"256",
-                "nonceLen":"128",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                 "entropyInputRange":{ "min": 256,
+                                "max": 512,
+                                "step" : 1},
+                "nonceLenRange": {"min" : 128,
+                                "max" : 256,
+                                 "step" : 128},
+                "persoStringLenRange": {"min": 256,
+                                 "max" : 512,
+                                 "step" : 1},
+              "additionalInputLenRange":{ "min": 256,
+                                 "max" : 512,
+                                 "step" : 1},
                 "returnedBitsLen":"1024"
             }
             ]]></artwork>
@@ -759,10 +782,18 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "HMAC", "valValue": "9012"}],
                 "predResistanceEnabled": "yes",
                 "reseedImplemented" : "yes",
-                "entropyInputLen":"256",
-                "nonceLen":"128",
-                "persoStringLen":"0",
-                "additionalInputLen":"0",
+                "entropyInputRange":{ "min": 256,
+                                 "max": 256,
+                                 "step" : 0},
+                "nonceLenRange": {"min" : 128,
+                                 "max" : 128,
+                                 "step" : 0},
+                "persoStringLenRange": {"min": 256,
+                                 "max" : 256,
+                                 "step" : 0},
+               "additionalInputLenRange":{ "min": 256,
+                                 "max" : 256,
+                                 "step" : 0},
                 "returnedBitsLen":"1024"
             }
             ]]></artwork>
@@ -779,11 +810,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
                   "mode": "3KeyTDEA",
                   "derFunc":"yes",
                   "predResistance": "yes",
-                  "entropyInputLen":"128",
-                  "nonceLen":"64",
-                  "persoStringLen":"0",
-                  "additionalInputLen":"0",
-                  "returnedBitsLen":"512",                  
+                  "entropyInputLen":"112",
+                  "nonceLen":"56",
+                  "persoStringLen":"112",
+                  "additionalInputLen":"112",
+                  "returnedBitsLen":"256",                  
                   "testGroups": [
                     {
                       "type": "long",
@@ -826,8 +857,8 @@ the bit lengths the supported values shall be specified explicitly. </t>
                   "predResistance": "yes",
                   "entropyInputLen":"256",
                   "nonceLen":"128",
-                  "persoStringLen":"0",
-                  "additionalInputLen":"0",
+                  "persoStringLen":"256",
+                  "additionalInputLen":"256",
                   "returnedBitsLen":"1024",                  
                   "testGroups": [
                     {
@@ -879,23 +910,23 @@ the bit lengths the supported values shall be specified explicitly. </t>
                       "tests": [
                         {
                           "tcId": "2151",
-                          "entropyInput":"b37f442929f21306d8750a82fc6b362a574babd3ed60f19a35c37e469a5f14bf",
-                          "nonce":"c3283de7bc8395b6acccbb5ea5fa96bb",
-                          "persoString":"5674ab88573f76754c9c23251ced43004e4e0839b8238dc02738c52fd4f0c6d2",
-                          "additionalInput":"54b90323d3985459897b6743006bc0b573c2374512bd4af306e094c791b3fe83",
-                          "entropyInputPR": "c7825bcd4d93f29759e605a71cbd7d926ad7ea5cef223e0c18ef9f6fbd60ca59",
-                          "additionalInput" : "589b34ca088e88ebc0013ebe1371ba59981a7dc28a430f1878dbea58da48bbc8",
-                          "entropyInputPR" : "3ab094c46749b53452230b757e06a0e73ae98154fee23b219b2d2cb3799f3ddd"
+                          "entropyInput":"ae0a3acd541d0d582a8510f3028caa143fe1e5226a8469d40b979d3a0d1bbe69",
+                          "nonce":"786f03ad697332d74fad7a14604cee44",
+                          "persoString":"",
+                          "additionalInput":"",
+                          "entropyInputPR": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"
                           },
                         {
                           "tcId": "2152",
-                          "entropyInput" : "453ee7be8e0c38345bc5bd41b3fc966bee51865cbdefef8de88c2e2f98e0d89c",
-                          "nonce": "caab6531ed1d096668e7d7e5bb8f306b",
-                          "persoString" : "ff6f535e2b41be7c17d4cfc0f14868ab838b739e643d269d624a1a0637152d78",
-                          "additionalInput" : "725ae7b8d850fbfda11ec61ff42ce3b886cff4ab2adeffc2cb9bc23d5dc59db9",
-                          "entropyInputPR" : "6a126e70a096b6e7ac6a717a6becbe98e1dee0c2181c5353701fcead24b0fe4e",
-                          "additionalInput" : "ff3cd93f88072a2fc8cd0e4a4317a97b504f8fc6beb6753214455b12f0044dfc",
-                          "entropyInputPR" : "dba352082e876c90f5a1411670b47610d7c3b6116b00a1d0056702bb8fa3b78e"
+                          "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
+                          "nonce": "36dff124f908a95a022edf615618cd31",
+                          "persoString" : "",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154",
+                          "additionalInput" : "",
+                          "entropyInputPR" : "fff51d05b1349506c354a0e6ee01edcff21c509dff5cbb582c8fdc01d6e8bd5b"
                         }
                       ]
                     }
@@ -953,11 +984,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
                     "testResults": [
                         {
                             "tcId": "2151",
-                            "returnedBits ": "3bcb4371e388a8c453f16fb48e46859b7cbd1b8307681083fb8c10e7a6ea77ff89f6ce2ab9efff8ea11e95117e577a139e5a2f99786282fefadf07c13d7ceb123d81f93d262ad84d9d1589ea6bb760a0cabd75285e29a11bb97a8ff3317d839639866195c3364c98f250ce97c974c06805821e66ce214333d275d8a01a6c69a7"
+                            "returnedBits ": "1af967534c670271e26c9b991ec975b78c84623853cd531368f5b2e81f015f97ffbb8cd4533d4354ed432fbdf8025f04786745fd006e173f34e6f01e136bd9b4db2b96919dfa12e8deecf7b7c72b1d329afa99c29e844b27ee34d468a4b20b5739c00ad405943aeb5084285468765190112c5e44756770479552f2f2913ed362"
                         },
                        {
                             "tcId": "2152",
-                            "returnedBits": "0302cb504af55d89d8aa03a05d5cd9969c0650e32c27d32dc5db991b95297885a593cb81ee2fbfea273f61830fa0d548c1d89ff1d8495a9fd4dee2c7ddc075620bec06d3641232b4433d229f2b4a791a11709fe3d6fe4f809f97d113bdaebe255223e6e5914296886861d28331ea702bf05f63a8fd62b97a845de43012ed4a55"
+                            "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
                        }
                     ]
                 }


### PR DESCRIPTION
This PR fixes several errors in the spec and makes improvements in how ranges of parameters are handled - see #65 for details. 

The examples are now consistent among
each other, so that if a particular parameter is set to zero, the corresponding data field is not tested. Please take a look and let me know if you have questions or comments.

Note I did not change the spec to allow for testing multiple intermediate values when additional input is used in prediction resistance mode. This enhancement can be introduced later if the server team is open to it. 