### PR TITLE
RSA Mode Fixes

### DIFF
--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -681,7 +681,7 @@
       <td class="left">algorithm</td>
       <td class="left">The RSA algorithm to be validated</td>
       <td class="left">value</td>
-      <td class="left">"RSA"</td>
+      <td class="left">"RSA-KeyGen", "RSA-SigGen", "RSA-SigVer"</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -996,9 +996,9 @@
   <tbody>
     <tr>
       <td class="left">mode</td>
-      <td class="left">The mode to be validated</td>
+      <td class="left">Key Generation mode to be validated. Random P and Q primes generated as (see <a href="#FIPS186-4">[FIPS186-4]</a>): provable primes (Appendix B.3.2); probable primes (Appendix B.3.3); provable primes with conditions (Appendix B.3.4); provable/probable primes with conditions (Appendix B.3.5); probable primes with conditions (Appendix B.3.6)</td>
       <td class="left">value</td>
-      <td class="left">"keyGen", see <a href="#algs_table">Table 1</a></td>
+      <td class="left">"B.3.2", "B.3.3", "B.3.4", "B.3.5", "B.3.6"</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1041,20 +1041,6 @@
       <td class="left">Supports random public key exponent e</td>
       <td class="left">value</td>
       <td class="left">true or false</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">randPQ</td>
-      <td class="left">Random P and Q primes generated as (see <a href="#FIPS186-4">[FIPS186-4]</a>): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</td>
-      <td class="left">value</td>
-      <td class="left">{1, 2, 3, 4, 5}</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1362,7 +1348,7 @@
     </tr>
     <tr>
       <td class="left">algorithm</td>
-      <td class="left">The RSA algorithm used for the test vectors.  See <a href="#supported_algs">Section 2.1</a> for possible values.</td>
+      <td class="left">The RSA algorithm used for the test vectors.  "RSA-KeyGen", "RSA-SigGen", or "RSA-SigVer".</td>
       <td class="left">value</td>
     </tr>
     <tr>
@@ -1394,21 +1380,9 @@
   <tbody>
     <tr>
       <td class="left">mode</td>
-      <td class="left">The RSA algorithm mode used for the test vectors.  See <a href="#supported_algs">Section 2.1</a> for possible values.</td>
+      <td class="left">The Key Gen method, or Sig Type.</td>
       <td class="left">value</td>
       <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">randPQ</td>
-      <td class="left">RSA prime generation method - see <a href="#keyGen_table">Table 7</a></td>
-      <td class="left">value</td>
-      <td class="left">Yes</td>
     </tr>
     <tr>
       <td class="left"/>
@@ -1455,7 +1429,7 @@
     <tr>
       <td class="left">pubExp</td>
       <td class="left">Fixed or random public exponent</td>
-      <td class="left">hex value or "random"</td>
+      <td class="left">"fixed" or "random"</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1463,12 +1437,6 @@
       <td class="left"/>
       <td class="left"/>
       <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">sigType</td>
-      <td class="left">The type of digital signature algorithm - see  <a href="#sigGenRSAMod">Table 8</a></td>
-      <td class="left">value</td>
-      <td class="left">Yes</td>
     </tr>
   </tbody>
 </table>

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -266,14 +266,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    object.  The following JSON values are used for RSA algorithm
    capabilities:
 
-   +-------------------+-----------+------------+------------+---------+
-   | JSON Value        | Descripti | JSON type  | Valid      | Optiona |
-   |                   | on        |            | Values     | l       |
-   +-------------------+-----------+------------+------------+---------+
-   | algorithm         | The RSA   | value      | "RSA"      | No      |
-   |                   | algorithm |            |            |         |
-   |                   | to be     |            |            |         |
-   |                   | validated |            |            |         |
+   +------------------+-----------+------------+-------------+---------+
+   | JSON Value       | Descripti | JSON type  | Valid       | Optiona |
+   |                  | on        |            | Values      | l       |
+   +------------------+-----------+------------+-------------+---------+
+   | algorithm        | The RSA   | value      | "RSA-       | No      |
+   |                  | algorithm |            | KeyGen",    |         |
+   |                  | to be     |            | "RSA-       |         |
+   |                  | validated |            | SigGen",    |         |
 
 
 
