### PR TITLE
Fixes typos in pub exponent examples

### DIFF
--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -428,12 +428,12 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2.dev0 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.3" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-12" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.4" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-4-14" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm implementations for conformance to  " />
   <meta name="description" content="This document defines the JSON schema for testing RSA algorithm implementations for conformance to  " />
 
@@ -454,10 +454,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">December 2016</td>
+  <td class="right">April 14, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: June 4, 2017</td>
+  <td class="left">Expires: October 16, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -466,7 +466,7 @@
   </table>
 
   <p class="title">ACVP RSA Algorithm Validation JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subrsa-0.3</span></p>
+  <span class="filename">draft-ietf-acvp-subrsa-0.4</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -478,11 +478,11 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on June 4, 2017.</p>
+<p>This Internet-Draft will expire on October 16, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2016 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -1852,7 +1852,7 @@
               "mode": "keyGen",
               "capSpecs" :  {
                       "fixedPubExp" : "yes",
-                      "fixedPubExpVal" : "100001",
+                      "fixedPubExpVal" : "10001",
                       "randPQ" : "1",
                       "capsProvPrime" : 
                             [
@@ -1890,7 +1890,7 @@
           "mode":"keyGen",
           "capSpecs": {
             "fixedPubExp":"yes",
-            "fixedPubExpVal":"100001",
+            "fixedPubExpVal":"10001",
             "randPQ":"2",
             "capProbPrime":{
               "modProbPrime":["2048", "3072", "4096"],
@@ -1914,7 +1914,7 @@
            "mode": "keyGen",
            "capSpecs" : {
                "fixedPubExp" : "yes",
-               "fixedPubExpVal" : "100001",
+               "fixedPubExpVal" : "10001",
                "randPQ" : "4",
                "capsProvPrime" : 
                     [
@@ -2110,7 +2110,7 @@
 <h1 id="rfc.appendix.B.1"><a href="#rfc.appendix.B.1">B.1.</a> <a href="#app-testVectProvProvPrime-ex" id="app-testVectProvProvPrime-ex">Example Test Vectors for keyGen JSON Objects</a></h1>
 <pre>
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1133",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2294,7 +2294,7 @@
 <h1 id="rfc.appendix.B.2"><a href="#rfc.appendix.B.2">B.2.</a> <a href="#app-testVectsigGen-ex" id="app-testVectsigGen-ex">Example Test Vectors for sigGen JSON Objects</a></h1>
 <pre>
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1163",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2360,7 +2360,7 @@
 <h1 id="rfc.appendix.B.3"><a href="#rfc.appendix.B.3">B.3.</a> <a href="#app-testVectsigVer-ex" id="app-testVectsigVer-ex">Example Test Vectors for sigVer JSON Objects</a></h1>
 <pre>
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2445,7 +2445,7 @@
 <h1 id="rfc.appendix.B.5"><a href="#rfc.appendix.B.5">B.5.</a> <a href="#app-testcomponentsigprimitive-ex" id="app-testcomponentsigprimitive-ex">Example Test Vectors for componentSigPrimitive JSON Objects</a></h1>
 <pre>
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2474,7 +2474,7 @@
 <h1 id="rfc.appendix.B.6"><a href="#rfc.appendix.B.6">B.6.</a> <a href="#app-testcomponentdecprimitive-ex" id="app-testcomponentdecprimitive-ex">Example Test Vectors for componentDecPrimitive JSON Objects</a></h1>
 <pre>
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2501,7 +2501,7 @@
 <p id="rfc.section.C.1.p.1">The following is a example JSON object for RSA keyGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
                 {
-                    "acvVersion": "0.3",
+                    "acvVersion": "0.4",
                     "vsId": "1133",
                     "testResults": [
                     {
@@ -2777,7 +2777,7 @@
 <p id="rfc.section.C.2.p.1">The following is a example JSON object for RSA sigGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
                 {
-                    "acvVersion": "0.3",
+                    "acvVersion": "0.4",
                     "vsId": "1163",
                     "testResults": [
                     {
@@ -2835,7 +2835,7 @@
 <p id="rfc.section.C.3.p.1">The following is a example JSON object for RSA sigVer test results sent from the crypto module to the ACVP server.</p>
 <pre>
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2890,7 +2890,7 @@
 <p id="rfc.section.C.5.p.1">The following is a example JSON object for RSA componentSigPrimitive test results sent from the crypto module to the ACVP server.</p>
 <pre>
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2916,7 +2916,7 @@
 <p id="rfc.section.C.6.p.1">The following is a example JSON object for RSA componentDecPrimitive test results sent from the crypto module to the ACVP server.</p>
 <pre>
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -4,12 +4,12 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                             December 2016
-Expires: June 4, 2017
+Intended status: Informational                            April 14, 2017
+Expires: October 16, 2017
 
 
             ACVP RSA Algorithm Validation JSON Specification
-                       draft-ietf-acvp-subrsa-0.3
+                       draft-ietf-acvp-subrsa-0.4
 
 Abstract
 
@@ -32,11 +32,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 4, 2017.
+   This Internet-Draft will expire on October 16, 2017.
 
 Copyright Notice
 
-   Copyright (c) 2016 IETF Trust and the persons identified as the
+   Copyright (c) 2017 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 1]
+Vassilev                Expires October 16, 2017                [Page 1]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 Table of Contents
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 2]
+Vassilev                Expires October 16, 2017                [Page 2]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
            Objects . . . . . . . . . . . . . . . . . . . . . . . . .  40
@@ -165,9 +165,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 3]
+Vassilev                Expires October 16, 2017                [Page 3]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    RSA algorithm in all allowed modes to the ACVP server - see
@@ -221,9 +221,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 4]
+Vassilev                Expires October 16, 2017                [Page 4]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +--------------+--------------+--------------+-----------+----------+
@@ -277,9 +277,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 5]
+Vassilev                Expires October 16, 2017                [Page 5]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +------------+--------------+--------------+-------------+----------+
@@ -333,9 +333,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 6]
+Vassilev                Expires October 16, 2017                [Page 6]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    message.  See the ACVP specification for details on the registration
@@ -389,9 +389,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 7]
+Vassilev                Expires October 16, 2017                [Page 7]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +--------------+-----------+-------------+-----------------+--------+
@@ -445,9 +445,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 8]
+Vassilev                Expires October 16, 2017                [Page 8]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 2.4.1.2.  keyGen With Probable Primes Capabilities
@@ -501,9 +501,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                  [Page 9]
+Vassilev                Expires October 16, 2017                [Page 9]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    | JSON Value  | Description   | JSON  | Valid Values      | Optiona |
@@ -557,9 +557,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 10]
+Vassilev                Expires October 16, 2017               [Page 10]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    | capProvPrim | capabilities  | array |                   | Yes     |
@@ -613,9 +613,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 11]
+Vassilev                Expires October 16, 2017               [Page 11]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +--------------+----------------+-------+----------------+----------+
@@ -669,9 +669,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 12]
+Vassilev                Expires October 16, 2017               [Page 12]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 2.4.3.  The sigVer Mode Capabilities
@@ -725,9 +725,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 13]
+Vassilev                Expires October 16, 2017               [Page 13]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +--------------+----------------+-------+----------------+----------+
@@ -781,9 +781,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 14]
+Vassilev                Expires October 16, 2017               [Page 14]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 2.4.4.  The legacySigVer Mode Capabilities
@@ -837,9 +837,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 15]
+Vassilev                Expires October 16, 2017               [Page 15]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +------------------+--------------+-------+--------------+----------+
@@ -893,9 +893,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 16]
+Vassilev                Expires October 16, 2017               [Page 16]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 2.4.5.  The componentSigPrimitive Mode Capabilities
@@ -949,9 +949,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 17]
+Vassilev                Expires October 16, 2017               [Page 17]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    sets to be downloaded and processed by the ACVP client.  Each test
@@ -1005,9 +1005,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 18]
+Vassilev                Expires October 16, 2017               [Page 18]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +-----------+--------------------------------+-----------+----------+
@@ -1061,9 +1061,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 19]
+Vassilev                Expires October 16, 2017               [Page 19]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +---------+--------------------------------------+-------+----------+
@@ -1117,9 +1117,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 20]
+Vassilev                Expires October 16, 2017               [Page 20]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    +-------------+---------------------------------------------+-------+
@@ -1173,9 +1173,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 21]
+Vassilev                Expires October 16, 2017               [Page 21]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    |             | [FIPS186-4],       |                     |          |
@@ -1229,9 +1229,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 22]
+Vassilev                Expires October 16, 2017               [Page 22]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    |             | for prime          |                     |          |
@@ -1285,9 +1285,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 23]
+Vassilev                Expires October 16, 2017               [Page 23]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    |             | applicable         |                     |          |
@@ -1341,9 +1341,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 24]
+Vassilev                Expires October 16, 2017               [Page 24]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    | reason      | additonal          | text                | Yes      |
@@ -1397,9 +1397,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 25]
+Vassilev                Expires October 16, 2017               [Page 25]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 Appendix A.  Example RSA Capabilities JSON Objects
@@ -1423,7 +1423,7 @@ A.1.  Example keyGen Capabilities JSON Objects
               "mode": "keyGen",
               "capSpecs" :  {
                       "fixedPubExp" : "yes",
-                      "fixedPubExpVal" : "100001",
+                      "fixedPubExpVal" : "10001",
                       "randPQ" : "1",
                       "capsProvPrime" :
                             [
@@ -1453,9 +1453,9 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 26]
+Vassilev                Expires October 16, 2017               [Page 26]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
       {
@@ -1476,7 +1476,7 @@ Internet-Draft                RSA Alg JSON                 December 2016
              "mode":"keyGen",
              "capSpecs": {
                "fixedPubExp":"yes",
-               "fixedPubExpVal":"100001",
+               "fixedPubExpVal":"10001",
                "randPQ":"2",
                "capProbPrime":{
                  "modProbPrime":["2048", "3072", "4096"],
@@ -1509,9 +1509,9 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 27]
+Vassilev                Expires October 16, 2017               [Page 27]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    {
@@ -1523,7 +1523,7 @@ Internet-Draft                RSA Alg JSON                 December 2016
            "mode": "keyGen",
            "capSpecs" : {
                "fixedPubExp" : "yes",
-               "fixedPubExpVal" : "100001",
+               "fixedPubExpVal" : "10001",
                "randPQ" : "4",
                "capsProvPrime" :
                     [
@@ -1565,9 +1565,9 @@ A.1.3.  Example keyGen with Probable Conditional Primes with Probable
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 28]
+Vassilev                Expires October 16, 2017               [Page 28]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    {
@@ -1621,9 +1621,9 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 29]
+Vassilev                Expires October 16, 2017               [Page 29]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                   [
@@ -1677,9 +1677,9 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 30]
+Vassilev                Expires October 16, 2017               [Page 30]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                   {"modRSASigVer" : "2048",
@@ -1733,9 +1733,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 31]
+Vassilev                Expires October 16, 2017               [Page 31]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 A.4.  Example RSA legacySigVer Capabilities JSON Objects
@@ -1789,15 +1789,15 @@ Appendix B.  Example Test Vectors JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 32]
+Vassilev                Expires October 16, 2017               [Page 32]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 B.1.  Example Test Vectors for keyGen JSON Objects
 
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1133",
       "algorithm": "RSA",
       "testGroups" : [
@@ -1845,9 +1845,9 @@ B.1.  Example Test Vectors for keyGen JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 33]
+Vassilev                Expires October 16, 2017               [Page 33]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                     }
@@ -1901,9 +1901,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 34]
+Vassilev                Expires October 16, 2017               [Page 34]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
              },
@@ -1957,9 +1957,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 35]
+Vassilev                Expires October 16, 2017               [Page 35]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                     }
@@ -2005,7 +2005,7 @@ Internet-Draft                RSA Alg JSON                 December 2016
 B.2.  Example Test Vectors for sigGen JSON Objects
 
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1163",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2013,9 +2013,9 @@ B.2.  Example Test Vectors for sigGen JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 36]
+Vassilev                Expires October 16, 2017               [Page 36]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                  "mode": "sigGen",
@@ -2069,9 +2069,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 37]
+Vassilev                Expires October 16, 2017               [Page 37]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "modRSA" : "3072",
@@ -2087,7 +2087,7 @@ Internet-Draft                RSA Alg JSON                 December 2016
 B.3.  Example Test Vectors for sigVer JSON Objects
 
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2125,9 +2125,9 @@ B.3.  Example Test Vectors for sigVer JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 38]
+Vassilev                Expires October 16, 2017               [Page 38]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "hashAlg" : "SHA-256",
@@ -2181,9 +2181,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 39]
+Vassilev                Expires October 16, 2017               [Page 39]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    public exponent e, the private key d for each test.  Note also that
@@ -2197,7 +2197,7 @@ B.4.  Example Test Vectors for legacySigVer JSON Objects
 B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
 
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2237,13 +2237,13 @@ B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 40]
+Vassilev                Expires October 16, 2017               [Page 40]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2278,7 +2278,7 @@ C.1.  Example keyGen Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
                 {
-                    "acvVersion": "0.3",
+                    "acvVersion": "0.4",
                     "vsId": "1133",
                     "testResults": [
                     {
@@ -2293,9 +2293,9 @@ C.1.  Example keyGen Test Results JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 41]
+Vassilev                Expires October 16, 2017               [Page 41]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "q" : "d13c3209bbc1bfa27c96688cbb325e8ce8d609efde1cc2417a578354c7bd248fb89eca31599d6b5b0d69a832bd2fafaacf3e9c3b71484328059dff1a7af54b003fee84f64f34e31ade0689f26fbc181443b7af3d8043657ddceefc1ff3160543825de3fe8f33fce4bf5d1c10357919c31729f8c0476f6b2fb6f405c875f06609",
@@ -2349,9 +2349,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 42]
+Vassilev                Expires October 16, 2017               [Page 42]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
@@ -2405,9 +2405,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 43]
+Vassilev                Expires October 16, 2017               [Page 43]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "xP" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e306705e39d2b621027353b4873898b36b3fe86ab203dee10260058ce77f13d315ea1dcc0b717ffe906bfb05f251f3e9d678c585917176e127ece648c788f28b05607d4f71e113842e289b0de45bed72b7e591ea55ae5750ebe86a8",
@@ -2461,9 +2461,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 44]
+Vassilev                Expires October 16, 2017               [Page 44]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "q1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd81009302660959",
@@ -2517,9 +2517,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 45]
+Vassilev                Expires October 16, 2017               [Page 45]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                     },
@@ -2573,9 +2573,9 @@ Internet-Draft                RSA Alg JSON                 December 2016
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 46]
+Vassilev                Expires October 16, 2017               [Page 46]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                    },
@@ -2604,7 +2604,7 @@ C.2.  Example sigGen Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
                 {
-                    "acvVersion": "0.3",
+                    "acvVersion": "0.4",
                     "vsId": "1163",
                     "testResults": [
                     {
@@ -2629,9 +2629,9 @@ C.2.  Example sigGen Test Results JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 47]
+Vassilev                Expires October 16, 2017               [Page 47]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                       "tcId" : "1167",
@@ -2672,7 +2672,7 @@ C.3.  Example sigVer Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
    {
-        "acvVersion": "0.3",
+        "acvVersion": "0.4",
          "vsId": "1173",
          "algorithm": "RSA",
          "testGroups" : [
@@ -2685,9 +2685,9 @@ C.3.  Example sigVer Test Results JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 48]
+Vassilev                Expires October 16, 2017               [Page 48]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
                          "sigResult" : "fail"
@@ -2741,9 +2741,9 @@ C.4.  Example legacySigVer Test Results JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 49]
+Vassilev                Expires October 16, 2017               [Page 49]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 C.5.  Example componentSigPrimitive Test Results JSON Objects
@@ -2752,7 +2752,7 @@ C.5.  Example componentSigPrimitive Test Results JSON Objects
    test results sent from the crypto module to the ACVP server.
 
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2797,13 +2797,13 @@ C.6.  Example componentDecPrimitive Test Results JSON Objects
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 50]
+Vassilev                Expires October 16, 2017               [Page 50]
 
-Internet-Draft                RSA Alg JSON                 December 2016
+Internet-Draft                RSA Alg JSON                    April 2017
 
 
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2853,4 +2853,4 @@ Author's Address
 
 
 
-Vassilev                  Expires June 4, 2017                 [Page 51]
+Vassilev                Expires October 16, 2017               [Page 51]

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subrsa-0.3" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subrsa-0.4" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"
@@ -69,7 +69,7 @@
       </address>
     </author>
 
-    <date month="December" year="2016"/>
+    <date month="April" year="2017"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -1141,7 +1141,7 @@
               "mode": "keyGen",
               "capSpecs" :  {
                       "fixedPubExp" : "yes",
-                      "fixedPubExpVal" : "100001",
+                      "fixedPubExpVal" : "10001",
                       "randPQ" : "1",
                       "capsProvPrime" : 
                             [
@@ -1181,7 +1181,7 @@
           "mode":"keyGen",
           "capSpecs": {
             "fixedPubExp":"yes",
-            "fixedPubExpVal":"100001",
+            "fixedPubExpVal":"10001",
             "randPQ":"2",
             "capProbPrime":{
               "modProbPrime":["2048", "3072", "4096"],
@@ -1208,7 +1208,7 @@
            "mode": "keyGen",
            "capSpecs" : {
                "fixedPubExp" : "yes",
-               "fixedPubExpVal" : "100001",
+               "fixedPubExpVal" : "10001",
                "randPQ" : "4",
                "capsProvPrime" : 
                     [
@@ -1425,7 +1425,7 @@
     <figure>
     <artwork><![CDATA[
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1133",
       "algorithm": "RSA",
       "testGroups" : [
@@ -1612,7 +1612,7 @@
     <figure>
     <artwork><![CDATA[
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1163",
       "algorithm": "RSA",
       "testGroups" : [
@@ -1681,7 +1681,7 @@
     <figure>
     <artwork><![CDATA[
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
@@ -1771,7 +1771,7 @@
     <figure>
     <artwork><![CDATA[
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
@@ -1804,7 +1804,7 @@
     <figure>
     <artwork><![CDATA[
    {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [
@@ -1836,7 +1836,7 @@
             <figure>
         <artwork><![CDATA[
                 {
-                    "acvVersion": "0.3",
+                    "acvVersion": "0.4",
                     "vsId": "1133",
                     "testResults": [
                     {
@@ -2115,7 +2115,7 @@
             <figure>
         <artwork><![CDATA[
                 {
-                    "acvVersion": "0.3",
+                    "acvVersion": "0.4",
                     "vsId": "1163",
                     "testResults": [
                     {
@@ -2176,7 +2176,7 @@
             <figure>
         <artwork><![CDATA[
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1173",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2235,7 +2235,7 @@
             <figure>
         <artwork><![CDATA[
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1193",
       "algorithm": "RSA",
       "testGroups" : [
@@ -2264,7 +2264,7 @@
             <figure>
         <artwork><![CDATA[
 {
-     "acvVersion": "0.3",
+     "acvVersion": "0.4",
       "vsId": "1194",
       "algorithm": "RSA",
       "testGroups" : [


### PR DESCRIPTION
This is intended for v0.4 hence it is going into the master branch. The protocol version in the examples is also bumped to v0.4.