### PR TITLE
Rsa fixes

### DIFF
--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -1139,7 +1139,7 @@
       <td class="left">modRSASigGen</td>
       <td class="left">supported RSA moduli for signature generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"2048", "3072", "4096"}</td>
+      <td class="left">any non-empty subset of {2048, 3072, 4096}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1211,7 +1211,7 @@
       <td class="left">modRSASigVer</td>
       <td class="left">supported RSA moduli for signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"2048", "3072", "4096"}</td>
+      <td class="left">any non-empty subset of {2048, 3072, 4096}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1284,7 +1284,7 @@
       <td class="left">modLegacyRSASigVer</td>
       <td class="left">supported RSA moduli for signature verification - see <a href="#SP800-131A">[SP800-131A]</a></td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"1024", "1536", "2048", "3072", "4096"}</td>
+      <td class="left">any non-empty subset of {1024, 1536, 2048, 3072, 4096}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1672,7 +1672,7 @@
     </tr>
     <tr>
       <td class="left">seed</td>
-      <td class="left">the seed used in prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4, or B3.5</td>
+      <td class="left">the seed used in prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, or B3.5</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1684,7 +1684,7 @@
     </tr>
     <tr>
       <td class="left">bitlen1</td>
-      <td class="left">the length of p1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4, B3.5 or the length of xP1 for B3.6</td>
+      <td class="left">the length of p1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B3.5 or the length of xP1 for B.3.6</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -1012,7 +1012,7 @@
       <td class="left">fixedPubExp</td>
       <td class="left">Supports fixed public key exponent e</td>
       <td class="left">value</td>
-      <td class="left">"yes","no"</td>
+      <td class="left">true or false</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1040,7 +1040,7 @@
       <td class="left">randPubExp</td>
       <td class="left">Supports random public key exponent e</td>
       <td class="left">value</td>