@@ -282,53 +282,53 @@ Vassilev                Expires November 2, 2017                [Page 5]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |                   |           |            |            |         |
-   | infoGeneratedBySe | This flag | value      | true or    | Yes     |
-   | rver              | indicates |            | false      |         |
-   |                   | that the  |            |            |         |
-   |                   | server is |            |            |         |
-   |                   | responsib |            |            |         |
-   |                   | le for ge |            |            |         |
-   |                   | nerating  |            |            |         |
-   |                   | inputs    |            |            |         |
-   |                   | for Key G |            |            |         |
-   |                   | eneration |            |            |         |
-   |                   | tests     |            |            |         |
-   |                   |           |            |            |         |
-   | prereqVals        | The prere | array of p | array      | No      |
-   |                   | quisite   | rereqAlgVa |            |         |
-   |                   | algorithm | l objects  |            |         |
-   |                   | validatio | - see      |            |         |
-   |                   | ns        | Section    |            |         |
-   |                   |           | 2.2        |            |         |
-   |                   |           |            |            |         |
-   | capSpecs          | The capab | an array   | array      | No      |
-   |                   | ilities   | of objects |            |         |
-   |                   | of a part | specific   |            |         |
-   |                   | icular    | to the     |            |         |
-   |                   | RSA mode  | mode being |            |         |
-   |                   |           | specified  |            |         |
-   |                   |           |            |            |         |
-   | modeSpecs         | The RSA   | an object  | object     | No      |
-   |                   | mode and  | with       |            |         |
-   |                   | its capab | "mode" and |            |         |
-   |                   | ilities   | "capSpecs" |            |         |
-   |                   |           | properties |            |         |
-   |                   |           |            |            |         |
-   | algSpecs          | Array of  | array of   | See Table  | No      |
-   |                   | modeSpecs | modeSpecs  | 1 and      |         |
-   |                   |           | objects,   | Section    |         |
-   |                   |           | each       | 2.4        |         |
-   |                   |           | identified |            |         |
-   |                   |           | uniquely   |            |         |
-   |                   |           | by the     |            |         |
-   |                   |           | "mode"     |            |         |
-   |                   |           | property   |            |         |
-   +-------------------+-----------+------------+------------+---------+
+   |                  |           |            | "RSA-       |         |
+   |                  |           |            | SigVer"     |         |
+   |                  |           |            |             |         |
+   | infoGeneratedByS | This flag | value      | true or     | Yes     |
+   | erver            | indicates |            | false       |         |
+   |                  | that the  |            |             |         |
+   |                  | server is |            |             |         |
+   |                  | responsib |            |             |         |
+   |                  | le for ge |            |             |         |
+   |                  | nerating  |            |             |         |
+   |                  | inputs    |            |             |         |
+   |                  | for Key G |            |             |         |
+   |                  | eneration |            |             |         |
+   |                  | tests     |            |             |         |
+   |                  |           |            |             |         |
+   | prereqVals       | The prere | array of p | array       | No      |
+   |                  | quisite   | rereqAlgVa |             |         |
+   |                  | algorithm | l objects  |             |         |
+   |                  | validatio | - see      |             |         |
+   |                  | ns        | Section    |             |         |
+   |                  |           | 2.2        |             |         |
+   |                  |           |            |             |         |
+   | capSpecs         | The capab | an array   | array       | No      |
+   |                  | ilities   | of objects |             |         |
+   |                  | of a part | specific   |             |         |
+   |                  | icular    | to the     |             |         |
+   |                  | RSA mode  | mode being |             |         |
+   |                  |           | specified  |             |         |
+   |                  |           |            |             |         |
+   | modeSpecs        | The RSA   | an object  | object      | No      |
+   |                  | mode and  | with       |             |         |
+   |                  | its capab | "mode" and |             |         |
+   |                  | ilities   | "capSpecs" |             |         |
+   |                  |           | properties |             |         |
+   |                  |           |            |             |         |
+   | algSpecs         | Array of  | array of   | See Table 1 | No      |
+   |                  | modeSpecs | modeSpecs  | and Section |         |
+   |                  |           | objects,   | 2.4         |         |
+   |                  |           | each       |             |         |
+   |                  |           | identified |             |         |
+   |                  |           | uniquely   |             |         |
+   |                  |           | by the     |             |         |
+   |                  |           | "mode"     |             |         |
+   |                  |           | property   |             |         |
+   +------------------+-----------+------------+-------------+---------+
 
               Table 3: RSA Algorithm Capabilities JSON Values
