### PR TITLE
Rolling back specific "range" changes

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -418,7 +418,7 @@
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.2" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-3-13" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-3-14" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -439,10 +439,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">March 13, 2017</td>
+  <td class="right">March 14, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: September 14, 2017</td>
+  <td class="left">Expires: September 15, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -463,7 +463,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 14, 2017.</p>
+<p>This Internet-Draft will expire on September 15, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -858,8 +858,6 @@ Accept:
 ],
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
-"supportsNonBlockBoundaryAadLen" : true
-"supportsNonBlockBoundaryPtLen" : true,
 "keyLen" : [
             128,
             256
@@ -867,18 +865,18 @@ Accept:
 "tagLen" : [
             96
                ],
-"ivLen" : {
-            "min" : 96,
-            "max" : 96
-               },
-"ptLen" : {
-            "min" : 0,
-            "max" : 256
-               },
-"aadLen" : {
-            "min" : 128,
-            "max" : 256
-               }
+"ivLen" : [
+             96
+               ],
+ "ptLen" : [
+             0,
+             128,
+             136
+               ],
+ "aadLen" : [
+             128,
+             136
+               ]
           }
        ]
    }

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                            March 13, 2017
-Expires: September 14, 2017
+Intended status: Informational                            March 14, 2017
+Expires: September 15, 2017
 
 
               Automated Cryptographic Validation Protocol
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 14, 2017.
+   This Internet-Draft will expire on September 15, 2017.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Fussell                Expires September 14, 2017               [Page 1]
+Fussell                Expires September 15, 2017               [Page 1]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Fussell                Expires September 14, 2017               [Page 2]
+Fussell                Expires September 15, 2017               [Page 2]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -165,7 +165,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 3]
+Fussell                Expires September 15, 2017               [Page 3]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -221,7 +221,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 4]
+Fussell                Expires September 15, 2017               [Page 4]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -277,7 +277,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 5]
+Fussell                Expires September 15, 2017               [Page 5]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -333,7 +333,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 6]
+Fussell                Expires September 15, 2017               [Page 6]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -389,7 +389,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 7]
+Fussell                Expires September 15, 2017               [Page 7]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -445,7 +445,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 8]
+Fussell                Expires September 15, 2017               [Page 8]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -501,7 +501,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017               [Page 9]
+Fussell                Expires September 15, 2017               [Page 9]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -557,7 +557,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 10]
+Fussell                Expires September 15, 2017              [Page 10]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -613,7 +613,7 @@ each message.
 
 
 
-Fussell                Expires September 14, 2017              [Page 11]
+Fussell                Expires September 15, 2017              [Page 11]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -669,7 +669,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 12]
+Fussell                Expires September 15, 2017              [Page 12]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -685,8 +685,6 @@ Internet-Draft              Abbreviated Title                 March 2017
    ],
    "ivGen" : "internal",
    "ivGenMode" : "8.2.1",
-   "supportsNonBlockBoundaryAadLen" : true
-   "supportsNonBlockBoundaryPtLen" : true,
    "keyLen" : [
                128,
                256
@@ -694,18 +692,18 @@ Internet-Draft              Abbreviated Title                 March 2017
    "tagLen" : [
                96
                   ],
-   "ivLen" : {
-               "min" : 96,
-               "max" : 96
-                  },
-   "ptLen" : {
-               "min" : 0,
-               "max" : 256
-                  },
-   "aadLen" : {
-               "min" : 128,
-               "max" : 256
-                  }
+   "ivLen" : [
+                96
+                  ],
+    "ptLen" : [
+                0,
+                128,
+                136
+                  ],
+    "aadLen" : [
+                128,
+                136
+                  ]
              }
           ]
       }
@@ -725,7 +723,9 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 13]
+
+
+Fussell                Expires September 15, 2017              [Page 13]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -781,7 +781,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 14]
+Fussell                Expires September 15, 2017              [Page 14]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -837,7 +837,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 15]
+Fussell                Expires September 15, 2017              [Page 15]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -893,7 +893,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 16]
+Fussell                Expires September 15, 2017              [Page 16]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -949,7 +949,7 @@ Content-Length: <length of results>
 
 
 
-Fussell                Expires September 14, 2017              [Page 17]
+Fussell                Expires September 15, 2017              [Page 17]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -1005,7 +1005,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 18]
+Fussell                Expires September 15, 2017              [Page 18]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -1061,7 +1061,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 19]
+Fussell                Expires September 15, 2017              [Page 19]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -1117,7 +1117,7 @@ Internet-Draft              Abbreviated Title                 March 2017
 
 
 