-      <td class="left">"yes","no"</td>
+      <td class="left">true or false</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1955,7 +1955,7 @@
          {"modeSpecs" : {
               "mode": "keyGen",
               "capSpecs" :  {
-                      "fixedPubExp" : "yes",
+                      "fixedPubExp" : true,
                       "fixedPubExpVal" : "010001",
                       "randPQ" : 1,
                       "capProvPrime" : 
@@ -1995,7 +1995,7 @@
         "modeSpecs": {
           "mode":"keyGen",
           "capSpecs": {
-            "fixedPubExp":"yes",
+            "fixedPubExp": true,
             "fixedPubExpVal":"010001",
             "randPQ": 2,
             "capProbPrime":[{
@@ -2025,7 +2025,7 @@
          {"modeSpecs" : {
            "mode": "keyGen",
            "capSpecs" : {
-               "fixedPubExp" : "yes",
+               "fixedPubExp" : true,
                "fixedPubExpVal" : "010001",
                "randPQ" : 4,
                "capsProvProbPrime" : 

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -383,9 +383,10 @@
 <link href="#rfc.section.2.3" rel="Chapter" title="2.3 Supported RSA Capabilities"/>
 <link href="#rfc.section.2.4" rel="Chapter" title="2.4 Supported RSA Modes Capabilities"/>
 <link href="#rfc.section.2.4.1" rel="Chapter" title="2.4.1 The keyGen Mode Capabilities"/>
-<link href="#rfc.section.2.4.1.1" rel="Chapter" title="2.4.1.1 keyGen With Provable Primes Capabilities"/>
+<link href="#rfc.section.2.4.1.1" rel="Chapter" title="2.4.1.1 keyGen With Provable Primes or Provable Primes with Conditions Capabilities"/>
 <link href="#rfc.section.2.4.1.2" rel="Chapter" title="2.4.1.2 keyGen With Probable Primes Capabilities"/>
-<link href="#rfc.section.2.4.1.3" rel="Chapter" title="2.4.1.3 keyGen Full Set Of Capabilities"/>
+<link href="#rfc.section.2.4.1.3" rel="Chapter" title="2.4.1.3 keyGen With Both Provable and Probable Primes With Conditions"/>
+<link href="#rfc.section.2.4.1.4" rel="Chapter" title="2.4.1.4 keyGen Full Set Of Capabilities"/>
 <link href="#rfc.section.2.4.2" rel="Chapter" title="2.4.2 The sigGen Mode Capabilities"/>
 <link href="#rfc.section.2.4.2.1" rel="Chapter" title="2.4.2.1 sigGen Capabilities"/>
 <link href="#rfc.section.2.4.3" rel="Chapter" title="2.4.3 The sigVer Mode Capabilities"/>
@@ -402,10 +403,9 @@
 <link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations"/>
 <link href="#rfc.references" rel="Chapter" title="8 Normative References"/>
 <link href="#rfc.appendix.A" rel="Chapter" title="A Example RSA Capabilities JSON Objects"/>
-<link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 Example keyGen Capabilities JSON Objects"/>
+<link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects"/>
 <link href="#rfc.appendix.A.1.1" rel="Chapter" title="A.1.1 Example keyGen with Probable Primes Capabilities JSON Object"/>
 <link href="#rfc.appendix.A.1.2" rel="Chapter" title="A.1.2 Example keyGen with Provable Conditional Primes with Probable Factors Capabilities JSON Object"/>
-<link href="#rfc.appendix.A.1.3" rel="Chapter" title="A.1.3 Example keyGen with Probable Conditional Primes with Probable Factors Capabilities JSON Object"/>
 <link href="#rfc.appendix.A.2" rel="Chapter" title="A.2 Example RSA sigGen Capabilities JSON Objects"/>
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Example RSA sigVer Capabilities JSON Objects"/>
 <link href="#rfc.appendix.A.4" rel="Chapter" title="A.4 Example RSA legacySigVer Capabilities JSON Objects"/>
@@ -428,14 +428,14 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.2.dev0 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-5-30" />
-  <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm implementations for conformance to  " />
-  <meta name="description" content="This document defines the JSON schema for testing RSA algorithm implementations for conformance to  " />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-5" />
+  <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  " />
+  <meta name="description" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  " />
 
 </head>
 
@@ -454,10 +454,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">May 30, 2017</td>
+  <td class="right">May 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: December 1, 2017</td>
+  <td class="left">Expires: November 2, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -471,14 +471,14 @@
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
 </h1>
-<p>This document defines the JSON schema for testing RSA algorithm implementations for conformance to  <a href="#FIPS186-4">[FIPS186-4]</a> with the ACVP specification.</p>
+<p>This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  <a href="#FIPS186-4">[FIPS186-4]</a> and <a href="#SP800-56B">[SP800-56B]</a> with the ACVP specification.</p>
 <h1 id="rfc.status">
   <a href="#rfc.status">Status of This Memo</a>
 </h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on December 1, 2017.</p>
+<p>This Internet-Draft will expire on November 2, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -499,9 +499,10 @@
 <li>2.3.   <a href="#rfc.section.2.3">Supported RSA Capabilities</a></li>
 <li>2.4.   <a href="#rfc.section.2.4">Supported RSA Modes Capabilities</a></li>
 <ul><li>2.4.1.   <a href="#rfc.section.2.4.1">The keyGen Mode Capabilities</a></li>
-<ul><li>2.4.1.1.   <a href="#rfc.section.2.4.1.1">keyGen With Provable Primes Capabilities</a></li>
+<ul><li>2.4.1.1.   <a href="#rfc.section.2.4.1.1">keyGen With Provable Primes or Provable Primes with Conditions Capabilities</a></li>
 <li>2.4.1.2.   <a href="#rfc.section.2.4.1.2">keyGen With Probable Primes Capabilities</a></li>
-<li>2.4.1.3.   <a href="#rfc.section.2.4.1.3">keyGen Full Set Of Capabilities</a></li>
+<li>2.4.1.3.   <a href="#rfc.section.2.4.1.3">keyGen With Both Provable and Probable Primes With Conditions</a></li>
+<li>2.4.1.4.   <a href="#rfc.section.2.4.1.4">keyGen Full Set Of Capabilities</a></li>
 </ul><li>2.4.2.   <a href="#rfc.section.2.4.2">The sigGen Mode Capabilities</a></li>
 <ul><li>2.4.2.1.   <a href="#rfc.section.2.4.2.1">sigGen Capabilities</a></li>
 </ul><li>2.4.3.   <a href="#rfc.section.2.4.3">The sigVer Mode Capabilities</a></li>
@@ -518,10 +519,9 @@
 <li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
 <li>8.   <a href="#rfc.references">Normative References</a></li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Example RSA Capabilities JSON Objects</a></li>
-<ul><li>A.1.   <a href="#rfc.appendix.A.1">Example keyGen Capabilities JSON Objects</a></li>
+<ul><li>A.1.   <a href="#rfc.appendix.A.1">Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects</a></li>
 <ul><li>A.1.1.   <a href="#rfc.appendix.A.1.1">Example keyGen with Probable Primes Capabilities JSON Object</a></li>
 <li>A.1.2.   <a href="#rfc.appendix.A.1.2">Example keyGen with Provable Conditional Primes with Probable Factors Capabilities JSON Object</a></li>
-<li>A.1.3.   <a href="#rfc.appendix.A.1.3">Example keyGen with Probable Conditional Primes with Probable Factors Capabilities JSON Object</a></li>
 </ul><li>A.2.   <a href="#rfc.appendix.A.2">Example RSA sigGen Capabilities JSON Objects</a></li>
 <li>A.3.   <a href="#rfc.appendix.A.3">Example RSA sigVer Capabilities JSON Objects</a></li>
 <li>A.4.   <a href="#rfc.appendix.A.4">Example RSA legacySigVer Capabilities JSON Objects</a></li>
@@ -547,11 +547,11 @@
   </ul>
 
   <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> Introduction</h1>
-<p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module.  The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more.  The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms.  Each sub-specification addresses a specific class of crypto algorithms.  This sub-specification defines the JSON constructs for testing RSA akgorithm implementations for conformance to <a href="#FIPS186-4">[FIPS186-4]</a> using ACVP.</p>
+<p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module.  The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more.  The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms.  Each sub-specification addresses a specific class of crypto algorithms.  This sub-specification defines the JSON constructs for testing RSA algorithm and component implementations for conformance to <a href="#FIPS186-4">[FIPS186-4]</a> and <a href="#SP800-56B">[SP800-56B]</a> using ACVP.</p>
 <h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
 <p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119">RFC 2119</a> <cite title="NONE">[RFC2119]</cite>.</p>
 <h1 id="rfc.section.1.2"><a href="#rfc.section.1.2">1.2.</a> <a href="#defaults_def" id="defaults_def">Testing scope</a></h1>
-<p id="rfc.section.1.2.p.1">The ACVP testing for RSA allows conformance testing for all modes of using the algorithm as specified in <a href="#FIPS186-4">[FIPS186-4]</a>: key generation, signature generation, signature verification, component primitives. Correspondingly, ACVP allows testing of the five different methods for key generation in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.  </p>
+<p id="rfc.section.1.2.p.1">The ACVP testing for RSA allows conformance testing for all modes of using the algorithm as specified in <a href="#FIPS186-4">[FIPS186-4]</a>: key generation, signature generation, signature verification, and component primitives. ACVP testing for RSA also allows conformance testing for <a href="#SP800-56B">[SP800-56B]</a>: decryption primitives.  Correspondingly, ACVP allows testing of the five different methods for key generation in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.  </p>
 <h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a></h1>
 <p id="rfc.section.2.p.1">ACVP requires cryptographic modules to register their capabilities.  This allows the cryptographic module to advertise support for specific algorithms and their modes, notifying the ACVP server which algorithms need test vectors generated for the validation process.  This section describes the constructs for advertising support of the RSA algorithm in all allowed modes to the ACVP server - see <a href="#FIPS186-4">[FIPS186-4]</a> for details.</p>
 <h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> <a href="#supported_algs" id="supported_algs">Supported RSA Algorithm modes</a></h1>
@@ -594,7 +594,7 @@
   </tbody>
 </table>
 <h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for RSA Mode Validations</a></h1>
-<p id="rfc.section.2.2.p.1">Each RSA Mode implementation relies on other cryptographic primitives (algorithms) - see <a href="#FIPS186-4">[FIPS186-4]</a>.  For example, a keyGen uses an underlying DRBG and hash algorithms. In some case, a single RSA Mode implementation may use several primitives of the same type.  For example, two different DRBG implementations may be used in the keyGen algorithms in Section B.3.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, one in step 4.2 and another in step 5.2.  Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<p id="rfc.section.2.2.p.1">Each RSA Mode implementation relies on other cryptographic primitives (algorithms) - see <a href="#FIPS186-4">[FIPS186-4]</a>.  For example, a keyGen implementation uses underlying DRBG and hash algorithms. In some case, a single RSA Mode implementation may use several primitives of the same type.  For example, two different DRBG implementations may be used in the keyGen algorithms in Appendix B.3.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, one in step 4.2 and another in step 5.2.  Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
 <div id="rfc.table.2"/>
 <div id="prereqs_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -679,10 +679,24 @@
   <tbody>
     <tr>
       <td class="left">algorithm</td>
-      <td class="left">The RSA algorithm to be validated.</td>
+      <td class="left">The RSA algorithm to be validated</td>
       <td class="left">value</td>
       <td class="left">"RSA"</td>
       <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">infoGeneratedByServer</td>
+      <td class="left">This flag indicates that the server is responsible for generating inputs for Key Generation tests</td>
+      <td class="left">value</td>
+      <td class="left">true or false</td>
+      <td class="left">Yes</td>
     </tr>
     <tr>
       <td class="left"/>
@@ -749,12 +763,12 @@
 <p id="rfc.section.2.4.1.p.1">The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.1.p.2">Each RSA keyGen mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.1.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
-<h1 id="rfc.section.2.4.1.1"><a href="#rfc.section.2.4.1.1">2.4.1.1.</a> <a href="#mode_keyGenProvPrim" id="mode_keyGenProvPrim">keyGen With Provable Primes Capabilities</a></h1>
-<p id="rfc.section.2.4.1.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<h1 id="rfc.section.2.4.1.1"><a href="#rfc.section.2.4.1.1">2.4.1.1.</a> <a href="#mode_keyGenProvPrim" id="mode_keyGenProvPrim">keyGen With Provable Primes or Provable Primes with Conditions Capabilities</a></h1>
+<p id="rfc.section.2.4.1.1.p.1">The following key generation with provable primes, or provable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.4"/>
 <div id="keyGenProvPrim_modulitable"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Supported RSA keyGen moduli and hash options for provable primes JSON Values </caption>
+  <caption>Supported RSA keyGen moduli and hash options for provable primes or provable primes with conditions JSON Values </caption>
   <thead>
     <tr>
       <th class="left">JSON value</th>
@@ -766,10 +780,10 @@
   </thead>
   <tbody>
     <tr>
-      <td class="left">modProvPrime</td>
-      <td class="left">supported RSA moduli for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2</td>
+      <td class="left">modulo</td>
+      <td class="left">Supported RSA moduli for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2 or Appendix B.3.4</td>
       <td class="left">value</td>
-      <td class="left">"2048", "3072", "4096"</td>
+      <td class="left">2048, 3072, or 4096</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -780,8 +794,8 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">hashProvPrime</td>
-      <td class="left">supported hash algorithms for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2</td>
+      <td class="left">hashAlg</td>
+      <td class="left">Supported hash algorithms for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2 or Appendix B.3.4</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
       <td class="left">Yes</td>
@@ -794,9 +808,9 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">singleCapProvPrime</td>
-      <td class="left">a testable combination of modulus and hash values</td>
-      <td class="left">object with "modProvPrime" and "hashProvPrime" properties</td>
+      <td class="left">singleCap</td>
+      <td class="left">A testable combination of modulus and hash values</td>
+      <td class="left">object with "modulo" and "hashAlg" properties</td>
       <td class="left">see above</td>
       <td class="left">Yes</td>
     </tr>
@@ -809,19 +823,19 @@
     </tr>
     <tr>
       <td class="left">capProvPrime</td>
-      <td class="left">supported capabilities for provable prime generation</td>
+      <td class="left">Supported capabilities for provable prime generation or provable prime with conditions generation</td>
       <td class="left">array</td>
-      <td class="left">"singleCapProvPrime" objects, see above for possible values</td>
+      <td class="left">"singleCap" objects, see above for possible values</td>
       <td class="left">Yes</td>
     </tr>
   </tbody>
 </table>
 <h1 id="rfc.section.2.4.1.2"><a href="#rfc.section.2.4.1.2">2.4.1.2.</a> <a href="#mode_keyGenProbPrim" id="mode_keyGenProbPrim">keyGen With Probable Primes Capabilities</a></h1>
-<p id="rfc.section.2.4.1.2.p.1">The following key generation with probable primes capabilities may be advertised by the ACVP compliant crypto modules:</p>
+<p id="rfc.section.2.4.1.2.p.1">The following key generation with probable primes or probable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.5"/>
 <div id="keyGenProbPrim_modulitable"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Supported RSA keyGen moduli and primality test options for probable primes JSON Values </caption>
+  <caption>Supported RSA keyGen moduli and primality test options for probable primes or probable primes with conditions JSON Values</caption>
   <thead>
     <tr>
       <th class="left">JSON value</th>
@@ -833,10 +847,10 @@
   </thead>
   <tbody>
     <tr>
-      <td class="left">modProbPrime</td>
-      <td class="left">supported RSA moduli for probable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3</td>
-      <td class="left">array</td>
-      <td class="left">any non-empty subset of {"2048", "3072", "4096"}</td>
+      <td class="left">modulo</td>
+      <td class="left">supported RSA moduli for probable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3 or Appendix B.3.5</td>
+      <td class="left">value</td>
+      <td class="left">2048, 3072 or 4096</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -848,9 +862,23 @@
     </tr>
     <tr>
       <td class="left">primeTest</td>
-      <td class="left">Primality test rounds of Miller-Rabin from Table C.2  or Table C.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.3</td>
-      <td class="left">value</td>
-      <td class="left">"tblC2", "tblC3"</td>
+      <td class="left">Primality test rounds of Miller-Rabin from Table C.2 or Table C.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.3</td>
+      <td class="left">array</td>
+      <td class="left">any non-empty set of {"tblC2", "tblC3"}</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">singleCap</td>
+      <td class="left">A testable combination of modulus and primality test rounds</td>
+      <td class="left">object with "modulo" and "primeTest" properties</td>
+      <td class="left">see above</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -862,16 +890,97 @@
     </tr>
     <tr>
       <td class="left">capProbPrime</td>
-      <td class="left">supported capabilities for probable prime generation</td>
-      <td class="left">object with "modeProbPrime" and "primeTest" properties</td>
+      <td class="left">supported capabilities for probable prime generation or probable primes with conditions generation</td>
+      <td class="left">object with "singleCap" properties</td>
       <td class="left">see above for possible values</td>
       <td class="left">Yes</td>
     </tr>
   </tbody>
 </table>
-<h1 id="rfc.section.2.4.1.3"><a href="#rfc.section.2.4.1.3">2.4.1.3.</a> <a href="#mode_keyGenFullSet" id="mode_keyGenFullSet">keyGen Full Set Of Capabilities</a></h1>
-<p id="rfc.section.2.4.1.3.p.1">The complete list of RSA key generation capabilities may be advertised by the ACVP compliant crypto module:</p>
+<h1 id="rfc.section.2.4.1.3"><a href="#rfc.section.2.4.1.3">2.4.1.3.</a> <a href="#mode_keyGenProvProbPrimWithCond" id="mode_keyGenProvProbPrimWithCond">keyGen With Both Provable and Probable Primes With Conditions</a></h1>
+<p id="rfc.section.2.4.1.3.p.1">The following key generation with both provable and probable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.6"/>
+<div id="keyGenProvProbPrimWithCond"/>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <caption>Supported RSA keyGen moduli, hash algorithms, and primality test options for provable and               probable primes with conditions JSON Values</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Valid values</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">modulo</td>
+      <td class="left">supported RSA modulo for provable primes with conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.6</td>
+      <td class="left">value</td>
+      <td class="left">2048, 3072 or 4096</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">hashAlg</td>
+      <td class="left">Supported hash algorithms for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.6</td>
+      <td class="left">array</td>
+      <td class="left">any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">primeTest</td>
+      <td class="left">Primality test rounds of Miller-Rabin from Table C.2 or Table C.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.3</td>
+      <td class="left">array</td>
+      <td class="left">any non-empty subset of {"tblC2", "tblC3"}</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">singleCap</td>
+      <td class="left">A testable combination of modulus, hash algorithm, and primality test rounds</td>
+      <td class="left">object with "modulo", "hashAlg", and "primeTest" properties</td>
+      <td class="left">see above</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">capProvProbPrime</td>
+      <td class="left">supported capabilities for both provable and probable primes with conditions generation</td>
+      <td class="left">object with "singleCap" properties</td>
+      <td class="left">see above for possible values</td>
+      <td class="left">Yes</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="rfc.section.2.4.1.4"><a href="#rfc.section.2.4.1.4">2.4.1.4.</a> <a href="#mode_keyGenFullSet" id="mode_keyGenFullSet">keyGen Full Set Of Capabilities</a></h1>
+<p id="rfc.section.2.4.1.4.p.1">The complete list of RSA key generation capabilities may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.7"/>
 <div id="keyGen_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>RSA keyGen Capabilities JSON Values</caption>
@@ -901,7 +1010,7 @@
     </tr>
     <tr>
       <td class="left">fixedPubExp</td>
-      <td class="left">supports fixed public key exponent e</td>
+      <td class="left">Supports fixed public key exponent e</td>
       <td class="left">value</td>
       <td class="left">"yes","no"</td>
       <td class="left">Yes</td>
@@ -915,7 +1024,7 @@
     </tr>
     <tr>
       <td class="left">fixedPubExpVal</td>
-      <td class="left">the value of the public key exponent e in hex</td>
+      <td class="left">The value of the public key exponent e in hex</td>
       <td class="left">value</td>
       <td class="left">hex</td>
       <td class="left">Yes</td>
@@ -929,7 +1038,7 @@
     </tr>
     <tr>
       <td class="left">randPubExp</td>
-      <td class="left">supports random public key exponent e</td>
+      <td class="left">Supports random public key exponent e</td>
       <td class="left">value</td>
       <td class="left">"yes","no"</td>
       <td class="left">Yes</td>
@@ -943,9 +1052,9 @@
     </tr>
     <tr>
       <td class="left">randPQ</td>
-      <td class="left">random P and Q primes generated as (see <a href="#FIPS186-4">[FIPS186-4]</a> ): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</td>
+      <td class="left">Random P and Q primes generated as (see <a href="#FIPS186-4">[FIPS186-4]</a>): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</td>
       <td class="left">value</td>
-      <td class="left">{"1","2","3","4","5"}</td>
+      <td class="left">{1, 2, 3, 4, 5}</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -957,7 +1066,7 @@
     </tr>
     <tr>
       <td class="left">capProvPrimes</td>
-      <td class="left">capabilities for all supported moduli and hash algorithms (see <a href="#keyGenProvPrim_modulitable">Table 4</a>)</td>
+      <td class="left">Capabilities for all supported moduli and hash algorithms (see <a href="#keyGenProvPrim_modulitable">Table 4</a>)</td>
       <td class="left">array</td>
       <td class="left"/>
       <td class="left">Yes</td>
@@ -971,7 +1080,7 @@
     </tr>
     <tr>
       <td class="left">modProbPrime</td>
-      <td class="left">see <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
+      <td class="left">See <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
       <td class="left">array</td>
       <td class="left">see <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
       <td class="left">Yes</td>
@@ -985,7 +1094,7 @@
     </tr>
     <tr>
       <td class="left">primeTest</td>
-      <td class="left">see <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
+      <td class="left">See <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
       <td class="left">value</td>
       <td class="left">see <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
       <td class="left">Yes</td>
@@ -998,7 +1107,7 @@
 <p id="rfc.section.2.4.2.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.2.1"><a href="#rfc.section.2.4.2.1">2.4.2.1.</a> <a href="#mode_sigGenCap" id="mode_sigGenCap">sigGen Capabilities</a></h1>
 <p id="rfc.section.2.4.2.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
-<div id="rfc.table.7"/>
+<div id="rfc.table.8"/>
 <div id="sigGenRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Supported RSA sigGen moduli and hash options JSON Values </caption>
@@ -1070,7 +1179,7 @@
 <p id="rfc.section.2.4.3.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.3.1"><a href="#rfc.section.2.4.3.1">2.4.3.1.</a> <a href="#mode_sigVerCap" id="mode_sigVerCap">sigVer Capabilities</a></h1>
 <p id="rfc.section.2.4.3.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
-<div id="rfc.table.8"/>
+<div id="rfc.table.9"/>
 <div id="sigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Supported RSA sigVer moduli and hash options JSON Values </caption>
@@ -1143,7 +1252,7 @@
 <p id="rfc.section.2.4.4.p.4">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.4.p.5">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <p id="rfc.section.2.4.4.p.6">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
-<div id="rfc.table.9"/>
+<div id="rfc.table.10"/>
 <div id="legacySigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Supported RSA legacySigVer moduli and hash options JSON Values </caption>
@@ -1210,16 +1319,16 @@
 </table>
 <p id="rfc.section.2.4.4.p.7">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.5"><a href="#rfc.section.2.4.5">2.4.5.</a> <a href="#mode_componentSigPrimitive" id="mode_componentSigPrimitive">The componentSigPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.5.p.1">The RSA componentSigPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation s = msg^d mod n, where msg is a message, d is the private exponent and n is the modulus, all supplied by the testing ACVP server. Only 2048-bit RSA keys are allowed for this capability.  There are no properties specified for this capability. See Section <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for msg and n.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.5.p.1">The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <a href="#RFC3447">[RFC3447]</a>) is advertised as a JSON object within the array of 'modeSpecs' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server.  Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability.  See <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for 'msg' and 'n'.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.5.p.2">Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.2.4.6"><a href="#rfc.section.2.4.6">2.4.6.</a> <a href="#mode_componentDecPrimitive" id="mode_componentDecPrimitive">The componentDecPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation s = msg^d mod n, where msg is a message, d is the private exponent and n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
-<p id="rfc.section.2.4.6.p.2">In testing, only msg is supplied by the ACVP server.  The client is responsible for generating RSA key pairs of modulus n, private key d, and calculates s.  Only 2048-bit RSA keys are allowed for this capability. See <a href="#app-testcomponentdecprimitive-ex">Appendix B.6</a> for additional details on constraints for msg and n. The client provides the public exponent e, modulus n, the private key d and the computed result s in its response to the ACVP - see <a href="#app-componentdec-results-ex">Appendix C.6</a> .  The client must first check if  0 &lt; msg &lt; n-1 and return an error if this is not the case. The client returns a value s only when msg is in the proper range for the size of the selected modulus n.  There are no properties specified for this capability.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
+<p id="rfc.section.2.4.6.p.2">In testing, only 'msg' is supplied by the ACVP server.  The client is responsible for generating RSA key pairs of modulus 'n', private key 'd', and calculates 's'.  Only 2048-bit RSA keys are allowed for this capability. See <a href="#app-testcomponentdecprimitive-ex">Appendix B.6</a> for additional details on constraints for 'msg' and 'n'. The client provides the public exponent 'e', modulus 'n', the private key 'd' and the computed result 's' in its response to the ACVP - see <a href="#app-componentdec-results-ex">Appendix C.6</a> .  The client must first check if  '0 &lt; msg &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 'msg' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.6.p.3">Each RSA componentDecPrimitive mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
 <p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm, such as Hash_DRBG, etc.  This section describes the JSON schema for a test vector set used with DRBG algorithms.</p>
 <p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
-<div id="rfc.table.10"/>
+<div id="rfc.table.11"/>
 <div id="vs_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Vector Set JSON Object</caption>
@@ -1270,7 +1379,7 @@
 </table>
 <h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a></h1>
 <p id="rfc.section.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. The Test Group JSON object contains meta data that applies to all test vectors within the group.  The following table describes the RSA JSON elements of the Test Group JSON object.</p>
-<div id="rfc.table.11"/>
+<div id="rfc.table.12"/>
 <div id="vs_tg_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Test Group JSON Object</caption>
@@ -1297,7 +1406,31 @@
     </tr>
     <tr>
       <td class="left">randPQ</td>
-      <td class="left">RSA prime generation method - see <a href="#keyGen_table">Table 6</a></td>
+      <td class="left">RSA prime generation method - see <a href="#keyGen_table">Table 7</a></td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">modRSA</td>
+      <td class="left">RSA modulus</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">hashAlg</td>
+      <td class="left">the hash algorithm</td>
       <td class="left">value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1333,7 +1466,7 @@
     </tr>
     <tr>
       <td class="left">sigType</td>
-      <td class="left">The type of digigital signature algrothm - see  <a href="#sigGenRSAMod">Table 7</a></td>
+      <td class="left">The type of digital signature algorithm - see  <a href="#sigGenRSAMod">Table 8</a></td>
       <td class="left">value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1341,7 +1474,7 @@
 </table>
 <h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a></h1>
 <p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each RSA test vector.</p>
-<div id="rfc.table.12"/>
+<div id="rfc.table.13"/>
 <div id="vs_tc_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>RSA Test Case JSON Object</caption>
@@ -1367,30 +1500,6 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">modRSA</td>
-      <td class="left">RSA modulus</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">hashAlg</td>
-      <td class="left">the hash algorithm</td>
-      <td class="left">value</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">e</td>
       <td class="left">the public exponent</td>
       <td class="left">hex value</td>
@@ -1404,7 +1513,7 @@
     </tr>
     <tr>
       <td class="left">pRand</td>
-      <td class="left">the random for P, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Section B.3.3 </td>
+      <td class="left">the random for P, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3 </td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1416,7 +1525,7 @@
     </tr>
     <tr>
       <td class="left">qRand</td>
-      <td class="left">the random for Q, if applicable, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Section B.3.3 </td>
+      <td class="left">the random for Q, if applicable, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3 </td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1436,7 +1545,7 @@
 </table>
 <h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a></h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.13"/>
+<div id="rfc.table.14"/>
 <div id="vr_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Vector Set Response JSON Object</caption>
@@ -1476,7 +1585,7 @@
   </tbody>
 </table>
 <p id="rfc.section.4.p.2">The following table describes the JSON elements for the response to a RSA test vector.</p>
-<div id="rfc.table.14"/>
+<div id="rfc.table.15"/>
 <div id="vs_tr_keyGen_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>RSA Test Case Results JSON Object</caption>
@@ -1515,7 +1624,7 @@
     </tr>
     <tr>
       <td class="left">pRand</td>
-      <td class="left">the random for P, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Section B.3.3 </td>
+      <td class="left">the random for P, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3 </td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1527,7 +1636,7 @@
     </tr>
     <tr>
       <td class="left">qRand</td>
-      <td class="left">the random for Q, if applicable, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Section B.3.3 </td>
+      <td class="left">the random for Q, if applicable, testing probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3 </td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1539,7 +1648,7 @@
     </tr>
     <tr>
       <td class="left">primeResult</td>
-      <td class="left">the verdict on the primality testing for the supplied pRand/qrand combination, see <a href="#FIPS186-4">[FIPS186-4]</a>, Section B.3.3 </td>
+      <td class="left">the verdict on the primality testing for the supplied pRand/qRand combination, see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3 </td>
       <td class="left">"prime"/"composite"</td>
       <td class="left">Yes</td>
     </tr>
@@ -1551,7 +1660,7 @@
     </tr>
     <tr>
       <td class="left">xP1</td>
-      <td class="left">the prime factor p1 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.1, if applicable</td>
+      <td class="left">the prime factor p1 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1563,7 +1672,7 @@
     </tr>
     <tr>
       <td class="left">seed</td>
-      <td class="left">the seed used in prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4 or B3.5</td>
+      <td class="left">the seed used in prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4, or B3.5</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1587,7 +1696,7 @@
     </tr>
     <tr>
       <td class="left">bitlen2</td>
-      <td class="left">the length of p2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4, B3.5 or the length of xP2 for B3.6</td>
+      <td class="left">the length of p2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B.3.5 or the length of xP2 for B.3.6</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1599,7 +1708,7 @@
     </tr>
     <tr>
       <td class="left">bitlen3</td>
-      <td class="left">the length of q1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4, B3.5 or the length of xQ1 for B3.6</td>
+      <td class="left">the length of q1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ1 for B.3.6</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1611,7 +1720,7 @@
     </tr>
     <tr>
       <td class="left">bitlen4</td>
-      <td class="left">the length of q2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B3.4, B3.5 or the length of xQ2 for B3.6</td>
+      <td class="left">the length of q2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ2 for B.3.6</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1623,7 +1732,7 @@
     </tr>
     <tr>
       <td class="left">primeSeedP2</td>
-      <td class="left">the prime seed used for p2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B3.5</td>
+      <td class="left">the prime seed used for p2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1635,7 +1744,7 @@
     </tr>
     <tr>
       <td class="left">primeSeedQ1</td>
-      <td class="left">the prime seed used for q1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B3.5</td>
+      <td class="left">the prime seed used for q1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1647,7 +1756,7 @@
     </tr>
     <tr>
       <td class="left">primeSeedQ2</td>
-      <td class="left">the prime seed used for q2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B3.5</td>
+      <td class="left">the prime seed used for q2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1659,7 +1768,7 @@
     </tr>
     <tr>
       <td class="left">xP2</td>
-      <td class="left">the prime factor p2 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.1, if applicable</td>
+      <td class="left">the prime factor p2 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1671,7 +1780,7 @@
     </tr>
     <tr>
       <td class="left">xP</td>
-      <td class="left">the random number used in Step Step 3 of the algorithm in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.9 "Compute a Probable Prime Factor Based on Auxiliary Primes" to generate the prime P, if applicable</td>
+      <td class="left">the random number used in Step 3 of the algorithm in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.9 to generate the prime P, if applicable</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1695,7 +1804,7 @@
     </tr>
     <tr>
       <td class="left">xQ1</td>
-      <td class="left">the prime factor q1 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.1, if applicable</td>
+      <td class="left">the prime factor q1 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1707,7 +1816,7 @@
     </tr>
     <tr>
       <td class="left">xQ2</td>
-      <td class="left">the prime factor q2 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.1, if applicable</td>
+      <td class="left">the prime factor q2 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1719,7 +1828,7 @@
     </tr>
     <tr>
       <td class="left">xQ</td>
-      <td class="left">the random number used in Step Step 3 of the algorithm in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.9 "Compute a Probable Prime Factor Based on Auxiliary Primes" to generate the prime Q, if applicable</td>
+      <td class="left">the random number used in Step 3 of the algorithm in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.9 to generate the prime Q, if applicable</td>
       <td class="left">hex value</td>
       <td class="left">Yes</td>
     </tr>
@@ -1783,18 +1892,6 @@
       <td class="left">"pass"/"fail"</td>
       <td class="left">Yes</td>
     </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">reason</td>
-      <td class="left">additonal information about a specific test case result</td>
-      <td class="left">text</td>
-      <td class="left">Yes</td>
-    </tr>
   </tbody>
 </table>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a></h1>
@@ -1810,19 +1907,25 @@
       <td class="reference">
         <b id="ACVP">[ACVP]</b>
       </td>
-      <td class="top"><a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
+      <td class="top"><a>NIST</a>, "<a>ACVP Specification</a>", 2016.</td>
     </tr>
     <tr>
       <td class="reference">
         <b id="FIPS186-4">[FIPS186-4]</b>
       </td>
-      <td class="top"><a title="NIST">, </a>, "<a href="http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf">FIPS PUB 186-4 Digital Signature Standard</a>", July 2013.</td>
+      <td class="top"><a>NIST</a>, "<a href="http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf">FIPS PUB 186-4 Digital Signature Standard</a>", July 2013.</td>
     </tr>
     <tr>
       <td class="reference">
         <b id="RFC2119">[RFC2119]</b>
       </td>
       <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC3447">[RFC3447]</b>
+      </td>
+      <td class="top"><a>Jonsson, J.</a> and <a>B. Kaliski</a>, "<a href="http://tools.ietf.org/html/rfc3447">Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1</a>", RFC 3447, DOI 10.17487/RFC3447, February 2003.</td>
     </tr>
     <tr>
       <td class="reference">
@@ -1840,12 +1943,13 @@
 </table>
 <h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example RSA Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.p.1">This appendix contains example JSON object advertising support for the verious RSA modes:keyGen, sigGen, sigVer, legacySigVer, compRSASP1. Note that all binary HEX representations are in big-endian format.</p>
-<h1 id="rfc.appendix.A.1"><a href="#rfc.appendix.A.1">A.1.</a> <a href="#app-ex-keyGenProvPrime" id="app-ex-keyGenProvPrime">Example keyGen Capabilities JSON Objects</a></h1>
-<p id="rfc.section.A.1.p.1">The following is an example JSON object advertising support for RSA keyGen with provable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2. See also <a href="#mode_keyGenFullSet">Section 2.4.1.3</a>.</p>
+<h1 id="rfc.appendix.A.1"><a href="#rfc.appendix.A.1">A.1.</a> <a href="#app-ex-keyGenProvPrime" id="app-ex-keyGenProvPrime">Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects</a></h1>
+<p id="rfc.section.A.1.p.1">The following is an example JSON object advertising support for RSA keyGen with provable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2. See also <a href="#mode_keyGenFullSet">Section 2.4.1.4</a>.</p>
 <pre>
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
+      "infoGeneratedByServer": true,
       "algSpecs" : 
       [
          {"modeSpecs" : {
@@ -1853,15 +1957,15 @@
               "capSpecs" :  {
                       "fixedPubExp" : "yes",
                       "fixedPubExpVal" : "010001",
-                      "randPQ" : "1",
-                      "capsProvPrime" : 
+                      "randPQ" : 1,
+                      "capProvPrime" : 
                             [
-                                {   "modProvPrime" : "2048",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modProvPrime" : "3072",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modProvPrime" : "4096",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+                                {   "modulo" : 2048,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                                {   "modulo" : 3072,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                                {   "modulo" : 4096,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
                             ]
                       }
                 }
@@ -1869,11 +1973,13 @@
       ]
    }
 </pre>
+<p id="rfc.section.A.1.p.2">In order to advertise support for RSA keyGen with provable primes with conditions, the same properties exist, but the 'randPQ' value should be '3' as an integer.</p>
 <h1 id="rfc.appendix.A.1.1"><a href="#rfc.appendix.A.1.1">A.1.1.</a> <a href="#app-ex-keyGenProbPrime" id="app-ex-keyGenProbPrime">Example keyGen with Probable Primes Capabilities JSON Object</a></h1>
-<p id="rfc.section.A.1.1.p.1">The following is an example JSON object advertising support for RSA keyGen with probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3. See also <a href="#mode_keyGenFullSet">Section 2.4.1.3</a>.</p>
+<p id="rfc.section.A.1.1.p.1">The following is an example JSON object advertising support for RSA keyGen with probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3. See also <a href="#mode_keyGenFullSet">Section 2.4.1.4</a>.</p>
 <pre>
    {
     "algorithm":"RSA",
+    "infoGeneratedByServer": true,
     "prereqVals":[
       {
         "algorithm":"DRBG",
@@ -1891,22 +1997,28 @@
           "capSpecs": {
             "fixedPubExp":"yes",
             "fixedPubExpVal":"010001",
-            "randPQ":"2",
-            "capProbPrime":{
-              "modProbPrime":["2048", "3072", "4096"],
-              "primeTest":"tblC2"
-            }
+            "randPQ": 2,
+            "capProbPrime":[{
+              "modulo": 2048,
+              "primeTest":["tblC2"]
+            },
+            {
+              "modulo": 3072,
+              "primeTest":["tblC2", "tblC3"]
+            }]
           }
         }
       }
     ]
   }
 </pre>
+<p id="rfc.section.A.1.1.p.2">In order to advertise support for RSA keyGen with all probable primes with conditions, the same properties exist, but the 'randPQ' value should be '5' as an integer.</p>
 <h1 id="rfc.appendix.A.1.2"><a href="#rfc.appendix.A.1.2">A.1.2.</a> <a href="#app-ex-keyGenProvProbPrime" id="app-ex-keyGenProvProbPrime">Example keyGen with Provable Conditional Primes with Probable Factors Capabilities JSON Object</a></h1>
-<p id="rfc.section.A.1.2.p.1">The following is an example JSON object advertising support for RSA keyGen with primes with conditions according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5. See also <a href="#mode_keyGenFullSet">Section 2.4.1.3</a>.</p>
+<p id="rfc.section.A.1.2.p.1">The following is an example JSON object advertising support for RSA keyGen with primes with conditions according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5. See also <a href="#mode_keyGenFullSet">Section 2.4.1.4</a>.</p>
 <pre>
    {
       "algorithm": "RSA",
+      "infoGeneratedByServer": false,
        "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
@@ -1915,40 +2027,20 @@
            "capSpecs" : {
                "fixedPubExp" : "yes",
                "fixedPubExpVal" : "010001",
-               "randPQ" : "4",
-               "capsProvPrime" : 
+               "randPQ" : 4,
+               "capsProvProbPrime" : 
                     [
-                        {"modProvPrime" : "2048",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                        {"modProvPrime" : "3072",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                        {"modProvPrime" : "4096",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                    ],
-              "capProbPrime" :{"modProbPrime" : ["2048","3072","4096"],
-                                             "primeTest" : "tblC3"}
+                        {"modulo" : 2048,
+                         "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                         "primeTest": ["tblC2", "tblC3"]},
+                       {"modulo" : 3072,
+                         "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                         "primeTest": ["tblC2"]},
+                       {"modulo" : 4096,
+                         "hashAlg" : ["SHA-512"],
+                         "primeTest": ["tblC3"]},
+                    ]
               }
-          }
-        }
-      ]
-   }
-</pre>
-<h1 id="rfc.appendix.A.1.3"><a href="#rfc.appendix.A.1.3">A.1.3.</a> <a href="#app-ex-keyGenProbProbPrime" id="app-ex-keyGenProbProbPrime">Example keyGen with Probable Conditional Primes with Probable Factors Capabilities JSON Object</a></h1>
-<p id="rfc.section.A.1.3.p.1">The following is an example JSON object advertising support for RSA keyGen with primes with conditions according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.6. See also <a href="#mode_keyGenFullSet">Section 2.4.1.3</a>.</p>
-<pre>
-   {
-      "algorithm": "RSA",
-       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" : 
-      [
-          {"modeSpecs" : {
-             "mode": "keyGen",
-             "capSpecs" : {
-                 "randPubExp" : "yes",
-                 "randPQ" : "5",
-                 "capProbPrime" :{"modProbPrime" : ["2048","3072","4096"],
-                                                "primeTest" : "tblC3"}
-                 }
           }
         }
       ]
@@ -1968,11 +2060,11 @@
                   "sigType" : "X9.31",
                   "capSigType" :
                   [
-                      {"modRSASigGen" : "2048",
+                      {"modRSASigGen" : 2048,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "3072",
+                      {"modRSASigGen" : 3072,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "4096",
+                      {"modRSASigGen" : 4096,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
                   ]
               }
@@ -1983,11 +2075,11 @@
                   "sigType" : "PKCS1v1.5",
                   "capSigType" :
                   [
-                      {"modRSASigGen" : "2048",
+                      {"modRSASigGen" : 2048,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "3072",
+                      {"modRSASigGen" : 3072,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "4096",
+                      {"modRSASigGen" : 4096,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
                   ]
               }
@@ -1998,15 +2090,15 @@
                 "sigType" : "PKCS1PSS",
                 "capSigType" :
                 [
-                    { "modRSASigGen" : "2048",
+                    { "modRSASigGen" : 2048,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]},
-                    { "modRSASigGen" : "3072",
+                      "saltSigGen" : [28, 32, 64]},
+                    { "modRSASigGen" : 3072,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]},
-                    { "modRSASigGen" : "4096",
+                      "saltSigGen" : [28, 32, 64]},
+                    { "modRSASigGen" : 4096,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]}
+                      "saltSigGen" : [28, 32, 64]}
                 ]
             }
          }}
@@ -2028,11 +2120,11 @@
                  "sigType" : "X9.31",
                  "capSigType" :
                 [
-                  {"modRSASigVer" : "2048",
+                  {"modRSASigVer" : 2048,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "3072",
+                  {"modRSASigVer" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "4096",
+                  {"modRSASigVer" : 4096,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
                ]
             }
@@ -2043,11 +2135,11 @@
                 "sigType" : "PKCS1v1.5",
                  "capSigType" :
                 [
-                  {"modRSASigVer" : "2048",
+                  {"modRSASigVer" : 2048,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "3072",
+                  {"modRSASigVer" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "4096",
+                  {"modRSASigVer" : 4096,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
                 ]
             }
@@ -2058,15 +2150,15 @@
                 "sigType" : "PKCS1PSS",
                 "capSigType" :
                   [
-                    { "modRSASigVer" : "2048",
+                    { "modRSASigVer" : 2048,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]},
-                    { "modRSASigVer" : "3072",
+                      "saltSigVer" : [28, 32, 64]},
+                    { "modRSASigVer" : 3072,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]},
-                    { "modRSASigVer" : "4096",
+                      "saltSigVer" : [28, 32, 64]},
+                    { "modRSASigVer" : 4096,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]}
+                      "saltSigVer" : [28, 32, 64]}
                  ]
             }
        }}
@@ -2080,12 +2172,10 @@
 <pre>
    {
       "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" : 
       [
        {"modeSpecs" : {
-           "mode": "componentSigPrimitive",
-           "capSpecs" : {}
+           "mode": "componentSigPrimitive"
          }}
       ]
    }
@@ -2099,8 +2189,7 @@
       "algSpecs" : 
       [
         {"modeSpecs" : {
-            "mode": "componentDecPrimitive",
-            "capSpecs" : {}
+            "mode": "componentDecPrimitive"
          }}
       ]
    }
@@ -2112,146 +2201,164 @@
 
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1133",
+   { "vsId": 1133,
       "algorithm": "RSA",
+      "infoGeneratedByServer": false,
       "testGroups" : [
              {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "1",
+                 "randPQ" : 1,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
                  "tests" : [
                     {
-                      "tcId" : "1145",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
+                      "tcId" : 1145,
                     },
                     {
-                      "tcId" : "1147",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    }
-                 ]
-             },
-              {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "3",
-                 "tests" : [
-                    {
-                      "tcId" : "1111",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1112",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1113",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1114",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
+                      "tcId" : 1146,
                     }
                  ]
              },
              {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 1,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1147,
+                  },
+                  {
+                    "tcId": 1148,
+                  }
+                ]
+              },
+             {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "4",
+                 "randPQ" : 3,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1149,
+                    },
+                    {
+                      "tcId" : 1150,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 3,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1151,
+                  },
+                  {
+                    "tcId": 1152,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 4,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1153,
+                    },
+                    {
+                      "tcId" : 1154,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 4,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1155,
+                  },
+                  {
+                    "tcId": 1156,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 5,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1157,
+                    },
+                    {
+                      "tcId" : 1158,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 5,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1159,
+                  },
+                  {
+                    "tcId": 1160,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
                  "primeTest" : "tblC2",
+                 "modRSA" : 2048,
                  "tests" : [
                     {
-                      "tcId" : "1115",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1116",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1117",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1118",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
-                    }
-                 ]
-             },
-             {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "5",
-                 "primeTest" : "tblC3",
-                 "tests" : [
-                    {
-                      "tcId" : "1135",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1137",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
-                    }
-                 ]
-             },
-             {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "2",
-                 "primeTest" : "tblC2",
-                 "tests" : [
-                    {
-                      "tcId" : "1119",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
+                      "tcId" : 1119,
+                      "e" : "df28ab",
                       "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "tcId" : "1120",
-                      "modRSA" : "2048",
-                      "e" : "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000085a4cf",
-                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5"
-                    },
+                      "tcId" : 1120,
+                      "e" : "85a4cf",
+                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                    }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC2",
+                 "modRSA" : 3072,
+                 "tests" : [
                     {
-                      "tcId" : "1121",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1121,
+                      "e" : "535c97",
                       "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
-                    },
-                    {
-                      "tcId" : "1122",
-                      "modRSA" : "3072",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000054a7dd",
-                      "pRand" : "0c5742407c0bac4f474edda6f92e42bd36ade552d947eb8bc5ac97c23efac563de8262ecc1e542cd489fcd33f3dcadcf900c8b0acd28abb1d25318c4f7dae3fa4b281c3b89a77d06db36115ff10496005b45fab68aa45e5f40296570ff97081007d907aa74b56f59841f6069900e14f5f2cf508b9094f3ee37aa4c0a43e38922dc3fce63d6d1e392d1a70da4e5ba7083188ca78693bb7e953352aeb76f3f5905613a10a04c791560717316e2a2c13bb4522aeb86680355bec7dda0b3674e10e9"
-                    },
-                    {
-                      "tcId" : "1129",
-                      "modRSA" : "2048"
-                    },
-                    {
-                      "tcId" : "1130",
-                      "modRSA" : "2048"
-                    },
-                    {
-                      "tcId" : "1131",
-                      "modRSA" : 3072
-                    },
-                    {
-                      "tcId" : "1132",
-                      "modRSA" : "3072"
                     }
                  ]
              },
@@ -2260,32 +2367,35 @@
                  "pubExp" : "random",
                  "randPQ" : 2,
                  "primeTest" : "tblC3",
+                 "modRSA" : 2048,
                  "tests" : [
                     {
-                      "tcId" : "1123",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037a7f1",
-                      "pRand" : "ea4fe1b753e17f7a99a648c1d111d7599eda7ed85b14c974df5d3f1a39e9b3bc2ce3d4e9ab70a2d184c4ce56fbe18c97b09fd47bb39a470ef2bfa5217e1aa8493326dfd9cc9e73da683691cef7d6ded642bfb56c919f8f54ea08de9bffa2f155e8a3a6746302347fb2f581be2deb55b057c3ac371d867c710a03cb9c1d218223",
-                      "qRand" : "c8435496e852f54eac36a1b8e29e5258ba383f3cd453293d98b9d565e72b03e44ead75ea341615062b504c3350b2404f53401f19b88b6a23bca4a19687300522489dbe3beab828e438b28b5a10e8c0da4b38162b458bb7f92804f1969fa3a1cd92f9b16b358047bcc1858e21ab787738cc311abd6bbdf138b352b26d206614cf"
+                      "tcId" : 1122,
+                      "e" : "df28ab",
+                      "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "tcId" : "1124",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000333f01",
-                      "pRand" : "0456038077312d974418bbe2432387d97b55158496263213df19a9ff7f888cdcf3dbae9bba8cdd5d8b6799de99cfb37d1bad0173fc38540a0d0e098ebdf1718b92c9361880af2025382ffb20fc094eced508b097f455f357a2b35a562be410cf44f4c44d5bc4bf0b57b43af86cd7cf37aa9edffa6d23132b1eeece0f09691645"
-                    },
+                      "tcId" : 1123,
+                      "e" : "85a4cf",
+                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                    }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC3",
+                 "modRSA" : 3072,
+                 "tests" : [
                     {
-                      "tcId" : "1125",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fe8ed9",
-                      "pRand" : "f26e1240a0a1b954430793b7b3e3bbf46b1cbc022e29444099c3edcbb66e9ecab3414c80275ca523ea269c085758582917e6cdb2b42f819011a9ddc1e1c25788c507e9dd8fb0bb3fb3d1103e6b0dff333394956aae41855584ec4119e4a3ab804764caa88db6d10c503402f3280aa573ef9066a2ca17a31aafe9bf0bcd412302505e6feb3fe7538bab064d415af979a32cc0b9e298d0b8bc7d1eb3f70e02004257c360bca9549a5bbedee3833ae23c8e65b430e8acb5035a7b410d55a2a5687b",
-                      "qRand" : "a57a699bc759f6e71049eeef16011b2b1549cb8b27a822ac7e45178f3f80680390e1ee99f5f531f5e44a8b570aece9aa0682cff9202cff065a704972748c117e9be5439f93198406bd33c7dded7956e692b531ee7c92133a1e6884a2a48459f55551f406e840461ef18e4c613906186f1ce95a9ba63f4f7673dd552678fba5b0672ac921de31eb7213c14387dd2a7b47c0dbdc088cd8b16f3b552c3fa95631f79cad18a98dc86e22728aa533db8e767396d6eceddb525dceb0baa1cecd57734b"
-                    },
-                    {
-                      "tcId" : "1126",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000524781",
-                      "pRand" : "aad0d971253463ae131e900189b1e978ca55c58dfa3797995f69e2ef147246402e78d3ad703f298943d6e02709289ab846deb65731cffa735239d787abfa6e26f0e295325efe9eab616422cdcbe391ce531bf5508b9d45cf5dc5bd2389c31cdf658cf1ac3ec714978da665d1867ac6846e629f3552172a8e2b879a2c4f326298d9c379cf97c1ddadfc0d8c4c112a0f6e48195131b756603b8052e2b25d010851749ea37cdbaa9490ea686546ee1688445673304d4df5024d834c9d9da965c7cb"
+                      "tcId" : 1124,
+                      "e" : "535c97",
+                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
              }
@@ -2293,11 +2403,12 @@
    }
  ]
 </pre>
+<p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table">Table 15</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the server validates that this pair matches the requirements.</p>
 <h1 id="rfc.appendix.B.2"><a href="#rfc.appendix.B.2">B.2.</a> <a href="#app-testVectsigGen-ex" id="app-testVectsigGen-ex">Example Test Vectors for sigGen JSON Objects</a></h1>
 <pre>
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1163",
+   { "vsId": 1163,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2305,14 +2416,14 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1165",
-                      "modRSA" : "2048",
+                      "tcId" : 1165,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
-                      "tcId" : "1166",
-                      "modRSA" : "3072",
+                      "tcId" : 1166,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
                     }
@@ -2323,14 +2434,14 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1167",
-                      "modRSA" : "2048",
+                      "tcId" : 1167,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
-                      "tcId" : "1168",
-                      "modRSA" : "3072",
+                      "tcId" : 1168,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
@@ -2341,17 +2452,17 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1169",
-                      "modRSA" : "2048",
+                      "tcId" : 1169,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
-                      "saltLen" : "20",
+                      "saltLen" : 20,
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
                     {
-                      "tcId" : "1170",
-                      "modRSA" : "3072",
+                      "tcId" : 1170,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-512",
-                      "saltLen" : "62",
+                      "saltLen" : 62,
                       "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
                     }
                  ]
@@ -2364,7 +2475,7 @@
 <pre>
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1173",
+   { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2372,8 +2483,8 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1174",
-                      "modRSA" : "2048",
+                      "tcId" : 1174,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
                       "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -2381,8 +2492,8 @@
                       "s" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
                     },
                     {
-                      "tcId" : "1175",
-                      "modRSA" : "3072",
+                      "tcId" : 1175,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
                       "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
@@ -2396,8 +2507,8 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1176",
-                      "modRSA" : "2048",
+                      "tcId" : 1176,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
                       "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
@@ -2405,8 +2516,8 @@
                       "s" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
                     },
                     {
-                      "tcId" : "1177",
-                      "modRSA" : "3072",
+                      "tcId" : 1177,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
                       "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
@@ -2420,8 +2531,8 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1178",
-                      "modRSA" : "2048",
+                      "tcId" : 1178,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
                       "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
@@ -2429,8 +2540,8 @@
                       "s" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
                     },
                     {
-                      "tcId" : "1179",
-                      "modRSA" : "3072",
+                      "tcId" : 1179,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
                       "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
@@ -2444,28 +2555,27 @@
   ]
 
 </pre>
-<p id="rfc.section.B.3.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation.  These may include the public key n, the public exponent e, the private key d for each test. Note also that each test for which msg is not between 0 and n -1 should fail.</p>
+<p id="rfc.section.B.3.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation.  These may include the public key n, the public exponent e, the private key d for each test. Note also that each test for which msg is not between 0 and n - 1 should fail.</p>
 <h1 id="rfc.appendix.B.4"><a href="#rfc.appendix.B.4">B.4.</a> <a href="#app-testVectlegacySigVer-ex" id="app-testVectlegacySigVer-ex">Example Test Vectors for legacySigVer JSON Objects</a></h1>
 <p id="rfc.section.B.4.p.1">The format and structure of legacySigVer Test Vector JSON Objects is identical to those for the Test Vectors for sigVer JSON Objects. </p>
 <h1 id="rfc.appendix.B.5"><a href="#rfc.appendix.B.5">B.5.</a> <a href="#app-testcomponentsigprimitive-ex" id="app-testcomponentsigprimitive-ex">Example Test Vectors for componentSigPrimitive JSON Objects</a></h1>
 <pre>
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1193",
+   { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentSigPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1194",
+                      "tcId" : 1194,
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
                     },
                     {
-                      "tcId" : "1195",
+                      "tcId" : 1195,
                       "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
                       "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
@@ -2476,24 +2586,23 @@
     }
   ]
 </pre>
-<p id="rfc.section.B.5.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key n, the public exponent e, the private key d for each test.  Note also that each test for which msg is not between 0 and n -1 should fail.</p>
+<p id="rfc.section.B.5.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key 'n', the public exponent 'e', the private key 'd' for each test.  Note also that each test for which 'msg' is not between '0' and 'n - 1' should fail.</p>
 <h1 id="rfc.appendix.B.6"><a href="#rfc.appendix.B.6">B.6.</a> <a href="#app-testcomponentdecprimitive-ex" id="app-testcomponentdecprimitive-ex">Example Test Vectors for componentDecPrimitive JSON Objects</a></h1>
 <pre>
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1194",
+   { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentDecPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1196",
+                      "tcId" : 1196,
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc" 
                     },
                     {
-                      "tcId" : "1197",
+                      "tcId" : 1197,
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
                     }
                  ]
@@ -2502,83 +2611,83 @@
     }
   ]
 </pre>
-<p id="rfc.section.B.6.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key n, the public exponent e, the private key d for each test.  Note also that each test for which msg is not between 0 and n -1 should fail.</p>
+<p id="rfc.section.B.6.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key 'n', the public exponent 'e', the private key 'd' for each test.  Note also that each test for which 'msg' is not between '0' and 'n - 1' should fail.</p>
 <h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Objects</a></h1>
 <h1 id="rfc.appendix.C.1"><a href="#rfc.appendix.C.1">C.1.</a> <a href="#app-keyGen-results-ex" id="app-keyGen-results-ex">Example keyGen Test Results JSON Objects</a></h1>
 <p id="rfc.section.C.1.p.1">The following is a example JSON object for RSA keyGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
              [
                 { "acvVersion": "0.3" },
-                { "vsId": "1133",
+                { "vsId": 1133,
                     "testResults": [
                     {
-                      "tcId" : "1111",
+                      "tcId" : 1111,
                       "e" : "10000021",
                       "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
-                      "bitlen1" : "312",
-                      "bitlen2" : "145",
-                      "bitlen3" : "144",
-                      "bitlen4" : "338",
+                      "bitlen1" : 312,
+                      "bitlen2" : 145,
+                      "bitlen3" : 144,
+                      "bitlen4" : 338,
                       "p" : "e2ab16d3026db341223bcef7f05b61d1682da54b0e2314f8eac9652752d6aa89ad65417e2c7f7b2824555a17c8c854ecbbc44c80c10c5ba132c3992f30308459b3afaee8f00ca318cd39a478c93dc1fa13268842ce88b2d5aeacbb4ac7638db6501eed3cedca65b777e910f701207cf96a81e46c418c3fdc493c02f708b2bacb",
                       "q" : "d13c3209bbc1bfa27c96688cbb325e8ce8d609efde1cc2417a578354c7bd248fb89eca31599d6b5b0d69a832bd2fafaacf3e9c3b71484328059dff1a7af54b003fee84f64f34e31ade0689f26fbc181443b7af3d8043657ddceefc1ff3160543825de3fe8f33fce4bf5d1c10357919c31729f8c0476f6b2fb6f405c875f06609",
                       "n" : "b942fa09a727ab488f8bc2d29b89814345dc96e7df9dc7188b7be6be7dc473869c914f612f5aa6b450a17ffc07b42db7b80d2ce88be1953e80ebff92f4aa12fb7fa9b9b258f249d876d69c1976df63a362d1a820f2cff4c88ae2a5fc3b607e7d62a4e60dcd9185929fcc1c931dea94147c03adfa41bf1e72d09376e4dbebaf44df6ec492530d9eb910970f45e41107ea313dccb11567e0832674335639b136b851d19e397be3f1681c72b62bc8defae88e02fe7e67ee56191cb874a53fc115652337277d3aea969adbba4a22d3d8840844cbe48b556895d06d0c7b3cd2c9fcc9a86ec93ca00ea5916090948820fd07f0b22a42f829d9bd1fcfa044ac6a057323",
                       "d" : "6b56ee657ebf6a54b35869b02f4e21d3ef0fb479a70309b522a95d955bf966385e770bd9e321bf95eca857ab36b5084ca6f7596255d11a4a49a1547d5b4306be33ff2ec560838565b6c45c6962ff4f8c64752f615c57fbed7d8b961a2e3fad976648feee6bf1d050c812badb0639188f9ff1e0faf4739b74c31ccb7fadd5c67ff4794ef7249b94abab145351aca47f8fe8e0628b7959f91f7eb06ff7a7a7e308365522c9ddc74c62c69662a9d0ee6b4223c66a4f102f4fbd436cab8723a9f416767ab85cd28ffbf5dc60cdf7a51648f3c57ad69d6b07bb77399bbf19c21ad01a9c782951782ac8a46ed8dac939442cbb280fbdc4056e68a5a7565e69c80c849"
                     },
                     {
-                      "tcId" : "1112",
+                      "tcId" : 1112,
                       "e" : "10000021",
                       "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
-                      "bitlen1" : "320",
-                      "bitlen2" : "159",
-                      "bitlen3" : "192",
-                      "bitlen4" : "222",
+                      "bitlen1" : 320,
+                      "bitlen2" : 159,
+                      "bitlen3" : 192,
+                      "bitlen4" : 222,
                       "p" : "f0be9d5e314bb494de341ffc759c0554e717a8e7e9c18ef346463b79e8b7a89f1ecec23dd9d209094c372ac900be610918fa2e03b0239d3175030d35debd7c8b003b4c00b7e4846d6b55147ac13de75311a1166d2806bc080de2b614cbaf3c96ed07b9c5ee82432926433b23a6423f8c3c7643f069922fe09fad621b8afd6255",
                       "q" : "e5b847367ad156efa1150d871d6e628db0087a0d6294dcfe980a614969cfecbfea6bb01f5ca8c0c6dd432bfdb7bc89279257b1fb13de663be9b8a24ab72a7ebcac84338c38261c547afb4d8ff441c34988f9ddce414f3dc900f011c8920ddbc832e7356d2cb067f0b0172cdb9a409ed61f1108fab68fc461cdbd2990ae420a85",
                       "n" : "d807cebe77262cdc1a8446cbde378993069449101a7d43d7c359783a9228a877f4c67749a44a876843d9138ab961e03264fc93b87faa2c5ff78299b45037ce967c4d08dc143c87506d026c78a43a4aa17787fc09428ec83f13d46b4bcf25197d96ed8fa7685f0dba09492d78b45b0e7223bd986fe423bf8e10236bdf18a7840cd67d9620260080d5c90253cdc8fa74e1f315f5bea878e2311cb782582bc26e6bb4e71c7d8d16ab4d0265ee39a4a9e03cc065c7f45027330cc24a7c8e1e1a9a8989da9dfe807d3f04d3b6eda3e31e75b4ccb42c3fb0cfb3fa6a740e252663807e56146cb13ed4517201cb8df4256d0249139aa00daae91d172b8306b63b656829",
                       "d" : "a5fc5868f19c7644f10b81ca056953cd38fce6dbbbc29a38416b42e256ec02172977d14e3733ee01d92a83179c61bcb01264e0b3b00fe4039981518a81020d3cbbe48b862e7ad121c45551a7104d5db2a6de18d1b9009857cdce08cd5f2bcdb6292b8f45f130ee755667e3c06109c4ae2b1145e1d8f3d427d5d4059df0fad45b1805c031dcc9d37e6d85faccbb7ef8e6bbb4ec91dc9899e723a11d0eb516079b38f9d31c6ba9cbe728ae6d126240cccf13eb8188c76dd0612fb1a766bcc80d05a5c84367a8c2097e3a7f57d438da460a682e8517ad2a83ca472f5a1f2893b821c0cf0a29c7cd476af9fe2c62adeb2d3bced5fdeee547714ebe71f79adc4239"
                     },
                     {
-                      "tcId" : "1113",
+                      "tcId" : 1113,
                       "e" : "10000021",
                       "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
-                      "bitlen1" : "448",
-                      "bitlen2" : "281",
-                      "bitlen3" : "240",
-                      "bitlen4" : "469",
+                      "bitlen1" : 448,
+                      "bitlen2" : 281,
+                      "bitlen3" : 240,
+                      "bitlen4" : 469,
                       "p" : "bb1b2d20748c09339570a703237260508ada21196ee89804db6fcdc5e523e4539fc17576906eaadc801107d883cb0fbbae9c8887fd4cffaeb43c59a770a005728f145f96c38b235870f0c773c85b088e2ef9248c944fc6a1aaf85092143898e62f05542326ed20d28f4cf867e766510539fc12c73517179c191e76c5ec974480280abe044378661052ac7e15d150130db856650881cbd3c674af51fb1bf9c8e095aea0f69b3d1eed8604c36368982584525f63c6f380dae557339ed7957b9a5f",
                       "q" : "cf22d352fc42b50ac8c2cf5fcbe36461b27191c8e9273a3956d6b5595a26fffe7728fc8c4966c5fd5ddd8bd1ecfd59f0321536fe04a41f1624c11272c40b4485361b52ab36119c0fa7bd73e499aefb62bf97a7254680c33c2c893e84e7a70310b9868ab1b968a25ef9e4e9ec7b4e11d7231921f04fe771ec2e4d992349f4db216e17b094d1443ada72a15f3a54342864670dcc880672214196e6aee9c9d3112c0241393b9bcc71538547c54c6269802fa4f827fffc44fdd31f8de74db3e34995",
                       "n" : "97646d8d49d26c3e5ceb9ef2b16ffc40b3f7f980cc99a9da1b3e94626a39c343c2d13108f05b3c33f8597ffe2574e8e8f31b892d60767fe93a58c24fb371a23bb2f6b69fc0ffb1b1e1b914f45530dd81b1436665294f39e8db0d4f30a0161d66926cec89f419ce58bd98abc0628adda5c3519789102813de712adbdef5dd1700e92087ece582b78c95c2954955283c5ec9d9c467d5357091428a3ad3804568f513cfc6fbb4c7a66ff29a4e7acb7e354565cf400a4d650ca703f468a30a990756e800d2e8c593f4ecbbe27d64821389bd40fd1b4f597ecf56703d4ce40b1acc62b733e6808b2d82ce572ec1a9fe296e9364d46ea317790b6faf553d8d3d7efbf372e0eb71e435fb5049e475388c52e2fa17ac976ac411ecb1a7a9983c3c069c9454006f5f60892cea95c32cd512692fe94f56af8bd89212b0618b519669a9c50cd8c6300790f687f0379a42e3442ecd1cf06693416e1bd692ce306b2602d7946867ac824cf9041c48642239b8895582c402687bb8361ef2fd15d20e378f32f04b",
                       "d" : "43f10b697929aee4aebeed949a829ed4a816927f2b1ba427e4305ac7e61ac923f9cea977dbc7b1c9759cc327d48a8205cd04e9357d9c1c83be78461f04e0a6d8e4243320e53ba638a94bc74bc130b7fc9fdca9c6c06c2c78b1c6e6727891117129de8642f4b2e633c5e5c1c7f2d04b315d7869dc29bd7e05ad55348ef3519451e66af3fbcaa396f93ffe357649e87cf1039a9e31d07cf08d0b8c305d40eb1880fe7d7fa84a6658ae3776dd1557fbdab1306b4aa305071ffeaa8548a6f25e32442c292a0acfb095d8aa591894d5bd2d3d349219ff9ec008730065a46301972fced0754e519234da6fbe84e63690dfc0ad860b644f79c091d8e0cfd1ec570f66689f3e0d78ae2c2129db1d30250149e4838be51441cd30e01157374181e6a8cf7b5a62392598db88330e4e386dc2a312c428016a9d076d3b1066b2538799fd21bfa29ff74c978104a500d4953277748cf637aab62423325e38be21118c0dfa9c68a4391eb65ee0b7226dd2ddbc6d64387acef2f29ea42b198aff6bfca3930f93d5"
                     },
                     {
-                      "tcId" : "1114",
+                      "tcId" : 1114,
                       "e" : "10000021",
                       "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
-                      "bitlen1" : "504",
-                      "bitlen2" : "238",
-                      "bitlen3" : "440",
-                      "bitlen4" : "185",
+                      "bitlen1" : 504,
+                      "bitlen2" : 238,
+                      "bitlen3" : 440,
+                      "bitlen4" : 185,
                       "p" : "b6bbf5a62930f4a89153ff826347d7b49339a5af07d29fbb4120847c914f4a09c98c95070c70c5498520a2e799138cdaaca5c2fe1cd8ef6da799b26af0ac9785bbc790e6b52c32389ef26afd447cc05baf8e6c628832772bce91eb120309332aa8735ce7eb34c640863bb7efc59f70a3d3038359d57b8ba5b009ff7b119aa0c2db32a1edbac51f4bddc1c4dbd3f70e83d43b07c23a4d3859a91f51014e6aec589693e66928c20467fe3c568298b43cb98d8b0f2a7504c19b01759bd4de5c4fad",
                       "q" : "c263d13aded6645ee10683efc4d216e6b51314684c7f3b84cbd59988c14134fd8327d5ee1b436cce2f8648a260f5fda5f9494dd2275ae475676439741aac62587fc2de745b68eb46c59eeee00cbf05f3d911752ba9223e5a0b88390023e79a60d94604b82ac6a51df27699c4b6672e17be555af0673bc2a5573c32ada7158272e08e02efd00d18932cdbd518b4e969b766fefd3f380f31f2180d55dbcbe55b3e6ffb755e07b03800537734c37e8644e66fe64cc7465a9a570e1ec03775cad1fb",
                       "n" : "8ac1b03163ab5e673e5ebfa0328b694a322da0819fd97f7be54f94b805f58a8a2f7ff4e273c98440ba862e7959658ee1c0876a19232bbd4f85c9f20ebb92d031269cf19f0dd46ba28759a452678be7b9c35efb788f3739183b512a56e781bb6a9d42534399b8795e63705c01a742ede7862d6670ca02a02e5c117ac0a6548035be5cfad0da0174c1872d3da8523b3efbf98115d168e74bb4f327661131753593f45550edfda6486dd4dbf870e50367ca1c39e446f3be3b50f197f5f4b3137e950350542e3688330a4e6fd607286f57f5771255ef9f3816658c2ce981132b0303ad34c21208f3c15846f21dbb77daddd4adf5ddcc6d1b828a5a5a6f3c4f85a42f1b51085d2d913e1d105d5565c029efd80d2f8c42701f6e7d51e8bab650c03a98bad191e3f6508d42aff30e6db1ca81228bf044d13eff53bcf6d688b73a423503a8e36808b61ecf499df708c06aae3b441257d154bb5c483bb52f3b0990e47b06b6efdcaa73fb29de1897df0cf8ffb915a35e36ed1011a8a97ffd16ab51105b9f",
                       "d" : "cf02aaaca392f5d21e80ac8e954ccc3eb738155b9ca03d96c1c7506b6593e97954e0b97eed739e6cd0eff08fe66e1584926d8d6ab9d6c686f99f758fec24627071a0f9164096b93c2693e296d2707f392ada019d010459b0783918f8f104423e2dfdcd418194144bde4b9fbbc766dc892bf9154803d41e8a295e2fd280592e4388dd78d792f96654da3268421553fa101f5e334b5149a6bd6857705ae9b5fbe4f80f2334fffec4a168a63c47d927d54e33571590f4450e005adb54c4a290f52141a7a502007a3508c6fad932f04e5b469cbab7228f69c34e89b5b4e7378fc82a9f1dd2132bceceb447dfd8a14679dd9df39194e4190b6d5fa79e2abe140abc4cc6cd428ed04c1bdb14cf51bd9133119138b1cee3bb1649bedb2e86c810010006e611237a901e3e404ca78c551253979c587a92440e11c2b742e87bea09a93fa2b1ed6cbf66907d3005a572b20055cc4870bce35d78b51f7b22ba37ff7f8af05dc2d0d6c743d95ac0a5e0eabf5be061991bb2fb505555589c5c5a0cd3b575d15"
                     },
                     {
-                      "tcId" : "1115",
+                      "tcId" : 1115,
                       "e" : "10000021",
                       "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
-                      "bitlen1" : "232",
+                      "bitlen1" : 232,
                       "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
                       "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
-                      "bitlen2" : "220",
+                      "bitlen2" : 220,
                       "p2" : "baf57f053b1f2a46705d9be799f90f28b800de871d88c95f24bf659",
                       "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
                       "p" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc4cf9e8d26cbe4b9def67b97305763aa17c09c8a939dddcef9fe0cc7773acbb3ef9beff7812132f7d432f9c77af59e95c7613c4cd47cd27a64463",
                       "primeSeedQ1" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc373fa",
-                      "bitlen3" : "336",
+                      "bitlen3" : 336,
                       "q1" : "bfbf1abfc1fb9b7e21342139053e7b05f56e664594419bbdcb14bb959ab66cf10e99a0d38f560a22cb33",
                       "primeSeedQ2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37484",
-                      "bitlen4" : "141",
+                      "bitlen4" : 141,
                       "q2" : "15e35869eb4f8dac49e317f09e3be3627c1d",
                       "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291",
                       "q" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910c7ad06973390b608cd2d39873222bff814db1a2c65797b58317226476d98846ec8037d4ca98f92afaa2fde97a6d0d53d4d17aec025d5933286c07b9ea7",
@@ -2586,21 +2695,21 @@
                       "d" : "bec8baec7da0634211ed76b770d9ef0834cfc689cb2a6d1c04a9c14d9ab249ebf5711147dde7a0120b521d8a0a2ba62fcedd767a8abde768e6bf1d12d5e88fd7f1a11d44684f6239512f976366236e270d39801eae4cab9109dc1746ffca0d868049551b7e27caa57d32ba0235dc8bf68a3955d562a283d31ac5f23342757e7918d85ffb654789ee39638543dbe76dea9ddbae3bb12c411b509923c101035ce53c7b642047bc91e3cbedb3f945f0cae1edad5a2c600db921722b4655742f8c10650cd1c868050d26c0caefff2dabf02a9841f1dff07e0094485e8965b06fd4ffb024a1d9a13ac241be9a2db0bcbfd656edcc5d1c945857a8ec3cd281d61f715"
                     },
                     {
-                      "tcId" : "1116",
+                      "tcId" : 1116,
                      "e" : "10000021",
                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
-                     "bitlen1" : "272",
+                     "bitlen1" : 272,
                      "p1" : "e43dc77ad0bbe2090a7d99a490f0b37188603691ebd453ef987e8358eee34be2def9",
                      "primeSeedP2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805cf1",
-                     "bitlen2" : "205",
+                     "bitlen2" : 205,
                      "p2" : "18dd5b6a27ca680f10764a0e2f49ffd384b650948aa6ba175f07",
                      "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
                      "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
                      "primeSeedQ1" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805e76",
-                     "bitlen3" : "296",
+                     "bitlen3" : 296,
                      "q1" : "bd76411ab7c1edb6873e76e5edc7b920b75cf8e2e1152010e6c34df592f8c3cd948212ca05",
                      "primeSeedQ2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805f9c",
-                     "bitlen4" : "157",
+                     "bitlen4" : 157,
                      "q2" : "123e72d9c914cde1b11d233a985f37f0769d2227",
                      "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
                      "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
@@ -2608,21 +2717,21 @@
                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
-                      "tcId" : "1117",
+                      "tcId" : 1117,
                       "e" : "10000021",
                       "seed" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddbbc",
-                      "bitlen1" : "512",
+                      "bitlen1" : 512,
                       "p1" : "e50610fd8a3b4f132e5c8d5904e0995b4e3782fa606593f1a80c4284920df7f14d310fab60d78bf97d2ad51472f2dc784e14f2f49734cc06ed299ecfd4764f51",
                       "primeSeedP2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddc59",
-                      "bitlen2" : "196",
+                      "bitlen2" : 196,
                       "p2" : "f974675ade75f0e11d66247a498fda86ec29e0c3a84052bbb",
                       "xP" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e306705e39d2b621027353b4873898b36b3fe86ab203dee10260058ce77f13d315ea1dcc0b717ffe906bfb05f251f3e9d678c585917176e127ece648c788f28b05607d4f71e113842e289b0de45bed72b7e591ea55ae5750ebe86a8",
                       "p" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e3092a9dfd7697a29e1c6952f0d71a7381d0bd64c4ac6102f54ae43b21f7d399583f86f6192717188b913ed16c1422d5fe5df0a407b1de9a05e178e4f47cdb3532866e2fcf36e57616f3473c5c967fa6703847d90ddfe0b822f24e9",
                       "primeSeedQ1" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddceb",
-                      "bitlen3" : "560",
+                      "bitlen3" : 560,
                       "q1" : "d2953e01641afc5d46b849c9c2568e6377e70c143ad23fc70d96b5c5b1528ba954a19e9905a235af27c4f2278fef63e112af66ed4ad84c595a6f84207f23e2a0c0b4d652a14b",
                       "primeSeedQ2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddef5",
-                      "bitlen4" : "180",
+                      "bitlen4" : 180,
                       "q2" : "c0f968cbe23b282c7f5516b3b59d13713fc04c8405473",
                       "xQ" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2dc5e9fe2c0077b65c79cb98bd4d7fced17121010598bbf410f3dd755df986b877e51058ef80649b486100c0d6eddf0825c69af34e3beace6e2810da3366c6f11520fd65b5ad7fbc7d33fa63a91f5ebb93b3d4b042478754ce89129e44add",
                       "q" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2f82363823d9c7bb2f1f4e19cee9d524d96f478637e8a5054c34fbf73483134a40034a75c72d30ee9499ff2e899da5ff65733155eb0ad9217e7ca2c57af22b12991882ab7fa7ea6d8a5f60ae7a71842a4b286d618374f496efd642ffcaa0f",
@@ -2630,21 +2739,21 @@
                       "d" : "4abd536c3f299e3c7365e496caedc45561ddc2a97d2d52f8c9e3eb1e7be52117e952ad9ee9768df7380ed09750d6c9bedf7d5da8ebe36046cb17f16e4f7cd88ced6279cceda200b17faa16b77000b53360c9e50bd5da91329a309bf422c716b7127b7331163987810ad08ca15b0580a97fe63bec434c72213f8527d939b02b60bd0902e97da8068d81354eedfa5d62067201a2b5b64c021022becda98b175bb57f4216211f22f11b28b5ce0021e87361e5c0f4e363f8f15123b1e7eb76cea6ecd065549925425f68fc80c8846d399205edbdf417d6554bb3eeaa58ef0e68be51a447c80438dcdff548203813d13e50f792e2aa106537d39198fde0a305446dfaf16de93e670600ce20a48ddb16ae196c43b4d1049c7c1c130c510b780e37591bee3bcf6c3d716f9acd305f81ab54675c95b7bef042f4c11ecae895d18c4fe1a986410e947b150deba89cf123fe11874304ae8922b61cae5c6b298cf20ea65cce98e94cb4849c85b813de46554ad6e0f0f844b679060855c02ae69b1806e55e21"
                     },
                     {
-                      "tcId" : "1118",
+                      "tcId" : 1118,
                       "e" : "10000021",
                       "seed" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b6e7",
-                      "bitlen1" : "512",
+                      "bitlen1" : 512,
                       "p1" : "a70dd2581283defd4b5689c942752af1eb31864fbe0c0894d434cff28ca5d5321505cb537675f2e9efbe3c05e5daf5ea63eb824d2fd9c43d5eeb6d3041a07e05",
                       "primeSeedP2" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b8f0",
-                      "bitlen2" : "182",
+                      "bitlen2" : 182,
                       "p2" : "28b81c23443dde1d774cd365ba50bd382677f8601bdb0f",
                       "xP" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f16221154aa62d139a67fb09edb0e6dcb091683e4136333b1cc7e9c2b09a8a06a335fd6f318532a068b9fd353ae12a1b57f9da498c6488ce863eb0a115af3ec15f70d4d78f030882a18bc14074a42daf322d2dd4b672c947fa21",
                       "p" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f162af6cd818f341cf0f652191e2debdf53eba1ada0b519eb3148708a9a0b36ac4087f7d3c446003111bc8c0db7bee01618f33432d81e3c7cca97e0733c88749f1ebe5e1edad984ecf3bc54651809fb0c5b4eaa45f12fb1155b1",
                       "primeSeedQ1" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b95e",
-                      "bitlen3" : "504",
+                      "bitlen3" : 504,
                       "q1" : "ec4ddb031e55ee7c840c3747782aa76ce88bd881a87b5877ccb664a25d0f3a60946383b612b69880c17b0e4b0b1171fe33eba748c01a51ed1cd63e162d24c9",
                       "primeSeedQ2" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b9da",
-                      "bitlen4" : "222",
+                      "bitlen4" : 222,
                       "q2" : "27b8373572544b1c79e79ba514a2a743ce60497fbfd56b522a26e327",
                       "xQ" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590d63fbdfb010f463a379e8a78e50ed95ce5c8fa3946970839492654ed0b70b3573354b2937cba400ced3fb1d8b5adfedcf0281fe13ca8b4348d18129afcf68f2bc27210e650d9434b344e2bf942fa03fdc50e4200014753afb998d15d8",
                       "q" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590fb74e9213473b3095212d37b0d1e20f93f260bd4ca1937b5eb936451eea0bd93274727a7ebaf6bdce546f0212c6c164eb30d7e139358bd71b16a6e26e6798c0ffbb9769d64a0e7de187b93b3cd102b56123d6a744c8fb3e88b07b62d9",
@@ -2652,20 +2761,20 @@
                       "d" : "f5931b10bdb7e1c3dacdee6a16a951420423cebcd3d0465edb82663895892780f3a3fd25a6fb04e58cc566c8642cf3e86a1d406ef151e468d44b99f7827560aa68edcbb6fc52129fbf08cb448e15e9b50495e87d32557dad8cde1f5f3a2882131a3b94acc231850feee3533552c7efcc773d5943db12f06ec781923345ae0403f53420b093b7df9128176984b43022733bcd377076372b3d450f7e5542ae4984c852343edbf566af7d72a5fd66779d2e84c23f9a62d4af26cb0f634373b061ebc0f32d50fabc87450af7ada7eba7ea454c16da4958edee2916f30b809f58e10651fe4c4c494105b7da2b0dcd0dec0bf5e5ec81207aae8be43edbc9936b3e12f95a78185dab006ba41d4bbc5c1712664c91dd0875a8694697449f058ea070d24f1300adc95ef81928af0bf716fd204a33fc3b1e0cd662147a467d49d26d24bb523de98c7de6548a82c559e5ecba493c6b2bce2c20686fbf73ca8f10965f0cf0f2a773a269df48e8c514da5a3b77b55f86ecc1179f86dcb9ca1847598a4f8da1"
                     },
                     {
-                      "tcId" : "1135",
+                      "tcId" : 1135,
                       "e" : "10000021",
-                      "bitlen1" : "224",
+                      "bitlen1" : 224,
                       "xP1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d811",
                       "p1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d839",
-                      "bitlen2" : "195",
+                      "bitlen2" : 195,
                       "xP2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f0f",
                       "p2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f45",
                       "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
                       "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
-                      "bitlen3" : "352",
+                      "bitlen3" : 352,
                       "xQ1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd810093026606fd",
                       "q1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd81009302660959",
-                      "bitlen4" : "142",
+                      "bitlen4" : 142,
                       "xQ2" : "20b8c2bae262b13e912094c937c4e8cfa573",
                       "q2" : "20b8c2bae262b13e912094c937c4e8cfa59f",
                       "xQ" : "fa97b510539a102879a78e8ac21b9840468ca6a2e2f16ab4a0f596cd1b36b3cc0d2cffa06173586b21af25b62b3bd9698c3644da4b4e399aed5c7e1cc97d7c2eb2e7b886e93f99a4bc98d47c07ee5ea995593e5e588a576add3db762b1d6f9de5c79ba02e96cf38bb5ac3c3fbb02f5e4462f4d26881854083630a769394bd57e",
@@ -2674,20 +2783,20 @@
                       "d" : "166bed3734b922f074460a0ae1a8fab231668de4a10daa969805338e6e738e9af173e2a5b0cb1cf132c40a0523dea617228cb7ec33779e86d91696a03218d1ee955f05fe9665d6416cca97600f89d30eed460a5638101137bb7e26a3f01ce9724e9570d372c593e6ff837b6eaabb0fc7698cb952a6122ba59f945d4e9b99a00b84dd150ecaa54ed35c280dc046b4af027beaec005a9768d23b38676d2a9d73e3b9c923d30c7e9ae8686815dda971de42fbf96872781231140d04e659c50a9e86bbd4cd9f5f5aa2df5e5e2ff7aa82ecebacb89a9931fa022a0982c42a304a0fad7e5da407be9e9b225664147a6837a05c43d704f4903a7a20f67a360bee822e21"
                     },
                     {
-                      "tcId" : "1137",
+                      "tcId" : 1137,
                       "e" : "10000021",
-                      "bitlen1" : "320",
+                      "bitlen1" : 320,
                       "xP1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077677",
                       "p1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077719",
-                      "bitlen2" : "315",
+                      "bitlen2" : 315,
                       "xP2" : "658ab200f20d118be4d915d5791f6397ee0ee2134b2460b1e10dce4911756eebd8cba8fc9763963",
                       "p2" : "658ab200f20d118be4d915d5791f6397ee0ee2134b2460b1e10dce4911756eebd8cba8fc976397d",
                       "xP" : "f007605f1bce4e4aff719cfe996315182cb858119e93e98e9a37ce08b4bbd725c0e3589374505e3fbe9f4831efab23713440d8a18179efe14ea5202e4797b997f3f062ff22af5f43bf2de896071965c4ddfb18074c07f96eaedaf8cf47b145eafd92583b3d33e9964f1cc000fd1688c33d1e63ec7cf20462fefa938100ef700fffb2417157607dda0f03a56c4dabdcab275b9ee4ba71a5936e8f1526708bf7dca446702bcdfeb6249bd701e8838f3a896c058f5cf3a3096543064eba0122e578",
                       "p" : "f007605f1bce4e4aff719cfe996315182cb858119e93e98e9a37ce08b4bbd725c0e3589374505e3fbe9f4831efab23713440d8a18179efe14ea5202e4797b997f3f062ff22af5f43bf2de896071965c4ddfb18074c07f96eaedaf8cf47b145eafd92583b3d33e9964f1cc000fd1688faa69707469eb820a29ea2e81ca882ba8f6084b37de51b2cf276adea9d35d6147b112d5d896228e1c614f7339e7e4a49f28195ded4d8943febca86e94cee78a9168e215e8409eb74b1d673847747ae4615",
-                      "bitlen3" : "320",
+                      "bitlen3" : 320,
                       "xQ1" : "f21ebb87473fdcff5f7a4fe439027a6c1853cd94a3b7209d1fdb3208c20f2625f9ae12e13ae9ee45",
                       "q1" : "f21ebb87473fdcff5f7a4fe439027a6c1853cd94a3b7209d1fdb3208c20f2625f9ae12e13ae9efb3",
-                      "bitlen4" : "277",
+                      "bitlen4" : 277,
                       "xQ2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8bf9",
                       "q2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8c89",
                       "xQ" : "e695e1de6811c9872ba9017fdde9a87969022882a295320cecd39f9a9bebae1e9edc0e42ff78cd17d05c58a93ec75ec09c3a75a8db24a19b073314f9d857fc43523291c58b23065660987ea793755ff238ffa5adfbd9ac26b53c6af016ebe9b646963ac139fa81b41534a0851a7e54ce3fe84af212452440f235701ec2dfd6b1b4980a67745b0144aed587ad04a692c86c0956bff44e263194efc4a26a7ef66dc056bc038d8d0aee995d8f71a3a68c4d2bc83042b96736663d1c34b13776b223",
@@ -2696,7 +2805,7 @@
                       "d" : "8c377a2f9817c497507f74c2d4d37c2093e5a204fe0bc04299c0337af153bf86022c2ad9f88d156b67263d21e0fff1fce1cf8e9affbf52bd83e33f38d7223b6aae31667b029188d939453b5cff019c1fc6ed87296f7897c2b3328bb888e1dd3b082e5b11272f7f8fc62473d701b35b342e4ac4f757c4b17924912dba913f17800f2a5dec389436b8d7288e6c44035d2aad9bba5bd1cfb8550fc3bdfd01c317ec222ea6f0cb90342367fdaa5b61513cdc3bea7a12bb44f1f07811a2c193b99615e89627164482248f474e89985ac1655df1054d93ec91f93b08c5ef077fad256cd042ac375cd536837b65489d62833c48fff221cb1092509e82fea082f0022151dbd9d2104314d10cef26fd4ea710898f42f956be2aa46756e5c436174e181f95e54ac8b6477baa5a32044678b3686d16df88e457bda4e0dddd94a24dbdb3ced4827392780cc96287fd6a46e82a5fb1daa0d372953c06ff6c2e1236926e0c11a367218a4291e6288e5cd1be03408770c5a667da57652eb46a9367369f732eb41"
                     },
                     {
-                      "tcId" : "1145",
+                      "tcId" : 1145,
                       "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
                       "e" : "10000021",
                       "p" : "f3ec667fe3c697769f89db44c48926f05285933f351ac5821458ea3414a1c62cf581e6cb702adc0323d7b86f6f013b471e24e4b25bbe731ecd023157a03656fb9a16fb7f6fcfa65020900822e8ce03bd967e38efd546ea30706698c7fa6d0f9e0316fe65d3195310e9baaaebcdd85e4a260341a90dd2c884f6e269e10647a2e9",
@@ -2705,7 +2814,7 @@
                       "d" : "8a19a9956ae2ccec6ca4fc0a5e56ab691c94b710dd668c00534bca4f5af84a568fee1bbbf36185747d11deac96faf66d13c08d97acfd29025d044630fdb2824c9435d8fa6ab7b6a349bf98ee86f5d1a7d6cf3956b43593c9a7b379fedcf2b78b1d4bcca082f0a9bbfeaa2a982a0cf16a1e812816bb9ede15edba51ffae5b65359e49b3c2e755fe32399614a35d45dd525709ae323b2828668be67c0c364d59925617f9583d399096d9f9cf085e29d011c78dc857e24376ebeeba688d72a2fbb1f8f09e92e7e606ff787fc9b395f6cac20c3ccb251bac325afdf1c3dbe75fce59753c7005bfd86957ba72172dc5a43b6192121e3cb97d0c43b9b63952bbe0d91"
                     },
                     {
-                      "tcId" : "1147",
+                      "tcId" : 1147,
                       "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
                       "e" : "10000021",
                       "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
@@ -2714,64 +2823,64 @@
                       "d" : "79815d367f924ba3509d3d4870cc729a82dc6dfb001e551baac15ff2ed77efdc6a00e628f29aabe062b5226a2e2689d26c82e8021958eda5fe0581f3bad0479942ec03bee965d79204c822d6c4e5cb82814419acd38a8779afae03b4a95ded204198bc2d68ee124cb5d2cbc68bc3621450168f55a9b9f2787b1cafb0328ceb9c0bc4e81d23bc155af9a172b18dac8f493f6753571b2f13cf56d7d93ac9d191dbfb7a2b6c6e795c2387722ee48d9bbf8fabd0fe58b3502a6a3173901057ae04bdd1f69cea58c38f9ac88c90427d8d3c60afd50dea9d98b669f8a052c7c26415885d70df8eb36fabd5d9fcde1a9cea5c4118f16af672fadb56f43e2fedf3b33ab4c0d6763b497d73164b778a1638af9c8e87e71cf64ed368c978179a2d7bfb2086ce8fd1ab6f3263603a71d0dc70fa5c56c6c0f233447bf4c93fb03c8e85ddbb204142e4414f0a1f35746c7f106931e25a1fe6a5f865b93d679ccd7742519b29803ed34ca40321c7e38fdeeed68195860b8157f14365a587ca58e1c5c7c46c9c1"
                     },
                     {
-                      "tcId" : "1119",
+                      "tcId" : 1119,
                       "primeResult" : "prime"
                     },
                    {
-                      "tcId" : "1120",
+                      "tcId" : 1120,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1121",
+                      "tcId" : 1121,
                        "primeResult" : "prime"
                    },
                    {
-                      "tcId" : "1122",
+                      "tcId" : 1122,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1123",
+                      "tcId" : 1123,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1124",
+                      "tcId" : 1124,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1125",
+                      "tcId" : 1125,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1126",
+                      "tcId" : 1126,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1129",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
+                      "tcId" : 1129,
+                      "e" : "df28ab",
                       "p" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "q" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275",
                       "n" : "cf91c0065d8e5797f0d1b1b3f4c31ac3d5e83d4be67ada7625b4b3a80fd24eda86c88b88c7fc4b2c60e311215abf8abc34e21c047035a93bbcb43387c6a44c7149c278ae27488ddc09ce56eacc7fbd437de9699d660b1dba4923ba60c9bb1fc69b7c90468ace5b7715d5d385c02e59f525ea01625c5c61760d8b23b962b7c80d14e6d58064a6064749ffdd260b0a8b0b2ffb846a6586e375a04163b61fb0af71dddf56e65478ae2101f30dc37a3f035f10ff86f53ac2e073b3a5b5f7017c6e6704b23e83c357aa171b23c49ff4d3820a03229a1962bf2e6b90acf79570f269e679292255755ad6362129870460c00799c5179e27a3b5182ee07c6ba07420e205",
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "tcId" : "1130",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e66d81",
+                    "tcId" : 1130,
+                      "e" : "e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
                       "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
                       "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
                    },
                    {
-                      "tcId" : "1131",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1131,
+                      "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   },
                   {
-                      "tcId" : "1132",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1132,
+                      "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
@@ -2786,18 +2895,18 @@
 <pre>
              [
                   { "acvVersion": "0.3" },
-                  { "vsId": "1163",
+                  { "vsId": 1163,
                     "testResults": [
                     {
-                      "tcId" : "1165",
+                      "tcId" : 1165,
                       "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f3e7af",
+                      "e" : "f3e7af",
                       "s" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
                     }
                     {
-                      "tcId" : "1166",
+                      "tcId" : 1166,
                       "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ebda09",
+                      "e" : "ebda09",
                       "s" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
                     }
                  ]
@@ -2807,13 +2916,13 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1167",
+                      "tcId" : 1167,
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "s" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
                     }
                     {
-                      "tcId" : "1168",
+                      "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
                       "s" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
@@ -2825,13 +2934,13 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1169",
+                      "tcId" : 1169,
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "s" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
                     }
                     {
-                      "tcId" : "1170",
+                      "tcId" : 1170,
                       "e" : "1415a7",
                       "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
                       "s" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
@@ -2845,7 +2954,7 @@
 <pre>
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1173",
+    { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2853,11 +2962,11 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1174",
+                      "tcId" : 1174,
                       "sigResult" : "fail"
                     },
                     {
-                      "tcId" : "1175",
+                      "tcId" : 1175,
                       "sigResult" : "fail"
                     }
                  ]
@@ -2867,11 +2976,11 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1176",
+                      "tcId" : 1176,
                       "sigResult" : "pass"
                     },
                     {
-                      "tcId" : "1177",
+                      "tcId" : 1177,
                       "sigResult" : "fail"
                     }
                  ]
@@ -2881,11 +2990,11 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1178",
+                      "tcId" : 1178,
                       "sigResult" : "fail"
                     },
                     {
-                      "tcId" : "1179",
+                      "tcId" : 1179,
                       "sigResult" : "fail"
                     }
                  ]
@@ -2901,21 +3010,19 @@
 <pre>
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1193",
+    { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentSigPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1194",
+                      "tcId" : 1194,
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "tcId" : "1195",
-                      "sigResult" : "fail",
-                      "reason" : "msg larger than modulus size"
+                      "tcId" : 1195,
+                      "sigResult" : "fail"
                     }
                  ]
              }
@@ -2928,24 +3035,22 @@
 <pre>
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1194",
+    { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentDecPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1196",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010001",
+                      "tcId" : 1196,
+                      "e" : "010001",
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "tcId" : "1197",
-                      "sigResult" : "fail",
-                      "reason" : "msg larger than modulus size"
+                      "tcId" : 1197,
+                      "sigResult" : "fail"
                     }
                  ]
              }

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -593,23 +593,23 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
-   +---------------+-------------------+-------+------------+----------+
-   | JSON Value    | Description       | JSON  | Valid      | Optional |
-   |               |                   | type  | Values     |          |
-   +---------------+-------------------+-------+------------+----------+
-   | mode          | The mode to be    | value | "keyGen",  | No       |
-   |               | validated         |       | see Table  |          |
-   |               |                   |       | 1          |          |
-   |               |                   |       |            |          |
-   | fixedPubExp   | Supports fixed    | value | "yes","no" | Yes      |
-   |               | public key        |       |            |          |
-   |               | exponent e        |       |            |          |
-   |               |                   |       |            |          |
-   | fixedPubExpVa | The value of the  | value | hex        | Yes      |
-   | l             | public key        |       |            |          |
-   |               | exponent e in hex |       |            |          |
-   |               |                   |       |            |          |
-   | randPubExp    | Supports random   | value | "yes","no" | Yes      |
+   +----------------+-------------------+-------+-----------+----------+
+   | JSON Value     | Description       | JSON  | Valid     | Optional |
+   |                |                   | type  | Values    |          |
+   +----------------+-------------------+-------+-----------+----------+
+   | mode           | The mode to be    | value | "keyGen", | No       |
+   |                | validated         |       | see Table |          |
+   |                |                   |       | 1         |          |
+   |                |                   |       |           |          |
+   | fixedPubExp    | Supports fixed    | value | true or   | Yes      |
+   |                | public key        |       | false     |          |
+   |                | exponent e        |       |           |          |
+   |                |                   |       |           |          |
+   | fixedPubExpVal | The value of the  | value | hex       | Yes      |
+   |                | public key        |       |           |          |
+   |                | exponent e in hex |       |           |          |
+   |                |                   |       |           |          |
+   | randPubExp     | Supports random   | value | true or   | Yes      |
 
 
 
@@ -618,39 +618,39 @@ Vassilev                Expires November 2, 2017               [Page 11]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |               | public key        |       |            |          |
-   |               | exponent e        |       |            |          |
-   |               |                   |       |            |          |
-   | randPQ        | Random P and Q    | value | {1, 2, 3,  | Yes      |
-   |               | primes generated  |       | 4, 5}      |          |
-   |               | as (see           |       |            |          |
-   |               | [FIPS186-4]): 1 - |       |            |          |
-   |               | provable primes   |       |            |          |
-   |               | (Appendix B.3.2); |       |            |          |
-   |               | 2 - probable      |       |            |          |
-   |               | primes (Appendix  |       |            |          |
-   |               | B.3.3); 3 -       |       |            |          |
-   |               | provable primes   |       |            |          |
-   |               | (Appendix B.3.4); |       |            |          |
-   |               | 4 -               |       |            |          |
-   |               | provable/probable |       |            |          |
-   |               | primes (Appendix  |       |            |          |
-   |               | B.3.5); 5 -       |       |            |          |
-   |               | probable primes   |       |            |          |
-   |               | (Appendix B.3.6)  |       |            |          |
-   |               |                   |       |            |          |
-   | capProvPrimes | Capabilities for  | array |            | Yes      |
-   |               | all supported     |       |            |          |
-   |               | moduli and hash   |       |            |          |
-   |               | algorithms (see   |       |            |          |
-   |               | Table 4)          |       |            |          |
-   |               |                   |       |            |          |
-   | modProbPrime  | See Table 5       | array | see Table  | Yes      |
-   |               |                   |       | 5          |          |
-   |               |                   |       |            |          |
-   | primeTest     | See Table 5       | value | see Table  | Yes      |
-   |               |                   |       | 5          |          |
-   +---------------+-------------------+-------+------------+----------+
+   |                | public key        |       | false     |          |
+   |                | exponent e        |       |           |          |
+   |                |                   |       |           |          |
+   | randPQ         | Random P and Q    | value | {1, 2, 3, | Yes      |
+   |                | primes generated  |       | 4, 5}     |          |
+   |                | as (see           |       |           |          |
+   |                | [FIPS186-4]): 1 - |       |           |          |
+   |                | provable primes   |       |           |          |
+   |                | (Appendix B.3.2); |       |           |          |
+   |                | 2 - probable      |       |           |          |
+   |                | primes (Appendix  |       |           |          |
+   |                | B.3.3); 3 -       |       |           |          |
+   |                | provable primes   |       |           |          |
+   |                | (Appendix B.3.4); |       |           |          |
+   |                | 4 -               |       |           |          |
+   |                | provable/probable |       |           |          |
+   |                | primes (Appendix  |       |           |          |
+   |                | B.3.5); 5 -       |       |           |          |
+   |                | probable primes   |       |           |          |
+   |                | (Appendix B.3.6)  |       |           |          |
+   |                |                   |       |           |          |
+   | capProvPrimes  | Capabilities for  | array |           | Yes      |
+   |                | all supported     |       |           |          |
+   |                | moduli and hash   |       |           |          |
+   |                | algorithms (see   |       |           |          |
+   |                | Table 4)          |       |           |          |
+   |                |                   |       |           |          |
+   | modProbPrime   | See Table 5       | array | see Table | Yes      |
+   |                |                   |       | 5         |          |
+   |                |                   |       |           |          |
+   | primeTest      | See Table 5       | value | see Table | Yes      |
+   |                |                   |       | 5         |          |
+   +----------------+-------------------+-------+-----------+----------+
 
                Table 7: RSA keyGen Capabilities JSON Values
 
@@ -1467,7 +1467,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
          {"modeSpecs" : {
               "mode": "keyGen",
               "capSpecs" :  {
-                      "fixedPubExp" : "yes",
+                      "fixedPubExp" : true,
                       "fixedPubExpVal" : "010001",
                       "randPQ" : 1,
                       "capProvPrime" :
@@ -1532,7 +1532,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
            "modeSpecs": {
              "mode":"keyGen",
              "capSpecs": {
-               "fixedPubExp":"yes",
+               "fixedPubExp": true,
                "fixedPubExpVal":"010001",
                "randPQ": 2,
                "capProbPrime":[{
@@ -1579,7 +1579,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
          {"modeSpecs" : {
            "mode": "keyGen",
            "capSpecs" : {
-               "fixedPubExp" : "yes",
+               "fixedPubExp" : true,
                "fixedPubExpVal" : "010001",
                "randPQ" : 4,
                "capsProvProbPrime" :

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                              May 30, 2017
-Expires: December 1, 2017
+Intended status: Informational                                  May 2017
+Expires: November 2, 2017
 
 
             ACVP RSA Algorithm Validation JSON Specification
@@ -13,9 +13,9 @@ Expires: December 1, 2017
 
 Abstract
 
-   This document defines the JSON schema for testing RSA algorithm
-   implementations for conformance to [FIPS186-4] with the ACVP
-   specification.
+   This document defines the JSON schema for testing RSA algorithm and
+   component implementations for conformance to [FIPS186-4] and
+   [SP800-56B] with the ACVP specification.
 
 Status of This Memo
 
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 1, 2017.
+   This Internet-Draft will expire on November 2, 2017.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev                Expires December 1, 2017                [Page 1]
+Vassilev                Expires November 2, 2017                [Page 1]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -63,68 +63,70 @@ Table of Contents
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
      1.2.  Testing scope . . . . . . . . . . . . . . . . . . . . . .   3
-   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
+   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   4
      2.1.  Supported RSA Algorithm modes . . . . . . . . . . . . . .   4
      2.2.  Required Prerequisite Algorithms for RSA Mode Validations   4
      2.3.  Supported RSA Capabilities  . . . . . . . . . . . . . . .   5
-     2.4.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   6
+     2.4.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   7
        2.4.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   7
-         2.4.1.1.  keyGen With Provable Primes Capabilities  . . . .   7
-         2.4.1.2.  keyGen With Probable Primes Capabilities  . . . .   9
-         2.4.1.3.  keyGen Full Set Of Capabilities . . . . . . . . .   9
-       2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  11
-         2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  11
-       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  13
-         2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  13
-       2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  15
-       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  17
-       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  17
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  17
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  18
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  19
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  20
+         2.4.1.1.  keyGen With Provable Primes or Provable Primes
+                   with Conditions Capabilities  . . . . . . . . . .   7
+         2.4.1.2.  keyGen With Probable Primes Capabilities  . . . .   8
+         2.4.1.3.  keyGen With Both Provable and Probable Primes
+                   With Conditions . . . . . . . . . . . . . . . . .  10
+         2.4.1.4.  keyGen Full Set Of Capabilities . . . . . . . . .  11
+       2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  12
+         2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  13
+       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  14
+         2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  14
+       2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  16
+       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  18
+       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  18
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  18
+     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  19
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  20
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  21
    5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
    6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
    8.  Normative References  . . . . . . . . . . . . . . . . . . . .  25
    Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  26
-     A.1.  Example keyGen Capabilities JSON Objects  . . . . . . . .  26
+     A.1.  Example keyGen with Provable Primes and Provable Primes
+           with Conditions Capabilities JSON Objects . . . . . . . .  26
        A.1.1.  Example keyGen with Probable Primes Capabilities JSON
-               Object  . . . . . . . . . . . . . . . . . . . . . . .  26
+               Object  . . . . . . . . . . . . . . . . . . . . . . .  27
        A.1.2.  Example keyGen with Provable Conditional Primes with
-               Probable Factors Capabilities JSON Object . . . . . .  27
-       A.1.3.  Example keyGen with Probable Conditional Primes with
                Probable Factors Capabilities JSON Object . . . . . .  28
      A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  29
      A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  30
      A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  32
      A.5.  Example componentSigPrimitive Capabilities JSON Objects .  32
      A.6.  Example componentDecPrimitive Capabilities JSON Objects .  32
-   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  32
+   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  33
      B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  33
-     B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  36
-     B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  38
-     B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  40
-     B.5.  Example Test Vectors for componentSigPrimitive JSON
+     B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  37
+     B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  39
 
 
 
-Vassilev                Expires December 1, 2017                [Page 2]
+Vassilev                Expires November 2, 2017                [Page 2]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  40
+     B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  41
+     B.5.  Example Test Vectors for componentSigPrimitive JSON
+           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  41
      B.6.  Example Test Vectors for componentDecPrimitive JSON
            Objects . . . . . . . . . . . . . . . . . . . . . . . . .  41
-   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  41
-     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  41
-     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  47
-     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  48
+   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  42
+     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  42
+     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  48
+     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  49
      C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  50
-     C.5.  Example componentSigPrimitive Test Results JSON Objects .  50
-     C.6.  Example componentDecPrimitive Test Results JSON Objects .  50
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  51
+     C.5.  Example componentSigPrimitive Test Results JSON Objects .  51
+     C.6.  Example componentDecPrimitive Test Results JSON Objects .  51
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  52
 
 1.  Introduction
 
@@ -139,7 +141,8 @@ Internet-Draft                RSA Alg JSON                      May 2017
    constructs for testing individual crypto algorithms.  Each sub-
    specification addresses a specific class of crypto algorithms.  This
    sub-specification defines the JSON constructs for testing RSA
-   akgorithm implementations for conformance to [FIPS186-4] using ACVP.
+   algorithm and component implementations for conformance to
+   [FIPS186-4] and [SP800-56B] using ACVP.
 
 1.1.  Requirements Language
 
@@ -151,9 +154,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    The ACVP testing for RSA allows conformance testing for all modes of
    using the algorithm as specified in [FIPS186-4]: key generation,
-   signature generation, signature verification, component primitives.
-   Correspondingly, ACVP allows testing of the five different methods
-   for key generation in [FIPS186-4], Appendix B.3.
+   signature generation, signature verification, and component
+   primitives.  ACVP testing for RSA also allows conformance testing for
+   [SP800-56B]: decryption primitives.  Correspondingly, ACVP allows
+   testing of the five different methods for key generation in
+   [FIPS186-4], Appendix B.3.
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017                [Page 3]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 2.  Capabilities Registration
 
@@ -162,14 +177,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    specific algorithms and their modes, notifying the ACVP server which
    algorithms need test vectors generated for the validation process.
    This section describes the constructs for advertising support of the
-
-
-
-Vassilev                Expires December 1, 2017                [Page 3]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    RSA algorithm in all allowed modes to the ACVP server - see
    [FIPS186-4] for details.
 
@@ -194,11 +201,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
 2.2.  Required Prerequisite Algorithms for RSA Mode Validations
 
    Each RSA Mode implementation relies on other cryptographic primitives
-   (algorithms) - see [FIPS186-4].  For example, a keyGen uses an
-   underlying DRBG and hash algorithms.  In some case, a single RSA Mode
-   implementation may use several primitives of the same type.  For
+   (algorithms) - see [FIPS186-4].  For example, a keyGen implementation
+   uses underlying DRBG and hash algorithms.  In some case, a single RSA
+   Mode implementation may use several primitives of the same type.  For
    example, two different DRBG implementations may be used in the keyGen
-   algorithms in Section B.3.3 in [FIPS186-4], one in step 4.2 and
+   algorithms in Appendix B.3.3 in [FIPS186-4], one in step 4.2 and
    another in step 5.2.  Each of these underlying algorithm primitives
    must be validated, either separately or as part of the same
    submission.  ACVP provides a mechanism for specifying the required
@@ -214,14 +221,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017                [Page 4]
+Vassilev                Expires November 2, 2017                [Page 4]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -266,61 +266,77 @@ Internet-Draft                RSA Alg JSON                      May 2017
    object.  The following JSON values are used for RSA algorithm
    capabilities:
 
+   +-------------------+-----------+------------+------------+---------+
+   | JSON Value        | Descripti | JSON type  | Valid      | Optiona |
+   |                   | on        |            | Values     | l       |
+   +-------------------+-----------+------------+------------+---------+
+   | algorithm         | The RSA   | value      | "RSA"      | No      |
+   |                   | algorithm |            |            |         |
+   |                   | to be     |            |            |         |
+   |                   | validated |            |            |         |
 
 
 
-
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017                [Page 5]
+Vassilev                Expires November 2, 2017                [Page 5]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +------------+--------------+--------------+-------------+----------+
-   | JSON Value | Description  | JSON type    | Valid       | Optional |
-   |            |              |              | Values      |          |
-   +------------+--------------+--------------+-------------+----------+
-   | algorithm  | The RSA      | value        | "RSA"       | No       |
-   |            | algorithm to |              |             |          |
-   |            | be           |              |             |          |
-   |            | validated.   |              |             |          |
-   |            |              |              |             |          |
-   | prereqVals | The          | array of     | array       | No       |
-   |            | prerequisite | prereqAlgVal |             |          |
-   |            | algorithm    | objects -    |             |          |
-   |            | validations  | see Section  |             |          |
-   |            |              | 2.2          |             |          |
-   |            |              |              |             |          |
-   | capSpecs   | The          | an array of  | array       | No       |
-   |            | capabilities | objects      |             |          |
-   |            | of a         | specific to  |             |          |
-   |            | particular   | the mode     |             |          |
-   |            | RSA mode     | being        |             |          |
-   |            |              | specified    |             |          |
-   |            |              |              |             |          |
-   | modeSpecs  | The RSA mode | an object    | object      | No       |
-   |            | and its      | with "mode"  |             |          |
-   |            | capabilities | and          |             |          |
-   |            |              | "capSpecs"   |             |          |
-   |            |              | properties   |             |          |
-   |            |              |              |             |          |
-   | algSpecs   | Array of     | array of     | See Table 1 | No       |
-   |            | modeSpecs    | modeSpecs    | and Section |          |
-   |            |              | objects,     | 2.4         |          |
-   |            |              | each         |             |          |
-   |            |              | identified   |             |          |
-   |            |              | uniquely by  |             |          |
-   |            |              | the "mode"   |             |          |
-   |            |              | property     |             |          |
-   +------------+--------------+--------------+-------------+----------+
+   |                   |           |            |            |         |
+   | infoGeneratedBySe | This flag | value      | true or    | Yes     |
+   | rver              | indicates |            | false      |         |
+   |                   | that the  |            |            |         |
+   |                   | server is |            |            |         |
+   |                   | responsib |            |            |         |
+   |                   | le for ge |            |            |         |
+   |                   | nerating  |            |            |         |
+   |                   | inputs    |            |            |         |
+   |                   | for Key G |            |            |         |
+   |                   | eneration |            |            |         |
+   |                   | tests     |            |            |         |
+   |                   |           |            |            |         |
+   | prereqVals        | The prere | array of p | array      | No      |
+   |                   | quisite   | rereqAlgVa |            |         |
+   |                   | algorithm | l objects  |            |         |
+   |                   | validatio | - see      |            |         |
+   |                   | ns        | Section    |            |         |
+   |                   |           | 2.2        |            |         |
+   |                   |           |            |            |         |
+   | capSpecs          | The capab | an array   | array      | No      |
+   |                   | ilities   | of objects |            |         |
+   |                   | of a part | specific   |            |         |
+   |                   | icular    | to the     |            |         |
+   |                   | RSA mode  | mode being |            |         |
+   |                   |           | specified  |            |         |
+   |                   |           |            |            |         |
+   | modeSpecs         | The RSA   | an object  | object     | No      |
+   |                   | mode and  | with       |            |         |
+   |                   | its capab | "mode" and |            |         |
+   |                   | ilities   | "capSpecs" |            |         |
+   |                   |           | properties |            |         |
+   |                   |           |            |            |         |
+   | algSpecs          | Array of  | array of   | See Table  | No      |
+   |                   | modeSpecs | modeSpecs  | 1 and      |         |
+   |                   |           | objects,   | Section    |         |
+   |                   |           | each       | 2.4        |         |
+   |                   |           | identified |            |         |
+   |                   |           | uniquely   |            |         |
+   |                   |           | by the     |            |         |
+   |                   |           | "mode"     |            |         |
+   |                   |           | property   |            |         |
+   +-------------------+-----------+------------+------------+---------+
 
               Table 3: RSA Algorithm Capabilities JSON Values
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017                [Page 6]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 2.4.  Supported RSA Modes Capabilities
 
@@ -330,14 +346,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    is an array of individual JSON objects corresponding to a particular
    RSA mode defined in this section.  The 'modeSpecs' value is part of
    the 'capability_exchange' element of the ACVP JSON registration
-
-
-
-Vassilev                Expires December 1, 2017                [Page 6]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    message.  See the ACVP specification for details on the registration
    message.
 
@@ -358,225 +366,293 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
 
-2.4.1.1.  keyGen With Provable Primes Capabilities
+2.4.1.1.  keyGen With Provable Primes or Provable Primes with Conditions
+          Capabilities
 
-   The following key generation with provable primes capabilities may be
-   advertised by the ACVP compliant crypto module:
+   The following key generation with provable primes, or provable primes
+   with conditions capabilities may be advertised by the ACVP compliant
+   crypto module:
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+   +-------------+-------------+-----------+----------------+----------+
+   | JSON value  | Description | JSON type | Valid values   | Optional |
+   +-------------+-------------+-----------+----------------+----------+
+   | modulo      | Supported   | value     | 2048, 3072, or | Yes      |
+   |             | RSA moduli  |           | 4096           |          |
+   |             | for         |           |                |          |
+   |             | provable    |           |                |          |
+   |             | prime       |           |                |          |
+   |             | generation  |           |                |          |
+   |             | - see [FIPS |           |                |          |
+   |             | 186-4],     |           |                |          |
+   |             | Appendix    |           |                |          |
+   |             | B.3.2 or    |           |                |          |
 
 
 
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017                [Page 7]
+Vassilev                Expires November 2, 2017                [Page 7]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +--------------+-----------+-------------+-----------------+--------+
-   | JSON value   | Descripti | JSON type   | Valid values    | Option |
-   |              | on        |             |                 | al     |
-   +--------------+-----------+-------------+-----------------+--------+
-   | modProvPrime | supported | value       | "2048", "3072", | Yes    |
-   |              | RSA       |             | "4096"          |        |
-   |              | moduli    |             |                 |        |
-   |              | for       |             |                 |        |
-   |              | provable  |             |                 |        |
-   |              | prime gen |             |                 |        |
-   |              | eration - |             |                 |        |
-   |              | see [FIPS |             |                 |        |
-   |              | 186-4],   |             |                 |        |
-   |              | Appendix  |             |                 |        |
-   |              | B.3.2     |             |                 |        |
-   |              |           |             |                 |        |
-   | hashProvPrim | supported | array       | any non-empty   | Yes    |
-   | e            | hash algo |             | subset of       |        |
-   |              | rithms    |             | {"SHA-1",       |        |
-   |              | for       |             | "SHA-224",      |        |
-   |              | provable  |             | "SHA-256",      |        |
-   |              | prime gen |             | "SHA-384",      |        |
-   |              | eration - |             | "SHA-512",      |        |
-   |              | see [FIPS |             | "SHA-512/224",  |        |
-   |              | 186-4],   |             | "SHA-512/256"}  |        |
-   |              | Appendix  |             |                 |        |
-   |              | B.3.2     |             |                 |        |
-   |              |           |             |                 |        |
-   | singleCapPro | a         | object with | see above       | Yes    |
-   | vPrime       | testable  | "modProvPri |                 |        |
-   |              | combinati | me" and "ha |                 |        |
-   |              | on of     | shProvPrime |                 |        |
-   |              | modulus   | "           |                 |        |
-   |              | and hash  | properties  |                 |        |
-   |              | values    |             |                 |        |
-   |              |           |             |                 |        |
-   | capProvPrime | supported | array       | "singleCapProvP | Yes    |
-   |              | capabilit |             | rime" objects,  |        |
-   |              | ies for   |             | see above for   |        |
-   |              | provable  |             | possible values |        |
-   |              | prime gen |             |                 |        |
-   |              | eration   |             |                 |        |
-   +--------------+-----------+-------------+-----------------+--------+
+   |             | Appendix    |           |                |          |
+   |             | B.3.4       |           |                |          |
+   |             |             |           |                |          |
+   | hashAlg     | Supported   | array     | any non-empty  | Yes      |
+   |             | hash        |           | subset of      |          |
+   |             | algorithms  |           | {"SHA-1",      |          |
+   |             | for         |           | "SHA-224",     |          |
+   |             | provable    |           | "SHA-256",     |          |
+   |             | prime       |           | "SHA-384",     |          |
+   |             | generation  |           | "SHA-512",     |          |
+   |             | - see [FIPS |           | "SHA-512/224", |          |
+   |             | 186-4],     |           | "SHA-512/256"} |          |
+   |             | Appendix    |           |                |          |
+   |             | B.3.2 or    |           |                |          |
+   |             | Appendix    |           |                |          |
+   |             | B.3.4       |           |                |          |
+   |             |             |           |                |          |
+   | singleCap   | A testable  | object    | see above      | Yes      |
+   |             | combination | with      |                |          |
+   |             | of modulus  | "modulo"  |                |          |
+   |             | and hash    | and       |                |          |
+   |             | values      | "hashAlg" |                |          |
+   |             |             | propertie |                |          |
+   |             |             | s         |                |          |
+   |             |             |           |                |          |
+   | capProvPrim | Supported c | array     | "singleCap"    | Yes      |
+   | e           | apabilities |           | objects, see   |          |
+   |             | for         |           | above for      |          |
+   |             | provable    |           | possible       |          |
+   |             | prime       |           | values         |          |
+   |             | generation  |           |                |          |
+   |             | or provable |           |                |          |
+   |             | prime with  |           |                |          |
+   |             | conditions  |           |                |          |
+   |             | generation  |           |                |          |
+   +-------------+-------------+-----------+----------------+----------+
 
     Table 4: Supported RSA keyGen moduli and hash options for provable
-                            primes JSON Values
-
-
-
-
-
-Vassilev                Expires December 1, 2017                [Page 8]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
+           primes or provable primes with conditions JSON Values
 
 2.4.1.2.  keyGen With Probable Primes Capabilities
 
-   The following key generation with probable primes capabilities may be
-   advertised by the ACVP compliant crypto modules:
+   The following key generation with probable primes or probable primes
+   with conditions capabilities may be advertised by the ACVP compliant
+   crypto module:
 
-   +-------------+-------------+----------------+-----------+----------+
-   | JSON value  | Description | JSON type      | Valid     | Optional |
-   |             |             |                | values    |          |
-   +-------------+-------------+----------------+-----------+----------+
-   | modProbPrim | supported   | array          | any non-  | Yes      |
-   | e           | RSA moduli  |                | empty     |          |
-   |             | for         |                | subset of |          |
-   |             | probable    |                | {"2048",  |          |
-   |             | prime       |                | "3072",   |          |
-   |             | generation  |                | "4096"}   |          |
-   |             | - see [FIPS |                |           |          |
-   |             | 186-4],     |                |           |          |
-   |             | Appendix    |                |           |          |
-   |             | B.3.3       |                |           |          |
-   |             |             |                |           |          |
-   | primeTest   | Primality   | value          | "tblC2",  | Yes      |
-   |             | test rounds |                | "tblC3"   |          |
-   |             | of Miller-  |                |           |          |
-   |             | Rabin from  |                |           |          |
-   |             | Table C.2   |                |           |          |
-   |             | or Table    |                |           |          |
-   |             | C.3 in [FIP |                |           |          |
-   |             | S186-4],    |                |           |          |
-   |             | Appendix    |                |           |          |
-   |             | C.3         |                |           |          |
-   |             |             |                |           |          |
-   | capProbPrim | supported c | object with "m | see above | Yes      |
-   | e           | apabilities | odeProbPrime"  | for       |          |
-   |             | for         | and            | possible  |          |
-   |             | probable    | "primeTest"    | values    |          |
-   |             | prime       | properties     |           |          |
-   |             | generation  |                |           |          |
-   +-------------+-------------+----------------+-----------+----------+
+
+
+
+
+
+Vassilev                Expires November 2, 2017                [Page 8]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   +--------------+---------------+-------------+-----------+----------+
+   | JSON value   | Description   | JSON type   | Valid     | Optional |
+   |              |               |             | values    |          |
+   +--------------+---------------+-------------+-----------+----------+
+   | modulo       | supported RSA | value       | 2048,     | Yes      |
+   |              | moduli for    |             | 3072 or   |          |
+   |              | probable      |             | 4096      |          |
+   |              | prime         |             |           |          |
+   |              | generation -  |             |           |          |
+   |              | see           |             |           |          |
+   |              | [FIPS186-4],  |             |           |          |
+   |              | Appendix      |             |           |          |
+   |              | B.3.3 or      |             |           |          |
+   |              | Appendix      |             |           |          |
+   |              | B.3.5         |             |           |          |
+   |              |               |             |           |          |
+   | primeTest    | Primality     | array       | any non-  | Yes      |
+   |              | test rounds   |             | empty set |          |
+   |              | of Miller-    |             | of        |          |
+   |              | Rabin from    |             | {"tblC2", |          |
+   |              | Table C.2 or  |             | "tblC3"}  |          |
+   |              | Table C.3 in  |             |           |          |
+   |              | [FIPS186-4],  |             |           |          |
+   |              | Appendix C.3  |             |           |          |
+   |              |               |             |           |          |
+   | singleCap    | A testable    | object with | see above | Yes      |
+   |              | combination   | "modulo"    |           |          |
+   |              | of modulus    | and         |           |          |
+   |              | and primality | "primeTest" |           |          |
+   |              | test rounds   | properties  |           |          |
+   |              |               |             |           |          |
+   | capProbPrime | supported     | object with | see above | Yes      |
+   |              | capabilities  | "singleCap" | for       |          |
+   |              | for probable  | properties  | possible  |          |
+   |              | prime         |             | values    |          |
+   |              | generation or |             |           |          |
+   |              | probable      |             |           |          |
+   |              | primes with   |             |           |          |
+   |              | conditions    |             |           |          |
+   |              | generation    |             |           |          |
+   +--------------+---------------+-------------+-----------+----------+
 
     Table 5: Supported RSA keyGen moduli and primality test options for
-                        probable primes JSON Values
+      probable primes or probable primes with conditions JSON Values
 
-2.4.1.3.  keyGen Full Set Of Capabilities
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017                [Page 9]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+2.4.1.3.  keyGen With Both Provable and Probable Primes With Conditions
+
+   The following key generation with both provable and probable primes
+   with conditions capabilities may be advertised by the ACVP compliant
+   crypto module:
+
+   +---------------+------------+------------+---------------+---------+
+   | JSON value    | Descriptio | JSON type  | Valid values  | Optiona |
+   |               | n          |            |               | l       |
+   +---------------+------------+------------+---------------+---------+
+   | modulo        | supported  | value      | 2048, 3072 or | Yes     |
+   |               | RSA modulo |            | 4096          |         |
+   |               | for        |            |               |         |
+   |               | provable   |            |               |         |
+   |               | primes     |            |               |         |
+   |               | with       |            |               |         |
+   |               | conditions |            |               |         |
+   |               | - see [FIP |            |               |         |
+   |               | S186-4],   |            |               |         |
+   |               | Appendix   |            |               |         |
+   |               | B.3.6      |            |               |         |
+   |               |            |            |               |         |
+   | hashAlg       | Supported  | array      | any non-empty | Yes     |
+   |               | hash       |            | subset of     |         |
+   |               | algorithms |            | {"SHA-1",     |         |
+   |               | for        |            | "SHA-224",    |         |
+   |               | provable   |            | "SHA-256",    |         |
+   |               | prime      |            | "SHA-384",    |         |
+   |               | generation |            | "SHA-512", "S |         |
+   |               | - see [FIP |            | HA-512/224",  |         |
+   |               | S186-4],   |            | "SHA-512/256" |         |
+   |               | Appendix   |            | }             |         |
+   |               | B.3.6      |            |               |         |
+   |               |            |            |               |         |
+   | primeTest     | Primality  | array      | any non-empty | Yes     |
+   |               | test       |            | subset of     |         |
+   |               | rounds of  |            | {"tblC2",     |         |
+   |               | Miller-    |            | "tblC3"}      |         |
+   |               | Rabin from |            |               |         |
+   |               | Table C.2  |            |               |         |
+   |               | or Table   |            |               |         |
+   |               | C.3 in [FI |            |               |         |
+   |               | PS186-4],  |            |               |         |
+   |               | Appendix   |            |               |         |
+   |               | C.3        |            |               |         |
+   |               |            |            |               |         |
+   | singleCap     | A testable | object     | see above     | Yes     |
+   |               | combinatio | with       |               |         |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 10]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   |               | n of       | "modulo",  |               |         |
+   |               | modulus,   | "hashAlg", |               |         |
+   |               | hash       | and "prime |               |         |
+   |               | algorithm, | Test"      |               |         |
+   |               | and        | properties |               |         |
+   |               | primality  |            |               |         |
+   |               | test       |            |               |         |
+   |               | rounds     |            |               |         |
+   |               |            |            |               |         |
+   | capProvProbPr | supported  | object     | see above for | Yes     |
+   | ime           | capabiliti | with "sing | possible      |         |
+   |               | es for     | leCap"     | values        |         |
+   |               | both       | properties |               |         |
+   |               | provable   |            |               |         |
+   |               | and        |            |               |         |
+   |               | probable   |            |               |         |
+   |               | primes     |            |               |         |
+   |               | with       |            |               |         |
+   |               | conditions |            |               |         |
+   |               | generation |            |               |         |
+   +---------------+------------+------------+---------------+---------+
+
+   Table 6: Supported RSA keyGen moduli, hash algorithms, and primality
+    test options for provable and probable primes with conditions JSON
+                                  Values
+
+2.4.1.4.  keyGen Full Set Of Capabilities
 
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
-   +-------------+---------------+-------+-------------------+---------+
+   +---------------+-------------------+-------+------------+----------+
+   | JSON Value    | Description       | JSON  | Valid      | Optional |
+   |               |                   | type  | Values     |          |
+   +---------------+-------------------+-------+------------+----------+
+   | mode          | The mode to be    | value | "keyGen",  | No       |
+   |               | validated         |       | see Table  |          |
+   |               |                   |       | 1          |          |
+   |               |                   |       |            |          |
+   | fixedPubExp   | Supports fixed    | value | "yes","no" | Yes      |
+   |               | public key        |       |            |          |
+   |               | exponent e        |       |            |          |
+   |               |                   |       |            |          |
+   | fixedPubExpVa | The value of the  | value | hex        | Yes      |
+   | l             | public key        |       |            |          |
+   |               | exponent e in hex |       |            |          |
+   |               |                   |       |            |          |
+   | randPubExp    | Supports random   | value | "yes","no" | Yes      |
 
 
 
-Vassilev                Expires December 1, 2017                [Page 9]
+Vassilev                Expires November 2, 2017               [Page 11]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   | JSON Value  | Description   | JSON  | Valid Values      | Optiona |
-   |             |               | type  |                   | l       |
-   +-------------+---------------+-------+-------------------+---------+
-   | mode        | The mode to   | value | "keyGen", see     | No      |
-   |             | be validated  |       | Table 1           |         |
-   |             |               |       |                   |         |
-   | fixedPubExp | supports      | value | "yes","no"        | Yes     |
-   |             | fixed public  |       |                   |         |
-   |             | key exponent  |       |                   |         |
-   |             | e             |       |                   |         |
-   |             |               |       |                   |         |
-   | fixedPubExp | the value of  | value | hex               | Yes     |
-   | Val         | the public    |       |                   |         |
-   |             | key exponent  |       |                   |         |
-   |             | e in hex      |       |                   |         |
-   |             |               |       |                   |         |
-   | randPubExp  | supports      | value | "yes","no"        | Yes     |
-   |             | random public |       |                   |         |
-   |             | key exponent  |       |                   |         |
-   |             | e             |       |                   |         |
-   |             |               |       |                   |         |
-   | randPQ      | random P and  | value | {"1","2","3","4", | Yes     |
-   |             | Q primes      |       | "5"}              |         |
-   |             | generated as  |       |                   |         |
-   |             | (see          |       |                   |         |
-   |             | [FIPS186-4]   |       |                   |         |
-   |             | ): 1 -        |       |                   |         |
-   |             | provable      |       |                   |         |
-   |             | primes        |       |                   |         |
-   |             | (Appendix     |       |                   |         |
-   |             | B.3.2); 2 -   |       |                   |         |
-   |             | probable      |       |                   |         |
-   |             | primes        |       |                   |         |
-   |             | (Appendix     |       |                   |         |
-   |             | B.3.3); 3 -   |       |                   |         |
-   |             | provable      |       |                   |         |
-   |             | primes        |       |                   |         |
-   |             | (Appendix     |       |                   |         |
-   |             | B.3.4); 4 - p |       |                   |         |
-   |             | rovable/proba |       |                   |         |
-   |             | ble primes    |       |                   |         |
-   |             | (Appendix     |       |                   |         |
-   |             | B.3.5); 5 -   |       |                   |         |
-   |             | probable      |       |                   |         |
-   |             | primes        |       |                   |         |
-   |             | (Appendix     |       |                   |         |
-   |             | B.3.6)        |       |                   |         |
-   |             |               |       |                   |         |
+   |               | public key        |       |            |          |
+   |               | exponent e        |       |            |          |
+   |               |                   |       |            |          |
+   | randPQ        | Random P and Q    | value | {1, 2, 3,  | Yes      |
+   |               | primes generated  |       | 4, 5}      |          |
+   |               | as (see           |       |            |          |
+   |               | [FIPS186-4]): 1 - |       |            |          |
+   |               | provable primes   |       |            |          |
+   |               | (Appendix B.3.2); |       |            |          |
+   |               | 2 - probable      |       |            |          |
+   |               | primes (Appendix  |       |            |          |
+   |               | B.3.3); 3 -       |       |            |          |
+   |               | provable primes   |       |            |          |
+   |               | (Appendix B.3.4); |       |            |          |
+   |               | 4 -               |       |            |          |
+   |               | provable/probable |       |            |          |
+   |               | primes (Appendix  |       |            |          |
+   |               | B.3.5); 5 -       |       |            |          |
+   |               | probable primes   |       |            |          |
+   |               | (Appendix B.3.6)  |       |            |          |
+   |               |                   |       |            |          |
+   | capProvPrimes | Capabilities for  | array |            | Yes      |
+   |               | all supported     |       |            |          |
+   |               | moduli and hash   |       |            |          |
+   |               | algorithms (see   |       |            |          |
+   |               | Table 4)          |       |            |          |
+   |               |                   |       |            |          |
+   | modProbPrime  | See Table 5       | array | see Table  | Yes      |
+   |               |                   |       | 5          |          |
+   |               |                   |       |            |          |
+   | primeTest     | See Table 5       | value | see Table  | Yes      |
+   |               |                   |       | 5          |          |
+   +---------------+-------------------+-------+------------+----------+
 
-
-
-Vassilev                Expires December 1, 2017               [Page 10]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-   | capProvPrim | capabilities  | array |                   | Yes     |
-   | es          | for all       |       |                   |         |
-   |             | supported     |       |                   |         |
-   |             | moduli and    |       |                   |         |
-   |             | hash          |       |                   |         |
-   |             | algorithms    |       |                   |         |
-   |             | (see Table 4) |       |                   |         |
-   |             |               |       |                   |         |
-   | modProbPrim | see Table 5   | array | see Table 5       | Yes     |
-   | e           |               |       |                   |         |
-   |             |               |       |                   |         |
-   | primeTest   | see Table 5   | value | see Table 5       | Yes     |
-   +-------------+---------------+-------+-------------------+---------+
-
-               Table 6: RSA keyGen Capabilities JSON Values
+               Table 7: RSA keyGen Capabilities JSON Values
 
 2.4.2.  The sigGen Mode Capabilities
 
@@ -589,6 +665,15 @@ Internet-Draft                RSA Alg JSON                      May 2017
    Each RSA sigGen mode capability is advertised as a self-contained
    JSON object.
 
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 12]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
 
@@ -596,27 +681,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    The following key generation with provable primes capabilities may be
    advertised by the ACVP compliant crypto module:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 11]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
    +--------------+----------------+-------+----------------+----------+
    | JSON value   | Description    | JSON  | Valid values   | Optional |
@@ -657,22 +721,18 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              | below.         |       |                |          |
    +--------------+----------------+-------+----------------+----------+
 
-     Table 7: Supported RSA sigGen moduli and hash options JSON Values
+     Table 8: Supported RSA sigGen moduli and hash options JSON Values
+
+
+
+Vassilev                Expires November 2, 2017               [Page 13]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    Note: the salt length for each hash algorithm used in PKCS1PSS
    signature generation is between 0 and the length of the corresponding
    hash function output block (in bytes), the end points included.
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 12]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 2.4.3.  The sigVer Mode Capabilities
 
@@ -721,11 +781,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 13]
+Vassilev                Expires November 2, 2017               [Page 14]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -769,7 +825,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              | below.         |       |                |          |
    +--------------+----------------+-------+----------------+----------+
 
-     Table 8: Supported RSA sigVer moduli and hash options JSON Values
+     Table 9: Supported RSA sigVer moduli and hash options JSON Values
 
    Note: the salt length for each hash algorithm used in PKCS1PSS
    signature generation is between 0 and the length of the corresponding
@@ -781,7 +837,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires December 1, 2017               [Page 14]
+Vassilev                Expires November 2, 2017               [Page 15]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -837,7 +893,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires December 1, 2017               [Page 15]
+Vassilev                Expires November 2, 2017               [Page 16]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -883,7 +939,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |                  | note below.  |       |              |          |
    +------------------+--------------+-------+--------------+----------+
 
-     Table 9: Supported RSA legacySigVer moduli and hash options JSON
+     Table 10: Supported RSA legacySigVer moduli and hash options JSON
                                   Values
 
    Note: the salt length for each hash algorithm used in PKCS1PSS
@@ -893,24 +949,25 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires December 1, 2017               [Page 16]
+Vassilev                Expires November 2, 2017               [Page 17]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
 2.4.5.  The componentSigPrimitive Mode Capabilities
 
-   The RSA componentSigPrimitive mode capability is advertised a JSON
-   object within the array of 'modeSpecs' value of the ACVP registration
-   message. as part of the 'capability_exchange' element of the ACVP
-   JSON registration message.  In this mode, the only tested capability
-   is the correct expontiation s = msg^d mod n, where msg is a message,
-   d is the private exponent and n is the modulus, all supplied by the
-   testing ACVP server.  Only 2048-bit RSA keys are allowed for this
+   The RSA componentSigPrimitive mode capability (otherwise known as
+   RSASP1 in [RFC3447]) is advertised as a JSON object within the array
+   of 'modeSpecs' value of the ACVP registration message, as part of the
+   'capability_exchange' element of the ACVP JSON registration message.
+   In this mode, the only tested capability is the correct expontiation
+   's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1',
+   'd' is the private exponent and 'n' is the modulus, all supplied by
+   the testing ACVP server.  Only 2048-bit RSA keys are allowed for this
    capability.  There are no properties specified for this capability.
-   See Section Appendix B.5 for additional details on constraints for
-   msg and n.  See the ACVP specification for details on the
-   registration message.
+   See Appendix B.5 for additional details on constraints for 'msg' and
+   'n'.  See the ACVP specification for details on the registration
+   message.
 
    Each RSA componentSigPrimitive mode capability is advertised as a
    self-contained JSON object.
@@ -921,22 +978,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
    object within the array of 'modeSpecs' value of the ACVP registration
    message. as part of the 'capability_exchange' element of the ACVP
    JSON registration message.  In this mode, the only tested capability
-   is the correct expontiation s = msg^d mod n, where msg is a message,
-   d is the private exponent and n is the modulus.  See [SP800-56B],
-   Section 7.1.2 for details.
+   is the correct expontiation 's = msg^d mod n', where 'msg' is a
+   message, 'd' is the private exponent and ''n is the modulus.  See
+   [SP800-56B], Section 7.1.2 for details.
 
-   In testing, only msg is supplied by the ACVP server.  The client is
-   responsible for generating RSA key pairs of modulus n, private key d,
-   and calculates s.  Only 2048-bit RSA keys are allowed for this
+   In testing, only 'msg' is supplied by the ACVP server.  The client is
+   responsible for generating RSA key pairs of modulus 'n', private key
+   'd', and calculates 's'.  Only 2048-bit RSA keys are allowed for this
    capability.  See Appendix B.6 for additional details on constraints
-   for msg and n.  The client provides the public exponent e, modulus n,
-   the private key d and the computed result s in its response to the
-   ACVP - see Appendix C.6 .  The client must first check if 0 < msg <
-   n-1 and return an error if this is not the case.  The client returns
-   a value s only when msg is in the proper range for the size of the
-   selected modulus n.  There are no properties specified for this
-   capability.  See the ACVP specification for details on the
-   registration message.
+   for 'msg' and 'n'.  The client provides the public exponent 'e',
+   modulus 'n', the private key 'd' and the computed result 's' in its
+   response to the ACVP - see Appendix C.6 .  The client must first
+   check if '0 < msg < n-1' and return an error if this is not the case.
+   The client returns a value 's' only when 'msg' is in the proper range
+   for the size of the selected modulus 'n'.  See the ACVP specification
+   for details on the registration message.
 
    Each RSA componentDecPrimitive mode capability is advertised as a
    self-contained JSON object.
@@ -949,7 +1005,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires December 1, 2017               [Page 17]
+Vassilev                Expires November 2, 2017               [Page 18]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -979,7 +1035,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |            | defined in Section 3.1                       |       |
    +------------+----------------------------------------------+-------+
 
-                     Table 10: Vector Set JSON Object
+                     Table 11: Vector Set JSON Object
 
 3.1.  Test Groups JSON Schema
 
@@ -1005,7 +1061,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires December 1, 2017               [Page 18]
+Vassilev                Expires November 2, 2017               [Page 19]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -1020,7 +1076,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |           | values.                        |           |          |
    |           |                                |           |          |
    | randPQ    | RSA prime generation method -  | value     | Yes      |
-   |           | see Table 6                    |           |          |
+   |           | see Table 7                    |           |          |
+   |           |                                |           |          |
+   | modRSA    | RSA modulus                    | value     | No       |
+   |           |                                |           |          |
+   | hashAlg   | the hash algorithm             | value     | Yes      |
    |           |                                |           |          |
    | primeTest | Miller-Rabin constraint from   | value     | Yes      |
    |           | Table C.2 or C.3               |           |          |
@@ -1029,12 +1089,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |           | exponent                       | or        |          |
    |           |                                | "random"  |          |
    |           |                                |           |          |
-   | sigType   | The type of digigital          | value     | Yes      |
-   |           | signature algrothm - see       |           |          |
-   |           | Table 7                        |           |          |
+   | sigType   | The type of digital signature  | value     | Yes      |
+   |           | algorithm - see  Table 8       |           |          |
    +-----------+--------------------------------+-----------+----------+
 
-                     Table 11: Test Group JSON Object
+                     Table 12: Test Group JSON Object
 
 3.2.  Test Case JSON Schema
 
@@ -1058,42 +1117,34 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-
-
-
-Vassilev                Expires December 1, 2017               [Page 19]
+Vassilev                Expires November 2, 2017               [Page 20]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +---------+--------------------------------------+-------+----------+
-   | JSON    | Description                          | JSON  | Optional |
-   | Value   |                                      | type  |          |
-   +---------+--------------------------------------+-------+----------+
-   | tcId    | Numeric identifier for the test      | value | No       |
-   |         | case, unique across the entire       |       |          |
-   |         | vector set.                          |       |          |
-   |         |                                      |       |          |
-   | modRSA  | RSA modulus                          | value | No       |
-   |         |                                      |       |          |
-   | hashAlg | the hash algorithm                   | value | Yes      |
-   |         |                                      |       |          |
-   | e       | the public exponent                  | hex   | Yes      |
-   |         |                                      | value |          |
-   |         |                                      |       |          |
-   | pRand   | the random for P, testing probable   | hex   | Yes      |
-   |         | primes according to [FIPS186-4],     | value |          |
-   |         | Section B.3.3                        |       |          |
-   |         |                                      |       |          |
-   | qRand   | the random for Q, if applicable,     | hex   | Yes      |
-   |         | testing probable primes according to | value |          |
-   |         | [FIPS186-4], Section B.3.3           |       |          |
-   |         |                                      |       |          |
-   | msg     | the message to be signed             | hex   | Yes      |
-   |         |                                      | value |          |
-   +---------+--------------------------------------+-------+----------+
+   +-------+----------------------------------------+-------+----------+
+   | JSON  | Description                            | JSON  | Optional |
+   | Value |                                        | type  |          |
+   +-------+----------------------------------------+-------+----------+
+   | tcId  | Numeric identifier for the test case,  | value | No       |
+   |       | unique across the entire vector set.   |       |          |
+   |       |                                        |       |          |
+   | e     | the public exponent                    | hex   | Yes      |
+   |       |                                        | value |          |
+   |       |                                        |       |          |
+   | pRand | the random for P, testing probable     | hex   | Yes      |
+   |       | primes according to [FIPS186-4],       | value |          |
+   |       | Appendix B.3.3                         |       |          |
+   |       |                                        |       |          |
+   | qRand | the random for Q, if applicable,       | hex   | Yes      |
+   |       | testing probable primes according to   | value |          |
+   |       | [FIPS186-4], Appendix B.3.3            |       |          |
+   |       |                                        |       |          |
+   | msg   | the message to be signed               | hex   | Yes      |
+   |       |                                        | value |          |
+   +-------+----------------------------------------+-------+----------+
 
-                    Table 12: RSA Test Case JSON Object
+                    Table 13: RSA Test Case JSON Object
 
 4.  Test Vector Responses
 
@@ -1101,26 +1152,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    send the response vectors back to the ACVP server.  The following
    table describes the JSON object that represents a vector set
    response.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 20]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
    +-------------+---------------------------------------------+-------+
    | JSON Value  | Description                                 | JSON  |
@@ -1136,7 +1167,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | JSON schema as defined in Section 3.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 13: Vector Set Response JSON Object
+                 Table 14: Vector Set Response JSON Object
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 21]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    The following table describes the JSON elements for the response to a
    RSA test vector.
@@ -1156,44 +1196,45 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | testing probable   |                     |          |
    |             | primes according   |                     |          |
    |             | to [FIPS186-4],    |                     |          |
-   |             | Section B.3.3      |                     |          |
+   |             | Appendix B.3.3     |                     |          |
    |             |                    |                     |          |
    | qRand       | the random for Q,  | hex value           | Yes      |
    |             | if applicable,     |                     |          |
    |             | testing probable   |                     |          |
    |             | primes according   |                     |          |
    |             | to [FIPS186-4],    |                     |          |
-   |             | Section B.3.3      |                     |          |
+   |             | Appendix B.3.3     |                     |          |
    |             |                    |                     |          |
    | primeResult | the verdict on the | "prime"/"composite" | Yes      |
    |             | primality testing  |                     |          |
    |             | for the supplied   |                     |          |
-   |             | pRand/qrand        |                     |          |
+   |             | pRand/qRand        |                     |          |
    |             | combination, see   |                     |          |
-
-
-
-Vassilev                Expires December 1, 2017               [Page 21]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | [FIPS186-4],       |                     |          |
-   |             | Section B.3.3      |                     |          |
+   |             | Appendix B.3.3     |                     |          |
    |             |                    |                     |          |
    | xP1         | the prime factor   | hex value           | Yes      |
    |             | p1 for Primes with |                     |          |
    |             | Conditions - see   |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B.3.1, if |                     |          |
-   |             | applicable         |                     |          |
+   |             | Appendix B.3.3,    |                     |          |
+   |             | B.3.4, or B.3.5,   |                     |          |
+   |             | if applicable      |                     |          |
    |             |                    |                     |          |
    | seed        | the seed used in   | hex value           | Yes      |
    |             | prime generation   |                     |          |
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
-   |             | B3.4 or B3.5       |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 22]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   |             | B3.4, or B3.5      |                     |          |
    |             |                    |                     |          |
    | bitlen1     | the length of p1   | hex value           | Yes      |
    |             | for prime          |                     |          |
@@ -1211,9 +1252,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
-   |             | B3.4, B3.5 or the  |                     |          |
-   |             | length of xP2 for  |                     |          |
-   |             | B3.6               |                     |          |
+   |             | B.3.4, B.3.5 or    |                     |          |
+   |             | the length of xP2  |                     |          |
+   |             | for B.3.6          |                     |          |
    |             |                    |                     |          |
    | bitlen3     | the length of q1   | hex value           | Yes      |
    |             | for prime          |                     |          |
@@ -1221,76 +1262,64 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
-   |             | B3.4, B3.5 or the  |                     |          |
-   |             | length of xQ1 for  |                     |          |
-   |             | B3.6               |                     |          |
+   |             | B.3.4, B.3.5 or    |                     |          |
+   |             | the length of xQ1  |                     |          |
+   |             | for B.3.6          |                     |          |
    |             |                    |                     |          |
    | bitlen4     | the length of q2   | hex value           | Yes      |
-
-
-
-Vassilev                Expires December 1, 2017               [Page 22]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | for prime          |                     |          |
    |             | generation         |                     |          |
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
-   |             | B3.4, B3.5 or the  |                     |          |
-   |             | length of xQ2 for  |                     |          |
-   |             | B3.6               |                     |          |
+   |             | B.3.4, B.3.5 or    |                     |          |
+   |             | the length of xQ2  |                     |          |
+   |             | for B.3.6          |                     |          |
    |             |                    |                     |          |
    | primeSeedP2 | the prime seed     | hex value           | Yes      |
    |             | used for p2 for    |                     |          |
    |             | prime generation   |                     |          |
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B3.5      |                     |          |
+   |             | Appendix B.3.5     |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 23]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    |             |                    |                     |          |
    | primeSeedQ1 | the prime seed     | hex value           | Yes      |
    |             | used for q1 for    |                     |          |
    |             | prime generation   |                     |          |
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B3.5      |                     |          |
+   |             | Appendix B.3.5     |                     |          |
    |             |                    |                     |          |
    | primeSeedQ2 | the prime seed     | hex value           | Yes      |
    |             | used for q2 for    |                     |          |
    |             | prime generation   |                     |          |
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B3.5      |                     |          |
+   |             | Appendix B.3.5     |                     |          |
    |             |                    |                     |          |
    | xP2         | the prime factor   | hex value           | Yes      |
    |             | p2 for Primes with |                     |          |
    |             | Conditions - see   |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B.3.1, if |                     |          |
-   |             | applicable         |                     |          |
+   |             | Appendix B.3.3,    |                     |          |
+   |             | B.3.4, or B.3.5,   |                     |          |
+   |             | if applicable      |                     |          |
    |             |                    |                     |          |
    | xP          | the random number  | hex value           | Yes      |
-   |             | used in Step Step  |                     |          |
-   |             | 3 of the algorithm |                     |          |
-   |             | in [FIPS186-4],    |                     |          |
-   |             | Appendix C.9       |                     |          |
-   |             | "Compute a         |                     |          |
-   |             | Probable Prime     |                     |          |
-   |             | Factor Based on    |                     |          |
-   |             | Auxiliary Primes"  |                     |          |
-   |             | to generate the    |                     |          |
-   |             | prime P, if        |                     |          |
-
-
-
-Vassilev                Expires December 1, 2017               [Page 23]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-   |             | applicable         |                     |          |
+   |             | used in Step 3 of  |                     |          |
+   |             | the algorithm in   |                     |          |
+   |             | [FIPS186-4],       |                     |          |
+   |             | Appendix C.9 to    |                     |          |
+   |             | generate the prime |                     |          |
+   |             | P, if applicable   |                     |          |
    |             |                    |                     |          |
    | p           | the private prime  | hex value           | Yes      |
    |             | factor p           |                     |          |
@@ -1299,28 +1328,33 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | q1 for Primes with |                     |          |
    |             | Conditions - see   |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B.3.1, if |                     |          |
-   |             | applicable         |                     |          |
+   |             | Appendix B.3.3,    |                     |          |
+   |             | B.3.4, or B.3.5,   |                     |          |
+   |             | if applicable      |                     |          |
    |             |                    |                     |          |
    | xQ2         | the prime factor   | hex value           | Yes      |
    |             | q2 for Primes with |                     |          |
    |             | Conditions - see   |                     |          |
    |             | [FIPS186-4],       |                     |          |
-   |             | Appendix B.3.1, if |                     |          |
-   |             | applicable         |                     |          |
+   |             | Appendix B.3.3,    |                     |          |
+   |             | B.3.4, or B.3.5,   |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 24]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   |             | if applicable      |                     |          |
    |             |                    |                     |          |
    | xQ          | the random number  | hex value           | Yes      |
-   |             | used in Step Step  |                     |          |
-   |             | 3 of the algorithm |                     |          |
-   |             | in [FIPS186-4],    |                     |          |
-   |             | Appendix C.9       |                     |          |
-   |             | "Compute a         |                     |          |
-   |             | Probable Prime     |                     |          |
-   |             | Factor Based on    |                     |          |
-   |             | Auxiliary Primes"  |                     |          |
-   |             | to generate the    |                     |          |
-   |             | prime Q, if        |                     |          |
-   |             | applicable         |                     |          |
+   |             | used in Step 3 of  |                     |          |
+   |             | the algorithm in   |                     |          |
+   |             | [FIPS186-4],       |                     |          |
+   |             | Appendix C.9 to    |                     |          |
+   |             | generate the prime |                     |          |
+   |             | Q, if applicable   |                     |          |
    |             |                    |                     |          |
    | q           | the private prime  | hex value           | Yes      |
    |             | factor q           |                     |          |
@@ -1337,22 +1371,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | the digital        |                     |          |
    |             | signature          |                     |          |
    |             | verirfication      |                     |          |
-   |             |                    |                     |          |
-
-
-
-Vassilev                Expires December 1, 2017               [Page 24]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-   | reason      | additonal          | text                | Yes      |
-   |             | information about  |                     |          |
-   |             | a specific test    |                     |          |
-   |             | case result        |                     |          |
    +-------------+--------------------+---------------------+----------+
 
-                Table 14: RSA Test Case Results JSON Object
+                Table 15: RSA Test Case Results JSON Object
 
 5.  Acknowledgements
 
@@ -1368,7 +1389,18 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 8.  Normative References
 
-   [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
+   [ACVP]     NIST, "ACVP Specification", 2016.
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 25]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    [FIPS186-4]
               NIST, "FIPS PUB 186-4 Digital Signature Standard", July
@@ -1379,6 +1411,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3447]  Jonsson, J. and B. Kaliski, "Public-Key Cryptography
+              Standards (PKCS) #1: RSA Cryptography Specifications
+              Version 2.1", RFC 3447, DOI 10.17487/RFC3447, February
+              2003, <http://www.rfc-editor.org/info/rfc3447>.
 
    [SP800-131A]
               Barker, E. and A. Roginsky, "Transitions: Recommendation
@@ -1394,14 +1431,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
               <http://nvlpubs.nist.gov/nistpubs/SpecialPublications/
               NIST.SP.800-56Br1.pdf>.
 
-
-
-
-Vassilev                Expires December 1, 2017               [Page 25]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
 Appendix A.  Example RSA Capabilities JSON Objects
 
    This appendix contains example JSON object advertising support for
@@ -1409,15 +1438,30 @@ Appendix A.  Example RSA Capabilities JSON Objects
    compRSASP1.  Note that all binary HEX representations are in big-
    endian format.
 
-A.1.  Example keyGen Capabilities JSON Objects
+A.1.  Example keyGen with Provable Primes and Provable Primes with
+      Conditions Capabilities JSON Objects
 
    The following is an example JSON object advertising support for RSA
    keyGen with provable primes according to [FIPS186-4], Appendix B.3.2.
-   See also Section 2.4.1.3.
+   See also Section 2.4.1.4.
+
+
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 26]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
+      "infoGeneratedByServer": true,
       "algSpecs" :
       [
          {"modeSpecs" : {
@@ -1425,15 +1469,15 @@ A.1.  Example keyGen Capabilities JSON Objects
               "capSpecs" :  {
                       "fixedPubExp" : "yes",
                       "fixedPubExpVal" : "010001",
-                      "randPQ" : "1",
-                      "capsProvPrime" :
+                      "randPQ" : 1,
+                      "capProvPrime" :
                             [
-                                {   "modProvPrime" : "2048",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modProvPrime" : "3072",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modProvPrime" : "4096",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+                                {   "modulo" : 2048,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                                {   "modulo" : 3072,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                                {   "modulo" : 4096,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
                             ]
                       }
                 }
@@ -1441,11 +1485,15 @@ A.1.  Example keyGen Capabilities JSON Objects
       ]
    }
 
+   In order to advertise support for RSA keyGen with provable primes
+   with conditions, the same properties exist, but the 'randPQ' value
+   should be '3' as an integer.
+
 A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
 
    The following is an example JSON object advertising support for RSA
    keyGen with probable primes according to [FIPS186-4], Appendix B.3.3.
-   See also Section 2.4.1.3.
+   See also Section 2.4.1.4.
 
 
 
@@ -1453,13 +1501,22 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
 
 
 
-Vassilev                Expires December 1, 2017               [Page 26]
+
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 27]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
       {
        "algorithm":"RSA",
+       "infoGeneratedByServer": true,
        "prereqVals":[
          {
            "algorithm":"DRBG",
@@ -1477,45 +1534,45 @@ Internet-Draft                RSA Alg JSON                      May 2017
              "capSpecs": {
                "fixedPubExp":"yes",
                "fixedPubExpVal":"010001",
-               "randPQ":"2",
-               "capProbPrime":{
-                 "modProbPrime":["2048", "3072", "4096"],
-                 "primeTest":"tblC2"
-               }
+               "randPQ": 2,
+               "capProbPrime":[{
+                 "modulo": 2048,
+                 "primeTest":["tblC2"]
+               },
+               {
+                 "modulo": 3072,
+                 "primeTest":["tblC2", "tblC3"]
+               }]
              }
            }
          }
        ]
      }
 
+   In order to advertise support for RSA keyGen with all probable primes
+   with conditions, the same properties exist, but the 'randPQ' value
+   should be '5' as an integer.
+
 A.1.2.  Example keyGen with Provable Conditional Primes with Probable
         Factors Capabilities JSON Object
 
    The following is an example JSON object advertising support for RSA
    keyGen with primes with conditions according to [FIPS186-4],
-   Appendix B.3.5.  See also Section 2.4.1.3.
+   Appendix B.3.5.  See also Section 2.4.1.4.
 
 
 
 
 
 
-
-
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 27]
+Vassilev                Expires November 2, 2017               [Page 28]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
    {
       "algorithm": "RSA",
+      "infoGeneratedByServer": false,
        "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" :
       [
@@ -1524,65 +1581,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
            "capSpecs" : {
                "fixedPubExp" : "yes",
                "fixedPubExpVal" : "010001",
-               "randPQ" : "4",
-               "capsProvPrime" :
+               "randPQ" : 4,
+               "capsProvProbPrime" :
                     [
-                        {"modProvPrime" : "2048",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                        {"modProvPrime" : "3072",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                        {"modProvPrime" : "4096",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                    ],
-              "capProbPrime" :{"modProbPrime" : ["2048","3072","4096"],
-                                             "primeTest" : "tblC3"}
+                        {"modulo" : 2048,
+                         "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                         "primeTest": ["tblC2", "tblC3"]},
+                       {"modulo" : 3072,
+                         "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                         "primeTest": ["tblC2"]},
+                       {"modulo" : 4096,
+                         "hashAlg" : ["SHA-512"],
+                         "primeTest": ["tblC3"]},
+                    ]
               }
-          }
-        }
-      ]
-   }
-
-A.1.3.  Example keyGen with Probable Conditional Primes with Probable
-        Factors Capabilities JSON Object
-
-   The following is an example JSON object advertising support for RSA
-   keyGen with primes with conditions according to [FIPS186-4],
-   Appendix B.3.6.  See also Section 2.4.1.3.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 28]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-   {
-      "algorithm": "RSA",
-       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" :
-      [
-          {"modeSpecs" : {
-             "mode": "keyGen",
-             "capSpecs" : {
-                 "randPubExp" : "yes",
-                 "randPQ" : "5",
-                 "capProbPrime" :{"modProbPrime" : ["2048","3072","4096"],
-                                                "primeTest" : "tblC3"}
-                 }
           }
         }
       ]
@@ -1604,11 +1616,19 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
                   "sigType" : "X9.31",
                   "capSigType" :
                   [
-                      {"modRSASigGen" : "2048",
+                      {"modRSASigGen" : 2048,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "3072",
+
+
+
+Vassilev                Expires November 2, 2017               [Page 29]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+                      {"modRSASigGen" : 3072,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "4096",
+                      {"modRSASigGen" : 4096,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
                   ]
               }
@@ -1618,20 +1638,12 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
                "capSpecs" : {
                   "sigType" : "PKCS1v1.5",
                   "capSigType" :
-
-
-
-Vassilev                Expires December 1, 2017               [Page 29]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                   [
-                      {"modRSASigGen" : "2048",
+                      {"modRSASigGen" : 2048,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "3072",
+                      {"modRSASigGen" : 3072,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "4096",
+                      {"modRSASigGen" : 4096,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
                   ]
               }
@@ -1642,15 +1654,15 @@ Internet-Draft                RSA Alg JSON                      May 2017
                 "sigType" : "PKCS1PSS",
                 "capSigType" :
                 [
-                    { "modRSASigGen" : "2048",
+                    { "modRSASigGen" : 2048,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]},
-                    { "modRSASigGen" : "3072",
+                      "saltSigGen" : [28, 32, 64]},
+                    { "modRSASigGen" : 3072,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]},
-                    { "modRSASigGen" : "4096",
+                      "saltSigGen" : [28, 32, 64]},
+                    { "modRSASigGen" : 4096,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]}
+                      "saltSigGen" : [28, 32, 64]}
                 ]
             }
          }}
@@ -1661,6 +1673,14 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
 
    The following is an example JSON object advertising support for RSA
    sigVer according to [FIPS186-4].
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 30]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    {
       "algorithm": "RSA",
@@ -1674,19 +1694,11 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
                  "sigType" : "X9.31",
                  "capSigType" :
                 [
-
-
-
-Vassilev                Expires December 1, 2017               [Page 30]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-                  {"modRSASigVer" : "2048",
+                  {"modRSASigVer" : 2048,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "3072",
+                  {"modRSASigVer" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "4096",
+                  {"modRSASigVer" : 4096,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
                ]
             }
@@ -1697,11 +1709,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
                 "sigType" : "PKCS1v1.5",
                  "capSigType" :
                 [
-                  {"modRSASigVer" : "2048",
+                  {"modRSASigVer" : 2048,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "3072",
+                  {"modRSASigVer" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "4096",
+                  {"modRSASigVer" : 4096,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
                 ]
             }
@@ -1712,31 +1724,28 @@ Internet-Draft                RSA Alg JSON                      May 2017
                 "sigType" : "PKCS1PSS",
                 "capSigType" :
                   [
-                    { "modRSASigVer" : "2048",
+                    { "modRSASigVer" : 2048,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]},
-                    { "modRSASigVer" : "3072",
+                      "saltSigVer" : [28, 32, 64]},
+                    { "modRSASigVer" : 3072,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]},
-                    { "modRSASigVer" : "4096",
+                      "saltSigVer" : [28, 32, 64]},
+
+
+
+Vassilev                Expires November 2, 2017               [Page 31]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+                    { "modRSASigVer" : 4096,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]}
+                      "saltSigVer" : [28, 32, 64]}
                  ]
             }
        }}
     ]
    }
-
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 31]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 A.4.  Example RSA legacySigVer Capabilities JSON Objects
 
@@ -1751,17 +1760,15 @@ A.5.  Example componentSigPrimitive Capabilities JSON Objects
    The following is an example JSON object advertising support for RSA
    componentSigPrimitive according to [FIPS186-4].
 
-   {
-      "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" :
-      [
-       {"modeSpecs" : {
-           "mode": "componentSigPrimitive",
-           "capSpecs" : {}
-         }}
-      ]
-   }
+      {
+         "algorithm": "RSA",
+         "algSpecs" :
+         [
+          {"modeSpecs" : {
+              "mode": "componentSigPrimitive"
+            }}
+         ]
+      }
 
 A.6.  Example componentDecPrimitive Capabilities JSON Objects
 
@@ -1774,195 +1781,211 @@ A.6.  Example componentDecPrimitive Capabilities JSON Objects
       "algSpecs" :
       [
         {"modeSpecs" : {
-            "mode": "componentDecPrimitive",
-            "capSpecs" : {}
+            "mode": "componentDecPrimitive"
          }}
       ]
    }
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 32]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 Appendix B.  Example Test Vectors JSON Objects
 
    This appendix contains example JSON objects for test vectors sent
    from the ACVP server to the crypto module.
 
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 32]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
 B.1.  Example Test Vectors for keyGen JSON Objects
 
 
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1133",
+   { "vsId": 1133,
       "algorithm": "RSA",
+      "infoGeneratedByServer": false,
       "testGroups" : [
              {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "1",
+                 "randPQ" : 1,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
                  "tests" : [
                     {
-                      "tcId" : "1145",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
+                      "tcId" : 1145,
                     },
                     {
-                      "tcId" : "1147",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
+                      "tcId" : 1146,
                     }
                  ]
              },
-              {
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 1,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1147,
+                  },
+                  {
+                    "tcId": 1148,
+                  }
+                ]
+              },
+             {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "3",
-                 "tests" : [
-                    {
-                      "tcId" : "1111",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1112",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1113",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1114",
-                      "modRSA" : "3072",
+                 "randPQ" : 3,
 
 
 
-Vassilev                Expires December 1, 2017               [Page 33]
+Vassilev                Expires November 2, 2017               [Page 33]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "hashAlg" : "SHA-512"
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1149,
+                    },
+                    {
+                      "tcId" : 1150,
                     }
                  ]
              },
              {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 3,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1151,
+                  },
+                  {
+                    "tcId": 1152,
+                  }
+                ]
+              },
+             {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "4",
-                 "primeTest" : "tblC2",
+                 "randPQ" : 4,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
                  "tests" : [
                     {
-                      "tcId" : "1115",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
+                      "tcId" : 1153,
                     },
                     {
-                      "tcId" : "1116",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1117",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1118",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
+                      "tcId" : 1154,
                     }
                  ]
              },
              {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "5",
-                 "primeTest" : "tblC3",
-                 "tests" : [
-                    {
-                      "tcId" : "1135",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1137",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
-                    }
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 4,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
 
 
 
-Vassilev                Expires December 1, 2017               [Page 34]
+Vassilev                Expires November 2, 2017               [Page 34]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                 ]
-             },
+                  {
+                    "tcId": 1155,
+                  },
+                  {
+                    "tcId": 1156,
+                  }
+                ]
+              },
              {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "2",
-                 "primeTest" : "tblC2",
+                 "randPQ" : 5,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
                  "tests" : [
                     {
-                      "tcId" : "1119",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
+                      "tcId" : 1157,
+                    },
+                    {
+                      "tcId" : 1158,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 5,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1159,
+                  },
+                  {
+                    "tcId": 1160,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC2",
+                 "modRSA" : 2048,
+                 "tests" : [
+                    {
+                      "tcId" : 1119,
+                      "e" : "df28ab",
+
+
+
+Vassilev                Expires November 2, 2017               [Page 35]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "tcId" : "1120",
-                      "modRSA" : "2048",
-                      "e" : "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000085a4cf",
-                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5"
-                    },
+                      "tcId" : 1120,
+                      "e" : "85a4cf",
+                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                    }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC2",
+                 "modRSA" : 3072,
+                 "tests" : [
                     {
-                      "tcId" : "1121",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1121,
+                      "e" : "535c97",
                       "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
-                    },
-                    {
-                      "tcId" : "1122",
-                      "modRSA" : "3072",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000054a7dd",
-                      "pRand" : "0c5742407c0bac4f474edda6f92e42bd36ade552d947eb8bc5ac97c23efac563de8262ecc1e542cd489fcd33f3dcadcf900c8b0acd28abb1d25318c4f7dae3fa4b281c3b89a77d06db36115ff10496005b45fab68aa45e5f40296570ff97081007d907aa74b56f59841f6069900e14f5f2cf508b9094f3ee37aa4c0a43e38922dc3fce63d6d1e392d1a70da4e5ba7083188ca78693bb7e953352aeb76f3f5905613a10a04c791560717316e2a2c13bb4522aeb86680355bec7dda0b3674e10e9"
-                    },
-                    {
-                      "tcId" : "1129",
-                      "modRSA" : "2048"
-                    },
-                    {
-                      "tcId" : "1130",
-                      "modRSA" : "2048"
-                    },
-                    {
-                      "tcId" : "1131",
-                      "modRSA" : 3072
-                    },
-                    {
-                      "tcId" : "1132",
-
-
-
-Vassilev                Expires December 1, 2017               [Page 35]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-                      "modRSA" : "3072"
                     }
                  ]
              },
@@ -1971,32 +1994,43 @@ Internet-Draft                RSA Alg JSON                      May 2017
                  "pubExp" : "random",
                  "randPQ" : 2,
                  "primeTest" : "tblC3",
+                 "modRSA" : 2048,
                  "tests" : [
                     {
-                      "tcId" : "1123",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037a7f1",
-                      "pRand" : "ea4fe1b753e17f7a99a648c1d111d7599eda7ed85b14c974df5d3f1a39e9b3bc2ce3d4e9ab70a2d184c4ce56fbe18c97b09fd47bb39a470ef2bfa5217e1aa8493326dfd9cc9e73da683691cef7d6ded642bfb56c919f8f54ea08de9bffa2f155e8a3a6746302347fb2f581be2deb55b057c3ac371d867c710a03cb9c1d218223",
-                      "qRand" : "c8435496e852f54eac36a1b8e29e5258ba383f3cd453293d98b9d565e72b03e44ead75ea341615062b504c3350b2404f53401f19b88b6a23bca4a19687300522489dbe3beab828e438b28b5a10e8c0da4b38162b458bb7f92804f1969fa3a1cd92f9b16b358047bcc1858e21ab787738cc311abd6bbdf138b352b26d206614cf"
+                      "tcId" : 1122,
+                      "e" : "df28ab",
+                      "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "tcId" : "1124",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000333f01",
-                      "pRand" : "0456038077312d974418bbe2432387d97b55158496263213df19a9ff7f888cdcf3dbae9bba8cdd5d8b6799de99cfb37d1bad0173fc38540a0d0e098ebdf1718b92c9361880af2025382ffb20fc094eced508b097f455f357a2b35a562be410cf44f4c44d5bc4bf0b57b43af86cd7cf37aa9edffa6d23132b1eeece0f09691645"
-                    },
+                      "tcId" : 1123,
+                      "e" : "85a4cf",
+                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                    }
+                 ]
+
+
+
+Vassilev                Expires November 2, 2017               [Page 36]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+             },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC3",
+                 "modRSA" : 3072,
+                 "tests" : [
                     {
-                      "tcId" : "1125",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fe8ed9",
-                      "pRand" : "f26e1240a0a1b954430793b7b3e3bbf46b1cbc022e29444099c3edcbb66e9ecab3414c80275ca523ea269c085758582917e6cdb2b42f819011a9ddc1e1c25788c507e9dd8fb0bb3fb3d1103e6b0dff333394956aae41855584ec4119e4a3ab804764caa88db6d10c503402f3280aa573ef9066a2ca17a31aafe9bf0bcd412302505e6feb3fe7538bab064d415af979a32cc0b9e298d0b8bc7d1eb3f70e02004257c360bca9549a5bbedee3833ae23c8e65b430e8acb5035a7b410d55a2a5687b",
-                      "qRand" : "a57a699bc759f6e71049eeef16011b2b1549cb8b27a822ac7e45178f3f80680390e1ee99f5f531f5e44a8b570aece9aa0682cff9202cff065a704972748c117e9be5439f93198406bd33c7dded7956e692b531ee7c92133a1e6884a2a48459f55551f406e840461ef18e4c613906186f1ce95a9ba63f4f7673dd552678fba5b0672ac921de31eb7213c14387dd2a7b47c0dbdc088cd8b16f3b552c3fa95631f79cad18a98dc86e22728aa533db8e767396d6eceddb525dceb0baa1cecd57734b"
-                    },
-                    {
-                      "tcId" : "1126",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000524781",
-                      "pRand" : "aad0d971253463ae131e900189b1e978ca55c58dfa3797995f69e2ef147246402e78d3ad703f298943d6e02709289ab846deb65731cffa735239d787abfa6e26f0e295325efe9eab616422cdcbe391ce531bf5508b9d45cf5dc5bd2389c31cdf658cf1ac3ec714978da665d1867ac6846e629f3552172a8e2b879a2c4f326298d9c379cf97c1ddadfc0d8c4c112a0f6e48195131b756603b8052e2b25d010851749ea37cdbaa9490ea686546ee1688445673304d4df5024d834c9d9da965c7cb"
+                      "tcId" : 1124,
+                      "e" : "535c97",
+                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
              }
@@ -2004,34 +2038,47 @@ Internet-Draft                RSA Alg JSON                      May 2017
    }
  ]
 