-
-
 
 
 
@@ -593,23 +593,23 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
-   +----------------+-------------------+-------+-----------+----------+
-   | JSON Value     | Description       | JSON  | Valid     | Optional |
-   |                |                   | type  | Values    |          |
-   +----------------+-------------------+-------+-----------+----------+
-   | mode           | The mode to be    | value | "keyGen", | No       |
-   |                | validated         |       | see Table |          |
-   |                |                   |       | 1         |          |
-   |                |                   |       |           |          |
-   | fixedPubExp    | Supports fixed    | value | true or   | Yes      |
-   |                | public key        |       | false     |          |
-   |                | exponent e        |       |           |          |
-   |                |                   |       |           |          |
-   | fixedPubExpVal | The value of the  | value | hex       | Yes      |
-   |                | public key        |       |           |          |
-   |                | exponent e in hex |       |           |          |
-   |                |                   |       |           |          |
-   | randPubExp     | Supports random   | value | true or   | Yes      |
+   +----------------+--------------------+-------+----------+----------+
+   | JSON Value     | Description        | JSON  | Valid    | Optional |
+   |                |                    | type  | Values   |          |
+   +----------------+--------------------+-------+----------+----------+
+   | mode           | Key Generation     | value | "B.3.2", | No       |
+   |                | mode to be         |       | "B.3.3", |          |
+   |                | validated. Random  |       | "B.3.4", |          |
+   |                | P and Q primes     |       | "B.3.5", |          |
+   |                | generated as (see  |       | "B.3.6"  |          |
+   |                | [FIPS186-4]):      |       |          |          |
+   |                | provable primes    |       |          |          |
+   |                | (Appendix B.3.2);  |       |          |          |
+   |                | probable primes    |       |          |          |
+   |                | (Appendix B.3.3);  |       |          |          |
+   |                | provable primes    |       |          |          |
+   |                | with conditions    |       |          |          |
+   |                | (Appendix B.3.4);  |       |          |          |
 
 
 
@@ -618,39 +618,38 @@ Vassilev                Expires November 2, 2017               [Page 11]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |                | public key        |       | false     |          |
-   |                | exponent e        |       |           |          |
-   |                |                   |       |           |          |
-   | randPQ         | Random P and Q    | value | {1, 2, 3, | Yes      |
-   |                | primes generated  |       | 4, 5}     |          |
-   |                | as (see           |       |           |          |
-   |                | [FIPS186-4]): 1 - |       |           |          |
-   |                | provable primes   |       |           |          |
-   |                | (Appendix B.3.2); |       |           |          |
-   |                | 2 - probable      |       |           |          |
-   |                | primes (Appendix  |       |           |          |
-   |                | B.3.3); 3 -       |       |           |          |
-   |                | provable primes   |       |           |          |
-   |                | (Appendix B.3.4); |       |           |          |
-   |                | 4 -               |       |           |          |
-   |                | provable/probable |       |           |          |
-   |                | primes (Appendix  |       |           |          |
-   |                | B.3.5); 5 -       |       |           |          |
-   |                | probable primes   |       |           |          |
-   |                | (Appendix B.3.6)  |       |           |          |
-   |                |                   |       |           |          |
-   | capProvPrimes  | Capabilities for  | array |           | Yes      |
-   |                | all supported     |       |           |          |
-   |                | moduli and hash   |       |           |          |
-   |                | algorithms (see   |       |           |          |
-   |                | Table 4)          |       |           |          |
-   |                |                   |       |           |          |
-   | modProbPrime   | See Table 5       | array | see Table | Yes      |
-   |                |                   |       | 5         |          |
-   |                |                   |       |           |          |
-   | primeTest      | See Table 5       | value | see Table | Yes      |
-   |                |                   |       | 5         |          |
-   +----------------+-------------------+-------+-----------+----------+
+   |                | provable/probable  |       |          |          |
+   |                | primes with        |       |          |          |
+   |                | conditions         |       |          |          |
+   |                | (Appendix B.3.5);  |       |          |          |
+   |                | probable primes    |       |          |          |
+   |                | with conditions    |       |          |          |
+   |                | (Appendix B.3.6)   |       |          |          |
+   |                |                    |       |          |          |
+   | fixedPubExp    | Supports fixed     | value | true or  | Yes      |
+   |                | public key         |       | false    |          |
+   |                | exponent e         |       |          |          |
+   |                |                    |       |          |          |
+   | fixedPubExpVal | The value of the   | value | hex      | Yes      |
+   |                | public key         |       |          |          |
+   |                | exponent e in hex  |       |          |          |
+   |                |                    |       |          |          |
+   | randPubExp     | Supports random    | value | true or  | Yes      |
+   |                | public key         |       | false    |          |
+   |                | exponent e         |       |          |          |
+   |                |                    |       |          |          |
+   | capProvPrimes  | Capabilities for   | array |          | Yes      |
+   |                | all supported      |       |          |          |
+   |                | moduli and hash    |       |          |          |
+   |                | algorithms (see    |       |          |          |
+   |                | Table 4)           |       |          |          |
+   |                |                    |       |          |          |
+   | modProbPrime   | See Table 5        | array | see      | Yes      |
+   |                |                    |       | Table 5  |          |
+   |                |                    |       |          |          |
+   | primeTest      | See Table 5        | value | see      | Yes      |
+   |                |                    |       | Table 5  |          |
+   +----------------+--------------------+-------+----------+----------+
 
                Table 7: RSA keyGen Capabilities JSON Values
 