-Fussell                Expires September 14, 2017              [Page 20]
+Fussell                Expires September 15, 2017              [Page 20]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -1173,7 +1173,7 @@ Appendix A.  JSON Formatting Guidelines
 
 
 
-Fussell                Expires September 14, 2017              [Page 21]
+Fussell                Expires September 15, 2017              [Page 21]
 
 Internet-Draft              Abbreviated Title                 March 2017
 
@@ -1229,4 +1229,4 @@ Author's Address
 
 
 
-Fussell                Expires September 14, 2017              [Page 22]
+Fussell                Expires September 15, 2017              [Page 22]

--- a/artifacts/acvp_sub_symmetric.html
+++ b/artifacts/acvp_sub_symmetric.html
@@ -619,7 +619,7 @@
     <tr>
       <td class="left">ptLen</td>
       <td class="left">The supported plaintext lengths in bits.   This varies depending on the algorithm type, for additional details see <a href="#data_lengths">Section 2.3</a></td>
-      <td class="left">range</td>
+      <td class="left">range or array</td>
       <td class="left">0-65536</td>
       <td class="left">No</td>
     </tr>
@@ -633,7 +633,7 @@
     <tr>
       <td class="left">ivLen</td>
       <td class="left">The supported IV/Nonce lengths in bits, see <a href="#data_lengths">Section 2.3</a></td>
-      <td class="left">range</td>
+      <td class="left">array</td>
       <td class="left">8-1024</td>
       <td class="left">Yes</td>
     </tr>
@@ -675,7 +675,7 @@
     <tr>
       <td class="left">aadLen</td>
       <td class="left">The supported AAD lengths in bits for AEAD algorithms, </td>
-      <td class="left">range</td>
+      <td class="left">range or array</td>
       <td class="left">0-65536</td>
       <td class="left">Yes</td>
     </tr>
@@ -743,34 +743,6 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">supportsNonBlockBoundaryPtLen</td>
-      <td class="left">Indicates the algorithm implementation supports Plain text lengths outside of the block boundary.  Example, 112 bits for AES which operates on a 128 bit block.</td>
-      <td class="left">bool</td>
-      <td class="left">true, false</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">supportsNonBlockBoundaryAadLen</td>
-      <td class="left">Indicates the algorithm implementation supports AAD lengths outside of the block boundary.</td>
-      <td class="left">bool</td>
-      <td class="left">true, false</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">ctrSource</td>
       <td class="left">The source of the counter for counter-mode</td>
       <td class="left">value</td>
@@ -812,10 +784,10 @@
     </tr>
     <tr>
       <td class="left">AES-GCM</td>
-      <td class="left">Range, minimum of zero, maximum less than or equal to 65536.  When not zero, value should be divisible by 128. Should indicate "true" for "supportsNonBlockBoundaryPtLen" when implementation allows.</td>
-      <td class="left">Range, minimum of 8, maximum of 1024</td>
+      <td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</td>
+      <td class="left">Array one to three values between 8 and 1024</td>
       <td class="left">Array of supported values of: 32, 64, 96, 104, 112, 120, 128</td>
-      <td class="left">Range, minimum of zero, maximum less than or equal to 65536.  When not zero, value should be divisible by 128.  Should indicate "true" for "supportsNonBlockBoundaryAadLen" when implementation allows.</td>
+      <td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</td>
     </tr>
     <tr>
       <td class="left"/>
@@ -826,7 +798,7 @@
     </tr>
     <tr>
       <td class="left">AES-XTS</td>
-      <td class="left">Range, minimum of zero, maximum less than or equal to 2^20.  When not zero, value should be divisible by 128.  Should indicate "true" for "supportsNonBlockBoundaryPtLen" when implementation allows.</td>
+      <td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128. Followed by the maximum data length not to exceed 2^20</td>
       <td class="left">N/A</td>
       <td class="left">N/A</td>
       <td class="left">N/A</td>

--- a/artifacts/acvp_sub_symmetric.txt
+++ b/artifacts/acvp_sub_symmetric.txt
@@ -66,22 +66,22 @@ Table of Contents
      2.1.  Required Prerequisite Algorithms for Symmetric
            Validations . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  Symmetric Algorithm Capabilities JSON Values  . . . . . .   4
