### PR TITLE
Introduce explict flags for testing mode

### DIFF
--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,7 +400,7 @@
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-3-20" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-3-21" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">March 20, 2017</td>
+  <td class="right">March 21, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: September 21, 2017</td>
+  <td class="left">Expires: September 22, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -445,7 +445,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 21, 2017.</p>
+<p>This Internet-Draft will expire on September 22, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -938,6 +938,18 @@
       <td class="left"/>
     </tr>
     <tr>
+      <td class="left">reSeed</td>
+      <td class="left">use reseeding</td>
+      <td class="left">value yes/no</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
       <td class="left">entropyInputLen</td>
       <td class="left">entropy length</td>
       <td class="left">value </td>
@@ -1005,9 +1017,95 @@
     </tr>
   </tbody>
 </table>
+<p id="rfc.section.3.1.p.3">Note 9: According to SP 800-90A <a href="#SP800-90A">[SP800-90A]</a>, a DRBG implementation has two separate controls for determining the correct test procedure for handling addtional entropy and other data in providing prediction resistance assurances. Depending on the capabilities advertised by the predResistanceEnabled and reseedImplemented flags ACVP generates test data according to the following test scenarios:      </p>
+<div id="rfc.table.6"/>
+<div id="tests_table"/>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <caption>Test Procedures for Supported Prediction Resistance Options</caption>
+  <thead>
+    <tr>
+      <th class="left">Prediction Resistance Assurance  Options</th>
+      <th class="left">Test Procedure</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">"predResistanceEnabled" : "yes"; "reseedImplemented": "yes" </td>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Instantiate DRBG</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate but don't output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Uninstantiate</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">"predResistanceEnabled" : "no"; "reseedImplemented" : "yes"</td>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Instantiate DRBG</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Reseed</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate but don't output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Uninstantiate</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">"predResistanceEnabled" : "yes"/"no"; "reseedImplemented": "no"</td>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Instantiate DRBG</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate but don't output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Generate output</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left">Uninstantiate</td>
+    </tr>
+  </tbody>
+</table>
 <h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a></h1>
 <p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single vector to be processed by the ACVP client.  The following table describes the JSON elements for each test case.</p>
-<div id="rfc.table.6"/>
+<div id="rfc.table.7"/>
 <div id="vs_tc_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>DRBG Test Case JSON Object</caption>
@@ -1070,14 +1168,26 @@
     </tr>
     <tr>
       <td class="left">predResistanceInput</td>
-      <td class="left">array of additonal input/entropy input value pairs for prediction resistance testing. See <a href="#vs_prtc_table">Table 7</a></td>
+      <td class="left">array of additonal input/entropy input value pairs for prediction resistance testing. See <a href="#vs_prtc_table">Table 8</a></td>
+      <td class="left">array</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">reseedInput</td>
+      <td class="left">array of additonal input/entropy input value pairs for reseeding testing. See <a href="#vs_prtc_table">Table 8</a></td>
       <td class="left">array</td>
       <td class="left">No</td>
     </tr>
   </tbody>
 </table>
 <p id="rfc.section.3.2.p.2">Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
-<div id="rfc.table.7"/>
+<div id="rfc.table.8"/>
 <div id="vs_prtc_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Prediction Resistance Test Case JSON Object</caption>
@@ -1112,7 +1222,7 @@
 </table>
 <h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a></h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.8"/>
+<div id="rfc.table.9"/>
 <div id="vr_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Vector Set Response JSON Object</caption>
@@ -1152,7 +1262,7 @@
   </tbody>
 </table>
 <p id="rfc.section.4.p.2">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG test vector.</p>
-<div id="rfc.table.9"/>
+<div id="rfc.table.10"/>
 <div id="vs_tr_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>DRBG Test Case Results JSON Object</caption>
@@ -1446,6 +1556,55 @@
                   ]
                 }
             </pre>
+<p id="rfc.section.B.p.4">The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", option.</p>
+<pre>
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1157",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",                  
+                      "tests": [
+                        {
+                          "tcId": "3151",
+                          "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
+                          "nonce":"5813070f9774d21e644d64e8d291b511",
+                          "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
+                          "reseedInput" : [
+                               {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                                "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
+                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                                "entropyInput" : ""}
+                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "3152",
+                          "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
+                          "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
+                          "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
+                          "reseedInput" : [
+                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                              "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
+                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                              "entropyInput" : ""}
+                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+            </pre>
 <h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Object</a></h1>
 <p id="rfc.section.C.p.1">The following is a example JSON object for ctrDRBG with 3KeyTDEA test results sent from the crypto module to the ACVP server.</p>
 <pre>
@@ -1495,6 +1654,23 @@
                        {
                             "tcId": "2152",
                             "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
+                       }
+                    ]
+                }
+            </pre>
+<p id="rfc.section.C.p.4">The following is a example JSON object for hashDRBG test results sent from the crypto module to the ACVP server.</p>
+<pre>
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1157",
+                    "testResults": [
+                        {
+                            "tcId": "3151",
+                            "returnedBits ": "0eadc82746890ee0b6c20b10016e2fd037073d952ed075d1ad4c53f6971ee6405ec40f6fd090c639a800ab9092f537913608787fbc77efd0465a84688da189f14c0d2adba5953f07ea463f4a772bb1f52a3c589cd89231acf0ff06269611f7a908eb171143d5a78d0fb7dca8326d235f3f4f3f25a0a69f0a596d6dbac1eb0cdc"
+                        },
+                       {
+                            "tcId": "3152",
+                            "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
                        }
                     ]
                 }

