### PR TITLE
Add option for reseed only prediction resistance

### DIFF
--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,7 +400,7 @@
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-3-20" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-3-21" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">March 20, 2017</td>
+  <td class="right">March 21, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: September 21, 2017</td>
+  <td class="left">Expires: September 22, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -445,7 +445,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 21, 2017.</p>
+<p>This Internet-Draft will expire on September 22, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -938,6 +938,18 @@
       <td class="left"/>
     </tr>
     <tr>
+      <td class="left">reSeed</td>
+      <td class="left">use reseeding</td>
+      <td class="left">value yes/no</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
       <td class="left">entropyInputLen</td>
       <td class="left">entropy length</td>
       <td class="left">value </td>
@@ -1005,9 +1017,95 @@
     </tr>
   </tbody>
 </table>
+<p id="rfc.section.3.1.p.3">Note 9: According to SP 800-90A <a href="#SP800-90A">[SP800-90A]</a>, a DRBG implementation has two separate controls for determining the correct test procedure for handling addtional entropy and other data in providing prediction resistance assurances. Depending on the capabilities advertised by the predResistanceEnabled and reseedImplemented flags ACVP generates test data according to the following test scenarios:      </p>
+<div id="rfc.table.6"/>
+<div id="tests_table"/>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <caption>Test Procedures for Supported Prediction Resistance Options</caption>
+  <thead>
+    <tr>
+      <th class="left">Prediction Resistance Assurance  Options</th>
+      <th class="left">Test Procedure</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">"predResistanceEnabled" : "yes"; "reseedImplemented": "yes" </td>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Instantiate DRBG</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate but don't output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Uninstantiate</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">"predResistanceEnabled" : "no"; "reseedImplemented" : "yes"</td>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Instantiate DRBG</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Reseed</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate but don't output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Uninstantiate</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">"predResistanceEnabled" : "yes"/"no"; "reseedImplemented": "no"</td>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Instantiate DRBG</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate but don't output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Uninstantiate</td>
+    </tr>
+  </tbody>
+</table>
 <h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a></h1>
 <p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single vector to be processed by the ACVP client.  The following table describes the JSON elements for each test case.</p>
-<div id="rfc.table.6"/>
+<div id="rfc.table.7"/>
 <div id="vs_tc_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>DRBG Test Case JSON Object</caption>
@@ -1070,14 +1168,26 @@
     </tr>
     <tr>
       <td class="left">predResistanceInput</td>
-      <td class="left">array of additonal input/entropy input value pairs for prediction resistance testing. See <a href="#vs_prtc_table">Table 7</a></td>
+      <td class="left">array of additonal input/entropy input value pairs for prediction resistance testing. See <a href="#vs_prtc_table">Table 8</a></td>
+      <td class="left">array</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">reseedInput</td>
+      <td class="left">array of additonal input/entropy input value pairs for reseeding testing. See <a href="#vs_prtc_table">Table 8</a></td>
       <td class="left">array</td>
       <td class="left">No</td>
     </tr>
   </tbody>
 </table>
 <p id="rfc.section.3.2.p.2">Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
-<div id="rfc.table.7"/>
+<div id="rfc.table.8"/>
 <div id="vs_prtc_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Prediction Resistance Test Case JSON Object</caption>
@@ -1112,7 +1222,7 @@
 </table>
 <h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a></h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.8"/>
+<div id="rfc.table.9"/>
 <div id="vr_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Vector Set Response JSON Object</caption>
@@ -1152,7 +1262,7 @@
   </tbody>
 </table>
 <p id="rfc.section.4.p.2">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG test vector.</p>
-<div id="rfc.table.9"/>
+<div id="rfc.table.10"/>
 <div id="vs_tr_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>DRBG Test Case Results JSON Object</caption>
@@ -1446,6 +1556,55 @@
                   ]
                 }
             </pre>
