### PR TITLE
Moving direction within TestGroups

### DIFF
--- a/artifacts/acvp_sub_symmetric.html
+++ b/artifacts/acvp_sub_symmetric.html
@@ -397,7 +397,7 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2.dev0 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Foley, J., Ed." />
@@ -882,16 +882,6 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">direction</td>
-      <td class="left">The encryption direction: encrypt or decrypt</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">testGroups</td>
       <td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs">Section 3.1</a></td>
       <td class="left">array</td>
@@ -913,6 +903,18 @@
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td class="left">direction</td>
+      <td class="left">The encryption direction: encrypt or decrypt</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
     <tr>
       <td class="left">keyLen</td>
       <td class="left">Length of key in bits to use</td>
@@ -1241,9 +1243,9 @@
                   "acvVersion": "0.3",
                   "vsId": 1564,
                   "algorithm": "AES-GCM",
-                  "direction": "encrypt",
                   "testGroups": [
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 96,
                       "ptLen": 0,
@@ -1278,6 +1280,7 @@
                       ]
                     },
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 96,
                       "ptLen": 0,
@@ -1300,6 +1303,7 @@
                       ]
                     },
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 96,
                       "ptLen": 128,
@@ -1437,9 +1441,9 @@
                   "acvVersion": "0.3",
                   "vsId": 1564,
                   "algorithm": "AES-CBC",
-                  "direction": "encrypt",
                   "testGroups": [
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 128
                       "ptLen": 128

--- a/artifacts/acvp_sub_symmetric.txt
+++ b/artifacts/acvp_sub_symmetric.txt
@@ -478,8 +478,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |            | the test vectors.  See Section 2.4 for       |       |
    |            | possible values.                             |       |
    |            |                                              |       |
-   | direction  | The encryption direction: encrypt or decrypt | value |
-   |            |                                              |       |
    | testGroups | Array of test group JSON objects, which are  | array |
    |            | defined in Section 3.1                       |       |
    +------------+----------------------------------------------+-------+
@@ -501,31 +499,37 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
+
+
 Foley                   Expires December 3, 2016                [Page 9]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +----------+-------------------------------------+-------+----------+
-   | JSON     | Description                         | JSON  | Optional |
-   | Value    |                                     | type  |          |
-   +----------+-------------------------------------+-------+----------+
-   | keyLen   | Length of key in bits to use        | value | No       |
-   |          |                                     |       |          |
-   | ivLen    | Length of IV in bits to use         | value | No       |
-   |          |                                     |       |          |
-   | ptLen    | Length of plaintext in bits to      | value | No       |
-   |          |                                     |       |          |
-   | aadLen   | Length of AAD in bits to use        | value | Yes      |
-   |          |                                     |       |          |
-   | tagLen   | Length of AEAD tag in bits to use   | value | Yes      |
-   |          |                                     |       |          |
-   | testType | The test category type (AFT or MCT) | value | No       |
-   |          |                                     |       |          |
-   | tests    | Array of individual test vector     | array | No       |
-   |          | JSON objects, which are defined in  |       |          |
-   |          | Section 3.2                         |       |          |
-   +----------+-------------------------------------+-------+----------+
+   +-----------+------------------------------------+-------+----------+
+   | JSON      | Description                        | JSON  | Optional |
+   | Value     |                                    | type  |          |
+   +-----------+------------------------------------+-------+----------+
+   | direction | The encryption direction: encrypt  | value | No       |
+   |           | or decrypt                         |       |          |
+   |           |                                    |       |          |
+   | keyLen    | Length of key in bits to use       | value | No       |
+   |           |                                    |       |          |
+   | ivLen     | Length of IV in bits to use        | value | No       |
+   |           |                                    |       |          |
+   | ptLen     | Length of plaintext in bits to     | value | No       |
+   |           |                                    |       |          |
+   | aadLen    | Length of AAD in bits to use       | value | Yes      |
+   |           |                                    |       |          |
+   | tagLen    | Length of AEAD tag in bits to use  | value | Yes      |
+   |           |                                    |       |          |
+   | testType  | The test category type (AFT or     | value | No       |
+   |           | MCT)                               |       |          |
+   |           |                                    |       |          |
+   | tests     | Array of individual test vector    | array | No       |
+   |           | JSON objects, which are defined in |       |          |
+   |           | Section 3.2                        |       |          |
+   +-----------+------------------------------------+-------+----------+
 
                       Table 5: Test Group JSON Object
 
@@ -535,10 +539,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    test case is a JSON object that represents a single vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each test case.
-
-
-
-
 
 
 
@@ -733,9 +733,9 @@ Internet-Draft                Sym Alg JSON                     June 2016
                      "acvVersion": "0.3",
                      "vsId": 1564,
                      "algorithm": "AES-GCM",
-                     "direction": "encrypt",
                      "testGroups": [
                        {
+                         "direction": "encrypt",
                          "keyLen": 128,
                          "ivLen": 96,
                          "ptLen": 0,
@@ -770,6 +770,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                          ]
                        },
                        {
+                         "direction": "encrypt",
                          "keyLen": 128,
                          "ivLen": 96,
                          "ptLen": 0,
@@ -777,7 +778,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                          "tagLen": 128,
                          "testType" : "AFT",
                          "tests": [
-                           {
 
 
 
@@ -786,6 +786,7 @@ Foley                   Expires December 3, 2016               [Page 14]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           {
                              "tcId": 2186,
                              "key": "5E296F244BB0A92BF0FF5F2C50FA7443",
                              "pt": "",
@@ -800,6 +801,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                          ]
                        },
                        {
+                         "direction": "encrypt",
                          "keyLen": 128,
                          "ivLen": 96,
                          "ptLen": 128,
@@ -832,8 +834,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                              "aad": "EABED39EE5B56F81CE5C858E507EAB13"
                            },
                            {
-                             "tcId": 2205,
-                             "key": "CE1D8C9E3AB2F46B01E3F110B3BC6E05",
 
 
 
@@ -842,6 +842,8 @@ Foley                   Expires December 3, 2016               [Page 15]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                             "tcId": 2205,
+                             "key": "CE1D8C9E3AB2F46B01E3F110B3BC6E05",
                              "pt": "3DD9EEFA5C6E89C43D460907E8946B9C",
                              "aad": "DBE62172F439956FF21A67A379324100"
                            },
@@ -888,8 +890,6 @@ Appendix C.  Example Test Results JSON Object
                                "iv": "01020304D678FBCC2EA341A2",
                                "ct": "",
                                "tag": "BAFBFA38AD5D6C6E7C97D08DDEC26580"
-                           },
-                           {
 
 
 
@@ -898,6 +898,8 @@ Foley                   Expires December 3, 2016               [Page 16]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           },
+                           {
                                "tcId": 2186,
                                "iv": "01020304C6A745B0C4C9F2D5",
                                "ct": "",
@@ -944,8 +946,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                "iv": "0102030474CBC83C647DBEAF",
                                "ct": "2CE1129D3E2F25468A9EE13ED39C902C",
                                "tag": "48F3D4D7EB4B9FCB924ACC05B3834F98"
-                           }
-                       ]
 
 
 
@@ -954,6 +954,8 @@ Foley                   Expires December 3, 2016               [Page 17]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           }
+                       ]
                    }
 
 