--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,7 +400,7 @@
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-3-21" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-3-23" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">March 21, 2017</td>
+  <td class="right">March 23, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: September 22, 2017</td>
+  <td class="left">Expires: September 24, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -445,7 +445,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 22, 2017.</p>
+<p>This Internet-Draft will expire on September 24, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -1167,20 +1167,8 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">predResistanceInput</td>
-      <td class="left">array of additonal input/entropy input value pairs for prediction resistance testing. See <a href="#vs_prtc_table">Table 8</a></td>
-      <td class="left">array</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">reseedInput</td>
-      <td class="left">array of additonal input/entropy input value pairs for reseeding testing. See <a href="#vs_prtc_table">Table 8</a></td>
+      <td class="left">otherInput</td>
+      <td class="left">array of additonal input/entropy input value pairs for testing. See <a href="#vs_prtc_table">Table 8</a></td>
       <td class="left">array</td>
       <td class="left">No</td>
     </tr>
@@ -1431,6 +1419,7 @@
                     {
                       "derFunc":"yes",
                       "predResistance": "yes",
+                      "reSeed": "yes",
                       "entropyInputLen":"112",
                       "nonceLen":"56",
                       "persoStringLen":"112",
@@ -1442,7 +1431,7 @@
                           "entropyInput":"78aac2cb444594e29dc97b0195b5",
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
                             {"additionalInput" : "f5357737023e3304508a00b3ba02",
@@ -1454,7 +1443,7 @@
                           "entropyInput" : "b8ab88b9c5fda8544b90a043684e",
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
                              {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
@@ -1476,6 +1465,7 @@
                   "testGroups": [
                     {
                       "predResistance": "yes",
+                      "reSeed": "no",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"256",
@@ -1487,7 +1477,7 @@
                           "entropyInput":"ee3392c5f3de6f3f8c4f28d852afacd2cbaa89ed48d1c5d4311662962aa70a98",
                           "nonce":"b991a820fac75fd02642ad8fa651eda4",
                           "persoString":"30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
                              {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
@@ -1499,7 +1489,7 @@
                           "entropyInput" : "a0ace75784b97224de2957e5f60dc85b25331fcf7901f37418d3c9de17ed4261",
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
@@ -1521,6 +1511,7 @@
                   "testGroups": [
                     {
                       "predResistance": "yes",
+                      "reSeed": "no",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"0",
@@ -1532,7 +1523,7 @@
                           "entropyInput":"ae0a3acd541d0d582a8510f3028caa143fe1e5226a8469d40b979d3a0d1bbe69",
                           "nonce":"786f03ad697332d74fad7a14604cee44",
                           "persoString":"",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                                {"additionalInput":"",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
                                {"additionalInput" : "",
@@ -1544,7 +1535,7 @@
                           "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
                              {"additionalInput" : "",
@@ -1556,7 +1547,7 @@
                   ]
                 }
             </pre>
-<p id="rfc.section.B.p.4">The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", option.</p>
+<p id="rfc.section.B.p.4">The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", "reSeed" : "yes" options.</p>
 <pre>
                 {
                   "version": "0.2",
@@ -1566,6 +1557,7 @@
                   "testGroups": [
                     {
                       "predResistance": "no",
+                      "reSeed": "yes",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"256",
@@ -1577,11 +1569,11 @@
                           "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
                           "nonce":"5813070f9774d21e644d64e8d291b511",
                           "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
-                          "reseedInput" : [
+                          "otherInput" : [
                                {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
-                                "entropyInput" : ""}
+                                "entropyInput" : ""},
                                {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
                                 "entropyInput" : ""}
                             ]
@@ -1591,12 +1583,58 @@
                           "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
-                          "reseedInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
                              {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
-                              "entropyInput" : ""}
+                              "entropyInput" : ""},
                              {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+            </pre>
+<p id="rfc.section.B.p.5">The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", "reSeed" : "no" options.</p>
+<pre>
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1167",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "reSeed": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",                  
+                      "tests": [
+                        {
+                          "tcId": "4151",
+                          "entropyInput":"090db63c22de171068527c6ad049e4aade69d5b590efb8f582604e6e07a2c2dc",
+                          "nonce":"6f7c6bec9825079cabd9478d88f337c8",
+                          "persoString":"c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
+                          "otherInput" : [
+                               {"additionalInput":"3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
+                                "entropyInput": ""},
+                               {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "4152",
+                          "entropyInput" : "bd0e2dbba872bb62ca2897be7fd038f5c7162eb9358ef970f120ea32f6fd3cb9",
+                          "nonce": "a97dfbaea505a3e36210a85636197b2d",
+                          "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
+                          "otherInput" : [
+                             {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
+                              "entropyInput" : ""},
+                             {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
                               "entropyInput" : ""}
                           ]
                         }
@@ -1671,6 +1709,23 @@
                        {
                             "tcId": "3152",
                             "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
+                       }
+                    ]
+                }
+            </pre>
+<p id="rfc.section.C.p.5">The following is a example JSON object for hashDRBG test results sent from the crypto module to the ACVP server.</p>
+<pre>
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1167",
+                    "testResults": [
+                        {
+                            "tcId": "4151",
+                            "returnedBits ": "5dbfd26651bc71597e8f5b06c650bbf2c8117c0735bd903027628b7d7e0658abb818ad63f67d5d9f38f3bc976a0d3c89764122acf3b6a704cd9af0c3ebbde3cd90e4787a4b90267752e5585188f572b2a7f7dfa424cf05f5a2bf49540b90a887af4b352ddf226ee62809f329652faba219c27b430172feb58b875d2611324f9e"
+                        },
+                       {
+                            "tcId": "4152",
+                            "returnedBits": "ff3cce0b5585172b1f93b22a00d9757f60f15f773b33a93b40f01a5e00328dcc78e8827897ec141132104dfb670b0d8ce7a60ab66e89aa5322ea3a497a6861dc0457ab86b1c28c290cef05fd52a78641172f5ef5a1511d31c8eeb9373cb0098c24e12abe3f907a1633f21defdfd2b232dedca7035de0bda31585d0b0321a9009"
                        }
                     ]
                 }

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                            March 20, 2017
-Expires: September 21, 2017
+Intended status: Informational                            March 21, 2017
+Expires: September 22, 2017
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 21, 2017.
+   This Internet-Draft will expire on September 22, 2017.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev               Expires September 21, 2017               [Page 1]
+Vassilev               Expires September 22, 2017               [Page 1]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -69,16 +69,16 @@ Table of Contents
      2.3.  Supported DRBG Algorithm Capabilities . . . . . . . . . .   4
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   8
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  10
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  12
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  13
-   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  13
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  16
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  19
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  20
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  11
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  13
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  14
+   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  14
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  17
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  22
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Vassilev               Expires September 21, 2017               [Page 2]
+Vassilev               Expires September 22, 2017               [Page 2]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -165,7 +165,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 3]
+Vassilev               Expires September 22, 2017               [Page 3]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -221,7 +221,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 4]
+Vassilev               Expires September 22, 2017               [Page 4]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -277,7 +277,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 5]
+Vassilev               Expires September 22, 2017               [Page 5]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -333,7 +333,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 6]
+Vassilev               Expires September 22, 2017               [Page 6]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -389,7 +389,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 7]
+Vassilev               Expires September 22, 2017               [Page 7]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -445,7 +445,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 8]
+Vassilev               Expires September 22, 2017               [Page 8]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -501,7 +501,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017               [Page 9]
+Vassilev               Expires September 22, 2017               [Page 9]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -517,6 +517,9 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                   | or not                    | yes/no |          |
    |                   |                           |        |          |
    | predResistance    | use prediction resistance | value  | No       |
+   |                   |                           | yes/no |          |
+   |                   |                           |        |          |
+   | reSeed            | use reseeding             | value  | No       |
    |                   |                           | yes/no |          |
    |                   |                           |        |          |
    | entropyInputLen   | entropy length            | value  | No       |
@@ -541,6 +544,53 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
                       Table 5: Test Group JSON Object
 
+   Note 9: According to SP 800-90A [SP800-90A], a DRBG implementation
+   has two separate controls for determining the correct test procedure
+   for handling addtional entropy and other data in providing prediction
+   resistance assurances.  Depending on the capabilities advertised by
+   the predResistanceEnabled and reseedImplemented flags ACVP generates
+   test data according to the following test scenarios:
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 10]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+   +---------------------------------------+---------------------------+
+   | Prediction Resistance Assurance       | Test Procedure            |
+   | Options                               |                           |
+   +---------------------------------------+---------------------------+
+   | "predResistanceEnabled" : "yes";      |                           |
+   | "reseedImplemented": "yes"            |                           |
+   |                                       | Instantiate DRBG          |
+   |                                       | Generate but don't output |
+   |                                       | Generate output           |
+   |                                       | Uninstantiate             |
+   |                                       |                           |
+   | "predResistanceEnabled" : "no";       |                           |
+   | "reseedImplemented" : "yes"           |                           |
+   |                                       | Instantiate DRBG          |
+   |                                       | Reseed                    |
+   |                                       | Generate but don't output |
+   |                                       | Generate output           |
+   |                                       | Uninstantiate             |
+   |                                       |                           |
+   | "predResistanceEnabled" : "yes"/"no"; |                           |
+   | "reseedImplemented": "no"             |                           |
+   |                                       | Instantiate DRBG          |
+   |                                       | Generate but don't output |
+   |                                       | Generate output           |
+   |                                       | Uninstantiate             |
+   +---------------------------------------+---------------------------+
+
+   Table 6: Test Procedures for Supported Prediction Resistance Options
+
 3.2.  Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
@@ -557,7 +607,13 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 10]
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 11]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -582,16 +638,41 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                     | input/entropy input      |       |          |
    |                     | value pairs for          |       |          |
    |                     | prediction resistance    |       |          |
-   |                     | testing. See Table 7     |       |          |
+   |                     | testing. See Table 8     |       |          |
+   |                     |                          |       |          |
+   | reseedInput         | array of additonal       | array | No       |
+   |                     | input/entropy input      |       |          |
+   |                     | value pairs for          |       |          |
+   |                     | reseeding testing. See   |       |          |
+   |                     | Table 8                  |       |          |
    +---------------------+--------------------------+-------+----------+
 
-                    Table 6: DRBG Test Case JSON Object
+                    Table 7: DRBG Test Case JSON Object
 
    Each prediction resistance test group contains an array of one or
    more test vectors, typically two.  Each test vector is a JSON object
    that represents a single test case to be processed by the ACVP
    client.  The following table describes the JSON elements for each
    DRBG predcition resistance test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 12]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    +-----------------+------------------------------+-------+----------+
    | JSON Value      | Description                  | JSON  | Optional |
@@ -606,17 +687,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                 | resistance tests             |       |          |
    +-----------------+------------------------------+-------+----------+
 
-           Table 7: Prediction Resistance Test Case JSON Object
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 11]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
+           Table 8: Prediction Resistance Test Case JSON Object
 
 4.  Test Vector Responses
 
@@ -639,12 +710,25 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |             | JSON schema as defined in Section 3.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 8: Vector Set Response JSON Object
+                 Table 9: Vector Set Response JSON Object
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each DRBG test vector.
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 13]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    +--------------+---------------------------------+-------+----------+
    | JSON Value   | Description                     | JSON  | Optional |