+<p id="rfc.section.B.p.4">The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", option.</p>
+<pre>
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1157",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",                  
+                      "tests": [
+                        {
+                          "tcId": "3151",
+                          "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
+                          "nonce":"5813070f9774d21e644d64e8d291b511",
+                          "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
+                          "reseedInput" : [
+                               {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                                "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
+                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                                "entropyInput" : ""}
+                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "3152",
+                          "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
+                          "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
+                          "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
+                          "reseedInput" : [
+                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                              "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
+                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                              "entropyInput" : ""}
+                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+            </pre>
 <h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Object</a></h1>
 <p id="rfc.section.C.p.1">The following is a example JSON object for ctrDRBG with 3KeyTDEA test results sent from the crypto module to the ACVP server.</p>
 <pre>
@@ -1495,6 +1654,23 @@
                        {
                             "tcId": "2152",
                             "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
+                       }
+                    ]
+                }
+            </pre>
+<p id="rfc.section.C.p.4">The following is a example JSON object for hashDRBG test results sent from the crypto module to the ACVP server.</p>
+<pre>
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1157",
+                    "testResults": [
+                        {
+                            "tcId": "3151",
+                            "returnedBits ": "0eadc82746890ee0b6c20b10016e2fd037073d952ed075d1ad4c53f6971ee6405ec40f6fd090c639a800ab9092f537913608787fbc77efd0465a84688da189f14c0d2adba5953f07ea463f4a772bb1f52a3c589cd89231acf0ff06269611f7a908eb171143d5a78d0fb7dca8326d235f3f4f3f25a0a69f0a596d6dbac1eb0cdc"
+                        },
+                       {
+                            "tcId": "3152",
+                            "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
                        }
                     ]
                 }

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                            March 20, 2017
-Expires: September 21, 2017
+Intended status: Informational                            March 21, 2017
+Expires: September 22, 2017
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 21, 2017.
+   This Internet-Draft will expire on September 22, 2017.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev               Expires September 21, 2017               [Page 1]
+Vassilev               Expires September 22, 2017               [Page 1]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -69,16 +69,16 @@ Table of Contents
      2.3.  Supported DRBG Algorithm Capabilities . . . . . . . . . .   4
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   8
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  10
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  12
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  13
-   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  13
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  16
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  19
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  20
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  11
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  13
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  14
+   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  14
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  17
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  22
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Vassilev               Expires September 21, 2017               [Page 2]
+Vassilev               Expires September 22, 2017               [Page 2]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -165,7 +165,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 3]
+Vassilev               Expires September 22, 2017               [Page 3]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -221,7 +221,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 4]
+Vassilev               Expires September 22, 2017               [Page 4]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -277,7 +277,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 5]
+Vassilev               Expires September 22, 2017               [Page 5]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -333,7 +333,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 6]
+Vassilev               Expires September 22, 2017               [Page 6]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -389,7 +389,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 7]
+Vassilev               Expires September 22, 2017               [Page 7]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -445,7 +445,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 8]
+Vassilev               Expires September 22, 2017               [Page 8]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -501,7 +501,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 9]
+Vassilev               Expires September 22, 2017               [Page 9]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -517,6 +517,9 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                   | or not                    | yes/no |          |
    |                   |                           |        |          |
    | predResistance    | use prediction resistance | value  | No       |
+   |                   |                           | yes/no |          |
+   |                   |                           |        |          |
+   | reSeed            | use reseeding             | value  | No       |
    |                   |                           | yes/no |          |
    |                   |                           |        |          |
    | entropyInputLen   | entropy length            | value  | No       |
@@ -541,6 +544,53 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
                       Table 5: Test Group JSON Object
 
+   Note 9: According to SP 800-90A [SP800-90A], a DRBG implementation
+   has two separate controls for determining the correct test procedure
+   for handling addtional entropy and other data in providing prediction
+   resistance assurances.  Depending on the capabilities advertised by
+   the predResistanceEnabled and reseedImplemented flags ACVP generates
+   test data according to the following test scenarios:
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 10]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+   +---------------------------------------+---------------------------+
+   | Prediction Resistance Assurance       | Test Procedure            |
+   | Options                               |                           |
+   +---------------------------------------+---------------------------+
+   | "predResistanceEnabled" : "yes";      |                           |
+   | "reseedImplemented": "yes"            |                           |
+   |                                       | Instantiate DRBG          |
+   |                                       | Generate but don't output |
+   |                                       | Generate output           |
+   |                                       | Uninstantiate             |
+   |                                       |                           |
+   | "predResistanceEnabled" : "no";       |                           |
+   | "reseedImplemented" : "yes"           |                           |
+   |                                       | Instantiate DRBG          |
+   |                                       | Reseed                    |
+   |                                       | Generate but don't output |
+   |                                       | Generate output           |
+   |                                       | Uninstantiate             |
+   |                                       |                           |
+   | "predResistanceEnabled" : "yes"/"no"; |                           |
+   | "reseedImplemented": "no"             |                           |
+   |                                       | Instantiate DRBG          |
+   |                                       | Generate but don't output |
+   |                                       | Generate output           |
+   |                                       | Uninstantiate             |
+   +---------------------------------------+---------------------------+
+
+   Table 6: Test Procedures for Supported Prediction Resistance Options
+
 3.2.  Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