+   Note that this example has "infoGeneratedByServer" set to false.
+   This means the client is responsible for providing the details by
+   running an instance of the appropriate Key Generation method for each
+   test.  The information returned should match all applicable data in
+   Table 15.  For Key Generation method 2 (Appendix B.3.3 [FIPS186-4])
+   if the public exponent is random, there are two test types.  One is a
+   known answer test (KAT) provided by the server resulting in a
+   "pass"/"fail" response determining if the input forms a valid key
+   pair.  The other, which exists for a fixed public exponent as well,
+   asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and
+   'd') and the server validates that this pair matches the
+   requirements.
+
 B.2.  Example Test Vectors for sigGen JSON Objects
 
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1163",
+   { "vsId": 1163,
       "algorithm": "RSA",
-
-
-
-Vassilev                Expires December 1, 2017               [Page 36]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
       "testGroups" : [
              {
                  "mode": "sigGen",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1165",
-                      "modRSA" : "2048",
+                      "tcId" : 1165,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
+
+
+
+Vassilev                Expires November 2, 2017               [Page 37]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
-                      "tcId" : "1166",
-                      "modRSA" : "3072",
+                      "tcId" : 1166,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
                     }
@@ -2042,14 +2089,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1167",
-                      "modRSA" : "2048",
+                      "tcId" : 1167,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
-                      "tcId" : "1168",
-                      "modRSA" : "3072",
+                      "tcId" : 1168,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
@@ -2060,29 +2107,29 @@ Internet-Draft                RSA Alg JSON                      May 2017
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1169",
-                      "modRSA" : "2048",
+                      "tcId" : 1169,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
-                      "saltLen" : "20",
+                      "saltLen" : 20,
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
-
-
-
-Vassilev                Expires December 1, 2017               [Page 37]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                     {
-                      "tcId" : "1170",
-                      "modRSA" : "3072",
+                      "tcId" : 1170,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-512",
-                      "saltLen" : "62",
+                      "saltLen" : 62,
                       "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
                     }
                  ]
              }