@@ -658,21 +742,11 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |              | output                          |       |          |
    +--------------+---------------------------------+-------+----------+
 
-                Table 9: DRBG Test Case Results JSON Object
+               Table 10: DRBG Test Case Results JSON Object
 
 5.  Acknowledgements
 
    TBD...
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 12]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
 
 6.  IANA Considerations
 
@@ -707,25 +781,7 @@ Appendix A.  Example DRBG Capabilities JSON Object
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 13]
+Vassilev               Expires September 22, 2017              [Page 14]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -781,7 +837,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 14]
+Vassilev               Expires September 22, 2017              [Page 15]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -837,7 +893,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 15]
+Vassilev               Expires September 22, 2017              [Page 16]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -893,7 +949,7 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-Vassilev               Expires September 21, 2017              [Page 16]
+Vassilev               Expires September 22, 2017              [Page 17]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -949,7 +1005,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 17]
+Vassilev               Expires September 22, 2017              [Page 18]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1005,7 +1061,119 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 21, 2017              [Page 18]
+Vassilev               Expires September 22, 2017              [Page 19]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+   The following is a example JSON object for hashDRBG test vectors sent
+   from the ACVP server to the crypto module.  In this example the
+   implementation is tested with "predResistance": "no", option.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 20]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1157",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",
+                      "tests": [
+                        {
+                          "tcId": "3151",
+                          "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
+                          "nonce":"5813070f9774d21e644d64e8d291b511",
+                          "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
+                          "reseedInput" : [
+                               {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                                "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
+                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                                "entropyInput" : ""}
+                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "3152",
+                          "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
+                          "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
+                          "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
+                          "reseedInput" : [
+                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                              "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
+                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                              "entropyInput" : ""}
+                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+
+
+
+
+
+Vassilev               Expires September 22, 2017              [Page 21]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1061,7 +1229,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev               Expires September 21, 2017              [Page 19]
+Vassilev               Expires September 22, 2017              [Page 22]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1077,6 +1245,24 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                        {
                             "tcId": "2152",
                             "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
+                       }
+                    ]
+                }
+
+   The following is a example JSON object for hashDRBG test results sent
+   from the crypto module to the ACVP server.
+
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1157",
+                    "testResults": [
+                        {
+                            "tcId": "3151",
+                            "returnedBits ": "0eadc82746890ee0b6c20b10016e2fd037073d952ed075d1ad4c53f6971ee6405ec40f6fd090c639a800ab9092f537913608787fbc77efd0465a84688da189f14c0d2adba5953f07ea463f4a772bb1f52a3c589cd89231acf0ff06269611f7a908eb171143d5a78d0fb7dca8326d235f3f4f3f25a0a69f0a596d6dbac1eb0cdc"
+                        },
+                       {
+                            "tcId": "3152",
+                            "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
                        }
                     ]
                 }