-     2.3.  Data, IV and AAD Lengths  . . . . . . . . . . . . . . . .   7
-     2.4.  Supported Symmetric Algorithms  . . . . . . . . . . . . .   9
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  10
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  10
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  11
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  12
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  13
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  13
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  13
-   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  14
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  14
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  17
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  20
+     2.3.  Data, IV and AAD Lengths  . . . . . . . . . . . . . . . .   6
+     2.4.  Supported Symmetric Algorithms  . . . . . . . . . . . . .   7
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   9
+     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  10
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  11
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  12
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  12
+   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  13
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  13
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  16
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  19
 
 1.  Introduction
 
@@ -175,49 +175,49 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +-----------------------+------------+----------+----------+--------+
-   | JSON Value            | Descriptio | JSON     | Valid    | Option |
-   |                       | n          | type     | Values   | al     |
-   +-----------------------+------------+----------+----------+--------+
-   | algorithm             | The        | value    | See      | No     |
-   |                       | symmetric  |          | Section  |        |
-   |                       | algorithm  |          | 2.4      |        |
-   |                       | and mode   |          |          |        |
-   |                       | to be      |          |          |        |
-   |                       | validated. |          |          |        |
-   |                       |            |          |          |        |
-   | prereqVals            | Prerequisi | array of | See      | Yes    |
-   |                       | te         | prereqAl | Section  |        |
-   |                       | algorithm  | gVal     | 2.1      |        |
-   |                       | validation | objects  |          |        |
-   |                       | s          |          |          |        |
-   |                       |            |          |          |        |
-   | direction             | The crypto | array    | encrypt, | No     |
-   |                       | operation  |          | decrypt  |        |
-   |                       | direction  |          |          |        |
-   |                       |            |          |          |        |
-   | keyLen                | The        | array    | 128,     | No     |
-   |                       | supported  |          | 168,     |        |
-   |                       | key        |          | 192, 256 |        |
-   |                       | lengths in |          |          |        |
-   |                       | bits       |          |          |        |
-   |                       |            |          |          |        |
-   | ptLen                 | The        | range    | 0-65536  | No     |
-   |                       | supported  |          |          |        |
-   |                       | plaintext  |          |          |        |
-   |                       | lengths in |          |          |        |
-   |                       | bits.      |          |          |        |
-   |                       | This       |          |          |        |
-   |                       | varies     |          |          |        |
-   |                       | depending  |          |          |        |
-   |                       | on the     |          |          |        |
-   |                       | algorithm  |          |          |        |
-   |                       | type, for  |          |          |        |
-   |                       | additional |          |          |        |
-   |                       | details    |          |          |        |
-   |                       | see        |          |          |        |
-   |                       | Section    |          |          |        |
-   |                       | 2.3        |          |          |        |
+   +-------------+--------------+--------------+------------+----------+
+   | JSON Value  | Description  | JSON type    | Valid      | Optional |
+   |             |              |              | Values     |          |
+   +-------------+--------------+--------------+------------+----------+
+   | algorithm   | The          | value        | See        | No       |
+   |             | symmetric    |              | Section    |          |
+   |             | algorithm    |              | 2.4        |          |
+   |             | and mode to  |              |            |          |
+   |             | be           |              |            |          |
+   |             | validated.   |              |            |          |
+   |             |              |              |            |          |
+   | prereqVals  | Prerequisite | array of     | See        | Yes      |
+   |             | algorithm    | prereqAlgVal | Section    |          |
+   |             | validations  | objects      | 2.1        |          |
+   |             |              |              |            |          |
+   | direction   | The crypto   | array        | encrypt,   | No       |
+   |             | operation    |              | decrypt    |          |
+   |             | direction    |              |            |          |
+   |             |              |              |            |          |
+   | keyLen      | The          | array        | 128, 168,  | No       |
+   |             | supported    |              | 192, 256   |          |
+   |             | key lengths  |              |            |          |
+   |             | in bits      |              |            |          |
+   |             |              |              |            |          |
+   | ptLen       | The          | range or     | 0-65536    | No       |
+   |             | supported    | array        |            |          |
+   |             | plaintext    |              |            |          |
+   |             | lengths in   |              |            |          |
+   |             | bits.   This |              |            |          |
+   |             | varies       |              |            |          |
+   |             | depending on |              |            |          |
+   |             | the          |              |            |          |
+   |             | algorithm    |              |            |          |
+   |             | type, for    |              |            |          |
+   |             | additional   |              |            |          |
+   |             | details see  |              |            |          |
+   |             | Section 2.3  |              |            |          |
+   |             |              |              |            |          |
+   | ivLen       | The          | array        | 8-1024     | Yes      |
+   |             | supported    |              |            |          |
+   |             | IV/Nonce     |              |            |          |
+   |             | lengths in   |              |            |          |
+   |             | bits, see    |              |            |          |
 
 
 