+
+
+
+Vassilev                Expires November 2, 2017               [Page 38]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
        ]
     }
   ]
@@ -2091,7 +2138,7 @@ B.3.  Example Test Vectors for sigVer JSON Objects
 
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1173",
+   { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2099,8 +2146,8 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1174",
-                      "modRSA" : "2048",
+                      "tcId" : 1174,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
                       "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -2108,8 +2155,8 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                       "s" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
                     },
                     {
-                      "tcId" : "1175",
-                      "modRSA" : "3072",
+                      "tcId" : 1175,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
                       "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
@@ -2122,26 +2169,26 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                  "mode": "sigVer",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
-
-
-
-Vassilev                Expires December 1, 2017               [Page 38]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                     {
-                      "tcId" : "1176",
-                      "modRSA" : "2048",
+                      "tcId" : 1176,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
                       "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
                       "msg" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
                       "s" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
                     },
+
+
+
+Vassilev                Expires November 2, 2017               [Page 39]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                     {
-                      "tcId" : "1177",
-                      "modRSA" : "3072",
+                      "tcId" : 1177,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
                       "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
@@ -2155,8 +2202,8 @@ Internet-Draft                RSA Alg JSON                      May 2017
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1178",
-                      "modRSA" : "2048",
+                      "tcId" : 1178,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
                       "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
@@ -2164,8 +2211,8 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "s" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
                     },
                     {
-                      "tcId" : "1179",
-                      "modRSA" : "3072",
+                      "tcId" : 1179,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
                       "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
@@ -2179,18 +2226,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
   ]
 
 
-
-
-Vassilev                Expires December 1, 2017               [Page 39]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    Note: The ACVP server does retain additional context for each test
    vector sent to the client in order to verify the results when
    submitted for validation.  These may include the public key n, the
    public exponent e, the private key d for each test.  Note also that
-   each test for which msg is not between 0 and n -1 should fail.
+   each test for which msg is not between 0 and n - 1 should fail.
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 40]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 B.4.  Example Test Vectors for legacySigVer JSON Objects
 