@@ -1099,22 +1285,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires September 21, 2017              [Page 20]
+Vassilev               Expires September 22, 2017              [Page 23]

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                            March 21, 2017
-Expires: September 22, 2017
+Intended status: Informational                            March 23, 2017
+Expires: September 24, 2017
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 22, 2017.
+   This Internet-Draft will expire on September 24, 2017.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev               Expires September 22, 2017               [Page 1]
+Vassilev               Expires September 24, 2017               [Page 1]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -70,15 +70,15 @@ Table of Contents
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   8
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  11
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  13
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  12
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
    8.  Normative References  . . . . . . . . . . . . . . . . . . . .  14
    Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  14
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  17
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  22
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  23
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  23
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  25
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Vassilev               Expires September 22, 2017               [Page 2]
+Vassilev               Expires September 24, 2017               [Page 2]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -165,7 +165,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 3]
+Vassilev               Expires September 24, 2017               [Page 3]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -221,7 +221,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 4]
+Vassilev               Expires September 24, 2017               [Page 4]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -277,7 +277,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 5]
+Vassilev               Expires September 24, 2017               [Page 5]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -333,7 +333,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 6]
+Vassilev               Expires September 24, 2017               [Page 6]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -389,7 +389,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 7]
+Vassilev               Expires September 24, 2017               [Page 7]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -445,7 +445,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 8]
+Vassilev               Expires September 24, 2017               [Page 8]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -501,7 +501,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017               [Page 9]
+Vassilev               Expires September 24, 2017               [Page 9]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -557,7 +557,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017              [Page 10]
+Vassilev               Expires September 24, 2017              [Page 10]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -613,39 +613,30 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017              [Page 11]
+Vassilev               Expires September 24, 2017              [Page 11]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
 
-   +---------------------+--------------------------+-------+----------+
-   | JSON Value          | Description              | JSON  | Optional |
-   |                     |                          | type  |          |
-   +---------------------+--------------------------+-------+----------+
-   | tcId                | Numeric identifier for   | value | No       |
-   |                     | the test case, unique    |       |          |
-   |                     | across the entire vector |       |          |
-   |                     | set.                     |       |          |
-   |                     |                          |       |          |
-   | entropyInput        | entropy value            | value | No       |
-   |                     |                          |       |          |
-   | nonce               | Value of the nonce       | value | No       |
-   |                     |                          |       |          |
-   | persoString         | value of the             | value | No       |
-   |                     | personlization string    |       |          |
-   |                     |                          |       |          |
-   | predResistanceInput | array of additonal       | array | No       |
-   |                     | input/entropy input      |       |          |
-   |                     | value pairs for          |       |          |
-   |                     | prediction resistance    |       |          |
-   |                     | testing. See Table 8     |       |          |
-   |                     |                          |       |          |
-   | reseedInput         | array of additonal       | array | No       |
-   |                     | input/entropy input      |       |          |
-   |                     | value pairs for          |       |          |
-   |                     | reseeding testing. See   |       |          |
-   |                     | Table 8                  |       |          |
-   +---------------------+--------------------------+-------+----------+
+   +--------------+---------------------------------+-------+----------+
+   | JSON Value   | Description                     | JSON  | Optional |
+   |              |                                 | type  |          |
+   +--------------+---------------------------------+-------+----------+
+   | tcId         | Numeric identifier for the test | value | No       |
+   |              | case, unique across the entire  |       |          |
+   |              | vector set.                     |       |          |
+   |              |                                 |       |          |
+   | entropyInput | entropy value                   | value | No       |
+   |              |                                 |       |          |
+   | nonce        | Value of the nonce              | value | No       |
+   |              |                                 |       |          |
+   | persoString  | value of the personlization     | value | No       |
+   |              | string                          |       |          |
+   |              |                                 |       |          |
+   | otherInput   | array of additonal              | array | No       |
+   |              | input/entropy input value pairs |       |          |
+   |              | for testing. See Table 8        |       |          |
+   +--------------+---------------------------------+-------+----------+
 
                     Table 7: DRBG Test Case JSON Object
 