@@ -226,54 +226,54 @@ Foley                   Expires December 3, 2016                [Page 4]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |                       |            |          |          |        |
-   | ivLen                 | The        | range    | 8-1024   | Yes    |
-   |                       | supported  |          |          |        |
-   |                       | IV/Nonce   |          |          |        |
-   |                       | lengths in |          |          |        |
-   |                       | bits, see  |          |          |        |
-   |                       | Section    |          |          |        |
-   |                       | 2.3        |          |          |        |
-   |                       |            |          |          |        |
-   | ivGen                 | IV         | value    | internal | Yes    |
-   |                       | generation |          | ,        |        |
-   |                       | method for |          | external |        |
-   |                       | AEAD       |          |          |        |
-   |                       | algorithms |          |          |        |
-   |                       |            |          |          |        |
-   | ivGenMode             | IV         | value    | 8.2.1,   | Yes    |
-   |                       | generation |          | 8.2.2    |        |
-   |                       | mode for   |          |          |        |
-   |                       | AEAD       |          |          |        |
-   |                       | algorithms |          |          |        |
-   |                       |            |          |          |        |
-   | aadLen                | The        | range    | 0-65536  | Yes    |
-   |                       | supported  |          |          |        |
-   |                       | AAD        |          |          |        |
-   |                       | lengths in |          |          |        |
-   |                       | bits for   |          |          |        |
-   |                       | AEAD algor |          |          |        |
-   |                       | ithms,     |          |          |        |
-   |                       |            |          |          |        |
-   | tagLen                | The        | array    | 4-128    | Yes    |
-   |                       | supported  |          |          |        |
-   |                       | Tag        |          |          |        |
-   |                       | lengths in |          |          |        |
-   |                       | bits for   |          |          |        |
-   |                       | AEAD algor |          |          |        |
-   |                       | ithms,     |          |          |        |
-   |                       | Section    |          |          |        |
-   |                       | 2.3        |          |          |        |
-   |                       |            |          |          |        |
-   | kwCipher              | The cipher | array    | cipher,  | Yes    |
-   |                       | as defined |          | inverse  |        |
-   |                       | in         |          |          |        |
-   |                       | SP800-38F  |          |          |        |
-   |                       | for key    |          |          |        |
-   |                       | wrap mode  |          |          |        |
-   |                       |            |          |          |        |
-   | tweakFormat           | The format | array    | 128hex,  | Yes    |
-   |                       | of tweak   |          | duSequen |        |
+   |             | Section 2.3  |              |            |          |
+   |             |              |              |            |          |
+   | ivGen       | IV           | value        | internal,  | Yes      |
+   |             | generation   |              | external   |          |
+   |             | method for   |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms   |              |            |          |
+   |             |              |              |            |          |
+   | ivGenMode   | IV           | value        | 8.2.1,     | Yes      |
+   |             | generation   |              | 8.2.2      |          |
+   |             | mode for     |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms   |              |            |          |
+   |             |              |              |            |          |
+   | aadLen      | The          | range or     | 0-65536    | Yes      |
+   |             | supported    | array        |            |          |
+   |             | AAD lengths  |              |            |          |
+   |             | in bits for  |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms,  |              |            |          |
+   |             |              |              |            |          |
+   | tagLen      | The          | array        | 4-128      | Yes      |
+   |             | supported    |              |            |          |
+   |             | Tag lengths  |              |            |          |
+   |             | in bits for  |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms,  |              |            |          |
+   |             | Section 2.3  |              |            |          |
+   |             |              |              |            |          |
+   | kwCipher    | The cipher   | array        | cipher,    | Yes      |
+   |             | as defined   |              | inverse    |          |
+   |             | in SP800-38F |              |            |          |
+   |             | for key wrap |              |            |          |
+   |             | mode         |              |            |          |
+   |             |              |              |            |          |
+   | tweakFormat | The format   | array        | 128hex,    | Yes      |
+   |             | of tweak     |              | duSequence |          |
+   |             | value input  |              |            |          |
+   |             | for AES-XTS  |              |            |          |
+   |             |              |              |            |          |
+   | keyingOptio | The Keying   | array        | 1, 2       | Yes      |
+   | n           | Option used  |              |            |          |
+   |             | in TDES.     |              |            |          |
+   |             | Keying       |              |            |          |
+   |             | option 1 (1) |              |            |          |
+   |             | is 3         |              |            |          |
+   |             | distinct     |              |            |          |
+   |             | keys (K1,    |              |            |          |
 
 
 
@@ -282,89 +282,31 @@ Foley                   Expires December 3, 2016                [Page 5]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |                       | value      |          | ce       |        |
-   |                       | input for  |          |          |        |
-   |                       | AES-XTS    |          |          |        |
-   |                       |            |          |          |        |
-   | keyingOption          | The Keying | array    | 1, 2     | Yes    |
-   |                       | Option     |          |          |        |
-   |                       | used in    |          |          |        |
-   |                       | TDES.      |          |          |        |
-   |                       | Keying     |          |          |        |
-   |                       | option 1   |          |          |        |
-   |                       | (1) is 3   |          |          |        |
-   |                       | distinct   |          |          |        |
-   |                       | keys (K1,  |          |          |        |
-   |                       | K2, K3).   |          |          |        |
-   |                       | Keying     |          |          |        |
-   |                       | Option 2   |          |          |        |
-   |                       | (2) is 2   |          |          |        |
-   |                       | distinct   |          |          |        |
-   |                       | only       |          |          |        |
-   |                       | suitable   |          |          |        |
-   |                       | for        |          |          |        |
-   |                       | decrypt    |          |          |        |
-   |                       | (K1, K2,   |          |          |        |
-   |                       | K1).       |          |          |        |
-   |                       | Keying     |          |          |        |
-   |                       | option 3   |          |          |        |
-   |                       | (No longer |          |          |        |
-   |                       | valid for  |          |          |        |
-   |                       | testing,   |          |          |        |
-   |                       | save KATs) |          |          |        |
-   |                       | is a       |          |          |        |
-   |                       | single     |          |          |        |
-   |                       | key, now   |          |          |        |
-   |                       | deprecated |          |          |        |
-   |                       | (K1, K1,   |          |          |        |
-   |                       | K1).       |          |          |        |
-   |                       |            |          |          |        |
-   | supportsNonBlockBound | Indicates  | bool     | true,    | Yes    |
-   | aryPtLen              | the        |          | false    |        |
-   |                       | algorithm  |          |          |        |
-   |                       | implementa |          |          |        |
-   |                       | tion       |          |          |        |
-   |                       | supports   |          |          |        |
-   |                       | Plain text |          |          |        |
-   |                       | lengths    |          |          |        |
-   |                       | outside of |          |          |        |
-   |                       | the block  |          |          |        |
-   |                       | boundary.  |          |          |        |
-
-
-
-Foley                   Expires December 3, 2016                [Page 6]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
-   |                       | Example,   |          |          |        |
-   |                       | 112 bits   |          |          |        |
-   |                       | for AES    |          |          |        |
-   |                       | which      |          |          |        |
-   |                       | operates   |          |          |        |
-   |                       | on a 128   |          |          |        |
-   |                       | bit block. |          |          |        |
-   |                       |            |          |          |        |
-   | supportsNonBlockBound | Indicates  | bool     | true,    | Yes    |
-   | aryAadLen             | the        |          | false    |        |
-   |                       | algorithm  |          |          |        |
-   |                       | implementa |          |          |        |
-   |                       | tion       |          |          |        |
-   |                       | supports   |          |          |        |
-   |                       | AAD        |          |          |        |
-   |                       | lengths    |          |          |        |
-   |                       | outside of |          |          |        |
-   |                       | the block  |          |          |        |
-   |                       | boundary.  |          |          |        |
-   |                       |            |          |          |        |
-   | ctrSource             | The source | value    | internal | Yes    |
-   |                       | of the     |          | ,        |        |
-   |                       | counter    |          | external |        |
-   |                       | for        |          |          |        |
-   |                       | counter-   |          |          |        |
-   |                       | mode       |          |          |        |
-   +-----------------------+------------+----------+----------+--------+
+   |             | K2, K3).     |              |            |          |
+   |             | Keying       |              |            |          |
+   |             | Option 2 (2) |              |            |          |
+   |             | is 2         |              |            |          |
+   |             | distinct     |              |            |          |
+   |             | only         |              |            |          |
+   |             | suitable for |              |            |          |
+   |             | decrypt (K1, |              |            |          |
+   |             | K2, K1).     |              |            |          |
+   |             | Keying       |              |            |          |
+   |             | option 3 (No |              |            |          |
+   |             | longer valid |              |            |          |
+   |             | for testing, |              |            |          |
+   |             | save KATs)   |              |            |          |
+   |             | is a single  |              |            |          |
+   |             | key, now     |              |            |          |
+   |             | deprecated   |              |            |          |
+   |             | (K1, K1,     |              |            |          |
+   |             | K1).         |              |            |          |
+   |             |              |              |            |          |
+   | ctrSource   | The source   | value        | internal,  | Yes      |
+   |             | of the       |              | external   |          |
+   |             | counter for  |              |            |          |
+   |             | counter-mode |              |            |          |
+   +-------------+--------------+--------------+------------+----------+
 
            Table 2: Symmetric Algorithm Capabilities JSON Values
 