@@ -557,7 +607,13 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 10]
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 11]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -582,16 +638,41 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                     | input/entropy input      |       |          |
    |                     | value pairs for          |       |          |
    |                     | prediction resistance    |       |          |
-   |                     | testing. See Table 7     |       |          |
+   |                     | testing. See Table 8     |       |          |
+   |                     |                          |       |          |
+   | reseedInput         | array of additonal       | array | No       |
+   |                     | input/entropy input      |       |          |
+   |                     | value pairs for          |       |          |
+   |                     | reseeding testing. See   |       |          |
+   |                     | Table 8                  |       |          |
    +---------------------+--------------------------+-------+----------+
 
-                    Table 6: DRBG Test Case JSON Object
+                    Table 7: DRBG Test Case JSON Object
 
    Each prediction resistance test group contains an array of one or
    more test vectors, typically two.  Each test vector is a JSON object
    that represents a single test case to be processed by the ACVP
    client.  The following table describes the JSON elements for each
    DRBG predcition resistance test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 12]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    +-----------------+------------------------------+-------+----------+
    | JSON Value      | Description                  | JSON  | Optional |
@@ -606,17 +687,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                 | resistance tests             |       |          |
    +-----------------+------------------------------+-------+----------+
 
-           Table 7: Prediction Resistance Test Case JSON Object
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 11]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
+           Table 8: Prediction Resistance Test Case JSON Object
 
 4.  Test Vector Responses
 
@@ -639,12 +710,25 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |             | JSON schema as defined in Section 3.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 8: Vector Set Response JSON Object
+                 Table 9: Vector Set Response JSON Object
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each DRBG test vector.
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 13]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    +--------------+---------------------------------+-------+----------+
    | JSON Value   | Description                     | JSON  | Optional |
@@ -658,21 +742,11 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |              | output                          |       |          |
    +--------------+---------------------------------+-------+----------+
 
-                Table 9: DRBG Test Case Results JSON Object
+               Table 10: DRBG Test Case Results JSON Object
 
 5.  Acknowledgements
 
    TBD...
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 12]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
 
 6.  IANA Considerations
 
@@ -707,25 +781,7 @@ Appendix A.  Example DRBG Capabilities JSON Object
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 13]
+Vassilev               Expires September 22, 2017              [Page 14]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -781,7 +837,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 14]
+Vassilev               Expires September 22, 2017              [Page 15]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -837,7 +893,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 15]
+Vassilev               Expires September 22, 2017              [Page 16]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -893,7 +949,7 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-Vassilev               Expires September 21, 2017              [Page 16]
+Vassilev               Expires September 22, 2017              [Page 17]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -949,7 +1005,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 17]
+Vassilev               Expires September 22, 2017              [Page 18]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1005,7 +1061,119 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 18]
+Vassilev               Expires September 22, 2017              [Page 19]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+   The following is a example JSON object for hashDRBG test vectors sent
+   from the ACVP server to the crypto module.  In this example the
+   implementation is tested with "predResistance": "no", option.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 20]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1157",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",
+                      "tests": [
+                        {
+                          "tcId": "3151",
+                          "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
+                          "nonce":"5813070f9774d21e644d64e8d291b511",
+                          "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
+                          "reseedInput" : [
+                               {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                                "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
+                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                                "entropyInput" : ""}
+                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "3152",
+                          "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
+                          "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
+                          "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
+                          "reseedInput" : [
+                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                              "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
+                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                              "entropyInput" : ""}
+                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 21]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1061,7 +1229,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev               Expires September 21, 2017              [Page 19]
+Vassilev               Expires September 22, 2017              [Page 22]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1077,6 +1245,24 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                        {
                             "tcId": "2152",
                             "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
+                       }
+                    ]
+                }
+
+   The following is a example JSON object for hashDRBG test results sent
+   from the crypto module to the ACVP server.
+
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1157",
+                    "testResults": [
+                        {
+                            "tcId": "3151",
+                            "returnedBits ": "0eadc82746890ee0b6c20b10016e2fd037073d952ed075d1ad4c53f6971ee6405ec40f6fd090c639a800ab9092f537913608787fbc77efd0465a84688da189f14c0d2adba5953f07ea463f4a772bb1f52a3c589cd89231acf0ff06269611f7a908eb171143d5a78d0fb7dca8326d235f3f4f3f25a0a69f0a596d6dbac1eb0cdc"
+                        },
+                       {
+                            "tcId": "3152",
+                            "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
                        }
                     ]
                 }
@@ -1099,22 +1285,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 20]
+Vassilev               Expires September 22, 2017              [Page 23]

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -460,7 +460,15 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>use prediction resistance</c>
 		<c>value yes/no</c>
 		<c>No</c>
