### PR TITLE
Remove aad block length bools #152

### DIFF
--- a/artifacts/acvp_sub_symmetric.html
+++ b/artifacts/acvp_sub_symmetric.html
@@ -1249,8 +1249,6 @@
                 ],
                 "ivGen": "internal",
                 "ivGenMode": "8.2.1",
-                "supportsNonBlockBoundaryAadLen" : true,
-                "supportsNonBlockBoundaryPtLen" : true,
                 "keyLen": [
                     128,
                     192,

--- a/artifacts/acvp_sub_symmetric.txt
+++ b/artifacts/acvp_sub_symmetric.txt
@@ -80,7 +80,7 @@ Table of Contents
      8.2.  Informative References  . . . . . . . . . . . . . . . . .  13
    Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  13
    Appendix B.  Example AES Test and Results Vectors JSON Object . .  14
-   Appendix C.  Example AES MCT Test and Results JSON Object . . . .  19
+   Appendix C.  Example AES MCT Test and Results JSON Object . . . .  18
    Appendix D.  Example TDES Test and Results JSON Object  . . . . .  20
    Appendix E.  Example TDES MCT Test and Results JSON Object  . . .  22
    Appendix F.  Example Test Results JSON Object . . . . . . . . . .  23
@@ -175,49 +175,49 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +-------------+-------------+--------------+-------------+----------+
-   | JSON Value  | Description | JSON type    | Valid       | Optional |
-   |             |             |              | Values      |          |
-   +-------------+-------------+--------------+-------------+----------+
-   | algorithm   | The         | value        | See Section | No       |
-   |             | symmetric   |              | 2.4         |          |
-   |             | algorithm   |              |             |          |
-   |             | and mode to |              |             |          |
-   |             | be          |              |             |          |
-   |             | validated.  |              |             |          |
-   |             |             |              |             |          |
-   | prereqVals  | Prerequisit | array of     | See Section | Yes      |
-   |             | e algorithm | prereqAlgVal | 2.1         |          |
-   |             | validations | objects      |             |          |
-   |             |             |              |             |          |
-   | direction   | The crypto  | array        | encrypt,    | No       |
-   |             | operation   |              | decrypt     |          |
-   |             | direction   |              |             |          |
-   |             |             |              |             |          |
-   | keyLen      | The         | array        | 128, 168,   | No       |
-   |             | supported   |              | 192, 256    |          |
-   |             | key lengths |              |             |          |
-   |             | in bits     |              |             |          |
-   |             |             |              |             |          |
-   | ptLen       | The         | range or     | 0-65536     | No       |
-   |             | supported   | array        |             |          |
-   |             | plaintext   |              |             |          |
-   |             | lengths in  |              |             |          |
-   |             | bits.       |              |             |          |
-   |             | This varies |              |             |          |
-   |             | depending   |              |             |          |
-   |             | on the      |              |             |          |
-   |             | algorithm   |              |             |          |
-   |             | type, for   |              |             |          |
-   |             | additional  |              |             |          |
-   |             | details see |              |             |          |
-   |             | Section 2.3 |              |             |          |
-   |             |             |              |             |          |
-   | ivLen       | The         | array        | 8-1024      | Yes      |
-   |             | supported   |              |             |          |
-   |             | IV/Nonce    |              |             |          |
-   |             | lengths in  |              |             |          |
-   |             | bits, see   |              |             |          |
+   +-------------+--------------+--------------+------------+----------+
+   | JSON Value  | Description  | JSON type    | Valid      | Optional |
+   |             |              |              | Values     |          |
+   +-------------+--------------+--------------+------------+----------+
+   | algorithm   | The          | value        | See        | No       |
+   |             | symmetric    |              | Section    |          |
+   |             | algorithm    |              | 2.4        |          |
+   |             | and mode to  |              |            |          |
+   |             | be           |              |            |          |
+   |             | validated.   |              |            |          |
+   |             |              |              |            |          |
+   | prereqVals  | Prerequisite | array of     | See        | Yes      |
+   |             | algorithm    | prereqAlgVal | Section    |          |
+   |             | validations  | objects      | 2.1        |          |
+   |             |              |              |            |          |
+   | direction   | The crypto   | array        | encrypt,   | No       |
+   |             | operation    |              | decrypt    |          |
+   |             | direction    |              |            |          |
+   |             |              |              |            |          |
+   | keyLen      | The          | array        | 128, 168,  | No       |
+   |             | supported    |              | 192, 256   |          |
+   |             | key lengths  |              |            |          |
+   |             | in bits      |              |            |          |
+   |             |              |              |            |          |
+   | ptLen       | The          | range or     | 0-65536    | No       |
+   |             | supported    | array        |            |          |
+   |             | plaintext    |              |            |          |
+   |             | lengths in   |              |            |          |
+   |             | bits.   This |              |            |          |
+   |             | varies       |              |            |          |
+   |             | depending on |              |            |          |
+   |             | the          |              |            |          |
+   |             | algorithm    |              |            |          |
+   |             | type, for    |              |            |          |
+   |             | additional   |              |            |          |
+   |             | details see  |              |            |          |
+   |             | Section 2.3  |              |            |          |
+   |             |              |              |            |          |
+   | ivLen       | The          | array        | 8-1024     | Yes      |
+   |             | supported    |              |            |          |
+   |             | IV/Nonce     |              |            |          |
+   |             | lengths in   |              |            |          |
+   |             | bits, see    |              |            |          |
 
 
 
@@ -226,54 +226,54 @@ Foley                   Expires December 3, 2016                [Page 4]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |             | Section 2.3 |              |             |          |
-   |             |             |              |             |          |
-   | ivGen       | IV          | value        | internal,   | Yes      |
-   |             | generation  |              | external    |          |
-   |             | method for  |              |             |          |
-   |             | AEAD        |              |             |          |
-   |             | algorithms  |              |             |          |
-   |             |             |              |             |          |
-   | ivGenMode   | IV          | value        | 8.2.1,      | Yes      |
-   |             | generation  |              | 8.2.2       |          |
-   |             | mode for    |              |             |          |
-   |             | AEAD        |              |             |          |
-   |             | algorithms  |              |             |          |
-   |             |             |              |             |          |
-   | aadLen      | The         | range or     | 0-65536     | Yes      |
-   |             | supported   | array        |             |          |
-   |             | AAD lengths |              |             |          |
-   |             | in bits for |              |             |          |
-   |             | AEAD        |              |             |          |
-   |             | algorithms, |              |             |          |
-   |             |             |              |             |          |
-   | tagLen      | The         | array        | 4-128       | Yes      |
-   |             | supported   |              |             |          |
-   |             | Tag lengths |              |             |          |
-   |             | in bits for |              |             |          |
-   |             | AEAD        |              |             |          |
-   |             | algorithms, |              |             |          |
-   |             | Section 2.3 |              |             |          |
-   |             |             |              |             |          |
-   | kwCipher    | The cipher  | array        | cipher,     | Yes      |
-   |             | as defined  |              | inverse     |          |
-   |             | in          |              |             |          |
-   |             | SP800-38F   |              |             |          |
-   |             | for key     |              |             |          |
-   |             | wrap mode   |              |             |          |
-   |             |             |              |             |          |
-   | tweakFormat | The format  | array        | 128hex,     | Yes      |
-   |             | of tweak    |              | duSequence  |          |
-   |             | value input |              |             |          |
-   |             | for AES-XTS |              |             |          |
-   |             |             |              |             |          |
-   | keyingOptio | The Keying  | array        | 1, 2        | Yes      |
-   | n           | Option used |              |             |          |
-   |             | in TDES.    |              |             |          |
-   |             | Keying      |              |             |          |
-   |             | option 1    |              |             |          |
-   |             | (1) is 3    |              |             |          |
-   |             | distinct    |              |             |          |
+   |             | Section 2.3  |              |            |          |
+   |             |              |              |            |          |
+   | ivGen       | IV           | value        | internal,  | Yes      |
+   |             | generation   |              | external   |          |
+   |             | method for   |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms   |              |            |          |
+   |             |              |              |            |          |
+   | ivGenMode   | IV           | value        | 8.2.1,     | Yes      |
+   |             | generation   |              | 8.2.2      |          |
+   |             | mode for     |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms   |              |            |          |
+   |             |              |              |            |          |
+   | aadLen      | The          | range or     | 0-65536    | Yes      |
+   |             | supported    | array        |            |          |
+   |             | AAD lengths  |              |            |          |
+   |             | in bits for  |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms,  |              |            |          |
+   |             |              |              |            |          |
+   | tagLen      | The          | array        | 4-128      | Yes      |
+   |             | supported    |              |            |          |
+   |             | Tag lengths  |              |            |          |
+   |             | in bits for  |              |            |          |
+   |             | AEAD         |              |            |          |
+   |             | algorithms,  |              |            |          |
+   |             | Section 2.3  |              |            |          |
+   |             |              |              |            |          |
+   | kwCipher    | The cipher   | array        | cipher,    | Yes      |
+   |             | as defined   |              | inverse    |          |
+   |             | in SP800-38F |              |            |          |
+   |             | for key wrap |              |            |          |
+   |             | mode         |              |            |          |
+   |             |              |              |            |          |
+   | tweakFormat | The format   | array        | 128hex,    | Yes      |
+   |             | of tweak     |              | duSequence |          |
+   |             | value input  |              |            |          |
+   |             | for AES-XTS  |              |            |          |
+   |             |              |              |            |          |
+   | keyingOptio | The Keying   | array        | 1, 2       | Yes      |
+   | n           | Option used  |              |            |          |
+   |             | in TDES.     |              |            |          |
+   |             | Keying       |              |            |          |
+   |             | option 1 (1) |              |            |          |
+   |             | is 3         |              |            |          |
+   |             | distinct     |              |            |          |
+   |             | keys (K1,    |              |            |          |
 
 
 
@@ -282,35 +282,31 @@ Foley                   Expires December 3, 2016                [Page 5]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |             | keys (K1,   |              |             |          |
-   |             | K2, K3).    |              |             |          |
-   |             | Keying      |              |             |          |
-   |             | Option 2    |              |             |          |
-   |             | (2) is 2    |              |             |          |
-   |             | distinct    |              |             |          |
-   |             | only        |              |             |          |
-   |             | suitable    |              |             |          |
-   |             | for decrypt |              |             |          |
-   |             | (K1, K2,    |              |             |          |
-   |             | K1).        |              |             |          |
-   |             | Keying      |              |             |          |
-   |             | option 3    |              |             |          |
-   |             | (No longer  |              |             |          |
-   |             | valid for   |              |             |          |
-   |             | testing,    |              |             |          |
-   |             | save KATs)  |              |             |          |
-   |             | is a single |              |             |          |
-   |             | key, now    |              |             |          |
-   |             | deprecated  |              |             |          |
-   |             | (K1, K1,    |              |             |          |
-   |             | K1).        |              |             |          |
-   |             |             |              |             |          |
-   | ctrSource   | The source  | value        | internal,   | Yes      |
-   |             | of the      |              | external    |          |
-   |             | counter for |              |             |          |
-   |             | counter-    |              |             |          |
-   |             | mode        |              |             |          |
-   +-------------+-------------+--------------+-------------+----------+
+   |             | K2, K3).     |              |            |          |
+   |             | Keying       |              |            |          |
+   |             | Option 2 (2) |              |            |          |
+   |             | is 2         |              |            |          |
+   |             | distinct     |              |            |          |
+   |             | only         |              |            |          |
+   |             | suitable for |              |            |          |
+   |             | decrypt (K1, |              |            |          |
+   |             | K2, K1).     |              |            |          |
+   |             | Keying       |              |            |          |
+   |             | option 3 (No |              |            |          |
+   |             | longer valid |              |            |          |
+   |             | for testing, |              |            |          |
+   |             | save KATs)   |              |            |          |
+   |             | is a single  |              |            |          |
+   |             | key, now     |              |            |          |
+   |             | deprecated   |              |            |          |
+   |             | (K1, K1,     |              |            |          |
+   |             | K1).         |              |            |          |
+   |             |              |              |            |          |
+   | ctrSource   | The source   | value        | internal,  | Yes      |
+   |             | of the       |              | external   |          |
+   |             | counter for  |              |            |          |
+   |             | counter-mode |              |            |          |
+   +-------------+--------------+--------------+------------+----------+
 
            Table 2: Symmetric Algorithm Capabilities JSON Values
 
@@ -323,6 +319,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    Some algorithms allow ranges of data, IV and AAD lengths.  This table
    outlines the allowed values.
+
+
+
+
 
 
 
@@ -740,8 +740,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 ],
                 "ivGen": "internal",
                 "ivGenMode": "8.2.1",