@@ -389,66 +331,53 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016                [Page 7]
+
+
+Foley                   Expires December 3, 2016                [Page 6]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +-------+--------------------+-------+--------+---------------------+
-   | Algor | Payload            | IV/No | Tag    | AAD                 |
-   | ithm  |                    | nce   |        |                     |
-   +-------+--------------------+-------+--------+---------------------+
-   | AES-  | Range (min, max),  | Array | Array  | Range (min, max),   |
-   | CCM   | minimum greater    | of va | of     | minimum greater     |
-   |       | than or equal to   | lues  | values | than or equal to    |
-   |       | zero and maximum   | from  | from 4 | zero and maximum    |
-   |       | less than or equal | 7 to  | to 16, | less than or equal  |
-   |       | to 32              | 13    | even   | to 65536            |
-   |       |                    |       | values |                     |
-   |       |                    |       | only   |                     |
-   |       |                    |       |        |                     |
-   | AES-  | Range, minimum of  | Range | Array  | Range, minimum of   |
-   | GCM   | zero, maximum less | , min | of sup | zero, maximum less  |
-   |       | than or equal to   | imum  | ported | than or equal to    |
-   |       | 65536.  When not   | of 8, | values | 65536.  When not    |
-   |       | zero, value should | maxim | of:    | zero, value should  |
-   |       | be divisible by    | um of | 32,    | be divisible by     |
-   |       | 128. Should        | 1024  | 64,    | 128.  Should        |
-   |       | indicate "true"    |       | 96,    | indicate "true" for |
-   |       | for "supportsNonBl |       | 104,   | "supportsNonBlockBo |
-   |       | ockBoundaryPtLen"  |       | 112,   | undaryAadLen" when  |
-   |       | when               |       | 120,   | implementation      |
-   |       | implementation     |       | 128    | allows.             |
-   |       | allows.            |       |        |                     |
-   |       |                    |       |        |                     |
-   | AES-  | Range, minimum of  | N/A   | N/A    | N/A                 |
-   | XTS   | zero, maximum less |       |        |                     |
-   |       | than or equal to   |       |        |                     |
-   |       | 2^20.  When not    |       |        |                     |
-   |       | zero, value should |       |        |                     |
-   |       | be divisible by    |       |        |                     |
-   |       | 128.  Should       |       |        |                     |
-   |       | indicate "true"    |       |        |                     |
-   |       | for "supportsNonBl |       |        |                     |
-   |       | ockBoundaryPtLen"  |       |        |                     |
-   |       | when               |       |        |                     |
-   |       | implementation     |       |        |                     |
-   |       | allows.            |       |        |                     |
-   +-------+--------------------+-------+--------+---------------------+
+  +-----------+-------------------+----------+-----------+-------------+
+  | Algorithm | Payload           | IV/Nonce | Tag       | AAD         |
+  +-----------+-------------------+----------+-----------+-------------+
+  | AES-CCM   | Range (min, max), | Array of | Array of  | Range (min, |
+  |           | minimum greater   | values   | values    | max),       |
+  |           | than or equal to  | from 7   | from 4 to | minimum     |
+  |           | zero and maximum  | to 13    | 16, even  | greater     |
+  |           | less than or      |          | values    | than or     |
+  |           | equal to 32       |          | only      | equal to    |
+  |           |                   |          |           | zero and    |
+  |           |                   |          |           | maximum     |
+  |           |                   |          |           | less than   |
+  |           |                   |          |           | or equal to |
+  |           |                   |          |           | 65536       |
+  |           |                   |          |           |             |
+  | AES-GCM   | Array to include, | Array    | Array of  | Array to    |
+  |           | if supported,     | one to   | supported | include, if |
+  |           | zero, two values  | three    | values    | supported,  |
+  |           | divisible by 128  | values   | of: 32,   | zero, two   |
+  |           | and two values    | between  | 64, 96,   | values      |
+  |           | not divisible by  | 8 and    | 104, 112, | divisible   |
+  |           | 128               | 1024     | 120, 128  | by 128 and  |
+  |           |                   |          |           | two values  |
+  |           |                   |          |           | not         |
+  |           |                   |          |           | divisible   |
+  |           |                   |          |           | by 128      |
+  |           |                   |          |           |             |
+  | AES-XTS   | Array to include, | N/A      | N/A       | N/A         |
+  |           | if supported,     |          |           |             |
+  |           | zero, two values  |          |           |             |
+  |           | divisible by 128  |          |           |             |
+  |           | and two values    |          |           |             |
+  |           | not divisible by  |          |           |             |
+  |           | 128. Followed by  |          |           |             |
+  |           | the maximum data  |          |           |             |
+  |           | length not to     |          |           |             |
+  |           | exceed 2^20       |          |           |             |
+  +-----------+-------------------+----------+-----------+-------------+
 
            Table 3: Symmetric Algorithm Capabilities JSON Values