@@ -654,25 +645,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    that represents a single test case to be processed by the ACVP
    client.  The following table describes the JSON elements for each
    DRBG predcition resistance test vector.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires September 22, 2017              [Page 12]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
 
    +-----------------+------------------------------+-------+----------+
    | JSON Value      | Description                  | JSON  | Optional |
@@ -693,6 +665,15 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 12]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
    table describes the JSON object that represents a vector set
    response.
 
@@ -717,19 +698,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    processed by the ACVP client.  The following table describes the JSON
    elements for each DRBG test vector.
 
-
-
-
-
-
-
-
-
-Vassilev               Expires September 22, 2017              [Page 13]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
-
    +--------------+---------------------------------+-------+----------+
    | JSON Value   | Description                     | JSON  | Optional |
    |              |                                 | type  |          |
@@ -751,6 +719,16 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 6.  IANA Considerations
 
    This memo includes no request to IANA.
+
+
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 13]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
 7.  Security Considerations
 
@@ -777,15 +755,6 @@ Appendix A.  Example DRBG Capabilities JSON Object
    The following is a example JSON object advertising support for
    ctrDRBG with 3KeyTDEA.
 
-
-
-
-
-Vassilev               Expires September 22, 2017              [Page 14]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
-
             {
                 "algorithm": "ctrDRBG",
                 "mode": "3KeyTDEA",
@@ -807,6 +776,15 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                                 "step" : 0},
                 "returnedBitsLen":"256"
             }
+
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 14]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
    The following is a example JSON object advertising support for
    ctrDRBG with AES-128.
@@ -833,18 +811,36 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                 "returnedBitsLen":"512"
             }
 