@@ -665,7 +664,8 @@ Internet-Draft                RSA Alg JSON                      May 2017
    Each RSA sigGen mode capability is advertised as a self-contained
    JSON object.
 
-
+   The following subsections define the capabilities that may be
+   advertised by the ACVP compliant crypto modules.
 
 
 
@@ -673,9 +673,6 @@ Vassilev                Expires November 2, 2017               [Page 12]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
-
-   The following subsections define the capabilities that may be
-   advertised by the ACVP compliant crypto modules.
 
 2.4.2.1.  sigGen Capabilities
 
@@ -722,6 +719,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    +--------------+----------------+-------+----------------+----------+
 
      Table 8: Supported RSA sigGen moduli and hash options JSON Values
+
+
+
 
 
 
@@ -1029,7 +1029,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | vsId       | Unique numeric identifier for the vector set | value |
    |            |                                              |       |
    | algorithm  | The RSA algorithm used for the test vectors. | value |
-   |            | See Section 2.1 for possible values.         |       |
+   |            | "RSA-KeyGen", "RSA-SigGen", or "RSA-SigVer". |       |
    |            |                                              |       |
    | testGroups | Array of test group JSON objects, which are  | array |
    |            | defined in Section 3.1                       |       |
@@ -1066,32 +1066,24 @@ Vassilev                Expires November 2, 2017               [Page 19]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +-----------+--------------------------------+-----------+----------+
-   | JSON      | Description                    | JSON type | Optional |
-   | Value     |                                |           |          |
-   +-----------+--------------------------------+-----------+----------+
-   | mode      | The RSA algorithm mode used    | value     | No       |
-   |           | for the test vectors.  See     |           |          |
-   |           | Section 2.1 for possible       |           |          |
-   |           | values.                        |           |          |
-   |           |                                |           |          |
-   | randPQ    | RSA prime generation method -  | value     | Yes      |
-   |           | see Table 7                    |           |          |
-   |           |                                |           |          |
-   | modRSA    | RSA modulus                    | value     | No       |
-   |           |                                |           |          |
-   | hashAlg   | the hash algorithm             | value     | Yes      |
-   |           |                                |           |          |
-   | primeTest | Miller-Rabin constraint from   | value     | Yes      |
-   |           | Table C.2 or C.3               |           |          |
-   |           |                                |           |          |
-   | pubExp    | Fixed or random public         | hex value | Yes      |
-   |           | exponent                       | or        |          |
-   |           |                                | "random"  |          |
-   |           |                                |           |          |
-   | sigType   | The type of digital signature  | value     | Yes      |
-   |           | algorithm - see  Table 8       |           |          |
-   +-----------+--------------------------------+-----------+----------+
+   +-----------+----------------------------+---------------+----------+
+   | JSON      | Description                | JSON type     | Optional |
+   | Value     |                            |               |          |
+   +-----------+----------------------------+---------------+----------+
+   | mode      | The Key Gen method, or Sig | value         | No       |
+   |           | Type.                      |               |          |
+   |           |                            |               |          |
+   | modRSA    | RSA modulus                | value         | No       |
+   |           |                            |               |          |
+   | hashAlg   | the hash algorithm         | value         | Yes      |
+   |           |                            |               |          |
+   | primeTest | Miller-Rabin constraint    | value         | Yes      |
+   |           | from Table C.2 or C.3      |               |          |
+   |           |                            |               |          |
+   | pubExp    | Fixed or random public     | "fixed" or    | Yes      |
+   |           | exponent                   | "random"      |          |
+   |           |                            |               |          |
+   +-----------+----------------------------+---------------+----------+
 
                      Table 12: Test Group JSON Object
 