-
-
-
-
-
-
-
-
-Foley                   Expires December 3, 2016                [Page 8]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
 2.4.  Supported Symmetric Algorithms
 
@@ -456,6 +385,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
    compliant crypto module:
 
    o  AES-ECB
+
+
+
+
+Foley                   Expires December 3, 2016                [Page 7]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    o  AES-CBC
 
@@ -499,18 +436,19 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    o  TDES-OFB
 
-
-
-Foley                   Expires December 3, 2016                [Page 9]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
    o  TDES-OFB-I
 
    o  TDES-CTR
 
    o  TDES-KW
+
+
+
+
+Foley                   Expires December 3, 2016                [Page 8]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
 3.  Test Vectors
 
@@ -554,18 +492,19 @@ Internet-Draft                Sym Alg JSON                     June 2016
    object is an array of test groups.  Test vectors are grouped into
    similar test cases to reduce the amount of data transmitted in the
    vector set.  For instance, all test vectors that use the same key
-
-
-
-Foley                   Expires December 3, 2016               [Page 10]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
    size would be grouped together.  The Test Group JSON object contains
    meta data that applies to all test vectors within the group.  The
    following table describes the JSON elements of the Test Group JSON
    object.
+
+
+
+
+
+Foley                   Expires December 3, 2016                [Page 9]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    +----------+-------------------------------------+-------+----------+
    | JSON     | Description                         | JSON  | Optional |