-
-
-
-
-Vassilev               Expires September 22, 2017              [Page 15]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
-
    The following is a example JSON object advertising support for
    hashDRBG with AES-256.  Note that in this example the implementation
    works with or without additional input and personalization data.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 15]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
             {
                 "algorithm": "hashDRBG",
@@ -893,7 +889,11 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
-Vassilev               Expires September 22, 2017              [Page 16]
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 16]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -902,6 +902,57 @@ Appendix B.  Example Test Vectors JSON Object
 
    The following is a example JSON object for ctrDRBG test vectors sent
    from the ACVP server to the crypto module.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 17]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
 
                 {
                   "version": "0.2",
@@ -912,6 +963,7 @@ Appendix B.  Example Test Vectors JSON Object
                     {
                       "derFunc":"yes",
                       "predResistance": "yes",
+                      "reSeed": "yes",
                       "entropyInputLen":"112",
                       "nonceLen":"56",
                       "persoStringLen":"112",
@@ -923,7 +975,7 @@ Appendix B.  Example Test Vectors JSON Object
                           "entropyInput":"78aac2cb444594e29dc97b0195b5",
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
                             {"additionalInput" : "f5357737023e3304508a00b3ba02",
@@ -935,7 +987,7 @@ Appendix B.  Example Test Vectors JSON Object
                           "entropyInput" : "b8ab88b9c5fda8544b90a043684e",
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
                              {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
@@ -947,15 +999,16 @@ Appendix B.  Example Test Vectors JSON Object
                   ]
                 }
 
+   The following is a example JSON object for hmacDRBG test vectors sent
+   from the ACVP server to the crypto module.
 
 
-Vassilev               Expires September 22, 2017              [Page 17]
+
+
+Vassilev               Expires September 24, 2017              [Page 18]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
-
-   The following is a example JSON object for hmacDRBG test vectors sent
-   from the ACVP server to the crypto module.
 
                 {
                   "version": "0.2",
@@ -965,6 +1018,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                   "testGroups": [
                     {
                       "predResistance": "yes",
+                      "reSeed": "no",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"256",
@@ -976,7 +1030,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                           "entropyInput":"ee3392c5f3de6f3f8c4f28d852afacd2cbaa89ed48d1c5d4311662962aa70a98",
                           "nonce":"b991a820fac75fd02642ad8fa651eda4",
                           "persoString":"30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
                              {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
@@ -988,7 +1042,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                           "entropyInput" : "a0ace75784b97224de2957e5f60dc85b25331fcf7901f37418d3c9de17ed4261",
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
@@ -1002,16 +1056,15 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
    The following is a example JSON object for hashDRBG test vectors sent
    from the ACVP server to the crypto module.  In this example the
+   implementation is tested without additional input and personalization
+   data.
 
 
 
-Vassilev               Expires September 22, 2017              [Page 18]
+Vassilev               Expires September 24, 2017              [Page 19]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
-
-   implementation is tested without additional input and personalization
-   data.
 
                 {
                   "version": "0.2",
@@ -1021,6 +1074,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                   "testGroups": [
                     {
                       "predResistance": "yes",
+                      "reSeed": "no",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"0",
@@ -1032,7 +1086,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                           "entropyInput":"ae0a3acd541d0d582a8510f3028caa143fe1e5226a8469d40b979d3a0d1bbe69",
                           "nonce":"786f03ad697332d74fad7a14604cee44",
                           "persoString":"",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                                {"additionalInput":"",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
                                {"additionalInput" : "",
@@ -1044,7 +1098,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                           "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
                              {"additionalInput" : "",
@@ -1056,68 +1110,14 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                   ]
                 }
 
-
-
-
-
-
-Vassilev               Expires September 22, 2017              [Page 19]
-
-Internet-Draft                DRBG Alg JSON                   March 2017
-
-
    The following is a example JSON object for hashDRBG test vectors sent
    from the ACVP server to the crypto module.  In this example the
-   implementation is tested with "predResistance": "no", option.
+   implementation is tested with "predResistance": "no", "reSeed" :
+   "yes" options.
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires September 22, 2017              [Page 20]
+Vassilev               Expires September 24, 2017              [Page 20]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1130,6 +1130,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                   "testGroups": [
                     {
                       "predResistance": "no",
+                      "reSeed": "yes",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"256",
@@ -1141,11 +1142,11 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                           "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
                           "nonce":"5813070f9774d21e644d64e8d291b511",
                           "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
-                          "reseedInput" : [
+                          "otherInput" : [
                                {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
-                                "entropyInput" : ""}
+                                "entropyInput" : ""},
                                {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
                                 "entropyInput" : ""}
                             ]
@@ -1155,11 +1156,11 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                           "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
-                          "reseedInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
                              {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
-                              "entropyInput" : ""}
+                              "entropyInput" : ""},
                              {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
                               "entropyInput" : ""}
                           ]
@@ -1172,8 +1173,63 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
 
 
+Vassilev               Expires September 24, 2017              [Page 21]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
 
-Vassilev               Expires September 22, 2017              [Page 21]
+
+   The following is a example JSON object for hashDRBG test vectors sent
+   from the ACVP server to the crypto module.  In this example the
+   implementation is tested with "predResistance": "no", "reSeed" : "no"
+   options.
+
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1167",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "reSeed": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",
+                      "tests": [
+                        {
+                          "tcId": "4151",
+                          "entropyInput":"090db63c22de171068527c6ad049e4aade69d5b590efb8f582604e6e07a2c2dc",
+                          "nonce":"6f7c6bec9825079cabd9478d88f337c8",
+                          "persoString":"c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
+                          "otherInput" : [
+                               {"additionalInput":"3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
+                                "entropyInput": ""},
+                               {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "4152",
+                          "entropyInput" : "bd0e2dbba872bb62ca2897be7fd038f5c7162eb9358ef970f120ea32f6fd3cb9",
+                          "nonce": "a97dfbaea505a3e36210a85636197b2d",
+                          "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
+                          "otherInput" : [
+                             {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
+                              "entropyInput" : ""},
+                             {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+
+
+
+Vassilev               Expires September 24, 2017              [Page 22]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1229,7 +1285,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev               Expires September 22, 2017              [Page 22]
+Vassilev               Expires September 24, 2017              [Page 23]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
@@ -1267,6 +1323,44 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                     ]
                 }
 
+   The following is a example JSON object for hashDRBG test results sent
+   from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 24]
+
+Internet-Draft                DRBG Alg JSON                   March 2017
+
+
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1167",
+                    "testResults": [
+                        {
+                            "tcId": "4151",
+                            "returnedBits ": "5dbfd26651bc71597e8f5b06c650bbf2c8117c0735bd903027628b7d7e0658abb818ad63f67d5d9f38f3bc976a0d3c89764122acf3b6a704cd9af0c3ebbde3cd90e4787a4b90267752e5585188f572b2a7f7dfa424cf05f5a2bf49540b90a887af4b352ddf226ee62809f329652faba219c27b430172feb58b875d2611324f9e"
+                        },
+                       {
+                            "tcId": "4152",
+                            "returnedBits": "ff3cce0b5585172b1f93b22a00d9757f60f15f773b33a93b40f01a5e00328dcc78e8827897ec141132104dfb670b0d8ce7a60ab66e89aa5322ea3a497a6861dc0457ab86b1c28c290cef05fd52a78641172f5ef5a1511d31c8eeb9373cb0098c24e12abe3f907a1633f21defdfd2b232dedca7035de0bda31585d0b0321a9009"
+                       }
+                    ]
+                }
+
 Author's Address
 
    Apostol Vassilev (editor)
@@ -1285,4 +1379,22 @@ Author's Address
 
 
 
-Vassilev               Expires September 22, 2017              [Page 23]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 24, 2017              [Page 25]

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -460,7 +460,15 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>use prediction resistance</c>
 		<c>value yes/no</c>
 		<c>No</c>
-<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>reSeed</c>
+		<c>use reseeding</c>
+		<c>value yes/no</c>
+		<c>No</c>
+    <c/>
 		<c/>
 		<c/>
 		<c/>
@@ -509,6 +517,45 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>array</c>
 		<c>No</c>
 	    </texttable>
+  <t>Note 9: According to SP 800-90A <xref target="SP800-90A"/>, a DRBG implementation has two separate controls for determining the correct test procedure for handling 
+      addtional entropy and other data in providing prediction resistance assurances. Depending on the capabilities advertised by the predResistanceEnabled and reseedImplemented flags ACVP generates test data according to the following test scenarios:      </t>
+
+      <texttable anchor="tests_table" title="Test Procedures for Supported Prediction Resistance Options">
+          <ttcol align="left" width="60%">Prediction Resistance Assurance  Options</ttcol>
+          <ttcol align="left" width="40%">Test Procedure</ttcol>
+          <c>"predResistanceEnabled" : "yes"; "reseedImplemented": "yes" </c>
+          <c/><c/>
+          <c>Instantiate DRBG</c>
+          <c/>
+          <c>Generate but don't output</c>
+          <c/>
+          <c>Generate output</c>
+          <c/>
+          <c>Uninstantiate</c>
+           <c/><c/>
+          <c>"predResistanceEnabled" : "no"; "reseedImplemented" : "yes"</c>
+           <c/><c/>
+          <c>Instantiate DRBG</c>
+          <c/>
+          <c>Reseed</c>
+          <c/>
+          <c>Generate but don't output</c>
+          <c/>
+          <c>Generate output</c>
+          <c/>
+          <c>Uninstantiate</c>
+           <c/><c/>
+          <c>"predResistanceEnabled" : "yes"/"no"; "reseedImplemented": "no"</c>
+           <c/><c/>
+          <c>Instantiate DRBG</c>
+          <c/>
+          <c>Generate but don't output</c>
+          <c/>
+          <c>Generate output</c>
+          <c/>
+          <c>Uninstantiate</c>
+</texttable>
+      
 
 	</section>
 
@@ -558,7 +605,15 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>array of additonal input/entropy input value pairs for prediction resistance testing. See <xref target="vs_prtc_table"/></c>
 		<c>array</c>
 		<c>No</c>
-		
+		<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>reseedInput</c>
+		<c>array of additonal input/entropy input value pairs for reseeding testing. See <xref target="vs_prtc_table"/></c>
+		<c>array</c>
+		<c>No</c>
+				
 	    </texttable>
 
 	    <t>Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object
@@ -944,6 +999,57 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 }
             ]]></artwork>
     </figure>   
+    <t>The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", option.</t>
+      <figure>
+        <artwork><![CDATA[
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1157",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",                  
+                      "tests": [
+                        {
+                          "tcId": "3151",
+                          "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
+                          "nonce":"5813070f9774d21e644d64e8d291b511",
+                          "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
+                          "reseedInput" : [
+                               {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                                "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
+                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                                "entropyInput" : ""}
+                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "3152",
+                          "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
+                          "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
+                          "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
+                          "reseedInput" : [
+                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                              "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
+                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                              "entropyInput" : ""}
+                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+            ]]></artwork>
+    </figure>   
 </section>
      <section anchor="app-results-ex" title="Example Test Results JSON Object">
       <t>The following is a example JSON object for ctrDRBG with 3KeyTDEA test results sent from the crypto module to the ACVP server.</t>
@@ -999,6 +1105,25 @@ the bit lengths the supported values shall be specified explicitly. </t>
                        {
                             "tcId": "2152",
                             "returnedBits": "8a74a8c31ea4e6e62f8a77b45da8ec9d8b75e6813f15327c5beb8cb4b56b15e85f95ace34826f8da9048be7c800b33d6c4d3c6558b3e2e0ccfe867a2c6107dc7bacf513017c1a5bcb65ce16ed49aefe764ea7a13d36ceb7f9c443a0cb81f55abcc0c7b2d7d97858ee0b237a72364e826dd6b25df84914f2b354e03fd7fea758e"
+                       }
+                    ]
+                }
+            ]]></artwork>
+    </figure>
+          <t>The following is a example JSON object for hashDRBG test results sent from the crypto module to the ACVP server.</t>
+      <figure>
+        <artwork><![CDATA[
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1157",
+                    "testResults": [
+                        {
+                            "tcId": "3151",
+                            "returnedBits ": "0eadc82746890ee0b6c20b10016e2fd037073d952ed075d1ad4c53f6971ee6405ec40f6fd090c639a800ab9092f537913608787fbc77efd0465a84688da189f14c0d2adba5953f07ea463f4a772bb1f52a3c589cd89231acf0ff06269611f7a908eb171143d5a78d0fb7dca8326d235f3f4f3f25a0a69f0a596d6dbac1eb0cdc"
+                        },
+                       {
+                            "tcId": "3152",
+                            "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
                        }
                     ]
                 }

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -601,19 +601,10 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c/>
 		<c/>
 		<c/>
-		<c>predResistanceInput</c>
-		<c>array of additonal input/entropy input value pairs for prediction resistance testing. See <xref target="vs_prtc_table"/></c>
+		<c>otherInput</c>
+		<c>array of additonal input/entropy input value pairs for testing. See <xref target="vs_prtc_table"/></c>
 		<c>array</c>
 		<c>No</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>reseedInput</c>
-		<c>array of additonal input/entropy input value pairs for reseeding testing. See <xref target="vs_prtc_table"/></c>
-		<c>array</c>
-		<c>No</c>
-				
 	    </texttable>
 
 	    <t>Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object
@@ -868,6 +859,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                     {
                       "derFunc":"yes",
                       "predResistance": "yes",
+                      "reSeed": "yes",
                       "entropyInputLen":"112",
                       "nonceLen":"56",
                       "persoStringLen":"112",
@@ -879,7 +871,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput":"78aac2cb444594e29dc97b0195b5",
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
                             {"additionalInput" : "f5357737023e3304508a00b3ba02",
@@ -891,7 +883,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput" : "b8ab88b9c5fda8544b90a043684e",
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
                              {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
@@ -916,6 +908,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                   "testGroups": [
                     {
                       "predResistance": "yes",
+                      "reSeed": "no",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"256",
@@ -927,7 +920,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput":"ee3392c5f3de6f3f8c4f28d852afacd2cbaa89ed48d1c5d4311662962aa70a98",
                           "nonce":"b991a820fac75fd02642ad8fa651eda4",
                           "persoString":"30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
                              {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
@@ -939,7 +932,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput" : "a0ace75784b97224de2957e5f60dc85b25331fcf7901f37418d3c9de17ed4261",
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
@@ -963,6 +956,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                   "testGroups": [
                     {
                       "predResistance": "yes",
+                      "reSeed": "no",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"0",
@@ -974,7 +968,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput":"ae0a3acd541d0d582a8510f3028caa143fe1e5226a8469d40b979d3a0d1bbe69",
                           "nonce":"786f03ad697332d74fad7a14604cee44",
                           "persoString":"",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                                {"additionalInput":"",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
                                {"additionalInput" : "",
@@ -986,7 +980,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
-                          "predResistsnceInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
                              {"additionalInput" : "",
@@ -999,7 +993,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 }
             ]]></artwork>
     </figure>   
-    <t>The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", option.</t>
+    <t>The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", "reSeed" : "yes" options.</t>
       <figure>
         <artwork><![CDATA[
                 {
@@ -1010,6 +1004,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                   "testGroups": [
                     {
                       "predResistance": "no",
+                      "reSeed": "yes",
                       "entropyInputLen":"256",
                       "nonceLen":"128",
                       "persoStringLen":"256",
@@ -1021,11 +1016,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput":"860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
                           "nonce":"5813070f9774d21e644d64e8d291b511",
                           "persoString":"545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
-                          "reseedInput" : [
+                          "otherInput" : [
                                {"additionalInput":"95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
-                                "entropyInput" : ""}
+                                "entropyInput" : ""},
                                {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
                                 "entropyInput" : ""}
                             ]
@@ -1035,12 +1030,60 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "entropyInput" : "371d2944c9ace670684d34d0bdc2eb45b0193fa6e7ec216867d8eb83f1f34104",
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
-                          "reseedInput" : [
+                          "otherInput" : [
                              {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
                              {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
-                              "entropyInput" : ""}
+                              "entropyInput" : ""},
                              {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+            ]]></artwork>
+    </figure>   
+       <t>The following is a example JSON object for hashDRBG test vectors sent from the ACVP server to the crypto module. In this example the implementation is tested with "predResistance": "no", "reSeed" : "no" options.</t>
+      <figure>
+        <artwork><![CDATA[
+                {
+                  "version": "0.2",
+                  "vectorSetId": "1167",
+                  "algorithm": "hashDRBG",
+                  "mode": "SHA-256",
+                  "testGroups": [
+                    {
+                      "predResistance": "no",
+                      "reSeed": "no",
+                      "entropyInputLen":"256",
+                      "nonceLen":"128",
+                      "persoStringLen":"256",
+                      "additionalInputLen":"256",
+                      "returnedBitsLen":"1024",                  
+                      "tests": [
+                        {
+                          "tcId": "4151",
+                          "entropyInput":"090db63c22de171068527c6ad049e4aade69d5b590efb8f582604e6e07a2c2dc",
+                          "nonce":"6f7c6bec9825079cabd9478d88f337c8",
+                          "persoString":"c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
+                          "otherInput" : [
+                               {"additionalInput":"3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
+                                "entropyInput": ""},
+                               {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
+                                "entropyInput" : ""}
+                            ]
+                          },
+                        {
+                          "tcId": "4152",
+                          "entropyInput" : "bd0e2dbba872bb62ca2897be7fd038f5c7162eb9358ef970f120ea32f6fd3cb9",
+                          "nonce": "a97dfbaea505a3e36210a85636197b2d",
+                          "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
+                          "otherInput" : [
+                             {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
+                              "entropyInput" : ""},
+                             {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
                               "entropyInput" : ""}
                           ]
                         }
@@ -1124,6 +1167,25 @@ the bit lengths the supported values shall be specified explicitly. </t>
                        {
                             "tcId": "3152",
                             "returnedBits": "6452be2ee730d7245b28efa7a0dcd50299aaa126c5aa6dc8be3ae1c75ff54c412b1776a4beba8cb7c7bf9e2ec8c7fe2de5f51c4d740e20f5d9bbef3b743c81b958e05880ad9bbc8794be156e6d4b2f6a826787ce1fb479e449a27aa99831eba6c0fc990eabff928fafa703619f85060090548e2a23911a1e5adec5ac15a29798"
+                       }
+                    ]
+                }
+            ]]></artwork>
+    </figure>
+            <t>The following is a example JSON object for hashDRBG test results sent from the crypto module to the ACVP server.</t>
+      <figure>
+        <artwork><![CDATA[
+                {
+                    "version": "0.2",
+                    "vectorSetId": "1167",
+                    "testResults": [
+                        {
+                            "tcId": "4151",
+                            "returnedBits ": "5dbfd26651bc71597e8f5b06c650bbf2c8117c0735bd903027628b7d7e0658abb818ad63f67d5d9f38f3bc976a0d3c89764122acf3b6a704cd9af0c3ebbde3cd90e4787a4b90267752e5585188f572b2a7f7dfa424cf05f5a2bf49540b90a887af4b352ddf226ee62809f329652faba219c27b430172feb58b875d2611324f9e"
+                        },
+                       {
+                            "tcId": "4152",
+                            "returnedBits": "ff3cce0b5585172b1f93b22a00d9757f60f15f773b33a93b40f01a5e00328dcc78e8827897ec141132104dfb670b0d8ce7a60ab66e89aa5322ea3a497a6861dc0457ab86b1c28c290cef05fd52a78641172f5ef5a1511d31c8eeb9373cb0098c24e12abe3f907a1633f21defdfd2b232dedca7035de0bda31585d0b0321a9009"
                        }
                     ]
                 }


### PR DESCRIPTION
This revision introduces reSeed and predResistance flags to define the mode of testing and the corresponding data. See also the table in Section 3.1 The array otherInput contains the extra test data for the configured mode of testing. Note that the same array contains the exra data for the various DRBG configurations, for the specific tests identified ni the table in Section 3.1. 

Added also a new example for the case of reSeed and predResistance both set to "no".  

See also #82. 