@@ -1101,6 +1093,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each RSA test vector.
+
+
+
+
+
+
+
+
 
 
 

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -226,7 +226,7 @@
           <c>algorithm</c>
 	  <c>The RSA algorithm to be validated</c>
           <c>value</c>
-          <c>"RSA"</c>
+          <c>"RSA-KeyGen", "RSA-SigGen", "RSA-SigVer"</c>
           <c>No</c>
          <c/>
          <c/>
@@ -451,9 +451,11 @@
           <ttcol align="left">Valid Values</ttcol>
           <ttcol align="left">Optional</ttcol>
           <c>mode</c>
-          <c>The mode to be validated</c>
+	         <c>Key Generation mode to be validated. Random P and Q primes generated as (see <xref target="FIPS186-4"/>): provable primes (Appendix B.3.2); 
+	           probable primes (Appendix B.3.3); provable primes with conditions (Appendix B.3.4); 
+	           provable/probable primes with conditions (Appendix B.3.5); probable primes with conditions (Appendix B.3.6)</c>
           <c>value</c>
-          <c>"keyGen", see <xref target="algs_table"/></c>
+	         <c>"B.3.2", "B.3.3", "B.3.4", "B.3.5", "B.3.6"</c>
           <c>No</c> 
          <c/>
          <c/>
@@ -490,16 +492,6 @@
           <c/>
           <c/>
           <c/> 
-          <c>randPQ</c>
-          <c>Random P and Q primes generated as (see <xref target="FIPS186-4"/>): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</c>
-          <c>value</c>
-          <c>{1, 2, 3, 4, 5}</c>
-          <c>Yes</c>
-          <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/>
           <c>capProvPrimes</c>
           <c>Capabilities for all supported moduli and hash algorithms (see <xref target="keyGenProvPrim_modulitable"/>)</c>
           <c>array</c>
@@ -751,7 +743,7 @@
 <c/>
 
 	  <c>algorithm</c>
-	  <c>The RSA algorithm used for the test vectors.  See <xref target="supported_algs"/> for possible values.</c>
+	  <c>The RSA algorithm used for the test vectors.  "RSA-KeyGen", "RSA-SigGen", or "RSA-SigVer".</c>
           <c>value</c>
 <c/>
 <c/>
@@ -774,21 +766,13 @@
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
 		<c>mode</c>
-	  <c>The RSA algorithm mode used for the test vectors.  See <xref target="supported_algs"/> for possible values.</c>
+	  <c>The Key Gen method, or Sig Type.</c>
    <c>value</c>
    <c>No</c>
    <c/>
    <c/>
    <c/>
    <c/>
-    <c>randPQ</c>
-    <c>RSA prime generation method - see <xref target="keyGen_table"/></c>
-    <c>value</c>
-    <c>Yes</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
     <c>modRSA</c>
     <c>RSA modulus</c>
     <c>value</c>
@@ -815,17 +799,12 @@
 		<c/>
     <c>pubExp</c>
 		<c>Fixed or random public exponent</c>
-		<c>hex value or "random"</c>
+		<c>"fixed" or "random"</c>
     <c>Yes</c>
     <c/>
 		<c/>
 		<c/>
 		<c/>
-    <c>sigType</c>
-		<c>The type of digital signature algorithm - see  <xref target="sigGenRSAMod"/></c>
-		<c>value</c>
-    <c>Yes</c>
-
 	    </texttable>
 
 	</section>


### PR DESCRIPTION
Fixes some possible redundancies in modes for RSA. Vector sets for KeyGen, SigGen and SigVer should be kept (and generated) separately. 