@@ -613,7 +552,12 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 11]
+
+
+
+
+
+Foley                   Expires December 3, 2016               [Page 10]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -669,7 +613,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 12]
+Foley                   Expires December 3, 2016               [Page 11]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -725,7 +669,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 13]
+Foley                   Expires December 3, 2016               [Page 12]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -781,7 +725,7 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-Foley                   Expires December 3, 2016               [Page 14]
+Foley                   Expires December 3, 2016               [Page 13]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -837,7 +781,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 15]
+Foley                   Expires December 3, 2016               [Page 14]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -893,7 +837,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 16]
+Foley                   Expires December 3, 2016               [Page 15]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -949,7 +893,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Foley                   Expires December 3, 2016               [Page 17]
+Foley                   Expires December 3, 2016               [Page 16]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1005,7 +949,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 18]
+Foley                   Expires December 3, 2016               [Page 17]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1061,7 +1005,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 19]
+Foley                   Expires December 3, 2016               [Page 18]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1117,7 +1061,7 @@ Author's Address
 
 
 
-Foley                   Expires December 3, 2016               [Page 20]
+Foley                   Expires December 3, 2016               [Page 19]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1173,4 +1117,4 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Foley                   Expires December 3, 2016               [Page 21]
+Foley                   Expires December 3, 2016               [Page 20]

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -479,8 +479,6 @@ Accept:
 ],
 "ivGen" : "internal",
 "ivGenMode" : "8.2.1",