-                "supportsNonBlockBoundaryAadLen" : true,
-                "supportsNonBlockBoundaryPtLen" : true,
                 "keyLen": [
                     128,
                     192,
@@ -778,6 +776,8 @@ Appendix B.  Example AES Test and Results Vectors JSON Object
                          "direction": "encrypt",
                          "keyLen": 128,
                          "ivLen": 96,
+                         "ptLen": 0,
+                         "aadLen": 128,
 
 
 
@@ -786,8 +786,6 @@ Foley                   Expires December 3, 2016               [Page 14]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                         "ptLen": 0,
-                         "aadLen": 128,
                          "tagLen": 128,
                          "testType": "AFT",
                          "tests": [
@@ -834,6 +832,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
                            },
                            {
                              "tcId": 2187,
+                             "key": "DAE8E9A248931962FDB03F4C3B227801",
+                             "pt": "",
 
 
 
@@ -842,8 +842,6 @@ Foley                   Expires December 3, 2016               [Page 15]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                             "key": "DAE8E9A248931962FDB03F4C3B227801",
-                             "pt": "",
                              "aad": "FFDBB1801C99C87C6782CAA36E4F0BDDD0"
                            }
                          ]
@@ -890,6 +888,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
                            {
                              "tcId": 2206,
                              "key": "962574476C8D12E6487C6CDDA952E8C8",
+                             "pt": "DFF4D0CFF9D8628FA51EB8E533A68C32",
+                             "aad": "AEF2547382355E157E15DBECB64A8C77"
 
 
 
@@ -898,8 +898,6 @@ Foley                   Expires December 3, 2016               [Page 16]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                             "pt": "DFF4D0CFF9D8628FA51EB8E533A68C32",
-                             "aad": "AEF2547382355E157E15DBECB64A8C77"
                            }
                          ]
                        }