@@ -2201,21 +2251,20 @@ B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
 
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1193",
+   { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentSigPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1194",
+                      "tcId" : 1194,
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
                     },
                     {
-                      "tcId" : "1195",
+                      "tcId" : 1195,
                       "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
                       "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
@@ -2228,37 +2277,41 @@ B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
 
    Note: The ACVP server does retain additional context for each test
    vector sent to the client in order to verify the results when
-   submitted for validation.  These may include the public key n, the
-   public exponent e, the private key d for each test.  Note also that
-   each test for which msg is not between 0 and n -1 should fail.
+   submitted for validation.  These may include the public key 'n', the
+   public exponent 'e', the private key 'd' for each test.  Note also
+   that each test for which 'msg' is not between '0' and 'n - 1' should
+   fail.
+
+B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
 
 
 
 
 
 
-Vassilev                Expires December 1, 2017               [Page 40]
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 41]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
-
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1194",
+   { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentDecPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1196",
+                      "tcId" : 1196,
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
                     },
                     {
-                      "tcId" : "1197",
+                      "tcId" : 1197,
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
                     }
                  ]
@@ -2269,9 +2322,10 @@ B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
 
    Note: The ACVP server does retain additional context for each test
    vector sent to the client in order to verify the results when
-   submitted for validation.  These may include the public key n, the
-   public exponent e, the private key d for each test.  Note also that
-   each test for which msg is not between 0 and n -1 should fail.
+   submitted for validation.  These may include the public key 'n', the
+   public exponent 'e', the private key 'd' for each test.  Note also
+   that each test for which 'msg' is not between '0' and 'n - 1' should
+   fail.
 
 Appendix C.  Example Test Results JSON Objects
 