-<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>reSeed</c>
+		<c>use reseeding</c>
+		<c>value yes/no</c>
+		<c>No</c>
+    <c/>
 		<c/>
 		<c/>
 		<c/>
@@ -509,6 +517,45 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>array</c>
 		<c>No</c>
 	    </texttable>
+  <t>Note 9: According to SP 800-90A <xref target="SP800-90A"/>, a DRBG implementation has two separate controls for determining the correct test procedure for handling 
+      addtional entropy and other data in providing prediction resistance assurances. Depending on the capabilities advertised by the predResistanceEnabled and reseedImplemented flags ACVP generates test data according to the following test scenarios:      </t>
+
+      <texttable anchor="tests_table" title="Test Procedures for Supported Prediction Resistance Options">
+          <ttcol align="left" width="60%">Prediction Resistance Assurance  Options</ttcol>
+          <ttcol align="left" width="40%">Test Procedure</ttcol>
+          <c>"predResistanceEnabled" : "yes"; "reseedImplemented": "yes" </c>
+          <c/><c/>
+          <c>Instantiate DRBG</c>
+          <c/>
+          <c>Generate but don't output</c>
+          <c/>
+          <c>Generate output</c>
+          <c/>
+          <c>Uninstantiate</c>
+           <c/><c/>
+          <c>"predResistanceEnabled" : "no"; "reseedImplemented" : "yes"</c>
+           <c/><c/>
+          <c>Instantiate DRBG</c>
+          <c/>
+          <c>Reseed</c>
+          <c/>
+          <c>Generate but don't output</c>
+          <c/>
+          <c>Generate output</c>
+          <c/>
+          <c>Uninstantiate</c>
+           <c/><c/>
+          <c>"predResistanceEnabled" : "yes"/"no"; "reseedImplemented": "no"</c>
+           <c/><c/>
+          <c>Instantiate DRBG</c>
+          <c/>
+          <c>Generate but don't output</c>
+          <c/>
+          <c>Generate output</c>
+          <c/>
+          <c>Uninstantiate</c>
+</texttable>
+      
 
 	</section>
 
@@ -558,7 +605,15 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>array of additonal input/entropy input value pairs for prediction resistance testing. See <xref target="vs_prtc_table"/></c>
 		<c>array</c>
 		<c>No</c>
-		
+		<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>reseedInput</c>
+		<c>array of additonal input/entropy input value pairs for reseeding testing. See <xref target="vs_prtc_table"/></c>
+		<c>array</c>
+		<c>No</c>
+				
 	    </texttable>
 
 	    <t>Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object
@@ -944,6 +999,57 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 }
             ]]></artwork>
     </figure>   
+    <t>The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", option.</t>
+      <figure>
+        <artwork><![CDATA[
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1157",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",                  
+                      "tests": [
+                        {
+                          "tcId": "3151",
+                          "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
+                          "nonce":"5813070f9774d21e644d64e8d291b511",
+                          "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
+                          "reseedInput" : [
+                               {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                                "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
+                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                                "entropyInput" : ""}
+                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "3152",
+                          "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
+                          "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
+                          "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
+                          "reseedInput" : [
+                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                              "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
+                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                              "entropyInput" : ""}
+                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+            ]]></artwork>
+    </figure>   
 </section>
      <section anchor="app-results-ex" title="Example Test Results JSON Object">
       <t>The following is a example JSON object for ctrDRBG with 3KeyTDEA test results sent from the crypto module to the ACVP server.</t>
@@ -999,6 +1105,25 @@ the bit lengths the supported values shall be specified explicitly. </t>
                        {
                             "tcId": "2152",
                             "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
+                       }
+                    ]
+                }
+            ]]></artwork>
+    </figure>
+          <t>The following is a example JSON object for hashDRBG test results sent from the crypto module to the ACVP server.</t>
+      <figure>
+        <artwork><![CDATA[
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1157",
+                    "testResults": [
+                        {
+                            "tcId": "3151",
+                            "returnedBits ": "0eadc82746890ee0b6c20b10016e2fd037073d952ed075d1ad4c53f6971ee6405ec40f6fd090c639a800ab9092f537913608787fbc77efd0465a84688da189f14c0d2adba5953f07ea463f4a772bb1f52a3c589cd89231acf0ff06269611f7a908eb171143d5a78d0fb7dca8326d235f3f4f3f25a0a69f0a596d6dbac1eb0cdc"
+                        },
+                       {
+                            "tcId": "3152",
+                            "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
                        }
                     ]
                 }


### PR DESCRIPTION
Added schema enahancements and new examples for supporting reseed-only option. This PR addresses #82. 