-"supportsNonBlockBoundaryAadLen" : true
-"supportsNonBlockBoundaryPtLen" : true,
 "keyLen" : [
             128,
             256
@@ -488,18 +486,18 @@ Accept:
 "tagLen" : [
             96
                ],
-"ivLen" : {
-            "min" : 96,
-            "max" : 96
-               },
-"ptLen" : {
-            "min" : 0,
-            "max" : 256
-               },
-"aadLen" : {
-            "min" : 128,
-            "max" : 256
-               }
+"ivLen" : [
+             96
+               ],
+ "ptLen" : [
+             0,
+             128,
+             136
+               ],
+ "aadLen" : [
+             128,
+             136
+               ]
           }
        ]
    }

--- a/src/acvp_sub_symmetric.xml
+++ b/src/acvp_sub_symmetric.xml
@@ -209,14 +209,14 @@
 
           <c>ptLen</c>
 	  <c>The supported plaintext lengths in bits.   This varies depending on the algorithm type, for additional details see <xref target="data_lengths" /></c>
-          <c>range</c>
+          <c>range or array</c>
           <c>0-65536</c>
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
 
           <c>ivLen</c>
           <c>The supported IV/Nonce lengths in bits, see <xref target="data_lengths" /></c>
-          <c>range</c>
+          <c>array</c>
           <c>8-1024</c>
           <c>Yes</c>
 	  <c/><c/><c/><c/><c/>
@@ -237,7 +237,7 @@
 
           <c>aadLen</c>
           <c>The supported AAD lengths in bits for AEAD algorithms, </c>
-          <c>range</c>
+          <c>range or array</c>
           <c>0-65536</c>
           <c>Yes</c>
 	  <c/><c/><c/><c/><c/>
@@ -274,20 +274,6 @@
           <c>Yes</c>
     <c/><c/><c/><c/><c/>          
 
-          <c>supportsNonBlockBoundaryPtLen</c>
-          <c>Indicates the algorithm implementation supports Plain text lengths outside of the block boundary.  Example, 112 bits for AES which operates on a 128 bit block.</c>  
-          <c>bool</c>
-          <c>true, false</c>
-          <c>Yes</c>
-    <c/><c/><c/><c/><c/>      
-
-          <c>supportsNonBlockBoundaryAadLen</c>
-          <c>Indicates the algorithm implementation supports AAD lengths outside of the block boundary.</c>    
-          <c>bool</c>
-          <c>true, false</c>
-          <c>Yes</c>
-    <c/><c/><c/><c/><c/>          
-
           <c>ctrSource</c>
           <c>The source of the counter for counter-mode</c>
           <c>value</c>
@@ -317,14 +303,14 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>AES-GCM</c>
-          <c>Range, minimum of zero, maximum less than or equal to 65536.  When not zero, value should be divisible by 128. Should indicate "true" for "supportsNonBlockBoundaryPtLen" when implementation allows.</c>
-          <c>Range, minimum of 8, maximum of 1024</c>
+          <c>Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</c>
+          <c>Array one to three values between 8 and 1024</c>
           <c>Array of supported values of: 32, 64, 96, 104, 112, 120, 128</c>
-          <c>Range, minimum of zero, maximum less than or equal to 65536.  When not zero, value should be divisible by 128.  Should indicate "true" for "supportsNonBlockBoundaryAadLen" when implementation allows.</c>
+          <c>Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</c>
 	  <c/><c/><c/><c/><c/>
 
           <c>AES-XTS</c>
-          <c>Range, minimum of zero, maximum less than or equal to 2^20.  When not zero, value should be divisible by 128.  Should indicate "true" for "supportsNonBlockBoundaryPtLen" when implementation allows.</c>
+          <c>Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128. Followed by the maximum data length not to exceed 2^20</c>
           <c>N/A</c>
           <c>N/A</c>
           <c>N/A</c>


### PR DESCRIPTION
Rolled back range changes related to AES-GCM and XTS (they still apply for AES-CCM). 

This PR consists of additional changes related to #67.  Sorry about the confusion, #71 was merged in prior to my being able to change it based on additional feedback.