@@ -2282,92 +2336,92 @@ C.1.  Example keyGen Test Results JSON Objects
 
              [
                 { "acvVersion": "0.3" },
-                { "vsId": "1133",
+                { "vsId": 1133,
                     "testResults": [
                     {
-                      "tcId" : "1111",
+                      "tcId" : 1111,
                       "e" : "10000021",
                       "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
-                      "bitlen1" : "312",
-                      "bitlen2" : "145",
+                      "bitlen1" : 312,
+                      "bitlen2" : 145,
+                      "bitlen3" : 144,
+                      "bitlen4" : 338,
 
 
 
-Vassilev                Expires December 1, 2017               [Page 41]
+Vassilev                Expires November 2, 2017               [Page 42]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "bitlen3" : "144",
-                      "bitlen4" : "338",
                       "p" : "e2ab16d3026db341223bcef7f05b61d1682da54b0e2314f8eac9652752d6aa89ad65417e2c7f7b2824555a17c8c854ecbbc44c80c10c5ba132c3992f30308459b3afaee8f00ca318cd39a478c93dc1fa13268842ce88b2d5aeacbb4ac7638db6501eed3cedca65b777e910f701207cf96a81e46c418c3fdc493c02f708b2bacb",
                       "q" : "d13c3209bbc1bfa27c96688cbb325e8ce8d609efde1cc2417a578354c7bd248fb89eca31599d6b5b0d69a832bd2fafaacf3e9c3b71484328059dff1a7af54b003fee84f64f34e31ade0689f26fbc181443b7af3d8043657ddceefc1ff3160543825de3fe8f33fce4bf5d1c10357919c31729f8c0476f6b2fb6f405c875f06609",
                       "n" : "b942fa09a727ab488f8bc2d29b89814345dc96e7df9dc7188b7be6be7dc473869c914f612f5aa6b450a17ffc07b42db7b80d2ce88be1953e80ebff92f4aa12fb7fa9b9b258f249d876d69c1976df63a362d1a820f2cff4c88ae2a5fc3b607e7d62a4e60dcd9185929fcc1c931dea94147c03adfa41bf1e72d09376e4dbebaf44df6ec492530d9eb910970f45e41107ea313dccb11567e0832674335639b136b851d19e397be3f1681c72b62bc8defae88e02fe7e67ee56191cb874a53fc115652337277d3aea969adbba4a22d3d8840844cbe48b556895d06d0c7b3cd2c9fcc9a86ec93ca00ea5916090948820fd07f0b22a42f829d9bd1fcfa044ac6a057323",
                       "d" : "6b56ee657ebf6a54b35869b02f4e21d3ef0fb479a70309b522a95d955bf966385e770bd9e321bf95eca857ab36b5084ca6f7596255d11a4a49a1547d5b4306be33ff2ec560838565b6c45c6962ff4f8c64752f615c57fbed7d8b961a2e3fad976648feee6bf1d050c812badb0639188f9ff1e0faf4739b74c31ccb7fadd5c67ff4794ef7249b94abab145351aca47f8fe8e0628b7959f91f7eb06ff7a7a7e308365522c9ddc74c62c69662a9d0ee6b4223c66a4f102f4fbd436cab8723a9f416767ab85cd28ffbf5dc60cdf7a51648f3c57ad69d6b07bb77399bbf19c21ad01a9c782951782ac8a46ed8dac939442cbb280fbdc4056e68a5a7565e69c80c849"
                     },
                     {
-                      "tcId" : "1112",
+                      "tcId" : 1112,
                       "e" : "10000021",
                       "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
-                      "bitlen1" : "320",
-                      "bitlen2" : "159",
-                      "bitlen3" : "192",
-                      "bitlen4" : "222",
+                      "bitlen1" : 320,
+                      "bitlen2" : 159,
+                      "bitlen3" : 192,
+                      "bitlen4" : 222,
                       "p" : "f0be9d5e314bb494de341ffc759c0554e717a8e7e9c18ef346463b79e8b7a89f1ecec23dd9d209094c372ac900be610918fa2e03b0239d3175030d35debd7c8b003b4c00b7e4846d6b55147ac13de75311a1166d2806bc080de2b614cbaf3c96ed07b9c5ee82432926433b23a6423f8c3c7643f069922fe09fad621b8afd6255",
                       "q" : "e5b847367ad156efa1150d871d6e628db0087a0d6294dcfe980a614969cfecbfea6bb01f5ca8c0c6dd432bfdb7bc89279257b1fb13de663be9b8a24ab72a7ebcac84338c38261c547afb4d8ff441c34988f9ddce414f3dc900f011c8920ddbc832e7356d2cb067f0b0172cdb9a409ed61f1108fab68fc461cdbd2990ae420a85",
                       "n" : "d807cebe77262cdc1a8446cbde378993069449101a7d43d7c359783a9228a877f4c67749a44a876843d9138ab961e03264fc93b87faa2c5ff78299b45037ce967c4d08dc143c87506d026c78a43a4aa17787fc09428ec83f13d46b4bcf25197d96ed8fa7685f0dba09492d78b45b0e7223bd986fe423bf8e10236bdf18a7840cd67d9620260080d5c90253cdc8fa74e1f315f5bea878e2311cb782582bc26e6bb4e71c7d8d16ab4d0265ee39a4a9e03cc065c7f45027330cc24a7c8e1e1a9a8989da9dfe807d3f04d3b6eda3e31e75b4ccb42c3fb0cfb3fa6a740e252663807e56146cb13ed4517201cb8df4256d0249139aa00daae91d172b8306b63b656829",
                       "d" : "a5fc5868f19c7644f10b81ca056953cd38fce6dbbbc29a38416b42e256ec02172977d14e3733ee01d92a83179c61bcb01264e0b3b00fe4039981518a81020d3cbbe48b862e7ad121c45551a7104d5db2a6de18d1b9009857cdce08cd5f2bcdb6292b8f45f130ee755667e3c06109c4ae2b1145e1d8f3d427d5d4059df0fad45b1805c031dcc9d37e6d85faccbb7ef8e6bbb4ec91dc9899e723a11d0eb516079b38f9d31c6ba9cbe728ae6d126240cccf13eb8188c76dd0612fb1a766bcc80d05a5c84367a8c2097e3a7f57d438da460a682e8517ad2a83ca472f5a1f2893b821c0cf0a29c7cd476af9fe2c62adeb2d3bced5fdeee547714ebe71f79adc4239"
                     },
                     {
-                      "tcId" : "1113",
+                      "tcId" : 1113,
                       "e" : "10000021",
                       "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
-                      "bitlen1" : "448",
-                      "bitlen2" : "281",
-                      "bitlen3" : "240",
-                      "bitlen4" : "469",
+                      "bitlen1" : 448,
+                      "bitlen2" : 281,
+                      "bitlen3" : 240,
+                      "bitlen4" : 469,
                       "p" : "bb1b2d20748c09339570a703237260508ada21196ee89804db6fcdc5e523e4539fc17576906eaadc801107d883cb0fbbae9c8887fd4cffaeb43c59a770a005728f145f96c38b235870f0c773c85b088e2ef9248c944fc6a1aaf85092143898e62f05542326ed20d28f4cf867e766510539fc12c73517179c191e76c5ec974480280abe044378661052ac7e15d150130db856650881cbd3c674af51fb1bf9c8e095aea0f69b3d1eed8604c36368982584525f63c6f380dae557339ed7957b9a5f",
                       "q" : "cf22d352fc42b50ac8c2cf5fcbe36461b27191c8e9273a3956d6b5595a26fffe7728fc8c4966c5fd5ddd8bd1ecfd59f0321536fe04a41f1624c11272c40b4485361b52ab36119c0fa7bd73e499aefb62bf97a7254680c33c2c893e84e7a70310b9868ab1b968a25ef9e4e9ec7b4e11d7231921f04fe771ec2e4d992349f4db216e17b094d1443ada72a15f3a54342864670dcc880672214196e6aee9c9d3112c0241393b9bcc71538547c54c6269802fa4f827fffc44fdd31f8de74db3e34995",
                       "n" : "97646d8d49d26c3e5ceb9ef2b16ffc40b3f7f980cc99a9da1b3e94626a39c343c2d13108f05b3c33f8597ffe2574e8e8f31b892d60767fe93a58c24fb371a23bb2f6b69fc0ffb1b1e1b914f45530dd81b1436665294f39e8db0d4f30a0161d66926cec89f419ce58bd98abc0628adda5c3519789102813de712adbdef5dd1700e92087ece582b78c95c2954955283c5ec9d9c467d5357091428a3ad3804568f513cfc6fbb4c7a66ff29a4e7acb7e354565cf400a4d650ca703f468a30a990756e800d2e8c593f4ecbbe27d64821389bd40fd1b4f597ecf56703d4ce40b1acc62b733e6808b2d82ce572ec1a9fe296e9364d46ea317790b6faf553d8d3d7efbf372e0eb71e435fb5049e475388c52e2fa17ac976ac411ecb1a7a9983c3c069c9454006f5f60892cea95c32cd512692fe94f56af8bd89212b0618b519669a9c50cd8c6300790f687f0379a42e3442ecd1cf06693416e1bd692ce306b2602d7946867ac824cf9041c48642239b8895582c402687bb8361ef2fd15d20e378f32f04b",
                       "d" : "43f10b697929aee4aebeed949a829ed4a816927f2b1ba427e4305ac7e61ac923f9cea977dbc7b1c9759cc327d48a8205cd04e9357d9c1c83be78461f04e0a6d8e4243320e53ba638a94bc74bc130b7fc9fdca9c6c06c2c78b1c6e6727891117129de8642f4b2e633c5e5c1c7f2d04b315d7869dc29bd7e05ad55348ef3519451e66af3fbcaa396f93ffe357649e87cf1039a9e31d07cf08d0b8c305d40eb1880fe7d7fa84a6658ae3776dd1557fbdab1306b4aa305071ffeaa8548a6f25e32442c292a0acfb095d8aa591894d5bd2d3d349219ff9ec008730065a46301972fced0754e519234da6fbe84e63690dfc0ad860b644f79c091d8e0cfd1ec570f66689f3e0d78ae2c2129db1d30250149e4838be51441cd30e01157374181e6a8cf7b5a62392598db88330e4e386dc2a312c428016a9d076d3b1066b2538799fd21bfa29ff74c978104a500d4953277748cf637aab62423325e38be21118c0dfa9c68a4391eb65ee0b7226dd2ddbc6d64387acef2f29ea42b198aff6bfca3930f93d5"
                     },
                     {
-                      "tcId" : "1114",
+                      "tcId" : 1114,
                       "e" : "10000021",
                       "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
-                      "bitlen1" : "504",
-                      "bitlen2" : "238",
-                      "bitlen3" : "440",
-                      "bitlen4" : "185",
+                      "bitlen1" : 504,
+                      "bitlen2" : 238,
+                      "bitlen3" : 440,
+                      "bitlen4" : 185,
                       "p" : "b6bbf5a62930f4a89153ff826347d7b49339a5af07d29fbb4120847c914f4a09c98c95070c70c5498520a2e799138cdaaca5c2fe1cd8ef6da799b26af0ac9785bbc790e6b52c32389ef26afd447cc05baf8e6c628832772bce91eb120309332aa8735ce7eb34c640863bb7efc59f70a3d3038359d57b8ba5b009ff7b119aa0c2db32a1edbac51f4bddc1c4dbd3f70e83d43b07c23a4d3859a91f51014e6aec589693e66928c20467fe3c568298b43cb98d8b0f2a7504c19b01759bd4de5c4fad",
                       "q" : "c263d13aded6645ee10683efc4d216e6b51314684c7f3b84cbd59988c14134fd8327d5ee1b436cce2f8648a260f5fda5f9494dd2275ae475676439741aac62587fc2de745b68eb46c59eeee00cbf05f3d911752ba9223e5a0b88390023e79a60d94604b82ac6a51df27699c4b6672e17be555af0673bc2a5573c32ada7158272e08e02efd00d18932cdbd518b4e969b766fefd3f380f31f2180d55dbcbe55b3e6ffb755e07b03800537734c37e8644e66fe64cc7465a9a570e1ec03775cad1fb",
                       "n" : "8ac1b03163ab5e673e5ebfa0328b694a322da0819fd97f7be54f94b805f58a8a2f7ff4e273c98440ba862e7959658ee1c0876a19232bbd4f85c9f20ebb92d031269cf19f0dd46ba28759a452678be7b9c35efb788f3739183b512a56e781bb6a9d42534399b8795e63705c01a742ede7862d6670ca02a02e5c117ac0a6548035be5cfad0da0174c1872d3da8523b3efbf98115d168e74bb4f327661131753593f45550edfda6486dd4dbf870e50367ca1c39e446f3be3b50f197f5f4b3137e950350542e3688330a4e6fd607286f57f5771255ef9f3816658c2ce981132b0303ad34c21208f3c15846f21dbb77daddd4adf5ddcc6d1b828a5a5a6f3c4f85a42f1b51085d2d913e1d105d5565c029efd80d2f8c42701f6e7d51e8bab650c03a98bad191e3f6508d42aff30e6db1ca81228bf044d13eff53bcf6d688b73a423503a8e36808b61ecf499df708c06aae3b441257d154bb5c483bb52f3b0990e47b06b6efdcaa73fb29de1897df0cf8ffb915a35e36ed1011a8a97ffd16ab51105b9f",
                       "d" : "cf02aaaca392f5d21e80ac8e954ccc3eb738155b9ca03d96c1c7506b6593e97954e0b97eed739e6cd0eff08fe66e1584926d8d6ab9d6c686f99f758fec24627071a0f9164096b93c2693e296d2707f392ada019d010459b0783918f8f104423e2dfdcd418194144bde4b9fbbc766dc892bf9154803d41e8a295e2fd280592e4388dd78d792f96654da3268421553fa101f5e334b5149a6bd6857705ae9b5fbe4f80f2334fffec4a168a63c47d927d54e33571590f4450e005adb54c4a290f52141a7a502007a3508c6fad932f04e5b469cbab7228f69c34e89b5b4e7378fc82a9f1dd2132bceceb447dfd8a14679dd9df39194e4190b6d5fa79e2abe140abc4cc6cd428ed04c1bdb14cf51bd9133119138b1cee3bb1649bedb2e86c810010006e611237a901e3e404ca78c551253979c587a92440e11c2b742e87bea09a93fa2b1ed6cbf66907d3005a572b20055cc4870bce35d78b51f7b22ba37ff7f8af05dc2d0d6c743d95ac0a5e0eabf5be061991bb2fb505555589c5c5a0cd3b575d15"
                     },
                     {
-                      "tcId" : "1115",
+                      "tcId" : 1115,
+                      "e" : "10000021",
+                      "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
 
 
 
-Vassilev                Expires December 1, 2017               [Page 42]
+Vassilev                Expires November 2, 2017               [Page 43]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "e" : "10000021",
-                      "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
-                      "bitlen1" : "232",
+                      "bitlen1" : 232,
                       "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
                       "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
-                      "bitlen2" : "220",
+                      "bitlen2" : 220,
                       "p2" : "baf57f053b1f2a46705d9be799f90f28b800de871d88c95f24bf659",
                       "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
                       "p" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc4cf9e8d26cbe4b9def67b97305763aa17c09c8a939dddcef9fe0cc7773acbb3ef9beff7812132f7d432f9c77af59e95c7613c4cd47cd27a64463",
                       "primeSeedQ1" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc373fa",
-                      "bitlen3" : "336",
+                      "bitlen3" : 336,
                       "q1" : "bfbf1abfc1fb9b7e21342139053e7b05f56e664594419bbdcb14bb959ab66cf10e99a0d38f560a22cb33",
                       "primeSeedQ2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37484",
-                      "bitlen4" : "141",
+                      "bitlen4" : 141,
                       "q2" : "15e35869eb4f8dac49e317f09e3be3627c1d",
                       "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291",
                       "q" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910c7ad06973390b608cd2d39873222bff814db1a2c65797b58317226476d98846ec8037d4ca98f92afaa2fde97a6d0d53d4d17aec025d5933286c07b9ea7",
@@ -2375,21 +2429,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "bec8baec7da0634211ed76b770d9ef0834cfc689cb2a6d1c04a9c14d9ab249ebf5711147dde7a0120b521d8a0a2ba62fcedd767a8abde768e6bf1d12d5e88fd7f1a11d44684f6239512f976366236e270d39801eae4cab9109dc1746ffca0d868049551b7e27caa57d32ba0235dc8bf68a3955d562a283d31ac5f23342757e7918d85ffb654789ee39638543dbe76dea9ddbae3bb12c411b509923c101035ce53c7b642047bc91e3cbedb3f945f0cae1edad5a2c600db921722b4655742f8c10650cd1c868050d26c0caefff2dabf02a9841f1dff07e0094485e8965b06fd4ffb024a1d9a13ac241be9a2db0bcbfd656edcc5d1c945857a8ec3cd281d61f715"
                     },
                     {
-                      "tcId" : "1116",
+                      "tcId" : 1116,
                      "e" : "10000021",
                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
-                     "bitlen1" : "272",
+                     "bitlen1" : 272,
                      "p1" : "e43dc77ad0bbe2090a7d99a490f0b37188603691ebd453ef987e8358eee34be2def9",
                      "primeSeedP2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805cf1",
-                     "bitlen2" : "205",
+                     "bitlen2" : 205,
                      "p2" : "18dd5b6a27ca680f10764a0e2f49ffd384b650948aa6ba175f07",
                      "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
                      "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
                      "primeSeedQ1" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805e76",
-                     "bitlen3" : "296",
+                     "bitlen3" : 296,
                      "q1" : "bd76411ab7c1edb6873e76e5edc7b920b75cf8e2e1152010e6c34df592f8c3cd948212ca05",
                      "primeSeedQ2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805f9c",
-                     "bitlen4" : "157",
+                     "bitlen4" : 157,
                      "q2" : "123e72d9c914cde1b11d233a985f37f0769d2227",
                      "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
                      "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
@@ -2397,29 +2451,29 @@ Internet-Draft                RSA Alg JSON                      May 2017
                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
-                      "tcId" : "1117",
+                      "tcId" : 1117,
                       "e" : "10000021",
                       "seed" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddbbc",
-                      "bitlen1" : "512",
+                      "bitlen1" : 512,
                       "p1" : "e50610fd8a3b4f132e5c8d5904e0995b4e3782fa606593f1a80c4284920df7f14d310fab60d78bf97d2ad51472f2dc784e14f2f49734cc06ed299ecfd4764f51",
+                      "primeSeedP2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddc59",
+                      "bitlen2" : 196,
 
 
 
-Vassilev                Expires December 1, 2017               [Page 43]
+Vassilev                Expires November 2, 2017               [Page 44]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "primeSeedP2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddc59",
-                      "bitlen2" : "196",
                       "p2" : "f974675ade75f0e11d66247a498fda86ec29e0c3a84052bbb",
                       "xP" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e306705e39d2b621027353b4873898b36b3fe86ab203dee10260058ce77f13d315ea1dcc0b717ffe906bfb05f251f3e9d678c585917176e127ece648c788f28b05607d4f71e113842e289b0de45bed72b7e591ea55ae5750ebe86a8",
                       "p" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e3092a9dfd7697a29e1c6952f0d71a7381d0bd64c4ac6102f54ae43b21f7d399583f86f6192717188b913ed16c1422d5fe5df0a407b1de9a05e178e4f47cdb3532866e2fcf36e57616f3473c5c967fa6703847d90ddfe0b822f24e9",
                       "primeSeedQ1" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddceb",
-                      "bitlen3" : "560",
+                      "bitlen3" : 560,
                       "q1" : "d2953e01641afc5d46b849c9c2568e6377e70c143ad23fc70d96b5c5b1528ba954a19e9905a235af27c4f2278fef63e112af66ed4ad84c595a6f84207f23e2a0c0b4d652a14b",
                       "primeSeedQ2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddef5",
-                      "bitlen4" : "180",
+                      "bitlen4" : 180,
                       "q2" : "c0f968cbe23b282c7f5516b3b59d13713fc04c8405473",
                       "xQ" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2dc5e9fe2c0077b65c79cb98bd4d7fced17121010598bbf410f3dd755df986b877e51058ef80649b486100c0d6eddf0825c69af34e3beace6e2810da3366c6f11520fd65b5ad7fbc7d33fa63a91f5ebb93b3d4b042478754ce89129e44add",
                       "q" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2f82363823d9c7bb2f1f4e19cee9d524d96f478637e8a5054c34fbf73483134a40034a75c72d30ee9499ff2e899da5ff65733155eb0ad9217e7ca2c57af22b12991882ab7fa7ea6d8a5f60ae7a71842a4b286d618374f496efd642ffcaa0f",
@@ -2427,21 +2481,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "4abd536c3f299e3c7365e496caedc45561ddc2a97d2d52f8c9e3eb1e7be52117e952ad9ee9768df7380ed09750d6c9bedf7d5da8ebe36046cb17f16e4f7cd88ced6279cceda200b17faa16b77000b53360c9e50bd5da91329a309bf422c716b7127b7331163987810ad08ca15b0580a97fe63bec434c72213f8527d939b02b60bd0902e97da8068d81354eedfa5d62067201a2b5b64c021022becda98b175bb57f4216211f22f11b28b5ce0021e87361e5c0f4e363f8f15123b1e7eb76cea6ecd065549925425f68fc80c8846d399205edbdf417d6554bb3eeaa58ef0e68be51a447c80438dcdff548203813d13e50f792e2aa106537d39198fde0a305446dfaf16de93e670600ce20a48ddb16ae196c43b4d1049c7c1c130c510b780e37591bee3bcf6c3d716f9acd305f81ab54675c95b7bef042f4c11ecae895d18c4fe1a986410e947b150deba89cf123fe11874304ae8922b61cae5c6b298cf20ea65cce98e94cb4849c85b813de46554ad6e0f0f844b679060855c02ae69b1806e55e21"
                     },
                     {
-                      "tcId" : "1118",
+                      "tcId" : 1118,
                       "e" : "10000021",
                       "seed" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b6e7",
-                      "bitlen1" : "512",
+                      "bitlen1" : 512,
                       "p1" : "a70dd2581283defd4b5689c942752af1eb31864fbe0c0894d434cff28ca5d5321505cb537675f2e9efbe3c05e5daf5ea63eb824d2fd9c43d5eeb6d3041a07e05",
                       "primeSeedP2" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b8f0",
-                      "bitlen2" : "182",
+                      "bitlen2" : 182,
                       "p2" : "28b81c23443dde1d774cd365ba50bd382677f8601bdb0f",
                       "xP" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f16221154aa62d139a67fb09edb0e6dcb091683e4136333b1cc7e9c2b09a8a06a335fd6f318532a068b9fd353ae12a1b57f9da498c6488ce863eb0a115af3ec15f70d4d78f030882a18bc14074a42daf322d2dd4b672c947fa21",
                       "p" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f162af6cd818f341cf0f652191e2debdf53eba1ada0b519eb3148708a9a0b36ac4087f7d3c446003111bc8c0db7bee01618f33432d81e3c7cca97e0733c88749f1ebe5e1edad984ecf3bc54651809fb0c5b4eaa45f12fb1155b1",
                       "primeSeedQ1" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b95e",
-                      "bitlen3" : "504",
+                      "bitlen3" : 504,
                       "q1" : "ec4ddb031e55ee7c840c3747782aa76ce88bd881a87b5877ccb664a25d0f3a60946383b612b69880c17b0e4b0b1171fe33eba748c01a51ed1cd63e162d24c9",
                       "primeSeedQ2" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b9da",
-                      "bitlen4" : "222",
+                      "bitlen4" : 222,
                       "q2" : "27b8373572544b1c79e79ba514a2a743ce60497fbfd56b522a26e327",
                       "xQ" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590d63fbdfb010f463a379e8a78e50ed95ce5c8fa3946970839492654ed0b70b3573354b2937cba400ced3fb1d8b5adfedcf0281fe13ca8b4348d18129afcf68f2bc27210e650d9434b344e2bf942fa03fdc50e4200014753afb998d15d8",
                       "q" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590fb74e9213473b3095212d37b0d1e20f93f260bd4ca1937b5eb936451eea0bd93274727a7ebaf6bdce546f0212c6c164eb30d7e139358bd71b16a6e26e6798c0ffbb9769d64a0e7de187b93b3cd102b56123d6a744c8fb3e88b07b62d9",
@@ -2449,28 +2503,28 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "f5931b10bdb7e1c3dacdee6a16a951420423cebcd3d0465edb82663895892780f3a3fd25a6fb04e58cc566c8642cf3e86a1d406ef151e468d44b99f7827560aa68edcbb6fc52129fbf08cb448e15e9b50495e87d32557dad8cde1f5f3a2882131a3b94acc231850feee3533552c7efcc773d5943db12f06ec781923345ae0403f53420b093b7df9128176984b43022733bcd377076372b3d450f7e5542ae4984c852343edbf566af7d72a5fd66779d2e84c23f9a62d4af26cb0f634373b061ebc0f32d50fabc87450af7ada7eba7ea454c16da4958edee2916f30b809f58e10651fe4c4c494105b7da2b0dcd0dec0bf5e5ec81207aae8be43edbc9936b3e12f95a78185dab006ba41d4bbc5c1712664c91dd0875a8694697449f058ea070d24f1300adc95ef81928af0bf716fd204a33fc3b1e0cd662147a467d49d26d24bb523de98c7de6548a82c559e5ecba493c6b2bce2c20686fbf73ca8f10965f0cf0f2a773a269df48e8c514da5a3b77b55f86ecc1179f86dcb9ca1847598a4f8da1"
                     },
                     {
-                      "tcId" : "1135",
+                      "tcId" : 1135,
                       "e" : "10000021",
-                      "bitlen1" : "224",
+                      "bitlen1" : 224,
                       "xP1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d811",
                       "p1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d839",
-                      "bitlen2" : "195",
+                      "bitlen2" : 195,
                       "xP2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f0f",
                       "p2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f45",
                       "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
+                      "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
+                      "bitlen3" : 352,
 
 
 
-Vassilev                Expires December 1, 2017               [Page 44]
+Vassilev                Expires November 2, 2017               [Page 45]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
-                      "bitlen3" : "352",
                       "xQ1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd810093026606fd",
                       "q1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd81009302660959",
-                      "bitlen4" : "142",
+                      "bitlen4" : 142,
                       "xQ2" : "20b8c2bae262b13e912094c937c4e8cfa573",
                       "q2" : "20b8c2bae262b13e912094c937c4e8cfa59f",
                       "xQ" : "fa97b510539a102879a78e8ac21b9840468ca6a2e2f16ab4a0f596cd1b36b3cc0d2cffa06173586b21af25b62b3bd9698c3644da4b4e399aed5c7e1cc97d7c2eb2e7b886e93f99a4bc98d47c07ee5ea995593e5e588a576add3db762b1d6f9de5c79ba02e96cf38bb5ac3c3fbb02f5e4462f4d26881854083630a769394bd57e",
@@ -2479,20 +2533,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "166bed3734b922f074460a0ae1a8fab231668de4a10daa969805338e6e738e9af173e2a5b0cb1cf132c40a0523dea617228cb7ec33779e86d91696a03218d1ee955f05fe9665d6416cca97600f89d30eed460a5638101137bb7e26a3f01ce9724e9570d372c593e6ff837b6eaabb0fc7698cb952a6122ba59f945d4e9b99a00b84dd150ecaa54ed35c280dc046b4af027beaec005a9768d23b38676d2a9d73e3b9c923d30c7e9ae8686815dda971de42fbf96872781231140d04e659c50a9e86bbd4cd9f5f5aa2df5e5e2ff7aa82ecebacb89a9931fa022a0982c42a304a0fad7e5da407be9e9b225664147a6837a05c43d704f4903a7a20f67a360bee822e21"
                     },
                     {
-                      "tcId" : "1137",
+                      "tcId" : 1137,
                       "e" : "10000021",
-                      "bitlen1" : "320",
+                      "bitlen1" : 320,
                       "xP1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077677",
                       "p1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077719",
-                      "bitlen2" : "315",
+                      "bitlen2" : 315,
                       "xP2" : "658ab200f20d118be4d915d5791f6397ee0ee2134b2460b1e10dce4911756eebd8cba8fc9763963",
                       "p2" : "658ab200f20d118be4d915d5791f6397ee0ee2134b2460b1e10dce4911756eebd8cba8fc976397d",
                       "xP" : "f007605f1bce4e4aff719cfe996315182cb858119e93e98e9a37ce08b4bbd725c0e3589374505e3fbe9f4831efab23713440d8a18179efe14ea5202e4797b997f3f062ff22af5f43bf2de896071965c4ddfb18074c07f96eaedaf8cf47b145eafd92583b3d33e9964f1cc000fd1688c33d1e63ec7cf20462fefa938100ef700fffb2417157607dda0f03a56c4dabdcab275b9ee4ba71a5936e8f1526708bf7dca446702bcdfeb6249bd701e8838f3a896c058f5cf3a3096543064eba0122e578",
                       "p" : "f007605f1bce4e4aff719cfe996315182cb858119e93e98e9a37ce08b4bbd725c0e3589374505e3fbe9f4831efab23713440d8a18179efe14ea5202e4797b997f3f062ff22af5f43bf2de896071965c4ddfb18074c07f96eaedaf8cf47b145eafd92583b3d33e9964f1cc000fd1688faa69707469eb820a29ea2e81ca882ba8f6084b37de51b2cf276adea9d35d6147b112d5d896228e1c614f7339e7e4a49f28195ded4d8943febca86e94cee78a9168e215e8409eb74b1d673847747ae4615",
-                      "bitlen3" : "320",
+                      "bitlen3" : 320,
                       "xQ1" : "f21ebb87473fdcff5f7a4fe439027a6c1853cd94a3b7209d1fdb3208c20f2625f9ae12e13ae9ee45",
                       "q1" : "f21ebb87473fdcff5f7a4fe439027a6c1853cd94a3b7209d1fdb3208c20f2625f9ae12e13ae9efb3",
-                      "bitlen4" : "277",
+                      "bitlen4" : 277,
                       "xQ2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8bf9",
                       "q2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8c89",
                       "xQ" : "e695e1de6811c9872ba9017fdde9a87969022882a295320cecd39f9a9bebae1e9edc0e42ff78cd17d05c58a93ec75ec09c3a75a8db24a19b073314f9d857fc43523291c58b23065660987ea793755ff238ffa5adfbd9ac26b53c6af016ebe9b646963ac139fa81b41534a0851a7e54ce3fe84af212452440f235701ec2dfd6b1b4980a67745b0144aed587ad04a692c86c0956bff44e263194efc4a26a7ef66dc056bc038d8d0aee995d8f71a3a68c4d2bc83042b96736663d1c34b13776b223",
@@ -2501,7 +2555,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "8c377a2f9817c497507f74c2d4d37c2093e5a204fe0bc04299c0337af153bf86022c2ad9f88d156b67263d21e0fff1fce1cf8e9affbf52bd83e33f38d7223b6aae31667b029188d939453b5cff019c1fc6ed87296f7897c2b3328bb888e1dd3b082e5b11272f7f8fc62473d701b35b342e4ac4f757c4b17924912dba913f17800f2a5dec389436b8d7288e6c44035d2aad9bba5bd1cfb8550fc3bdfd01c317ec222ea6f0cb90342367fdaa5b61513cdc3bea7a12bb44f1f07811a2c193b99615e89627164482248f474e89985ac1655df1054d93ec91f93b08c5ef077fad256cd042ac375cd536837b65489d62833c48fff221cb1092509e82fea082f0022151dbd9d2104314d10cef26fd4ea710898f42f956be2aa46756e5c436174e181f95e54ac8b6477baa5a32044678b3686d16df88e457bda4e0dddd94a24dbdb3ced4827392780cc96287fd6a46e82a5fb1daa0d372953c06ff6c2e1236926e0c11a367218a4291e6288e5cd1be03408770c5a667da57652eb46a9367369f732eb41"
                     },
                     {
-                      "tcId" : "1145",
+                      "tcId" : 1145,
                       "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
                       "e" : "10000021",
                       "p" : "f3ec667fe3c697769f89db44c48926f05285933f351ac5821458ea3414a1c62cf581e6cb702adc0323d7b86f6f013b471e24e4b25bbe731ecd023157a03656fb9a16fb7f6fcfa65020900822e8ce03bd967e38efd546ea30706698c7fa6d0f9e0316fe65d3195310e9baaaebcdd85e4a260341a90dd2c884f6e269e10647a2e9",
@@ -2510,89 +2564,89 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "8a19a9956ae2ccec6ca4fc0a5e56ab691c94b710dd668c00534bca4f5af84a568fee1bbbf36185747d11deac96faf66d13c08d97acfd29025d044630fdb2824c9435d8fa6ab7b6a349bf98ee86f5d1a7d6cf3956b43593c9a7b379fedcf2b78b1d4bcca082f0a9bbfeaa2a982a0cf16a1e812816bb9ede15edba51ffae5b65359e49b3c2e755fe32399614a35d45dd525709ae323b2828668be67c0c364d59925617f9583d399096d9f9cf085e29d011c78dc857e24376ebeeba688d72a2fbb1f8f09e92e7e606ff787fc9b395f6cac20c3ccb251bac325afdf1c3dbe75fce59753c7005bfd86957ba72172dc5a43b6192121e3cb97d0c43b9b63952bbe0d91"
                     },
                     {
-                      "tcId" : "1147",
+                      "tcId" : 1147,
                       "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
                       "e" : "10000021",
                       "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
+                      "q" : "be7263212933d452800cf89edbad8e01a79eeab335bc8a4ff375173f29542f6cc14551432f2c715cf8f9b9852c6cf15fb5eae3a5895154c5c83c28ee1a5dd8ae12a963af318c0ce398cefd324c1099240367cd961e081d41884d812f48d5735d15348a8638ac700519874e6d82300bebd050273a69c4ca59ef61f17f239fe17d4dc7092d64a986fba02dcee818b62be6587ad56ff6c92627eff9e2ac767b1a9799f8108b1be9613b2a07b0a5512b8b3aaa300c586678a08cd13f22d20e5d4b95",
+                      "n" : "969cc8d2bf6bce77575d8d3d62ffca22fbe43d0572ab27a7070b4324bd39a74e6adcf2cc69baeaa0af404512273702959f2393aff9375e58d1460e74f514a6f0887a8f607b0fa8e12682d76b663ae82716072e4d15722e70b2dc0fa0c73729393889e6c7b130311f47a27a988a098bf390a956be56648840c781b1cf82484df708821a53a6c9c0d64f23ea499ec274e5c31e78f702ffa21aa87da832f2e12300c389be1d965764acf2cae1ace36493cae1776513c1c30637f8dd98bcde0083224d5e65a7695d5f05b707ae40dec91d34f41df9094814f0f20154356232b54df9b40a31421e015cb47968a4ca77629b2493cb74054c30517e92606967aa3d14ce12260995d3d0243502192940b6d552b1015e5ac16f756f2152bf259c5a72468783f87a92e371a2f9a9c829f4397fc59e9b874a7a3222bfb2207cabbef0f3949d4871fbae9deb742ed9eae8a1baeb6088d92f904a132234ef6fc3e8b170904d56e276436135e3abe67054c139699e37601e44f3dc6b73a6935793f062de998049",
 
 
 
-Vassilev                Expires December 1, 2017               [Page 45]
+Vassilev                Expires November 2, 2017               [Page 46]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "q" : "be7263212933d452800cf89edbad8e01a79eeab335bc8a4ff375173f29542f6cc14551432f2c715cf8f9b9852c6cf15fb5eae3a5895154c5c83c28ee1a5dd8ae12a963af318c0ce398cefd324c1099240367cd961e081d41884d812f48d5735d15348a8638ac700519874e6d82300bebd050273a69c4ca59ef61f17f239fe17d4dc7092d64a986fba02dcee818b62be6587ad56ff6c92627eff9e2ac767b1a9799f8108b1be9613b2a07b0a5512b8b3aaa300c586678a08cd13f22d20e5d4b95",
-                      "n" : "969cc8d2bf6bce77575d8d3d62ffca22fbe43d0572ab27a7070b4324bd39a74e6adcf2cc69baeaa0af404512273702959f2393aff9375e58d1460e74f514a6f0887a8f607b0fa8e12682d76b663ae82716072e4d15722e70b2dc0fa0c73729393889e6c7b130311f47a27a988a098bf390a956be56648840c781b1cf82484df708821a53a6c9c0d64f23ea499ec274e5c31e78f702ffa21aa87da832f2e12300c389be1d965764acf2cae1ace36493cae1776513c1c30637f8dd98bcde0083224d5e65a7695d5f05b707ae40dec91d34f41df9094814f0f20154356232b54df9b40a31421e015cb47968a4ca77629b2493cb74054c30517e92606967aa3d14ce12260995d3d0243502192940b6d552b1015e5ac16f756f2152bf259c5a72468783f87a92e371a2f9a9c829f4397fc59e9b874a7a3222bfb2207cabbef0f3949d4871fbae9deb742ed9eae8a1baeb6088d92f904a132234ef6fc3e8b170904d56e276436135e3abe67054c139699e37601e44f3dc6b73a6935793f062de998049",
                       "d" : "79815d367f924ba3509d3d4870cc729a82dc6dfb001e551baac15ff2ed77efdc6a00e628f29aabe062b5226a2e2689d26c82e8021958eda5fe0581f3bad0479942ec03bee965d79204c822d6c4e5cb82814419acd38a8779afae03b4a95ded204198bc2d68ee124cb5d2cbc68bc3621450168f55a9b9f2787b1cafb0328ceb9c0bc4e81d23bc155af9a172b18dac8f493f6753571b2f13cf56d7d93ac9d191dbfb7a2b6c6e795c2387722ee48d9bbf8fabd0fe58b3502a6a3173901057ae04bdd1f69cea58c38f9ac88c90427d8d3c60afd50dea9d98b669f8a052c7c26415885d70df8eb36fabd5d9fcde1a9cea5c4118f16af672fadb56f43e2fedf3b33ab4c0d6763b497d73164b778a1638af9c8e87e71cf64ed368c978179a2d7bfb2086ce8fd1ab6f3263603a71d0dc70fa5c56c6c0f233447bf4c93fb03c8e85ddbb204142e4414f0a1f35746c7f106931e25a1fe6a5f865b93d679ccd7742519b29803ed34ca40321c7e38fdeeed68195860b8157f14365a587ca58e1c5c7c46c9c1"
                     },
                     {
-                      "tcId" : "1119",
+                      "tcId" : 1119,
                       "primeResult" : "prime"
                     },
                    {
-                      "tcId" : "1120",
+                      "tcId" : 1120,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1121",
+                      "tcId" : 1121,
                        "primeResult" : "prime"
                    },
                    {
-                      "tcId" : "1122",
+                      "tcId" : 1122,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1123",
+                      "tcId" : 1123,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1124",
+                      "tcId" : 1124,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1125",
+                      "tcId" : 1125,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1126",
+                      "tcId" : 1126,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1129",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
+                      "tcId" : 1129,
+                      "e" : "df28ab",
                       "p" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "q" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275",
                       "n" : "cf91c0065d8e5797f0d1b1b3f4c31ac3d5e83d4be67ada7625b4b3a80fd24eda86c88b88c7fc4b2c60e311215abf8abc34e21c047035a93bbcb43387c6a44c7149c278ae27488ddc09ce56eacc7fbd437de9699d660b1dba4923ba60c9bb1fc69b7c90468ace5b7715d5d385c02e59f525ea01625c5c61760d8b23b962b7c80d14e6d58064a6064749ffdd260b0a8b0b2ffb846a6586e375a04163b61fb0af71dddf56e65478ae2101f30dc37a3f035f10ff86f53ac2e073b3a5b5f7017c6e6704b23e83c357aa171b23c49ff4d3820a03229a1962bf2e6b90acf79570f269e679292255755ad6362129870460c00799c5179e27a3b5182ee07c6ba07420e205",
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "tcId" : "1130",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e66d81",
+                    "tcId" : 1130,
+                      "e" : "e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
+                      "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
+                      "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
 
 
 
-Vassilev                Expires December 1, 2017               [Page 46]
+Vassilev                Expires November 2, 2017               [Page 47]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
-                      "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
                       "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
                    },
                    {
-                      "tcId" : "1131",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1131,
+                      "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   },
                   {
-                      "tcId" : "1132",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1132,
+                      "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
@@ -2609,42 +2663,42 @@ C.2.  Example sigGen Test Results JSON Objects
 
              [
                   { "acvVersion": "0.3" },
-                  { "vsId": "1163",
+                  { "vsId": 1163,
                     "testResults": [
                     {
-                      "tcId" : "1165",
+                      "tcId" : 1165,
                       "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f3e7af",
+                      "e" : "f3e7af",
                       "s" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
                     }
                     {
-                      "tcId" : "1166",
+                      "tcId" : 1166,
                       "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ebda09",
+                      "e" : "ebda09",
                       "s" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
                     }
                  ]
              }
               {
+                 "mode": "sigGen",
+                 "sigType" : "PKCS1v1.5",
 
 
 
-Vassilev                Expires December 1, 2017               [Page 47]
+Vassilev                Expires November 2, 2017               [Page 48]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                 "mode": "sigGen",
-                 "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1167",
+                      "tcId" : 1167,
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "s" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
                     }
                     {
-                      "tcId" : "1168",
+                      "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
                       "s" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
@@ -2656,13 +2710,13 @@ Internet-Draft                RSA Alg JSON                      May 2017
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1169",
+                      "tcId" : 1169,
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "s" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
                     }
                     {
-                      "tcId" : "1170",
+                      "tcId" : 1170,
                       "e" : "1415a7",
                       "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
                       "s" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
@@ -2678,27 +2732,27 @@ C.3.  Example sigVer Test Results JSON Objects
 
     [
        { "acvVersion": "0.3" },
-       { "vsId": "1173",
+       { "vsId": 1173,
          "algorithm": "RSA",
          "testGroups" : [
                 {
+                    "mode": "sigVer",
+                    "sigType" : "X9.31",
 
 
 
-Vassilev                Expires December 1, 2017               [Page 48]
+Vassilev                Expires November 2, 2017               [Page 49]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                    "mode": "sigVer",
-                    "sigType" : "X9.31",
                     "tests" : [
                        {
-                         "tcId" : "1174",
+                         "tcId" : 1174,
                          "sigResult" : "fail"
                        },
                        {
-                         "tcId" : "1175",
+                         "tcId" : 1175,
                          "sigResult" : "fail"
                        }
                     ]
@@ -2708,11 +2762,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     "sigType" : "PKCS1v1.5",
                     "tests" : [
                        {
-                         "tcId" : "1176",
+                         "tcId" : 1176,
                          "sigResult" : "pass"
                        },
                        {
-                         "tcId" : "1177",
+                         "tcId" : 1177,
                          "sigResult" : "fail"
                        }
                     ]
@@ -2722,11 +2776,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     "sigType" : "PKCS1PSS",
                     "tests" : [
                        {
-                         "tcId" : "1178",
+                         "tcId" : 1178,
                          "sigResult" : "fail"
                        },
                        {
-                         "tcId" : "1179",
+                         "tcId" : 1179,
                          "sigResult" : "fail"
                        }
                     ]
@@ -2735,22 +2789,18 @@ Internet-Draft                RSA Alg JSON                      May 2017
        }
      ]
 
-
-
-
-
-
-
-Vassilev                Expires December 1, 2017               [Page 49]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
 C.4.  Example legacySigVer Test Results JSON Objects
 
    The format and structure of the RSA legacySigVer Test Results JSON
    Objects are identical to those of the RSA sigVer Test Results JSON
    Objects.
+
+
+
+Vassilev                Expires November 2, 2017               [Page 50]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 C.5.  Example componentSigPrimitive Test Results JSON Objects
 
@@ -2759,21 +2809,19 @@ C.5.  Example componentSigPrimitive Test Results JSON Objects
 
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1193",
+    { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentSigPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1194",
+                      "tcId" : 1194,
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "tcId" : "1195",
-                      "sigResult" : "fail",
-                      "reason" : "msg larger than modulus size"
+                      "tcId" : 1195,
+                      "sigResult" : "fail"
                     }
                  ]
              }
@@ -2797,31 +2845,37 @@ C.6.  Example componentDecPrimitive Test Results JSON Objects
 
 
 
-Vassilev                Expires December 1, 2017               [Page 50]
+
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 51]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1194",
+    { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentDecPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1196",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010001",
+                      "tcId" : 1196,
+                      "e" : "010001",
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "tcId" : "1197",
-                      "sigResult" : "fail",
-                      "reason" : "msg larger than modulus size"
+                      "tcId" : 1197,
+                      "sigResult" : "fail"
                     }
                  ]
              }
@@ -2853,4 +2907,6 @@ Author's Address
 
 
 
-Vassilev                Expires December 1, 2017               [Page 51]
+
+
+Vassilev                Expires November 2, 2017               [Page 52]

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -694,9 +694,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              |                |       |                |          |
    | modRSASigGen | supported RSA  | array | any non-empty  | No       |
    |              | moduli for     |       | subset of      |          |
-   |              | signature      |       | {"2048",       |          |
-   |              | generation -   |       | "3072",        |          |
-   |              | see            |       | "4096"}        |          |
+   |              | signature      |       | {2048, 3072,   |          |
+   |              | generation -   |       | 4096}          |          |
+   |              | see            |       |                |          |
    |              | [FIPS186-4],   |       |                |          |
    |              | Section 5      |       |                |          |
    |              |                |       |                |          |
@@ -798,9 +798,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              |                |       |                |          |
    | modRSASigVer | supported RSA  | array | any non-empty  | No       |
    |              | moduli for     |       | subset of      |          |
-   |              | signature      |       | {"2048",       |          |
-   |              | verification - |       | "3072",        |          |
-   |              | see            |       | "4096"}        |          |
+   |              | signature      |       | {2048, 3072,   |          |
+   |              | verification - |       | 4096}          |          |
+   |              | see            |       |                |          |
    |              | [FIPS186-4],   |       |                |          |
    |              | Section 5      |       |                |          |
    |              |                |       |                |          |
@@ -911,11 +911,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |                  |              |       |              |          |
    | modLegacyRSASigV | supported    | array | any non-     | No       |
    | er               | RSA moduli   |       | empty subset |          |
-   |                  | for          |       | of {"1024",  |          |
-   |                  | signature    |       | "1536",      |          |
-   |                  | verification |       | "2048",      |          |
-   |                  | - see        |       | "3072",      |          |
-   |                  | [SP800-131A] |       | "4096"}      |          |
+   |                  | for          |       | of {1024,    |          |
+   |                  | signature    |       | 1536, 2048,  |          |
+   |                  | verification |       | 3072, 4096}  |          |
+   |                  | - see        |       |              |          |
+   |                  | [SP800-131A] |       |              |          |
    |                  |              |       |              |          |
    | hashLegacySigVer | supported    | array | any non-     | No       |
    |                  | hash         |       | empty subset |          |
@@ -1234,7 +1234,7 @@ Vassilev                Expires November 2, 2017               [Page 22]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |             | B3.4, or B3.5      |                     |          |
+   |             | B.3.4, or B3.5     |                     |          |
    |             |                    |                     |          |
    | bitlen1     | the length of p1   | hex value           | Yes      |
    |             | for prime          |                     |          |
@@ -1242,9 +1242,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
-   |             | B3.4, B3.5 or the  |                     |          |
+   |             | B.3.4, B3.5 or the |                     |          |
    |             | length of xP1 for  |                     |          |
-   |             | B3.6               |                     |          |
+   |             | B.3.6              |                     |          |
    |             |                    |                     |          |
    | bitlen2     | the length of p2   | hex value           | Yes      |
    |             | for prime          |                     |          |

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -463,7 +463,7 @@
           <c>fixedPubExp</c>
 	       <c>Supports fixed public key exponent e</c>
           <c>value</c>
-          <c>"yes","no"</c>
+          <c>true or false</c>
           <c>Yes</c>
          <c/>
          <c/>
@@ -483,7 +483,7 @@
           <c>randPubExp</c>
           <c>Supports random public key exponent e</c>
           <c>value</c>
-          <c>"yes","no"</c>
+          <c>true or false</c>
           <c>Yes</c>
           <c/>
          <c/>
@@ -1212,7 +1212,7 @@
          {"modeSpecs" : {
               "mode": "keyGen",
               "capSpecs" :  {
-                      "fixedPubExp" : "yes",
+                      "fixedPubExp" : true,
                       "fixedPubExpVal" : "010001",
                       "randPQ" : 1,
                       "capProvPrime" : 
@@ -1255,7 +1255,7 @@
         "modeSpecs": {
           "mode":"keyGen",
           "capSpecs": {
-            "fixedPubExp":"yes",
+            "fixedPubExp": true,
             "fixedPubExpVal":"010001",
             "randPQ": 2,
             "capProbPrime":[{
@@ -1290,7 +1290,7 @@
          {"modeSpecs" : {
            "mode": "keyGen",
            "capSpecs" : {
-               "fixedPubExp" : "yes",
+               "fixedPubExp" : true,
                "fixedPubExpVal" : "010001",
                "randPQ" : 4,
                "capsProvProbPrime" : 

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -556,7 +556,7 @@
           <c>modRSASigGen</c>
           <c>supported RSA moduli for signature generation - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
-          <c>any non-empty subset of {"2048", "3072", "4096"}</c>
+          <c>any non-empty subset of {2048, 3072, 4096}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -610,7 +610,7 @@
           <c>modRSASigVer</c>
           <c>supported RSA moduli for signature verification - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
-          <c>any non-empty subset of {"2048", "3072", "4096"}</c>
+          <c>any non-empty subset of {2048, 3072, 4096}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -668,7 +668,7 @@
           <c>modLegacyRSASigVer</c>
           <c>supported RSA moduli for signature verification - see <xref target="SP800-131A"/></c>
           <c>array</c>
-          <c>any non-empty subset of {"1024", "1536", "2048", "3072", "4096"}</c>
+          <c>any non-empty subset of {1024, 1536, 2048, 3072, 4096}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -963,7 +963,7 @@
 		<c/>
 		<c/>
 		<c>seed</c>
-    <c>the seed used in prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4, or B3.5</c>
+    <c>the seed used in prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, or B3.5</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>
@@ -971,7 +971,7 @@
 		<c/>
 		<c/>
 		<c>bitlen1</c>
-    <c>the length of p1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4, B3.5 or the length of xP1 for B3.6</c>
+    <c>the length of p1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B3.5 or the length of xP1 for B.3.6</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
+<!ENTITY RFC3447 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3447.xml">
 ]>
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
 <!-- used by XSLT processors -->
@@ -102,21 +103,21 @@
          keywords will be used for the search engine. -->
 
     <abstract>
-      <t>This document defines the JSON schema for testing RSA algorithm implementations for conformance to  <xref target="FIPS186-4"/> with the ACVP specification.</t>
+      <t>This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  <xref target="FIPS186-4"/> and <xref target="SP800-56B"/> with the ACVP specification.</t>
     </abstract>
   </front>
 
   <middle>
     <section title="Introduction">
       <t>The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically
-              verify the cryptographic implementation of a software or hardware crypto module.
-              The ACVP specification defines how a crypto module communicates with an ACVP
-              server, including crypto capabilities negotiation, session management, authentication,
+        verify the cryptographic implementation of a software or hardware crypto module.
+        The ACVP specification defines how a crypto module communicates with an ACVP
+        server, including crypto capabilities negotiation, session management, authentication,
 	      vector processing and more.  The ACVP specification does not define algorithm specific
 	      JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications
 	      define the constructs for testing individual crypto algorithms.  Each sub-specification
 	      addresses a specific class of crypto algorithms.  This sub-specification defines the JSON
-	      constructs for testing RSA akgorithm implementations for conformance to <xref target="FIPS186-4"/> using ACVP.</t>
+	      constructs for testing RSA algorithm and component implementations for conformance to <xref target="FIPS186-4"/> and <xref target="SP800-56B"/> using ACVP.</t>
 
       <section title="Requirements Language">
         <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
@@ -126,8 +127,8 @@
       </section>
       <section anchor="defaults_def" title="Testing scope">
           <t> The ACVP testing for RSA allows conformance testing for all modes of using the algorithm as specified in <xref target="FIPS186-4"/>: key generation, 
-          signature generation, signature verification, component primitives. Correspondingly, ACVP allows testing of the five different methods for key generation in <xref target="FIPS186-4"/>, 
-          Appendix B.3.
+          signature generation, signature verification, and component primitives. ACVP testing for RSA also allows conformance testing for <xref target="SP800-56B"/>: decryption primitives.
+          Correspondingly, ACVP allows testing of the five different methods for key generation in <xref target="FIPS186-4"/>, Appendix B.3.
               </t>
       </section>
     </section>
@@ -159,8 +160,8 @@
 	</section>
 	<section anchor="prereq_algs" title="Required Prerequisite Algorithms for RSA Mode Validations">
 	    <t>Each RSA Mode implementation relies on other cryptographic primitives (algorithms) - see <xref target="FIPS186-4"/>. 
-	    For example, a keyGen uses an underlying DRBG and hash algorithms. In some case, a single RSA Mode implementation may use several primitives of the same type. 
-	    For example, two different DRBG implementations may be used in the keyGen algorithms in Section B.3.3 in <xref target="FIPS186-4"/>, one in step 4.2 and another in step 5.2. 
+	    For example, a keyGen implementation uses underlying DRBG and hash algorithms. In some case, a single RSA Mode implementation may use several primitives of the same type. 
+	    For example, two different DRBG implementations may be used in the keyGen algorithms in Appendix B.3.3 in <xref target="FIPS186-4"/>, one in step 4.2 and another in step 5.2. 
 	    Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</t>
 	    <texttable anchor="prereqs_table" title="Required RSA Modes Prerequisite Algorithms JSON Values">
           <ttcol align="left">JSON Value</ttcol>
@@ -223,7 +224,7 @@
           <ttcol align="left">Optional</ttcol>
 
           <c>algorithm</c>
-	  <c>The RSA algorithm to be validated.</c>
+	  <c>The RSA algorithm to be validated</c>
           <c>value</c>
           <c>"RSA"</c>
           <c>No</c>
@@ -232,7 +233,17 @@
           <c/>
           <c/>
           <c/>
-         <c>prereqVals</c>
+          <c>infoGeneratedByServer</c>
+          <c>This flag indicates that the server is responsible for generating inputs for Key Generation tests</c>
+          <c>value</c>
+          <c>true or false</c>
+          <c>Yes</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>prereqVals</c>
 	       <c>The prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects - see <xref target="prereq_algs"/></c>
           <c>array</c>
@@ -285,26 +296,26 @@
 	<t>Each RSA keyGen mode capability is advertised as a self-contained JSON object.</t>
 	
 	    <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
-          <section anchor="mode_keyGenProvPrim" title="keyGen With Provable Primes Capabilities">
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
-         <texttable anchor="keyGenProvPrim_modulitable" title="Supported RSA keyGen moduli and hash options for provable primes JSON Values ">
+          <section anchor="mode_keyGenProvPrim" title="keyGen With Provable Primes or Provable Primes with Conditions Capabilities">
+          <t>The following key generation with provable primes, or provable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</t>
+         <texttable anchor="keyGenProvPrim_modulitable" title="Supported RSA keyGen moduli and hash options for provable primes or provable primes with conditions JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
           <ttcol align="left">JSON type</ttcol>
          <ttcol align="left">Valid values</ttcol>
          <ttcol align="left">Optional</ttcol>
-          <c>modProvPrime</c>
-          <c>supported RSA moduli for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.2</c>
+          <c>modulo</c>
+          <c>Supported RSA moduli for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.2 or Appendix B.3.4</c>
           <c>value</c>
-          <c>"2048", "3072", "4096"</c>
+          <c>2048, 3072, or 4096</c>
           <c>Yes</c>
           <c/>
           <c/>
           <c/>
           <c/>
           <c/>
-          <c>hashProvPrime</c>
-          <c>supported hash algorithms for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.2</c>
+          <c>hashAlg</c>
+          <c>Supported hash algorithms for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.2 or Appendix B.3.4</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
           <c>Yes</c>
@@ -313,9 +324,9 @@
           <c/>
           <c/>
           <c/>
-          <c>singleCapProvPrime</c>
-          <c>a testable combination of modulus and hash values</c>
-          <c>object with "modProvPrime" and "hashProvPrime" properties</c>
+          <c>singleCap</c>
+          <c>A testable combination of modulus and hash values</c>
+          <c>object with "modulo" and "hashAlg" properties</c>
           <c>see above</c>
           <c>Yes</c>
           <c/>
@@ -324,24 +335,24 @@
           <c/>
           <c/>
           <c>capProvPrime</c>
-          <c>supported capabilities for provable prime generation</c>
+          <c>Supported capabilities for provable prime generation or provable prime with conditions generation</c>
           <c>array</c>
-          <c>"singleCapProvPrime" objects, see above for possible values</c>
+          <c>"singleCap" objects, see above for possible values</c>
           <c>Yes</c> 
           </texttable>          
           </section>
           <section anchor="mode_keyGenProbPrim" title="keyGen With Probable Primes Capabilities">
-           <t>The following key generation with probable primes capabilities may be advertised by the ACVP compliant crypto modules:</t>
-         <texttable anchor="keyGenProbPrim_modulitable" title="Supported RSA keyGen moduli and primality test options for probable primes JSON Values ">
+           <t>The following key generation with probable primes or probable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</t>
+         <texttable anchor="keyGenProbPrim_modulitable" title="Supported RSA keyGen moduli and primality test options for probable primes or probable primes with conditions JSON Values">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
           <ttcol align="left">JSON type</ttcol>
          <ttcol align="left">Valid values</ttcol>
          <ttcol align="left">Optional</ttcol>
-          <c>modProbPrime</c>
-          <c>supported RSA moduli for probable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.3</c>
-          <c>array</c>
-          <c>any non-empty subset of {"2048", "3072", "4096"}</c>
+          <c>modulo</c>
+          <c>supported RSA moduli for probable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.3 or Appendix B.3.5</c>
+          <c>value</c>
+          <c>2048, 3072 or 4096</c>
           <c>Yes</c>
           <c/>
           <c/>
@@ -349,22 +360,88 @@
           <c/>
           <c/>
           <c>primeTest</c>
-          <c>Primality test rounds of Miller-Rabin from Table C.2  or Table C.3 in <xref target="FIPS186-4"/>, Appendix C.3</c>
-          <c>value</c>
-          <c>"tblC2", "tblC3"</c>
+          <c>Primality test rounds of Miller-Rabin from Table C.2 or Table C.3 in <xref target="FIPS186-4"/>, Appendix C.3</c>
+          <c>array</c>
+          <c>any non-empty set of {"tblC2", "tblC3"}</c>
           <c>Yes</c>
            <c/>
           <c/>
           <c/>
           <c/>
           <c/>
+           <c>singleCap</c>
+           <c>A testable combination of modulus and primality test rounds</c>
+           <c>object with "modulo" and "primeTest" properties</c>
+           <c>see above</c>
+           <c>Yes</c>
+           <c/>
+           <c/>
+           <c/>
+           <c/>
+           <c/>
           <c>capProbPrime</c>
-          <c>supported capabilities for probable prime generation</c>
-          <c>object with "modeProbPrime" and "primeTest" properties</c>
+          <c>supported capabilities for probable prime generation or probable primes with conditions generation</c>
+          <c>object with "singleCap" properties</c>
           <c>see above for possible values</c>
           <c>Yes</c> 
           </texttable>          
           </section>
+	        <section anchor="mode_keyGenProvProbPrimWithCond" title="keyGen With Both Provable and Probable Primes With Conditions">
+	          <t>The following key generation with both provable and probable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</t>
+	          <texttable anchor="keyGenProvProbPrimWithCond" title="Supported RSA keyGen moduli, hash algorithms, and primality test options for provable and 
+	            probable primes with conditions JSON Values">
+	            <ttcol align="left">JSON value</ttcol>
+	            <ttcol align="left">Description</ttcol>
+	            <ttcol align="left">JSON type</ttcol>
+	            <ttcol align="left">Valid values</ttcol>
+	            <ttcol align="left">Optional</ttcol>
+	            <c>modulo</c>
+	            <c>supported RSA modulo for provable primes with conditions - see <xref target="FIPS186-4"/>, Appendix B.3.6</c>
+	            <c>value</c>
+	            <c>2048, 3072 or 4096</c>
+	            <c>Yes</c>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c>hashAlg</c>
+	            <c>Supported hash algorithms for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.6</c>
+	            <c>array</c>
+	            <c>any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
+	            <c>Yes</c>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c>primeTest</c>
+	            <c>Primality test rounds of Miller-Rabin from Table C.2 or Table C.3 in <xref target="FIPS186-4"/>, Appendix C.3</c>
+	            <c>array</c>
+	            <c>any non-empty subset of {"tblC2", "tblC3"}</c>
+	            <c>Yes</c>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c>singleCap</c>
+	            <c>A testable combination of modulus, hash algorithm, and primality test rounds</c>
+	            <c>object with "modulo", "hashAlg", and "primeTest" properties</c>
+	            <c>see above</c>
+	            <c>Yes</c>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c/>
+	            <c>capProvProbPrime</c>
+	            <c>supported capabilities for both provable and probable primes with conditions generation</c>
+	            <c>object with "singleCap" properties</c>
+	            <c>see above for possible values</c>
+	            <c>Yes</c> 
+	          </texttable>
+	        </section>
            <section anchor="mode_keyGenFullSet" title="keyGen Full Set Of Capabilities">
            <t>The complete list of RSA key generation capabilities may be advertised by the ACVP compliant crypto module:</t>
 	       <texttable anchor="keyGen_table" title="RSA keyGen Capabilities JSON Values">
@@ -384,7 +461,7 @@
           <c/>
           <c/>
           <c>fixedPubExp</c>
-	       <c>supports fixed public key exponent e</c>
+	       <c>Supports fixed public key exponent e</c>
           <c>value</c>
           <c>"yes","no"</c>
           <c>Yes</c>
@@ -394,7 +471,7 @@
           <c/>
           <c/>
            <c>fixedPubExpVal</c>
-	       <c>the value of the public key exponent e in hex</c>
+	       <c>The value of the public key exponent e in hex</c>
           <c>value</c>
           <c>hex</c>
           <c>Yes</c>
@@ -404,7 +481,7 @@
           <c/>
           <c/>
           <c>randPubExp</c>
-          <c>supports random public key exponent e</c>
+          <c>Supports random public key exponent e</c>
           <c>value</c>
           <c>"yes","no"</c>
           <c>Yes</c>
@@ -414,9 +491,9 @@
           <c/>
           <c/> 
           <c>randPQ</c>
-          <c>random P and Q primes generated as (see <xref target="FIPS186-4"/> ): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</c>
+          <c>Random P and Q primes generated as (see <xref target="FIPS186-4"/>): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</c>
           <c>value</c>
-          <c>{"1","2","3","4","5"}</c>
+          <c>{1, 2, 3, 4, 5}</c>
           <c>Yes</c>
           <c/>
          <c/>
@@ -424,7 +501,7 @@
           <c/>
           <c/>
           <c>capProvPrimes</c>
-          <c>capabilities for all supported moduli and hash algorithms (see <xref target="keyGenProvPrim_modulitable"/>)</c>
+          <c>Capabilities for all supported moduli and hash algorithms (see <xref target="keyGenProvPrim_modulitable"/>)</c>
           <c>array</c>
           <c/>
           <c>Yes</c>
@@ -434,7 +511,7 @@
           <c/>
           <c/>
           <c>modProbPrime</c>
-          <c>see <xref target="keyGenProbPrim_modulitable"/></c>
+          <c>See <xref target="keyGenProbPrim_modulitable"/></c>
           <c>array</c>
           <c>see <xref target="keyGenProbPrim_modulitable"/></c>
           <c>Yes</c>
@@ -444,7 +521,7 @@
           <c/>
           <c/>
           <c>primeTest</c>
-          <c>see <xref target="keyGenProbPrim_modulitable"/></c>
+          <c>See <xref target="keyGenProbPrim_modulitable"/></c>
           <c>value</c>
           <c>see <xref target="keyGenProbPrim_modulitable"/></c>
           <c>Yes</c>
@@ -617,10 +694,11 @@
           <t>Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</t>
 	</section>
 	<section anchor="mode_componentSigPrimitive" title="The componentSigPrimitive Mode Capabilities">
-	  <t>The RSA componentSigPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
-	is the correct expontiation s = msg^d mod n, where msg is a message, d is the private exponent and n is the modulus, all supplied by the testing ACVP server. Only 2048-bit RSA keys are allowed for this capability. 
-	There are no properties specified for this capability. See Section <xref target="app-testcomponentsigprimitive-ex"/> for additional details on constraints for msg and n.
+	  <t>The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <xref target="RFC3447"/>) is advertised as a JSON object within the array of 'modeSpecs'
+	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
+	is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server. 
+	Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability. 
+	See <xref target="app-testcomponentsigprimitive-ex"/> for additional details on constraints for 'msg' and 'n'.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</t>
@@ -628,16 +706,14 @@
 	<section anchor="mode_componentDecPrimitive" title="The componentDecPrimitive Mode Capabilities">
 <t>The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs'
 	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
-	is the correct expontiation s = msg^d mod n, where msg is a message, d is the private exponent and n is the modulus. See <xref target="SP800-56B"/>, Section 7.1.2 for details.</t>
+	is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <xref target="SP800-56B"/>, Section 7.1.2 for details.</t>
 	
-	<t>In testing, only msg is supplied by the ACVP server. 
-	The client is responsible for generating RSA key pairs of modulus n, private key d, and calculates s.
-	Only 2048-bit RSA keys are allowed for this capability. See <xref target="app-testcomponentdecprimitive-ex"/> for additional details on constraints for msg and n. The client
-	provides the public exponent e, modulus n, the private key d and the computed result s in its response to the ACVP - see <xref target="app-componentdec-results-ex"/> . 
-	The client must first check if  0 &lt; msg &lt; n-1 and return an error if this is not the case. The client returns a value s only when 
-	msg is in the proper range for the size of the selected modulus n. 
-	There are no properties specified for this capability. 
-	See the ACVP specification for details on the registration message.</t>
+	<t>In testing, only 'msg' is supplied by the ACVP server. 
+	The client is responsible for generating RSA key pairs of modulus 'n', private key 'd', and calculates 's'.
+	Only 2048-bit RSA keys are allowed for this capability. See <xref target="app-testcomponentdecprimitive-ex"/> for additional details on constraints for 'msg' and 'n'. The client
+	provides the public exponent 'e', modulus 'n', the private key 'd' and the computed result 's' in its response to the ACVP - see <xref target="app-componentdec-results-ex"/> . 
+	The client must first check if  '0 &lt; msg &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 
+	'msg' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA componentDecPrimitive mode capability is advertised as a self-contained JSON object.</t>
 	</section>
@@ -713,6 +789,22 @@
 		<c/>
 		<c/>
 		<c/>
+    <c>modRSA</c>
+    <c>RSA modulus</c>
+    <c>value</c>
+    <c>No</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
+    <c>hashAlg</c>
+    <c>the hash algorithm</c>
+    <c>value</c>
+    <c>Yes</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
 		<c>primeTest</c>
 		<c>Miller-Rabin constraint from Table C.2 or C.3</c>
 		<c>value</c>
@@ -730,7 +822,7 @@
 		<c/>
 		<c/>
     <c>sigType</c>
-		<c>The type of digigital signature algrothm - see  <xref target="sigGenRSAMod"/></c>
+		<c>The type of digital signature algorithm - see  <xref target="sigGenRSAMod"/></c>
 		<c>value</c>
     <c>Yes</c>
 
@@ -756,22 +848,6 @@
 		<c/>
 		<c/>
 		<c/>
-    <c>modRSA</c>
-    <c>RSA modulus</c>
-    <c>value</c>
-    <c>No</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-    <c>hashAlg</c>
-    <c>the hash algorithm</c>
-    <c>value</c>
-    <c>Yes</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
     <c>e</c>
     <c>the public exponent</c>
     <c>hex value</c>
@@ -781,7 +857,7 @@
 		<c/>
 		<c/>
 		<c>pRand</c>
-    <c>the random for P, testing probable primes according to <xref target="FIPS186-4"/>, Section B.3.3 </c>
+    <c>the random for P, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -789,7 +865,7 @@
 		<c/>
 		<c/>
 		<c>qRand</c>
-    <c>the random for Q, if applicable, testing probable primes according to <xref target="FIPS186-4"/>, Section B.3.3 </c>
+	      <c>the random for Q, if applicable, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -855,7 +931,7 @@
 		<c/>
 		<c/>
 		<c>pRand</c>
-    <c>the random for P, testing probable primes according to <xref target="FIPS186-4"/>, Section B.3.3 </c>
+	      <c>the random for P, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -863,7 +939,7 @@
 		<c/>
 		<c/>
 		<c>qRand</c>
-    <c>the random for Q, if applicable, testing probable primes according to <xref target="FIPS186-4"/>, Section B.3.3 </c>
+	      <c>the random for Q, if applicable, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -871,7 +947,7 @@
 		<c/>
 		<c/>
 		<c>primeResult</c>
-    <c>the verdict on the primality testing for the supplied pRand/qrand combination, see <xref target="FIPS186-4"/>, Section B.3.3 </c>
+	      <c>the verdict on the primality testing for the supplied pRand/qRand combination, see <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
     <c>"prime"/"composite"</c>
     <c>Yes</c>
 		<c/>
@@ -879,7 +955,7 @@
 		<c/>
 		<c/>
 		<c>xP1</c>
-    <c>the prime factor p1 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.1, if applicable</c>
+    <c>the prime factor p1 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>
@@ -887,7 +963,7 @@
 		<c/>
 		<c/>
 		<c>seed</c>
-    <c>the seed used in prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4 or B3.5</c>
+    <c>the seed used in prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4, or B3.5</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>
@@ -903,7 +979,7 @@
 		<c/>
 		<c/>
 		<c>bitlen2</c>
-    <c>the length of p2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4, B3.5 or the length of xP2 for B3.6</c>
+    <c>the length of p2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B.3.5 or the length of xP2 for B.3.6</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>
@@ -911,7 +987,7 @@
 		<c/>
 		<c/>
 		<c>bitlen3</c>
-    <c>the length of q1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4, B3.5 or the length of xQ1 for B3.6</c>
+    <c>the length of q1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ1 for B.3.6</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>
@@ -919,7 +995,7 @@
 		<c/>
 		<c/>
 		<c>bitlen4</c>
-    <c>the length of q2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B3.4, B3.5 or the length of xQ2 for B3.6</c>
+    <c>the length of q2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ2 for B.3.6</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -927,7 +1003,7 @@
 		<c/>
 		<c/>
     <c>primeSeedP2</c>
-    <c>the prime seed used for p2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B3.5</c>
+    <c>the prime seed used for p2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.5</c>
     <c>hex value</c>
     <c>Yes</c>
     <c/>
@@ -935,7 +1011,7 @@
 		<c/>
 		<c/>
     <c>primeSeedQ1</c>
-    <c>the prime seed used for q1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B3.5</c>
+    <c>the prime seed used for q1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.5</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -943,7 +1019,7 @@
 		<c/>
 		<c/>
     <c>primeSeedQ2</c>
-    <c>the prime seed used for q2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B3.5</c>
+    <c>the prime seed used for q2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.5</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -951,7 +1027,7 @@
 		<c/>
 		<c/>
 		<c>xP2</c>
-    <c>the prime factor p2 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.1, if applicable</c>
+	      <c>the prime factor p2 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -959,7 +1035,7 @@
 		<c/>
 		<c/>
 		<c>xP</c>
-    <c>the random number used in Step Step 3 of the algorithm in <xref target="FIPS186-4"/>, Appendix C.9 "Compute a Probable Prime Factor Based on Auxiliary Primes" to generate the prime P, if applicable</c>
+    <c>the random number used in Step 3 of the algorithm in <xref target="FIPS186-4"/>, Appendix C.9 to generate the prime P, if applicable</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -975,7 +1051,7 @@
 		<c/>
 		<c/>
 		<c>xQ1</c>
-    <c>the prime factor q1 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.1, if applicable</c>
+	      <c>the prime factor q1 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -983,7 +1059,7 @@
 		<c/>
 		<c/>
 		<c>xQ2</c>
-    <c>the prime factor q2 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.1, if applicable</c>
+	      <c>the prime factor q2 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -991,7 +1067,7 @@
 		<c/>
 		<c/>
 		<c>xQ</c>
-    <c>the random number used in Step Step 3 of the algorithm in <xref target="FIPS186-4"/>, Appendix C.9 "Compute a Probable Prime Factor Based on Auxiliary Primes" to generate the prime Q, if applicable</c>
+    <c>the random number used in Step 3 of the algorithm in <xref target="FIPS186-4"/>, Appendix C.9 to generate the prime Q, if applicable</c>
     <c>hex value</c>
     <c>Yes</c>
 		<c/>
@@ -1034,14 +1110,6 @@
     <c>the result from the digital signature verirfication</c>
     <c>"pass"/"fail"</c>
     <c>Yes</c>
-      <c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>reason</c>
-    <c>additonal information about a specific test case result</c>
-    <c>text</c>
-    <c>Yes</c>
 	    </texttable>
     </section>
 
@@ -1068,6 +1136,9 @@
     <references title="Normative References">
       <!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?-->
       &RFC2119;
+      
+      <!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.3447.xml"?-->
+      &RFC3447;
 
       <reference anchor="ACVP">
         <!-- the following is the minimum to make xml2rfc happy -->
@@ -1075,7 +1146,7 @@
         <front>
           <title>ACVP Specification</title>
 
-          <author initials="authInitials" surname="authSurName">
+          <author>
             <organization>NIST</organization>
           </author>
 
@@ -1087,7 +1158,7 @@
 
         <front>
           <title>FIPS PUB 186-4 Digital Signature Standard</title>
-          <author initials="" surname="">
+          <author>
             <organization>NIST</organization>
           </author>
           <date month="July" year="2013"/>
@@ -1128,13 +1199,14 @@
     <section anchor="app-reg-ex" title="Example RSA Capabilities JSON Objects">
       <t>This appendix contains example JSON object advertising support for the verious RSA modes:keyGen, sigGen, sigVer, legacySigVer, compRSASP1. Note that all binary HEX representations are in big-endian format.</t>
       
-      <section anchor="app-ex-keyGenProvPrime" title="Example keyGen Capabilities JSON Objects">
+      <section anchor="app-ex-keyGenProvPrime" title="Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects">
       <t>The following is an example JSON object advertising support for RSA keyGen with provable primes according to <xref target="FIPS186-4"/>, Appendix B.3.2. See also <xref target="mode_keyGenFullSet"/>.</t>
       <figure>
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
+      "infoGeneratedByServer": true,
       "algSpecs" : 
       [
          {"modeSpecs" : {
@@ -1142,15 +1214,15 @@
               "capSpecs" :  {
                       "fixedPubExp" : "yes",
                       "fixedPubExpVal" : "010001",
-                      "randPQ" : "1",
-                      "capsProvPrime" : 
+                      "randPQ" : 1,
+                      "capProvPrime" : 
                             [
-                                {   "modProvPrime" : "2048",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modProvPrime" : "3072",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modProvPrime" : "4096",
-                                    "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+                                {   "modulo" : 2048,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                                {   "modulo" : 3072,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                                {   "modulo" : 4096,
+                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
                             ]
                       }
                 }
@@ -1159,12 +1231,15 @@
    }
 ]]></artwork>
     </figure>
+        
+    <t>In order to advertise support for RSA keyGen with provable primes with conditions, the same properties exist, but the 'randPQ' value should be '3' as an integer.</t>
     <section anchor="app-ex-keyGenProbPrime" title="Example keyGen with Probable Primes Capabilities JSON Object">
       <t>The following is an example JSON object advertising support for RSA keyGen with probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3. See also <xref target="mode_keyGenFullSet"/>.</t>
       <figure>
         <artwork><![CDATA[
    {
     "algorithm":"RSA",
+    "infoGeneratedByServer": true,
     "prereqVals":[
       {
         "algorithm":"DRBG",
@@ -1182,11 +1257,15 @@
           "capSpecs": {
             "fixedPubExp":"yes",
             "fixedPubExpVal":"010001",
-            "randPQ":"2",
-            "capProbPrime":{
-              "modProbPrime":["2048", "3072", "4096"],
-              "primeTest":"tblC2"
-            }
+            "randPQ": 2,
+            "capProbPrime":[{
+              "modulo": 2048,
+              "primeTest":["tblC2"]
+            },
+            {
+              "modulo": 3072,
+              "primeTest":["tblC2", "tblC3"]
+            }]
           }
         }
       }
@@ -1194,13 +1273,17 @@
   }
 ]]></artwork>
     </figure>
+      <t>In order to advertise support for RSA keyGen with all probable primes with conditions, the same properties exist, but the 'randPQ' value should be '5' as an integer.</t>
+      
 </section>
+        
       <section anchor="app-ex-keyGenProvProbPrime" title="Example keyGen with Provable Conditional Primes with Probable Factors Capabilities JSON Object">
       <t>The following is an example JSON object advertising support for RSA keyGen with primes with conditions according to <xref target="FIPS186-4"/>, Appendix B.3.5. See also <xref target="mode_keyGenFullSet"/>.</t>
       <figure>
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
+      "infoGeneratedByServer": false,
        "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
@@ -1209,43 +1292,20 @@
            "capSpecs" : {
                "fixedPubExp" : "yes",
                "fixedPubExpVal" : "010001",
-               "randPQ" : "4",
-               "capsProvPrime" : 
+               "randPQ" : 4,
+               "capsProvProbPrime" : 
                     [
-                        {"modProvPrime" : "2048",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                        {"modProvPrime" : "3072",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                        {"modProvPrime" : "4096",
-                         "hashProvPrime" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                    ],
-              "capProbPrime" :{"modProbPrime" : ["2048","3072","4096"],
-                                             "primeTest" : "tblC3"}
+                        {"modulo" : 2048,
+                         "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                         "primeTest": ["tblC2", "tblC3"]},
+                       {"modulo" : 3072,
+                         "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                         "primeTest": ["tblC2"]},
+                       {"modulo" : 4096,
+                         "hashAlg" : ["SHA-512"],
+                         "primeTest": ["tblC3"]},
+                    ]
               }
-          }
-        }
-      ]
-   }
-]]></artwork>
-    </figure>
-</section>
-<section anchor="app-ex-keyGenProbProbPrime" title="Example keyGen with Probable Conditional Primes with Probable Factors Capabilities JSON Object">
-      <t>The following is an example JSON object advertising support for RSA keyGen with primes with conditions according to <xref target="FIPS186-4"/>, Appendix B.3.6. See also <xref target="mode_keyGenFullSet"/>.</t>
-      <figure>
-        <artwork><![CDATA[
-   {
-      "algorithm": "RSA",
-       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" : 
-      [
-          {"modeSpecs" : {
-             "mode": "keyGen",
-             "capSpecs" : {
-                 "randPubExp" : "yes",
-                 "randPQ" : "5",
-                 "capProbPrime" :{"modProbPrime" : ["2048","3072","4096"],
-                                                "primeTest" : "tblC3"}
-                 }
           }
         }
       ]
@@ -1269,11 +1329,11 @@
                   "sigType" : "X9.31",
                   "capSigType" :
                   [
-                      {"modRSASigGen" : "2048",
+                      {"modRSASigGen" : 2048,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "3072",
+                      {"modRSASigGen" : 3072,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "4096",
+                      {"modRSASigGen" : 4096,
                         "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
                   ]
               }
@@ -1284,11 +1344,11 @@
                   "sigType" : "PKCS1v1.5",
                   "capSigType" :
                   [
-                      {"modRSASigGen" : "2048",
+                      {"modRSASigGen" : 2048,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "3072",
+                      {"modRSASigGen" : 3072,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : "4096",
+                      {"modRSASigGen" : 4096,
                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
                   ]
               }
@@ -1299,15 +1359,15 @@
                 "sigType" : "PKCS1PSS",
                 "capSigType" :
                 [
-                    { "modRSASigGen" : "2048",
+                    { "modRSASigGen" : 2048,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]},
-                    { "modRSASigGen" : "3072",
+                      "saltSigGen" : [28, 32, 64]},
+                    { "modRSASigGen" : 3072,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]},
-                    { "modRSASigGen" : "4096",
+                      "saltSigGen" : [28, 32, 64]},
+                    { "modRSASigGen" : 4096,
                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : ["28", "32", "64"]}
+                      "saltSigGen" : [28, 32, 64]}
                 ]
             }
          }}
@@ -1332,11 +1392,11 @@
                  "sigType" : "X9.31",
                  "capSigType" :
                 [
-                  {"modRSASigVer" : "2048",
+                  {"modRSASigVer" : 2048,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "3072",
+                  {"modRSASigVer" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "4096",
+                  {"modRSASigVer" : 4096,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
                ]
             }
@@ -1347,11 +1407,11 @@
                 "sigType" : "PKCS1v1.5",
                  "capSigType" :
                 [
-                  {"modRSASigVer" : "2048",
+                  {"modRSASigVer" : 2048,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "3072",
+                  {"modRSASigVer" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : "4096",
+                  {"modRSASigVer" : 4096,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
                 ]
             }
@@ -1362,15 +1422,15 @@
                 "sigType" : "PKCS1PSS",
                 "capSigType" :
                   [
-                    { "modRSASigVer" : "2048",
+                    { "modRSASigVer" : 2048,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]},
-                    { "modRSASigVer" : "3072",
+                      "saltSigVer" : [28, 32, 64]},
+                    { "modRSASigVer" : 3072,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]},
-                    { "modRSASigVer" : "4096",
+                      "saltSigVer" : [28, 32, 64]},
+                    { "modRSASigVer" : 4096,
                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : ["28", "32", "64"]}
+                      "saltSigVer" : [28, 32, 64]}
                  ]
             }
        }}
@@ -1388,12 +1448,10 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" : 
       [
        {"modeSpecs" : {
-           "mode": "componentSigPrimitive",
-           "capSpecs" : {}
+           "mode": "componentSigPrimitive"
          }}
       ]
    }
@@ -1410,8 +1468,7 @@
       "algSpecs" : 
       [
         {"modeSpecs" : {
-            "mode": "componentDecPrimitive",
-            "capSpecs" : {}
+            "mode": "componentDecPrimitive"
          }}
       ]
    }
@@ -1427,146 +1484,164 @@
 
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1133",
+   { "vsId": 1133,
       "algorithm": "RSA",
+      "infoGeneratedByServer": false,
       "testGroups" : [
              {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "1",
+                 "randPQ" : 1,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
                  "tests" : [
                     {
-                      "tcId" : "1145",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
+                      "tcId" : 1145,
                     },
                     {
-                      "tcId" : "1147",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    }
-                 ]
-             },
-              {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "3",
-                 "tests" : [
-                    {
-                      "tcId" : "1111",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1112",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1113",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1114",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
+                      "tcId" : 1146,
                     }
                  ]
              },
              {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 1,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1147,
+                  },
+                  {
+                    "tcId": 1148,
+                  }
+                ]
+              },
+             {
                  "mode": "keyGen",
                  "pubExp" : "random",
-                 "randPQ" : "4",
+                 "randPQ" : 3,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1149,
+                    },
+                    {
+                      "tcId" : 1150,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 3,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1151,
+                  },
+                  {
+                    "tcId": 1152,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 4,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1153,
+                    },
+                    {
+                      "tcId" : 1154,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 4,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1155,
+                  },
+                  {
+                    "tcId": 1156,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 5,
+                 "modRSA" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                    {
+                      "tcId" : 1157,
+                    },
+                    {
+                      "tcId" : 1158,
+                    }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "pubExp": "random",
+                "randPQ": 5,
+                "modRSA" : 3072,
+                "hashAlg" : "SHA-256"
+                "tests": [
+                  {
+                    "tcId": 1159,
+                  },
+                  {
+                    "tcId": 1160,
+                  }
+                ]
+              },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
                  "primeTest" : "tblC2",
+                 "modRSA" : 2048,
                  "tests" : [
                     {
-                      "tcId" : "1115",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1116",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1117",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-256"
-                    },
-                    {
-                      "tcId" : "1118",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
-                    }
-                 ]
-             },
-             {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "5",
-                 "primeTest" : "tblC3",
-                 "tests" : [
-                    {
-                      "tcId" : "1135",
-                      "modRSA" : "2048",
-                      "hashAlg" : "SHA-512"
-                    },
-                    {
-                      "tcId" : "1137",
-                      "modRSA" : "3072",
-                      "hashAlg" : "SHA-512"
-                    }
-                 ]
-             },
-             {
-                 "mode": "keyGen",
-                 "pubExp" : "random",
-                 "randPQ" : "2",
-                 "primeTest" : "tblC2",
-                 "tests" : [
-                    {
-                      "tcId" : "1119",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
+                      "tcId" : 1119,
+                      "e" : "df28ab",
                       "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "tcId" : "1120",
-                      "modRSA" : "2048",
-                      "e" : "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000085a4cf",
-                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5"
-                    },
+                      "tcId" : 1120,
+                      "e" : "85a4cf",
+                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                    }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC2",
+                 "modRSA" : 3072,
+                 "tests" : [
                     {
-                      "tcId" : "1121",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1121,
+                      "e" : "535c97",
                       "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
-                    },
-                    {
-                      "tcId" : "1122",
-                      "modRSA" : "3072",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000054a7dd",
-                      "pRand" : "0c5742407c0bac4f474edda6f92e42bd36ade552d947eb8bc5ac97c23efac563de8262ecc1e542cd489fcd33f3dcadcf900c8b0acd28abb1d25318c4f7dae3fa4b281c3b89a77d06db36115ff10496005b45fab68aa45e5f40296570ff97081007d907aa74b56f59841f6069900e14f5f2cf508b9094f3ee37aa4c0a43e38922dc3fce63d6d1e392d1a70da4e5ba7083188ca78693bb7e953352aeb76f3f5905613a10a04c791560717316e2a2c13bb4522aeb86680355bec7dda0b3674e10e9"
-                    },
-                    {
-                      "tcId" : "1129",
-                      "modRSA" : "2048"
-                    },
-                    {
-                      "tcId" : "1130",
-                      "modRSA" : "2048"
-                    },
-                    {
-                      "tcId" : "1131",
-                      "modRSA" : 3072
-                    },
-                    {
-                      "tcId" : "1132",
-                      "modRSA" : "3072"
                     }
                  ]
              },
@@ -1575,32 +1650,35 @@
                  "pubExp" : "random",
                  "randPQ" : 2,
                  "primeTest" : "tblC3",
+                 "modRSA" : 2048,
                  "tests" : [
                     {
-                      "tcId" : "1123",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037a7f1",
-                      "pRand" : "ea4fe1b753e17f7a99a648c1d111d7599eda7ed85b14c974df5d3f1a39e9b3bc2ce3d4e9ab70a2d184c4ce56fbe18c97b09fd47bb39a470ef2bfa5217e1aa8493326dfd9cc9e73da683691cef7d6ded642bfb56c919f8f54ea08de9bffa2f155e8a3a6746302347fb2f581be2deb55b057c3ac371d867c710a03cb9c1d218223",
-                      "qRand" : "c8435496e852f54eac36a1b8e29e5258ba383f3cd453293d98b9d565e72b03e44ead75ea341615062b504c3350b2404f53401f19b88b6a23bca4a19687300522489dbe3beab828e438b28b5a10e8c0da4b38162b458bb7f92804f1969fa3a1cd92f9b16b358047bcc1858e21ab787738cc311abd6bbdf138b352b26d206614cf"
+                      "tcId" : 1122,
+                      "e" : "df28ab",
+                      "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
-                      "tcId" : "1124",
-                      "modRSA" : "2048",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000333f01",
-                      "pRand" : "0456038077312d974418bbe2432387d97b55158496263213df19a9ff7f888cdcf3dbae9bba8cdd5d8b6799de99cfb37d1bad0173fc38540a0d0e098ebdf1718b92c9361880af2025382ffb20fc094eced508b097f455f357a2b35a562be410cf44f4c44d5bc4bf0b57b43af86cd7cf37aa9edffa6d23132b1eeece0f09691645"
-                    },
+                      "tcId" : 1123,
+                      "e" : "85a4cf",
+                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                    }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "pubExp" : "random",
+                 "randPQ" : 2,
+                 "primeTest" : "tblC3",
+                 "modRSA" : 3072,
+                 "tests" : [
                     {
-                      "tcId" : "1125",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fe8ed9",
-                      "pRand" : "f26e1240a0a1b954430793b7b3e3bbf46b1cbc022e29444099c3edcbb66e9ecab3414c80275ca523ea269c085758582917e6cdb2b42f819011a9ddc1e1c25788c507e9dd8fb0bb3fb3d1103e6b0dff333394956aae41855584ec4119e4a3ab804764caa88db6d10c503402f3280aa573ef9066a2ca17a31aafe9bf0bcd412302505e6feb3fe7538bab064d415af979a32cc0b9e298d0b8bc7d1eb3f70e02004257c360bca9549a5bbedee3833ae23c8e65b430e8acb5035a7b410d55a2a5687b",
-                      "qRand" : "a57a699bc759f6e71049eeef16011b2b1549cb8b27a822ac7e45178f3f80680390e1ee99f5f531f5e44a8b570aece9aa0682cff9202cff065a704972748c117e9be5439f93198406bd33c7dded7956e692b531ee7c92133a1e6884a2a48459f55551f406e840461ef18e4c613906186f1ce95a9ba63f4f7673dd552678fba5b0672ac921de31eb7213c14387dd2a7b47c0dbdc088cd8b16f3b552c3fa95631f79cad18a98dc86e22728aa533db8e767396d6eceddb525dceb0baa1cecd57734b"
-                    },
-                    {
-                      "tcId" : "1126",
-                      "modRSA" : "3072",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000524781",
-                      "pRand" : "aad0d971253463ae131e900189b1e978ca55c58dfa3797995f69e2ef147246402e78d3ad703f298943d6e02709289ab846deb65731cffa735239d787abfa6e26f0e295325efe9eab616422cdcbe391ce531bf5508b9d45cf5dc5bd2389c31cdf658cf1ac3ec714978da665d1867ac6846e629f3552172a8e2b879a2c4f326298d9c379cf97c1ddadfc0d8c4c112a0f6e48195131b756603b8052e2b25d010851749ea37cdbaa9490ea686546ee1688445673304d4df5024d834c9d9da965c7cb"
+                      "tcId" : 1124,
+                      "e" : "535c97",
+                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
              }
@@ -1609,13 +1687,18 @@
  ]
 ]]></artwork>
     </figure>
+    <t>Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate
+      Key Generation method for each test. The information returned should match all applicable data in <xref target="vs_tr_keyGen_table"/>. For Key Generation method 2 (Appendix
+    B.3.3 <xref target="FIPS186-4"/>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" 
+    response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd')
+    and the server validates that this pair matches the requirements.</t>
     </section>
 <section anchor="app-testVectsigGen-ex" title="Example Test Vectors for sigGen JSON Objects">
     <figure>
     <artwork><![CDATA[
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1163",
+   { "vsId": 1163,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1623,14 +1706,14 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1165",
-                      "modRSA" : "2048",
+                      "tcId" : 1165,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
-                      "tcId" : "1166",
-                      "modRSA" : "3072",
+                      "tcId" : 1166,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
                     }
@@ -1641,14 +1724,14 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1167",
-                      "modRSA" : "2048",
+                      "tcId" : 1167,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
-                      "tcId" : "1168",
-                      "modRSA" : "3072",
+                      "tcId" : 1168,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
@@ -1659,17 +1742,17 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1169",
-                      "modRSA" : "2048",
+                      "tcId" : 1169,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
-                      "saltLen" : "20",
+                      "saltLen" : 20,
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
                     {
-                      "tcId" : "1170",
-                      "modRSA" : "3072",
+                      "tcId" : 1170,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-512",
-                      "saltLen" : "62",
+                      "saltLen" : 62,
                       "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
                     }
                  ]
@@ -1685,7 +1768,7 @@
     <artwork><![CDATA[
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1173",
+   { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -1693,8 +1776,8 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1174",
-                      "modRSA" : "2048",
+                      "tcId" : 1174,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
                       "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -1702,8 +1785,8 @@
                       "s" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
                     },
                     {
-                      "tcId" : "1175",
-                      "modRSA" : "3072",
+                      "tcId" : 1175,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
                       "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
@@ -1717,8 +1800,8 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1176",
-                      "modRSA" : "2048",
+                      "tcId" : 1176,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
                       "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
@@ -1726,8 +1809,8 @@
                       "s" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
                     },
                     {
-                      "tcId" : "1177",
-                      "modRSA" : "3072",
+                      "tcId" : 1177,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
                       "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
@@ -1741,8 +1824,8 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1178",
-                      "modRSA" : "2048",
+                      "tcId" : 1178,
+                      "modRSA" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
                       "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
@@ -1750,8 +1833,8 @@
                       "s" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
                     },
                     {
-                      "tcId" : "1179",
-                      "modRSA" : "3072",
+                      "tcId" : 1179,
+                      "modRSA" : 3072,
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
                       "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
@@ -1767,7 +1850,7 @@
 ]]></artwork>
     </figure>
     <t>Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. 
-    These may include the public key n, the public exponent e, the private key d for each test. Note also that each test for which msg is not between 0 and n -1 should fail.</t>
+    These may include the public key n, the public exponent e, the private key d for each test. Note also that each test for which msg is not between 0 and n - 1 should fail.</t>
     </section>
 <section anchor="app-testVectlegacySigVer-ex" title="Example Test Vectors for legacySigVer JSON Objects">
 <t>The format and structure of legacySigVer Test Vector JSON Objects is identical to those for the Test Vectors for sigVer JSON Objects. </t>
@@ -1777,21 +1860,20 @@
     <artwork><![CDATA[
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1193",
+   { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentSigPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1194",
+                      "tcId" : 1194,
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
                     },
                     {
-                      "tcId" : "1195",
+                      "tcId" : 1195,
                       "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
                       "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
@@ -1803,27 +1885,26 @@
   ]
 ]]></artwork>
     </figure>
-    <t>Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key n, the public exponent e, the private key d for each test. 
-    Note also that each test for which msg is not between 0 and n -1 should fail.</t>
+    <t>Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key 'n', the public exponent 'e', the private key 'd' for each test. 
+    Note also that each test for which 'msg' is not between '0' and 'n - 1' should fail.</t>
     </section>
 <section anchor="app-testcomponentdecprimitive-ex" title="Example Test Vectors for componentDecPrimitive JSON Objects">
     <figure>
     <artwork><![CDATA[
  [
    { "acvVersion": "0.3" },
-   { "vsId": "1194",
+   { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentDecPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1196",
+                      "tcId" : 1196,
                       "msg" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc" 
                     },
                     {
-                      "tcId" : "1197",
+                      "tcId" : 1197,
                       "msg" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
                     }
                  ]
@@ -1833,8 +1914,8 @@
   ]
 ]]></artwork>
     </figure>
-    <t>Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key n, the public exponent e, the private key d for each test. 
-    Note also that each test for which msg is not between 0 and n -1 should fail.</t>
+    <t>Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key 'n', the public exponent 'e', the private key 'd' for each test. 
+    Note also that each test for which 'msg' is not between '0' and 'n - 1' should fail.</t>
     </section>
     </section>
          <section anchor="app-results-ex" title="Example Test Results JSON Objects">
@@ -1844,76 +1925,76 @@
         <artwork><![CDATA[
              [
                 { "acvVersion": "0.3" },
-                { "vsId": "1133",
+                { "vsId": 1133,
                     "testResults": [
                     {
-                      "tcId" : "1111",
+                      "tcId" : 1111,
                       "e" : "10000021",
                       "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
-                      "bitlen1" : "312",
-                      "bitlen2" : "145",
-                      "bitlen3" : "144",
-                      "bitlen4" : "338",
+                      "bitlen1" : 312,
+                      "bitlen2" : 145,
+                      "bitlen3" : 144,
+                      "bitlen4" : 338,
                       "p" : "e2ab16d3026db341223bcef7f05b61d1682da54b0e2314f8eac9652752d6aa89ad65417e2c7f7b2824555a17c8c854ecbbc44c80c10c5ba132c3992f30308459b3afaee8f00ca318cd39a478c93dc1fa13268842ce88b2d5aeacbb4ac7638db6501eed3cedca65b777e910f701207cf96a81e46c418c3fdc493c02f708b2bacb",
                       "q" : "d13c3209bbc1bfa27c96688cbb325e8ce8d609efde1cc2417a578354c7bd248fb89eca31599d6b5b0d69a832bd2fafaacf3e9c3b71484328059dff1a7af54b003fee84f64f34e31ade0689f26fbc181443b7af3d8043657ddceefc1ff3160543825de3fe8f33fce4bf5d1c10357919c31729f8c0476f6b2fb6f405c875f06609",
                       "n" : "b942fa09a727ab488f8bc2d29b89814345dc96e7df9dc7188b7be6be7dc473869c914f612f5aa6b450a17ffc07b42db7b80d2ce88be1953e80ebff92f4aa12fb7fa9b9b258f249d876d69c1976df63a362d1a820f2cff4c88ae2a5fc3b607e7d62a4e60dcd9185929fcc1c931dea94147c03adfa41bf1e72d09376e4dbebaf44df6ec492530d9eb910970f45e41107ea313dccb11567e0832674335639b136b851d19e397be3f1681c72b62bc8defae88e02fe7e67ee56191cb874a53fc115652337277d3aea969adbba4a22d3d8840844cbe48b556895d06d0c7b3cd2c9fcc9a86ec93ca00ea5916090948820fd07f0b22a42f829d9bd1fcfa044ac6a057323",
                       "d" : "6b56ee657ebf6a54b35869b02f4e21d3ef0fb479a70309b522a95d955bf966385e770bd9e321bf95eca857ab36b5084ca6f7596255d11a4a49a1547d5b4306be33ff2ec560838565b6c45c6962ff4f8c64752f615c57fbed7d8b961a2e3fad976648feee6bf1d050c812badb0639188f9ff1e0faf4739b74c31ccb7fadd5c67ff4794ef7249b94abab145351aca47f8fe8e0628b7959f91f7eb06ff7a7a7e308365522c9ddc74c62c69662a9d0ee6b4223c66a4f102f4fbd436cab8723a9f416767ab85cd28ffbf5dc60cdf7a51648f3c57ad69d6b07bb77399bbf19c21ad01a9c782951782ac8a46ed8dac939442cbb280fbdc4056e68a5a7565e69c80c849"
                     },
                     {
-                      "tcId" : "1112",
+                      "tcId" : 1112,
                       "e" : "10000021",
                       "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
-                      "bitlen1" : "320",
-                      "bitlen2" : "159",
-                      "bitlen3" : "192",
-                      "bitlen4" : "222",
+                      "bitlen1" : 320,
+                      "bitlen2" : 159,
+                      "bitlen3" : 192,
+                      "bitlen4" : 222,
                       "p" : "f0be9d5e314bb494de341ffc759c0554e717a8e7e9c18ef346463b79e8b7a89f1ecec23dd9d209094c372ac900be610918fa2e03b0239d3175030d35debd7c8b003b4c00b7e4846d6b55147ac13de75311a1166d2806bc080de2b614cbaf3c96ed07b9c5ee82432926433b23a6423f8c3c7643f069922fe09fad621b8afd6255",
                       "q" : "e5b847367ad156efa1150d871d6e628db0087a0d6294dcfe980a614969cfecbfea6bb01f5ca8c0c6dd432bfdb7bc89279257b1fb13de663be9b8a24ab72a7ebcac84338c38261c547afb4d8ff441c34988f9ddce414f3dc900f011c8920ddbc832e7356d2cb067f0b0172cdb9a409ed61f1108fab68fc461cdbd2990ae420a85",
                       "n" : "d807cebe77262cdc1a8446cbde378993069449101a7d43d7c359783a9228a877f4c67749a44a876843d9138ab961e03264fc93b87faa2c5ff78299b45037ce967c4d08dc143c87506d026c78a43a4aa17787fc09428ec83f13d46b4bcf25197d96ed8fa7685f0dba09492d78b45b0e7223bd986fe423bf8e10236bdf18a7840cd67d9620260080d5c90253cdc8fa74e1f315f5bea878e2311cb782582bc26e6bb4e71c7d8d16ab4d0265ee39a4a9e03cc065c7f45027330cc24a7c8e1e1a9a8989da9dfe807d3f04d3b6eda3e31e75b4ccb42c3fb0cfb3fa6a740e252663807e56146cb13ed4517201cb8df4256d0249139aa00daae91d172b8306b63b656829",
                       "d" : "a5fc5868f19c7644f10b81ca056953cd38fce6dbbbc29a38416b42e256ec02172977d14e3733ee01d92a83179c61bcb01264e0b3b00fe4039981518a81020d3cbbe48b862e7ad121c45551a7104d5db2a6de18d1b9009857cdce08cd5f2bcdb6292b8f45f130ee755667e3c06109c4ae2b1145e1d8f3d427d5d4059df0fad45b1805c031dcc9d37e6d85faccbb7ef8e6bbb4ec91dc9899e723a11d0eb516079b38f9d31c6ba9cbe728ae6d126240cccf13eb8188c76dd0612fb1a766bcc80d05a5c84367a8c2097e3a7f57d438da460a682e8517ad2a83ca472f5a1f2893b821c0cf0a29c7cd476af9fe2c62adeb2d3bced5fdeee547714ebe71f79adc4239"
                     },
                     {
-                      "tcId" : "1113",
+                      "tcId" : 1113,
                       "e" : "10000021",
                       "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
-                      "bitlen1" : "448",
-                      "bitlen2" : "281",
-                      "bitlen3" : "240",
-                      "bitlen4" : "469",
+                      "bitlen1" : 448,
+                      "bitlen2" : 281,
+                      "bitlen3" : 240,
+                      "bitlen4" : 469,
                       "p" : "bb1b2d20748c09339570a703237260508ada21196ee89804db6fcdc5e523e4539fc17576906eaadc801107d883cb0fbbae9c8887fd4cffaeb43c59a770a005728f145f96c38b235870f0c773c85b088e2ef9248c944fc6a1aaf85092143898e62f05542326ed20d28f4cf867e766510539fc12c73517179c191e76c5ec974480280abe044378661052ac7e15d150130db856650881cbd3c674af51fb1bf9c8e095aea0f69b3d1eed8604c36368982584525f63c6f380dae557339ed7957b9a5f",
                       "q" : "cf22d352fc42b50ac8c2cf5fcbe36461b27191c8e9273a3956d6b5595a26fffe7728fc8c4966c5fd5ddd8bd1ecfd59f0321536fe04a41f1624c11272c40b4485361b52ab36119c0fa7bd73e499aefb62bf97a7254680c33c2c893e84e7a70310b9868ab1b968a25ef9e4e9ec7b4e11d7231921f04fe771ec2e4d992349f4db216e17b094d1443ada72a15f3a54342864670dcc880672214196e6aee9c9d3112c0241393b9bcc71538547c54c6269802fa4f827fffc44fdd31f8de74db3e34995",
                       "n" : "97646d8d49d26c3e5ceb9ef2b16ffc40b3f7f980cc99a9da1b3e94626a39c343c2d13108f05b3c33f8597ffe2574e8e8f31b892d60767fe93a58c24fb371a23bb2f6b69fc0ffb1b1e1b914f45530dd81b1436665294f39e8db0d4f30a0161d66926cec89f419ce58bd98abc0628adda5c3519789102813de712adbdef5dd1700e92087ece582b78c95c2954955283c5ec9d9c467d5357091428a3ad3804568f513cfc6fbb4c7a66ff29a4e7acb7e354565cf400a4d650ca703f468a30a990756e800d2e8c593f4ecbbe27d64821389bd40fd1b4f597ecf56703d4ce40b1acc62b733e6808b2d82ce572ec1a9fe296e9364d46ea317790b6faf553d8d3d7efbf372e0eb71e435fb5049e475388c52e2fa17ac976ac411ecb1a7a9983c3c069c9454006f5f60892cea95c32cd512692fe94f56af8bd89212b0618b519669a9c50cd8c6300790f687f0379a42e3442ecd1cf06693416e1bd692ce306b2602d7946867ac824cf9041c48642239b8895582c402687bb8361ef2fd15d20e378f32f04b",
                       "d" : "43f10b697929aee4aebeed949a829ed4a816927f2b1ba427e4305ac7e61ac923f9cea977dbc7b1c9759cc327d48a8205cd04e9357d9c1c83be78461f04e0a6d8e4243320e53ba638a94bc74bc130b7fc9fdca9c6c06c2c78b1c6e6727891117129de8642f4b2e633c5e5c1c7f2d04b315d7869dc29bd7e05ad55348ef3519451e66af3fbcaa396f93ffe357649e87cf1039a9e31d07cf08d0b8c305d40eb1880fe7d7fa84a6658ae3776dd1557fbdab1306b4aa305071ffeaa8548a6f25e32442c292a0acfb095d8aa591894d5bd2d3d349219ff9ec008730065a46301972fced0754e519234da6fbe84e63690dfc0ad860b644f79c091d8e0cfd1ec570f66689f3e0d78ae2c2129db1d30250149e4838be51441cd30e01157374181e6a8cf7b5a62392598db88330e4e386dc2a312c428016a9d076d3b1066b2538799fd21bfa29ff74c978104a500d4953277748cf637aab62423325e38be21118c0dfa9c68a4391eb65ee0b7226dd2ddbc6d64387acef2f29ea42b198aff6bfca3930f93d5"
                     },
                     {
-                      "tcId" : "1114",
+                      "tcId" : 1114,
                       "e" : "10000021",
                       "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
-                      "bitlen1" : "504",
-                      "bitlen2" : "238",
-                      "bitlen3" : "440",
-                      "bitlen4" : "185",
+                      "bitlen1" : 504,
+                      "bitlen2" : 238,
+                      "bitlen3" : 440,
+                      "bitlen4" : 185,
                       "p" : "b6bbf5a62930f4a89153ff826347d7b49339a5af07d29fbb4120847c914f4a09c98c95070c70c5498520a2e799138cdaaca5c2fe1cd8ef6da799b26af0ac9785bbc790e6b52c32389ef26afd447cc05baf8e6c628832772bce91eb120309332aa8735ce7eb34c640863bb7efc59f70a3d3038359d57b8ba5b009ff7b119aa0c2db32a1edbac51f4bddc1c4dbd3f70e83d43b07c23a4d3859a91f51014e6aec589693e66928c20467fe3c568298b43cb98d8b0f2a7504c19b01759bd4de5c4fad",
                       "q" : "c263d13aded6645ee10683efc4d216e6b51314684c7f3b84cbd59988c14134fd8327d5ee1b436cce2f8648a260f5fda5f9494dd2275ae475676439741aac62587fc2de745b68eb46c59eeee00cbf05f3d911752ba9223e5a0b88390023e79a60d94604b82ac6a51df27699c4b6672e17be555af0673bc2a5573c32ada7158272e08e02efd00d18932cdbd518b4e969b766fefd3f380f31f2180d55dbcbe55b3e6ffb755e07b03800537734c37e8644e66fe64cc7465a9a570e1ec03775cad1fb",
                       "n" : "8ac1b03163ab5e673e5ebfa0328b694a322da0819fd97f7be54f94b805f58a8a2f7ff4e273c98440ba862e7959658ee1c0876a19232bbd4f85c9f20ebb92d031269cf19f0dd46ba28759a452678be7b9c35efb788f3739183b512a56e781bb6a9d42534399b8795e63705c01a742ede7862d6670ca02a02e5c117ac0a6548035be5cfad0da0174c1872d3da8523b3efbf98115d168e74bb4f327661131753593f45550edfda6486dd4dbf870e50367ca1c39e446f3be3b50f197f5f4b3137e950350542e3688330a4e6fd607286f57f5771255ef9f3816658c2ce981132b0303ad34c21208f3c15846f21dbb77daddd4adf5ddcc6d1b828a5a5a6f3c4f85a42f1b51085d2d913e1d105d5565c029efd80d2f8c42701f6e7d51e8bab650c03a98bad191e3f6508d42aff30e6db1ca81228bf044d13eff53bcf6d688b73a423503a8e36808b61ecf499df708c06aae3b441257d154bb5c483bb52f3b0990e47b06b6efdcaa73fb29de1897df0cf8ffb915a35e36ed1011a8a97ffd16ab51105b9f",
                       "d" : "cf02aaaca392f5d21e80ac8e954ccc3eb738155b9ca03d96c1c7506b6593e97954e0b97eed739e6cd0eff08fe66e1584926d8d6ab9d6c686f99f758fec24627071a0f9164096b93c2693e296d2707f392ada019d010459b0783918f8f104423e2dfdcd418194144bde4b9fbbc766dc892bf9154803d41e8a295e2fd280592e4388dd78d792f96654da3268421553fa101f5e334b5149a6bd6857705ae9b5fbe4f80f2334fffec4a168a63c47d927d54e33571590f4450e005adb54c4a290f52141a7a502007a3508c6fad932f04e5b469cbab7228f69c34e89b5b4e7378fc82a9f1dd2132bceceb447dfd8a14679dd9df39194e4190b6d5fa79e2abe140abc4cc6cd428ed04c1bdb14cf51bd9133119138b1cee3bb1649bedb2e86c810010006e611237a901e3e404ca78c551253979c587a92440e11c2b742e87bea09a93fa2b1ed6cbf66907d3005a572b20055cc4870bce35d78b51f7b22ba37ff7f8af05dc2d0d6c743d95ac0a5e0eabf5be061991bb2fb505555589c5c5a0cd3b575d15"
                     },
                     {
-                      "tcId" : "1115",
+                      "tcId" : 1115,
                       "e" : "10000021",
                       "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
-                      "bitlen1" : "232",
+                      "bitlen1" : 232,
                       "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
                       "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
-                      "bitlen2" : "220",
+                      "bitlen2" : 220,
                       "p2" : "baf57f053b1f2a46705d9be799f90f28b800de871d88c95f24bf659",
                       "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
                       "p" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc4cf9e8d26cbe4b9def67b97305763aa17c09c8a939dddcef9fe0cc7773acbb3ef9beff7812132f7d432f9c77af59e95c7613c4cd47cd27a64463",
                       "primeSeedQ1" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc373fa",
-                      "bitlen3" : "336",
+                      "bitlen3" : 336,
                       "q1" : "bfbf1abfc1fb9b7e21342139053e7b05f56e664594419bbdcb14bb959ab66cf10e99a0d38f560a22cb33",
                       "primeSeedQ2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37484",
-                      "bitlen4" : "141",
+                      "bitlen4" : 141,
                       "q2" : "15e35869eb4f8dac49e317f09e3be3627c1d",
                       "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291",
                       "q" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910c7ad06973390b608cd2d39873222bff814db1a2c65797b58317226476d98846ec8037d4ca98f92afaa2fde97a6d0d53d4d17aec025d5933286c07b9ea7",
@@ -1921,21 +2002,21 @@
                       "d" : "bec8baec7da0634211ed76b770d9ef0834cfc689cb2a6d1c04a9c14d9ab249ebf5711147dde7a0120b521d8a0a2ba62fcedd767a8abde768e6bf1d12d5e88fd7f1a11d44684f6239512f976366236e270d39801eae4cab9109dc1746ffca0d868049551b7e27caa57d32ba0235dc8bf68a3955d562a283d31ac5f23342757e7918d85ffb654789ee39638543dbe76dea9ddbae3bb12c411b509923c101035ce53c7b642047bc91e3cbedb3f945f0cae1edad5a2c600db921722b4655742f8c10650cd1c868050d26c0caefff2dabf02a9841f1dff07e0094485e8965b06fd4ffb024a1d9a13ac241be9a2db0bcbfd656edcc5d1c945857a8ec3cd281d61f715"
                     },
                     {
-                      "tcId" : "1116",
+                      "tcId" : 1116,
                      "e" : "10000021",
                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
-                     "bitlen1" : "272",
+                     "bitlen1" : 272,
                      "p1" : "e43dc77ad0bbe2090a7d99a490f0b37188603691ebd453ef987e8358eee34be2def9",
                      "primeSeedP2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805cf1",
-                     "bitlen2" : "205",
+                     "bitlen2" : 205,
                      "p2" : "18dd5b6a27ca680f10764a0e2f49ffd384b650948aa6ba175f07",
                      "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
                      "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
                      "primeSeedQ1" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805e76",
-                     "bitlen3" : "296",
+                     "bitlen3" : 296,
                      "q1" : "bd76411ab7c1edb6873e76e5edc7b920b75cf8e2e1152010e6c34df592f8c3cd948212ca05",
                      "primeSeedQ2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805f9c",
-                     "bitlen4" : "157",
+                     "bitlen4" : 157,
                      "q2" : "123e72d9c914cde1b11d233a985f37f0769d2227",
                      "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
                      "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
@@ -1943,21 +2024,21 @@
                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
-                      "tcId" : "1117",
+                      "tcId" : 1117,
                       "e" : "10000021",
                       "seed" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddbbc",
-                      "bitlen1" : "512",
+                      "bitlen1" : 512,
                       "p1" : "e50610fd8a3b4f132e5c8d5904e0995b4e3782fa606593f1a80c4284920df7f14d310fab60d78bf97d2ad51472f2dc784e14f2f49734cc06ed299ecfd4764f51",
                       "primeSeedP2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddc59",
-                      "bitlen2" : "196",
+                      "bitlen2" : 196,
                       "p2" : "f974675ade75f0e11d66247a498fda86ec29e0c3a84052bbb",
                       "xP" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e306705e39d2b621027353b4873898b36b3fe86ab203dee10260058ce77f13d315ea1dcc0b717ffe906bfb05f251f3e9d678c585917176e127ece648c788f28b05607d4f71e113842e289b0de45bed72b7e591ea55ae5750ebe86a8",
                       "p" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e3092a9dfd7697a29e1c6952f0d71a7381d0bd64c4ac6102f54ae43b21f7d399583f86f6192717188b913ed16c1422d5fe5df0a407b1de9a05e178e4f47cdb3532866e2fcf36e57616f3473c5c967fa6703847d90ddfe0b822f24e9",
                       "primeSeedQ1" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddceb",
-                      "bitlen3" : "560",
+                      "bitlen3" : 560,
                       "q1" : "d2953e01641afc5d46b849c9c2568e6377e70c143ad23fc70d96b5c5b1528ba954a19e9905a235af27c4f2278fef63e112af66ed4ad84c595a6f84207f23e2a0c0b4d652a14b",
                       "primeSeedQ2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddef5",
-                      "bitlen4" : "180",
+                      "bitlen4" : 180,
                       "q2" : "c0f968cbe23b282c7f5516b3b59d13713fc04c8405473",
                       "xQ" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2dc5e9fe2c0077b65c79cb98bd4d7fced17121010598bbf410f3dd755df986b877e51058ef80649b486100c0d6eddf0825c69af34e3beace6e2810da3366c6f11520fd65b5ad7fbc7d33fa63a91f5ebb93b3d4b042478754ce89129e44add",
                       "q" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2f82363823d9c7bb2f1f4e19cee9d524d96f478637e8a5054c34fbf73483134a40034a75c72d30ee9499ff2e899da5ff65733155eb0ad9217e7ca2c57af22b12991882ab7fa7ea6d8a5f60ae7a71842a4b286d618374f496efd642ffcaa0f",
@@ -1965,21 +2046,21 @@
                       "d" : "4abd536c3f299e3c7365e496caedc45561ddc2a97d2d52f8c9e3eb1e7be52117e952ad9ee9768df7380ed09750d6c9bedf7d5da8ebe36046cb17f16e4f7cd88ced6279cceda200b17faa16b77000b53360c9e50bd5da91329a309bf422c716b7127b7331163987810ad08ca15b0580a97fe63bec434c72213f8527d939b02b60bd0902e97da8068d81354eedfa5d62067201a2b5b64c021022becda98b175bb57f4216211f22f11b28b5ce0021e87361e5c0f4e363f8f15123b1e7eb76cea6ecd065549925425f68fc80c8846d399205edbdf417d6554bb3eeaa58ef0e68be51a447c80438dcdff548203813d13e50f792e2aa106537d39198fde0a305446dfaf16de93e670600ce20a48ddb16ae196c43b4d1049c7c1c130c510b780e37591bee3bcf6c3d716f9acd305f81ab54675c95b7bef042f4c11ecae895d18c4fe1a986410e947b150deba89cf123fe11874304ae8922b61cae5c6b298cf20ea65cce98e94cb4849c85b813de46554ad6e0f0f844b679060855c02ae69b1806e55e21"
                     },
                     {
-                      "tcId" : "1118",
+                      "tcId" : 1118,
                       "e" : "10000021",
                       "seed" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b6e7",
-                      "bitlen1" : "512",
+                      "bitlen1" : 512,
                       "p1" : "a70dd2581283defd4b5689c942752af1eb31864fbe0c0894d434cff28ca5d5321505cb537675f2e9efbe3c05e5daf5ea63eb824d2fd9c43d5eeb6d3041a07e05",
                       "primeSeedP2" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b8f0",
-                      "bitlen2" : "182",
+                      "bitlen2" : 182,
                       "p2" : "28b81c23443dde1d774cd365ba50bd382677f8601bdb0f",
                       "xP" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f16221154aa62d139a67fb09edb0e6dcb091683e4136333b1cc7e9c2b09a8a06a335fd6f318532a068b9fd353ae12a1b57f9da498c6488ce863eb0a115af3ec15f70d4d78f030882a18bc14074a42daf322d2dd4b672c947fa21",
                       "p" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f162af6cd818f341cf0f652191e2debdf53eba1ada0b519eb3148708a9a0b36ac4087f7d3c446003111bc8c0db7bee01618f33432d81e3c7cca97e0733c88749f1ebe5e1edad984ecf3bc54651809fb0c5b4eaa45f12fb1155b1",
                       "primeSeedQ1" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b95e",
-                      "bitlen3" : "504",
+                      "bitlen3" : 504,
                       "q1" : "ec4ddb031e55ee7c840c3747782aa76ce88bd881a87b5877ccb664a25d0f3a60946383b612b69880c17b0e4b0b1171fe33eba748c01a51ed1cd63e162d24c9",
                       "primeSeedQ2" : "7da214c48281d4647edc13973594780a0e6ddfa089d730e47e9e4dd53a85b9da",
-                      "bitlen4" : "222",
+                      "bitlen4" : 222,
                       "q2" : "27b8373572544b1c79e79ba514a2a743ce60497fbfd56b522a26e327",
                       "xQ" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590d63fbdfb010f463a379e8a78e50ed95ce5c8fa3946970839492654ed0b70b3573354b2937cba400ced3fb1d8b5adfedcf0281fe13ca8b4348d18129afcf68f2bc27210e650d9434b344e2bf942fa03fdc50e4200014753afb998d15d8",
                       "q" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590fb74e9213473b3095212d37b0d1e20f93f260bd4ca1937b5eb936451eea0bd93274727a7ebaf6bdce546f0212c6c164eb30d7e139358bd71b16a6e26e6798c0ffbb9769d64a0e7de187b93b3cd102b56123d6a744c8fb3e88b07b62d9",
@@ -1987,20 +2068,20 @@
                       "d" : "f5931b10bdb7e1c3dacdee6a16a951420423cebcd3d0465edb82663895892780f3a3fd25a6fb04e58cc566c8642cf3e86a1d406ef151e468d44b99f7827560aa68edcbb6fc52129fbf08cb448e15e9b50495e87d32557dad8cde1f5f3a2882131a3b94acc231850feee3533552c7efcc773d5943db12f06ec781923345ae0403f53420b093b7df9128176984b43022733bcd377076372b3d450f7e5542ae4984c852343edbf566af7d72a5fd66779d2e84c23f9a62d4af26cb0f634373b061ebc0f32d50fabc87450af7ada7eba7ea454c16da4958edee2916f30b809f58e10651fe4c4c494105b7da2b0dcd0dec0bf5e5ec81207aae8be43edbc9936b3e12f95a78185dab006ba41d4bbc5c1712664c91dd0875a8694697449f058ea070d24f1300adc95ef81928af0bf716fd204a33fc3b1e0cd662147a467d49d26d24bb523de98c7de6548a82c559e5ecba493c6b2bce2c20686fbf73ca8f10965f0cf0f2a773a269df48e8c514da5a3b77b55f86ecc1179f86dcb9ca1847598a4f8da1"
                     },
                     {
-                      "tcId" : "1135",
+                      "tcId" : 1135,
                       "e" : "10000021",
-                      "bitlen1" : "224",
+                      "bitlen1" : 224,
                       "xP1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d811",
                       "p1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d839",
-                      "bitlen2" : "195",
+                      "bitlen2" : 195,
                       "xP2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f0f",
                       "p2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f45",
                       "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
                       "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
-                      "bitlen3" : "352",
+                      "bitlen3" : 352,
                       "xQ1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd810093026606fd",
                       "q1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd81009302660959",
-                      "bitlen4" : "142",
+                      "bitlen4" : 142,
                       "xQ2" : "20b8c2bae262b13e912094c937c4e8cfa573",
                       "q2" : "20b8c2bae262b13e912094c937c4e8cfa59f",
                       "xQ" : "fa97b510539a102879a78e8ac21b9840468ca6a2e2f16ab4a0f596cd1b36b3cc0d2cffa06173586b21af25b62b3bd9698c3644da4b4e399aed5c7e1cc97d7c2eb2e7b886e93f99a4bc98d47c07ee5ea995593e5e588a576add3db762b1d6f9de5c79ba02e96cf38bb5ac3c3fbb02f5e4462f4d26881854083630a769394bd57e",
@@ -2009,20 +2090,20 @@
                       "d" : "166bed3734b922f074460a0ae1a8fab231668de4a10daa969805338e6e738e9af173e2a5b0cb1cf132c40a0523dea617228cb7ec33779e86d91696a03218d1ee955f05fe9665d6416cca97600f89d30eed460a5638101137bb7e26a3f01ce9724e9570d372c593e6ff837b6eaabb0fc7698cb952a6122ba59f945d4e9b99a00b84dd150ecaa54ed35c280dc046b4af027beaec005a9768d23b38676d2a9d73e3b9c923d30c7e9ae8686815dda971de42fbf96872781231140d04e659c50a9e86bbd4cd9f5f5aa2df5e5e2ff7aa82ecebacb89a9931fa022a0982c42a304a0fad7e5da407be9e9b225664147a6837a05c43d704f4903a7a20f67a360bee822e21"
                     },
                     {
-                      "tcId" : "1137",
+                      "tcId" : 1137,
                       "e" : "10000021",
-                      "bitlen1" : "320",
+                      "bitlen1" : 320,
                       "xP1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077677",
                       "p1" : "b95de5dee2eb96d9e4a5e6a87d0630c0439febc21cfdd9c6f973b8f7501a1919211d120fea077719",
-                      "bitlen2" : "315",
+                      "bitlen2" : 315,
                       "xP2" : "658ab200f20d118be4d915d5791f6397ee0ee2134b2460b1e10dce4911756eebd8cba8fc9763963",
                       "p2" : "658ab200f20d118be4d915d5791f6397ee0ee2134b2460b1e10dce4911756eebd8cba8fc976397d",
                       "xP" : "f007605f1bce4e4aff719cfe996315182cb858119e93e98e9a37ce08b4bbd725c0e3589374505e3fbe9f4831efab23713440d8a18179efe14ea5202e4797b997f3f062ff22af5f43bf2de896071965c4ddfb18074c07f96eaedaf8cf47b145eafd92583b3d33e9964f1cc000fd1688c33d1e63ec7cf20462fefa938100ef700fffb2417157607dda0f03a56c4dabdcab275b9ee4ba71a5936e8f1526708bf7dca446702bcdfeb6249bd701e8838f3a896c058f5cf3a3096543064eba0122e578",
                       "p" : "f007605f1bce4e4aff719cfe996315182cb858119e93e98e9a37ce08b4bbd725c0e3589374505e3fbe9f4831efab23713440d8a18179efe14ea5202e4797b997f3f062ff22af5f43bf2de896071965c4ddfb18074c07f96eaedaf8cf47b145eafd92583b3d33e9964f1cc000fd1688faa69707469eb820a29ea2e81ca882ba8f6084b37de51b2cf276adea9d35d6147b112d5d896228e1c614f7339e7e4a49f28195ded4d8943febca86e94cee78a9168e215e8409eb74b1d673847747ae4615",
-                      "bitlen3" : "320",
+                      "bitlen3" : 320,
                       "xQ1" : "f21ebb87473fdcff5f7a4fe439027a6c1853cd94a3b7209d1fdb3208c20f2625f9ae12e13ae9ee45",
                       "q1" : "f21ebb87473fdcff5f7a4fe439027a6c1853cd94a3b7209d1fdb3208c20f2625f9ae12e13ae9efb3",
-                      "bitlen4" : "277",
+                      "bitlen4" : 277,
                       "xQ2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8bf9",
                       "q2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8c89",
                       "xQ" : "e695e1de6811c9872ba9017fdde9a87969022882a295320cecd39f9a9bebae1e9edc0e42ff78cd17d05c58a93ec75ec09c3a75a8db24a19b073314f9d857fc43523291c58b23065660987ea793755ff238ffa5adfbd9ac26b53c6af016ebe9b646963ac139fa81b41534a0851a7e54ce3fe84af212452440f235701ec2dfd6b1b4980a67745b0144aed587ad04a692c86c0956bff44e263194efc4a26a7ef66dc056bc038d8d0aee995d8f71a3a68c4d2bc83042b96736663d1c34b13776b223",
@@ -2031,7 +2112,7 @@
                       "d" : "8c377a2f9817c497507f74c2d4d37c2093e5a204fe0bc04299c0337af153bf86022c2ad9f88d156b67263d21e0fff1fce1cf8e9affbf52bd83e33f38d7223b6aae31667b029188d939453b5cff019c1fc6ed87296f7897c2b3328bb888e1dd3b082e5b11272f7f8fc62473d701b35b342e4ac4f757c4b17924912dba913f17800f2a5dec389436b8d7288e6c44035d2aad9bba5bd1cfb8550fc3bdfd01c317ec222ea6f0cb90342367fdaa5b61513cdc3bea7a12bb44f1f07811a2c193b99615e89627164482248f474e89985ac1655df1054d93ec91f93b08c5ef077fad256cd042ac375cd536837b65489d62833c48fff221cb1092509e82fea082f0022151dbd9d2104314d10cef26fd4ea710898f42f956be2aa46756e5c436174e181f95e54ac8b6477baa5a32044678b3686d16df88e457bda4e0dddd94a24dbdb3ced4827392780cc96287fd6a46e82a5fb1daa0d372953c06ff6c2e1236926e0c11a367218a4291e6288e5cd1be03408770c5a667da57652eb46a9367369f732eb41"
                     },
                     {
-                      "tcId" : "1145",
+                      "tcId" : 1145,
                       "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
                       "e" : "10000021",
                       "p" : "f3ec667fe3c697769f89db44c48926f05285933f351ac5821458ea3414a1c62cf581e6cb702adc0323d7b86f6f013b471e24e4b25bbe731ecd023157a03656fb9a16fb7f6fcfa65020900822e8ce03bd967e38efd546ea30706698c7fa6d0f9e0316fe65d3195310e9baaaebcdd85e4a260341a90dd2c884f6e269e10647a2e9",
@@ -2040,7 +2121,7 @@
                       "d" : "8a19a9956ae2ccec6ca4fc0a5e56ab691c94b710dd668c00534bca4f5af84a568fee1bbbf36185747d11deac96faf66d13c08d97acfd29025d044630fdb2824c9435d8fa6ab7b6a349bf98ee86f5d1a7d6cf3956b43593c9a7b379fedcf2b78b1d4bcca082f0a9bbfeaa2a982a0cf16a1e812816bb9ede15edba51ffae5b65359e49b3c2e755fe32399614a35d45dd525709ae323b2828668be67c0c364d59925617f9583d399096d9f9cf085e29d011c78dc857e24376ebeeba688d72a2fbb1f8f09e92e7e606ff787fc9b395f6cac20c3ccb251bac325afdf1c3dbe75fce59753c7005bfd86957ba72172dc5a43b6192121e3cb97d0c43b9b63952bbe0d91"
                     },
                     {
-                      "tcId" : "1147",
+                      "tcId" : 1147,
                       "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
                       "e" : "10000021",
                       "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
@@ -2049,64 +2130,64 @@
                       "d" : "79815d367f924ba3509d3d4870cc729a82dc6dfb001e551baac15ff2ed77efdc6a00e628f29aabe062b5226a2e2689d26c82e8021958eda5fe0581f3bad0479942ec03bee965d79204c822d6c4e5cb82814419acd38a8779afae03b4a95ded204198bc2d68ee124cb5d2cbc68bc3621450168f55a9b9f2787b1cafb0328ceb9c0bc4e81d23bc155af9a172b18dac8f493f6753571b2f13cf56d7d93ac9d191dbfb7a2b6c6e795c2387722ee48d9bbf8fabd0fe58b3502a6a3173901057ae04bdd1f69cea58c38f9ac88c90427d8d3c60afd50dea9d98b669f8a052c7c26415885d70df8eb36fabd5d9fcde1a9cea5c4118f16af672fadb56f43e2fedf3b33ab4c0d6763b497d73164b778a1638af9c8e87e71cf64ed368c978179a2d7bfb2086ce8fd1ab6f3263603a71d0dc70fa5c56c6c0f233447bf4c93fb03c8e85ddbb204142e4414f0a1f35746c7f106931e25a1fe6a5f865b93d679ccd7742519b29803ed34ca40321c7e38fdeeed68195860b8157f14365a587ca58e1c5c7c46c9c1"
                     },
                     {
-                      "tcId" : "1119",
+                      "tcId" : 1119,
                       "primeResult" : "prime"
                     },
                    {
-                      "tcId" : "1120",
+                      "tcId" : 1120,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1121",
+                      "tcId" : 1121,
                        "primeResult" : "prime"
                    },
                    {
-                      "tcId" : "1122",
+                      "tcId" : 1122,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1123",
+                      "tcId" : 1123,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1124",
+                      "tcId" : 1124,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1125",
+                      "tcId" : 1125,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1126",
+                      "tcId" : 1126,
                       "primeResult" : "composite"
                    },
                    {
-                      "tcId" : "1129",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df28ab",
+                      "tcId" : 1129,
+                      "e" : "df28ab",
                       "p" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "q" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275",
                       "n" : "cf91c0065d8e5797f0d1b1b3f4c31ac3d5e83d4be67ada7625b4b3a80fd24eda86c88b88c7fc4b2c60e311215abf8abc34e21c047035a93bbcb43387c6a44c7149c278ae27488ddc09ce56eacc7fbd437de9699d660b1dba4923ba60c9bb1fc69b7c90468ace5b7715d5d385c02e59f525ea01625c5c61760d8b23b962b7c80d14e6d58064a6064749ffdd260b0a8b0b2ffb846a6586e375a04163b61fb0af71dddf56e65478ae2101f30dc37a3f035f10ff86f53ac2e073b3a5b5f7017c6e6704b23e83c357aa171b23c49ff4d3820a03229a1962bf2e6b90acf79570f269e679292255755ad6362129870460c00799c5179e27a3b5182ee07c6ba07420e205",
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "tcId" : "1130",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e66d81",
+                    "tcId" : 1130,
+                      "e" : "e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
                       "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
                       "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
                    },
                    {
-                      "tcId" : "1131",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1131,
+                      "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   },
                   {
-                      "tcId" : "1132",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000535c97",
+                      "tcId" : 1132,
+                      "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
@@ -2124,18 +2205,18 @@
         <artwork><![CDATA[
              [
                   { "acvVersion": "0.3" },
-                  { "vsId": "1163",
+                  { "vsId": 1163,
                     "testResults": [
                     {
-                      "tcId" : "1165",
+                      "tcId" : 1165,
                       "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f3e7af",
+                      "e" : "f3e7af",
                       "s" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
                     }
                     {
-                      "tcId" : "1166",
+                      "tcId" : 1166,
                       "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
-                      "e" : "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ebda09",
+                      "e" : "ebda09",
                       "s" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
                     }
                  ]
@@ -2145,13 +2226,13 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1167",
+                      "tcId" : 1167,
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "s" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
                     }
                     {
-                      "tcId" : "1168",
+                      "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
                       "s" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
@@ -2163,13 +2244,13 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1169",
+                      "tcId" : 1169,
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "s" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
                     }
                     {
-                      "tcId" : "1170",
+                      "tcId" : 1170,
                       "e" : "1415a7",
                       "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
                       "s" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
@@ -2186,7 +2267,7 @@
         <artwork><![CDATA[
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1173",
+    { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
@@ -2194,11 +2275,11 @@
                  "sigType" : "X9.31",
                  "tests" : [
                     {
-                      "tcId" : "1174",
+                      "tcId" : 1174,
                       "sigResult" : "fail"
                     },
                     {
-                      "tcId" : "1175",
+                      "tcId" : 1175,
                       "sigResult" : "fail"
                     }
                  ]
@@ -2208,11 +2289,11 @@
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
-                      "tcId" : "1176",
+                      "tcId" : 1176,
                       "sigResult" : "pass"
                     },
                     {
-                      "tcId" : "1177",
+                      "tcId" : 1177,
                       "sigResult" : "fail"
                     }
                  ]
@@ -2222,11 +2303,11 @@
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
-                      "tcId" : "1178",
+                      "tcId" : 1178,
                       "sigResult" : "fail"
                     },
                     {
-                      "tcId" : "1179",
+                      "tcId" : 1179,
                       "sigResult" : "fail"
                     }
                  ]
@@ -2246,21 +2327,19 @@
         <artwork><![CDATA[
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1193",
+    { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentSigPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1194",
+                      "tcId" : 1194,
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "tcId" : "1195",
-                      "sigResult" : "fail",
-                      "reason" : "msg larger than modulus size"
+                      "tcId" : 1195,
+                      "sigResult" : "fail"
                     }
                  ]
              }
@@ -2276,24 +2355,22 @@
         <artwork><![CDATA[
  [
     { "acvVersion": "0.3" },
-    { "vsId": "1194",
+    { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "componentDecPrimitive",
-                 "modRSA" : "2048",
                  "tests" : [
                     {
-                      "tcId" : "1196",
-                      "e" : "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010001",
+                      "tcId" : 1196,
+                      "e" : "010001",
                       "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
                       "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
                       "s" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
                     },
                     {
-                      "tcId" : "1197",
-                      "sigResult" : "fail",
-                      "reason" : "msg larger than modulus size"
+                      "tcId" : 1197,
+                      "sigResult" : "fail"
                     }
                  ]
              }


### PR DESCRIPTION
Cleans up RSA spec. Focused on KeyGen. Any changes to SigGen/Ver would be moving hash functions out of the test cases and up to the test group. As well, any strings of integers ("123") were changed to just integers (123). 