@@ -946,6 +944,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
                            },
                            {
                                "tcId": 2187,
+                               "iv": "010203043E56946A9C9E18D7",
+                               "ct": "",
 
 
 
@@ -954,8 +954,6 @@ Foley                   Expires December 3, 2016               [Page 17]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                               "iv": "010203043E56946A9C9E18D7",
-                               "ct": "",
                                "tag": "7DA8BA92D64071909972395C981C4567"
                            },
                            {
@@ -999,8 +997,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
                  ]
 
 
+Appendix C.  Example AES MCT Test and Results JSON Object
 
-
+   The following is a example JSON object for test vectors sent from the
+   ACVP server to the crypto module for an AES-CBC Monte Carlo test.
 
 
 
@@ -1009,11 +1009,6 @@ Foley                   Expires December 3, 2016               [Page 18]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
-
-Appendix C.  Example AES MCT Test and Results JSON Object
-
-   The following is a example JSON object for test vectors sent from the
-   ACVP server to the crypto module for an AES-CBC Monte Carlo test.
 
                  [
                    { "acvVersion": "0.3" },
@@ -1042,6 +1037,11 @@ Appendix C.  Example AES MCT Test and Results JSON Object
    only 2 iterations shown for brevity.  For MCT results of each
    iteration are fed into the next iteration.  Therefore the results
    carry all fields to assist in any failure diagnosis.
+
+
+
+
+
 
 
 

--- a/src/acvp_sub_symmetric.xml
+++ b/src/acvp_sub_symmetric.xml
@@ -685,8 +685,6 @@
                 ],
                 "ivGen": "internal",
                 "ivGenMode": "8.2.1",
-                "supportsNonBlockBoundaryAadLen" : true,
-                "supportsNonBlockBoundaryPtLen" : true,
                 "keyLen": [
                     128,
                     192,


### PR DESCRIPTION
`
"supportsNonBlockBoundaryAadLen" : true,
"supportsNonBlockBoundaryPtLen" : true,
`

Are not needed due to current literal inputs specified for aes-gcm.  Removing from .xml and regenerated artifacts.  fixes #152