@@ -964,9 +966,9 @@ Internet-Draft                Sym Alg JSON                     June 2016
                      "acvVersion": "0.3",
                      "vsId": 1564,
                      "algorithm": "AES-CBC",
-                     "direction": "encrypt",
                      "testGroups": [
                        {
+                         "direction": "encrypt",
                          "keyLen": 128,
                          "ivLen": 128
                          "ptLen": 128
@@ -987,8 +989,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    iterations shown for brevity.  For MCT results of each iteration are
    fed into the next iteration.  Therefore the results carry all fields
    to assist in any failure diagnosis.
-
-
 
 
 

--- a/src/acvp_sub_symmetric.xml
+++ b/src/acvp_sub_symmetric.xml
@@ -45,8 +45,7 @@
 
     <!-- Another author who claims to be an editor -->
 
-    <author fullname="John Foley" initials="J.F." role="editor"
-            surname="Foley">
+    <author fullname="John Foley" initials="J.F." role="editor" surname="Foley">
       <organization>Cisco Systems, Inc.</organization>
 
       <address>
@@ -70,7 +69,7 @@
       </address>
     </author>
 
-    <date month="June" year="2016" />
+    <date month="June" year="2016"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -182,14 +181,14 @@
           <c>algorithm</c>
 	  <c>The symmetric algorithm and mode to be validated.</c>
           <c>value</c>
-          <c>See <xref target="supported_algs" /></c>
+          <c>See <xref target="supported_algs"/></c>
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
 
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
-          <c>See <xref target="prereq_algs" /></c>
+          <c>See <xref target="prereq_algs"/></c>
           <c>Yes</c>
 	  <c/><c/><c/><c/><c/>
 
@@ -208,14 +207,14 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>ptLen</c>
-	  <c>The supported plaintext lengths in bits.   This varies depending on the algorithm type, for additional details see <xref target="data_lengths" /></c>
+	  <c>The supported plaintext lengths in bits.   This varies depending on the algorithm type, for additional details see <xref target="data_lengths"/></c>
           <c>range or array</c>
           <c>0-65536</c>
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
 
           <c>ivLen</c>
-          <c>The supported IV/Nonce lengths in bits, see <xref target="data_lengths" /></c>
+          <c>The supported IV/Nonce lengths in bits, see <xref target="data_lengths"/></c>
           <c>array</c>
           <c>8-1024</c>
           <c>Yes</c>
@@ -243,7 +242,7 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>tagLen</c>
-          <c>The supported Tag lengths in bits for AEAD algorithms, <xref target="data_lengths" /></c>
+          <c>The supported Tag lengths in bits for AEAD algorithms, <xref target="data_lengths"/></c>
           <c>array</c>
           <c>4-128</c>
           <c>Yes</c>
@@ -378,17 +377,12 @@
 	  <c/><c/><c/>
 
 	  <c>algorithm</c>
-	  <c>The symmetric algorithm and mode used for the test vectors.  See <xref target="supported_algs" /> for possible values.</c>
-          <c>value</c>
-	  <c/><c/><c/>
-
-	  <c>direction</c>
-	  <c>The encryption direction: encrypt or decrypt</c>
+	  <c>The symmetric algorithm and mode used for the test vectors.  See <xref target="supported_algs"/> for possible values.</c>
           <c>value</c>
 	  <c/><c/><c/>
 
 	  <c>testGroups</c>
-	  <c>Array of test group JSON objects, which are defined in <xref target="tgjs" /></c>
+	  <c>Array of test group JSON objects, which are defined in <xref target="tgjs"/></c>
           <c>array</c>
 	</texttable>
 
@@ -403,7 +397,12 @@
 		<ttcol align="left">Description</ttcol>
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
-
+	  <c>direction</c>
+	  <c>The encryption direction: encrypt or decrypt</c>
+    <c>value</c>
+		<c>No</c>	  
+	  <c/><c/><c/><c/>
+	  
 		<c>keyLen</c>
 		<c>Length of key in bits to use</c>
 		<c>value</c>
@@ -441,7 +440,7 @@
 		<c/><c/><c/><c/>
 
 		<c>tests</c>
-		<c>Array of individual test vector JSON objects, which are defined in <xref target="tvjs" /></c>
+		<c>Array of individual test vector JSON objects, which are defined in <xref target="tvjs"/></c>
 		<c>array</c>
 		<c>No</c>
 	    </texttable>
@@ -523,7 +522,7 @@
 
 	  <c>testResults</c>
 	  <c>Array of JSON objects that represent each test vector result, which uses the same
-	      JSON schema as defined in <xref target="tvjs" /> </c>
+	      JSON schema as defined in <xref target="tvjs"/> </c>
           <c>array</c>
 	</texttable>
     </section>
@@ -562,7 +561,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2016" />
+          <date year="2016"/>
         </front>
       </reference>
     </references>
@@ -578,7 +577,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2002" />
+          <date year="2002"/>
         </front>
       </reference>
 
@@ -592,7 +591,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2012" />
+          <date year="2012"/>
         </front>
       </reference>
 
@@ -606,7 +605,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2016" />
+          <date year="2016"/>
         </front>
       </reference>
 
@@ -620,7 +619,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2013" />
+          <date year="2013"/>
         </front>
       </reference>
 
@@ -634,7 +633,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2014" />
+          <date year="2014"/>
         </front>
       </reference>
 
@@ -648,7 +647,7 @@
             <organization>NIST</organization>
           </author>
 
-          <date year="2012" />
+          <date year="2012"/>
         </front>
       </reference>
     </references>
@@ -704,9 +703,9 @@
                   "acvVersion": "0.3",
                   "vsId": 1564,
                   "algorithm": "AES-GCM",
-                  "direction": "encrypt",
                   "testGroups": [
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 96,
                       "ptLen": 0,
@@ -741,6 +740,7 @@
                       ]
                     },
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 96,
                       "ptLen": 0,
@@ -763,6 +763,7 @@
                       ]
                     },
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 96,
                       "ptLen": 128,
@@ -907,9 +908,9 @@
                   "acvVersion": "0.3",
                   "vsId": 1564,
                   "algorithm": "AES-CBC",
-                  "direction": "encrypt",
                   "testGroups": [
                     {
+                      "direction": "encrypt",
                       "keyLen": 128,
                       "ivLen": 128
                       "ptLen": 128


### PR DESCRIPTION
Per agreement, moved direction down to TestGroups. Each test group can
have own direction (encrypt/decrypt). See #93 for details.