### PR TITLE
Clarifies SHA3 is little endian and SHA2 is big endian

### DIFF
--- a/artifacts/acvp_sub_sha.html
+++ b/artifacts/acvp_sub_sha.html
@@ -395,11 +395,11 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.3" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.4" />
   <meta name="dct.issued" scheme="ISO8601" content="2017-2" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
@@ -433,7 +433,7 @@
   </table>
 
   <p class="title">ACVP Secure Hash Algorithm (SHA) JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subsha-0.3</span></p>
+  <span class="filename">draft-ietf-acvp-subsha-0.4</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -646,7 +646,7 @@
     </tr>
     <tr>
       <td class="left">msg</td>
-      <td class="left">Value of the message or seed</td>
+      <td class="left">Value of the message or seed in big-endian hex</td>
       <td class="left">value</td>
       <td class="left">No</td>
     </tr>
@@ -736,11 +736,11 @@
 
   	            </pre>
 <h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example Test Vectors JSON Object</a></h1>
-<p id="rfc.section.B.p.1">The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module.</p>
+<p id="rfc.section.B.p.1">The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module. Note the single bit message is represented as "80".  This complies with SHA1 and SHA2 being big-endian by nature. All hex strings associated with SHA1 and SHA2 will be big-endian.  </p>
 <pre>
 
 {
-	"acvVersion": "0.3",
+	"acvVersion": "0.4",
 	"vsId": 1564,
   	"algorithm": "SHA-512/224",
   	"testGroups": [
@@ -764,7 +764,7 @@
 <pre>
 
 {
-  	"acvVersion": "0.3",
+  	"acvVersion": "0.4",
   	"vsId": 1564,
   	"algorithm": "SHA-256",
   	"testGroups": [
@@ -788,7 +788,7 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "algorithm": "SHA-1",
     "testGroups": [
@@ -808,7 +808,7 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -825,7 +825,7 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {

--- a/artifacts/acvp_sub_sha.txt
+++ b/artifacts/acvp_sub_sha.txt
@@ -9,7 +9,7 @@ Expires: August 5, 2017
 
 
           ACVP Secure Hash Algorithm (SHA) JSON Specification
-                       draft-ietf-acvp-subsha-0.3
+                       draft-ietf-acvp-subsha-0.4
 
 Abstract
 
@@ -77,7 +77,7 @@ Table of Contents
      5.2.  Informative References  . . . . . . . . . . . . . . . . .   7
    Appendix A.  Example Secure Hash Capabilities JSON Object . . . .   7
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .   7
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .   8
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .   9
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   9
 
 1.  Introduction
@@ -265,12 +265,12 @@ Internet-Draft                Sym Alg JSON                 February 2017
    | tcId   | Numeric identifier for the test case, | value | No       |
    |        | unique across the entire vector set.  |       |          |
    | len    | Length of the message or seed         | value | No       |
-   | msg    | Value of the message or seed          | value | No       |
+   | msg    | Value of the message or seed in big-  | value | No       |
+   |        | endian hex                            |       |          |
    | md     | Hash value generated                  | value | Yes      |
    +--------+---------------------------------------+-------+----------+
 
                       Table 4: Test Case JSON Object
-
 
 
 
@@ -359,11 +359,14 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
 Appendix B.  Example Test Vectors JSON Object
 
    The following is an example JSON object for secure hash test vectors
-   sent from the ACVP server to the crypto module.
+   sent from the ACVP server to the crypto module.  Note the single bit
+   message is represented as "80".  This complies with SHA1 and SHA2
+   being big-endian by nature.  All hex strings associated with SHA1 and
+   SHA2 will be big-endian.
 
 
    {
-           "acvVersion": "0.3",
+           "acvVersion": "0.4",
            "vsId": 1564,
            "algorithm": "SHA-512/224",
            "testGroups": [
@@ -383,9 +386,6 @@ Appendix B.  Example Test Vectors JSON Object
            }]
    }
 
-   The following is another example JSON object for secure hash test
-   vectors sent from the ACVP server to the crypto module.
-
 
 
 
@@ -394,8 +394,12 @@ Celi                     Expires August 5, 2017                 [Page 7]
 Internet-Draft                Sym Alg JSON                 February 2017
 
 
+   The following is another example JSON object for secure hash test
+   vectors sent from the ACVP server to the crypto module.
+
+
 {
-        "acvVersion": "0.3",
+        "acvVersion": "0.4",
         "vsId": 1564,
         "algorithm": "SHA-256",
         "testGroups": [
@@ -420,7 +424,7 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
    {
-       "acvVersion": "0.3",
+       "acvVersion": "0.4",
        "vsId": 1564,
        "algorithm": "SHA-1",
        "testGroups": [
@@ -435,10 +439,6 @@ Internet-Draft                Sym Alg JSON                 February 2017
        }]
    }
 
-Appendix C.  Example Test Results JSON Object
-
-   The following is a example JSON object for secure hash test results
-   sent from the crypto module to the ACVP server.
 
 
 
@@ -450,8 +450,14 @@ Celi                     Expires August 5, 2017                 [Page 8]
 Internet-Draft                Sym Alg JSON                 February 2017
 
 
+Appendix C.  Example Test Results JSON Object
+
+   The following is a example JSON object for secure hash test results
+   sent from the crypto module to the ACVP server.
+
+
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -470,7 +476,7 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -491,12 +497,6 @@ Author's Address
    USA
 
    Email: christopher.celi@nist.gov
-
-
-
-
-
-
 
 
 

--- a/artifacts/acvp_sub_sha3.html
+++ b/artifacts/acvp_sub_sha3.html
@@ -400,7 +400,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.3" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.4" />
   <meta name="dct.issued" scheme="ISO8601" content="2017-2" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA3 and SHAKE with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA3 and SHAKE with the ACVP specification." />
@@ -434,7 +434,7 @@
   </table>
 
   <p class="title">ACVP SHA3 and SHAKE JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subsha-0.3</span></p>
+  <span class="filename">draft-ietf-acvp-subsha-0.4</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -667,7 +667,7 @@
     </tr>
     <tr>
       <td class="left">msg</td>
-      <td class="left">Value of the message or seed</td>
+      <td class="left">Value of the message or seed.  Messages are represented as little-endian hex for all SHA3 variations.</td>
       <td class="left">value</td>
       <td class="left">No</td>
     </tr>
@@ -772,11 +772,11 @@
  	    			
   	    		</pre>
 <h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example Test Vectors JSON Object</a></h1>
-<p id="rfc.section.B.p.1">The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module.</p>
+<p id="rfc.section.B.p.1">The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module.  Notice that the single bit message is represented as "01". This complies with the little-endian nature of SHA3. All hex displayed is little-endian bit order when associated with SHA3 or any of its variations.  </p>
 <pre>
 
 {
-	"acvVersion": "0.3",
+	"acvVersion": "0.4",
 	"vsId": 1564,
   	"algorithm": "SHA3-512",
   	"testGroups": [
@@ -791,7 +791,7 @@
   		{
   			"tcId": 1,
   			"len": 1,
-  			"msg": "80"
+  			"msg": "01"
   		}]
   	}]
 }
@@ -800,7 +800,7 @@
 <pre>
 
 {
-  	"acvVersion": "0.3",
+  	"acvVersion": "0.4",
   	"vsId": 1564,
   	"algorithm": "SHA3-256",
   	"testGroups": [
@@ -824,7 +824,7 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "algorithm": "SHA3-384",
     "testGroups": [
@@ -844,7 +844,7 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -861,7 +861,7 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -878,7 +878,7 @@
 <pre>
 
 {
-  	"acvVersion": "0.3",
+  	"acvVersion": "0.4",
   	"vsId": 1564,
   	"algorithm": "SHAKE-128",
   	"testGroups": [
@@ -904,13 +904,13 @@
 <pre>
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
         "tcId": 2170,
-        "outputLen": 80
-        "md": "c60048b8ad8fc71e50ff"
+        "outputLen": 16
+        "md": "c604"
     },
     {
         "tcId": 2171,

--- a/artifacts/acvp_sub_sha3.txt
+++ b/artifacts/acvp_sub_sha3.txt
@@ -9,7 +9,7 @@ Expires: August 5, 2017
 
 
                  ACVP SHA3 and SHAKE JSON Specification
-                       draft-ietf-acvp-subsha-0.3
+                       draft-ietf-acvp-subsha-0.4
 
 Abstract
 
@@ -70,7 +70,7 @@ Table of Contents
      4.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   5
      4.3.  Test Vector Responses . . . . . . . . . . . . . . . . . .   6
      4.4.  Acknowledgements  . . . . . . . . . . . . . . . . . . . .   6
-     4.5.  IANA Considerations . . . . . . . . . . . . . . . . . . .   6
+     4.5.  IANA Considerations . . . . . . . . . . . . . . . . . . .   7
      4.6.  Security Considerations . . . . . . . . . . . . . . . . .   7
    5.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
      5.1.  Normative References  . . . . . . . . . . . . . . . . . .   7
@@ -282,19 +282,23 @@ Celi                     Expires August 5, 2017                 [Page 5]
 Internet-Draft                Sym Alg JSON                 February 2017
 
 
-   +--------+----------------------------------+----------+------------+
-   | JSON   | Description                      | JSON     | Optional   |
-   | Value  |                                  | type     |            |
-   +--------+----------------------------------+----------+------------+
-   | tcId   | Numeric identifier for the test  | value    | No         |
-   |        | case, unique across the entire   |          |            |
-   |        | vector set.                      |          |            |
-   | len    | Length of the message or seed    | value    | No         |
-   | outLen | Length of the digest             | 16-65536 | Required   |
-   |        |                                  |          | for SHAKE  |
-   | msg    | Value of the message or seed     | value    | No         |
-   | md     | Hash value generated             | value    | Yes        |
-   +--------+----------------------------------+----------+------------+
+   +--------+------------------------------------+----------+----------+
+   | JSON   | Description                        | JSON     | Optional |
+   | Value  |                                    | type     |          |
+   +--------+------------------------------------+----------+----------+
+   | tcId   | Numeric identifier for the test    | value    | No       |
+   |        | case, unique across the entire     |          |          |
+   |        | vector set.                        |          |          |
+   | len    | Length of the message or seed      | value    | No       |
+   | outLen | Length of the digest               | 16-65536 | Required |
+   |        |                                    |          | for      |
+   |        |                                    |          | SHAKE    |
+   | msg    | Value of the message or seed.      | value    | No       |
+   |        | Messages are represented as        |          |          |
+   |        | little-endian hex for all SHA3     |          |          |
+   |        | variations.                        |          |          |
+   | md     | Hash value generated               | value    | Yes      |
+   +--------+------------------------------------+----------+----------+
 
                       Table 4: Test Case JSON Object
 
@@ -323,10 +327,6 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
    TBD...
 
-4.5.  IANA Considerations
-
-   This memo includes no request to IANA.
-
 
 
 
@@ -337,6 +337,10 @@ Celi                     Expires August 5, 2017                 [Page 6]
 
 Internet-Draft                Sym Alg JSON                 February 2017
 
+
+4.5.  IANA Considerations
+
+   This memo includes no request to IANA.
 
 4.6.  Security Considerations
 
@@ -375,6 +379,21 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
    SHAKE-128.
 
 
+
+
+
+
+
+
+
+
+
+
+Celi                     Expires August 5, 2017                 [Page 7]
+
+Internet-Draft                Sym Alg JSON                 February 2017
+
+
    {
            "algorithm": "SHAKE-128",
            "inBit": "yes",
@@ -387,21 +406,17 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
    }
 
 
-
-
-Celi                     Expires August 5, 2017                 [Page 7]
-
-Internet-Draft                Sym Alg JSON                 February 2017
-
-
 Appendix B.  Example Test Vectors JSON Object
 
    The following is an example JSON object for secure hash test vectors
-   sent from the ACVP server to the crypto module.
+   sent from the ACVP server to the crypto module.  Notice that the
+   single bit message is represented as "01".  This complies with the
+   little-endian nature of SHA3.  All hex displayed is little-endian bit
+   order when associated with SHA3 or any of its variations.
 
 
    {
-           "acvVersion": "0.3",
+           "acvVersion": "0.4",
            "vsId": 1564,
            "algorithm": "SHA3-512",
            "testGroups": [
@@ -416,7 +431,7 @@ Appendix B.  Example Test Vectors JSON Object
                    {
                            "tcId": 1,
                            "len": 1,
-                           "msg": "80"
+                           "msg": "01"
                    }]
            }]
    }
@@ -430,28 +445,13 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 Celi                     Expires August 5, 2017                 [Page 8]
 
 Internet-Draft                Sym Alg JSON                 February 2017
 
 
 {
-        "acvVersion": "0.3",
+        "acvVersion": "0.4",
         "vsId": 1564,
         "algorithm": "SHA3-256",
         "testGroups": [
@@ -476,7 +476,7 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "algorithm": "SHA3-384",
     "testGroups": [
@@ -507,7 +507,7 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -526,7 +526,7 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -563,7 +563,7 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
    {
-           "acvVersion": "0.3",
+           "acvVersion": "0.4",
            "vsId": 1564,
            "algorithm": "SHAKE-128",
            "testGroups": [
@@ -590,13 +590,13 @@ Internet-Draft                Sym Alg JSON                 February 2017
 
 
    {
-       "acvVersion": "0.3",
+       "acvVersion": "0.4",
        "vsId": 1564,
        "testResults": [
        {
            "tcId": 2170,
-           "outputLen": 80
-           "md": "c60048b8ad8fc71e50ff"
+           "outputLen": 16
+           "md": "c604"
        },
        {
            "tcId": 2171,

--- a/src/acvp_sub_sha.xml
+++ b/src/acvp_sub_sha.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subsha-0.3" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subsha-0.4" ipr="trust200902">
 	<!-- category values: std, bcp, info, exp, and historic
     	 ipr values: full3667, noModification3667, noDerivatives3667
     	 you can add the attributes updates="NNNN" and obsoletes="NNNN"
@@ -276,7 +276,7 @@
 					<c>No</c>
 
 					<c>msg</c>
-					<c>Value of the message or seed</c>
+					<c>Value of the message or seed in big-endian hex</c>
 					<c>value</c>
 					<c>No</c>
 
@@ -374,12 +374,15 @@
 		</section>
 		<section anchor="app-vs-ex" title="Example Test Vectors JSON Object">
 			<t>The following is an example JSON object for secure hash test vectors sent from the
-				ACVP server to the crypto module.</t>
+				ACVP server to the crypto module. Note the single bit message is represented as "80".
+				This complies with SHA1 and SHA2 being big-endian by nature. All hex strings associated
+				with SHA1 and SHA2 will be big-endian.
+			</t>
 			<figure>
 				<artwork>
 <![CDATA[
 {
-	"acvVersion": "0.3",
+	"acvVersion": "0.4",
 	"vsId": 1564,
   	"algorithm": "SHA-512/224",
   	"testGroups": [
@@ -406,7 +409,7 @@
 				<artwork>
 <![CDATA[
 {
-  	"acvVersion": "0.3",
+  	"acvVersion": "0.4",
   	"vsId": 1564,
   	"algorithm": "SHA-256",
   	"testGroups": [
@@ -433,7 +436,7 @@
 				<artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "algorithm": "SHA-1",
     "testGroups": [
@@ -458,7 +461,7 @@
 				<artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -478,7 +481,7 @@
 				<artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {

--- a/src/acvp_sub_sha3.xml
+++ b/src/acvp_sub_sha3.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subsha-0.3" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subsha-0.4" ipr="trust200902">
   	<!-- category values: std, bcp, info, exp, and historic
     	 ipr values: full3667, noModification3667, noDerivatives3667
     	 you can add the attributes updates="NNNN" and obsoletes="NNNN"
@@ -282,7 +282,7 @@
   					<c>Required for SHAKE</c>
 
   					<c>msg</c>
-  					<c>Value of the message or seed</c>
+  		    		<c>Value of the message or seed.  Messages are represented as little-endian hex for all SHA3 variations.</c>
   					<c>value</c>
   					<c>No</c>
   					
@@ -396,12 +396,15 @@
   	    	</figure>
   	    </section>
   	    <section anchor="app-vs-ex" title="Example Test Vectors JSON Object">
-  	    	<t>The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module.</t>
+  	    	<t>The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module. 
+  	    		Notice that the single bit message is represented as "01". This complies with the little-endian nature of SHA3. All
+  	    		hex displayed is little-endian bit order when associated with SHA3 or any of its variations.
+  	    	</t>
   	    	<figure>
   	    		<artwork>
 <![CDATA[
 {
-	"acvVersion": "0.3",
+	"acvVersion": "0.4",
 	"vsId": 1564,
   	"algorithm": "SHA3-512",
   	"testGroups": [
@@ -416,7 +419,7 @@
   		{
   			"tcId": 1,
   			"len": 1,
-  			"msg": "80"
+  			"msg": "01"
   		}]
   	}]
 }]]>
@@ -427,7 +430,7 @@
 	  	        <artwork>
 <![CDATA[
 {
-  	"acvVersion": "0.3",
+  	"acvVersion": "0.4",
   	"vsId": 1564,
   	"algorithm": "SHA3-256",
   	"testGroups": [
@@ -453,7 +456,7 @@
 	  	        <artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "algorithm": "SHA3-384",
     "testGroups": [
@@ -477,7 +480,7 @@
 	  	        <artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -496,7 +499,7 @@
   	        	<artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
@@ -517,7 +520,7 @@
 				<artwork>
 <![CDATA[
 {
-  	"acvVersion": "0.3",
+  	"acvVersion": "0.4",
   	"vsId": 1564,
   	"algorithm": "SHAKE-128",
   	"testGroups": [
@@ -545,13 +548,13 @@
 				<artwork>
 <![CDATA[
 {
-    "acvVersion": "0.3",
+    "acvVersion": "0.4",
     "vsId": 1564,
     "testResults": [
     {
         "tcId": 2170,
-        "outputLen": 80
-        "md": "c60048b8ad8fc71e50ff"
+        "outputLen": 16
+        "md": "c604"
     },
     {
         "tcId": 2171,


### PR DESCRIPTION
#109 

Code adjusts examples as well with a mention towards endianness.