### PR TITLE
RSA Changes for v0.4

### DIFF
--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -585,11 +585,11 @@
     </tr>
     <tr>
       <td class="left"/>
-      <td class="left">"componentSigPrimitive"</td>
+      <td class="left">"componentSigPrim"</td>
     </tr>
     <tr>
       <td class="left"/>
-      <td class="left">"componentDecPrimitive"</td>
+      <td class="left">"componentDecPrim"</td>
     </tr>
   </tbody>
 </table>
@@ -692,20 +692,6 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">infoGeneratedByServer</td>
-      <td class="left">This flag indicates that the server is responsible for generating inputs for Key Generation tests</td>
-      <td class="left">value</td>
-      <td class="left">true or false</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">prereqVals</td>
       <td class="left">The prerequisite algorithm validations</td>
       <td class="left">array of prereqAlgVal objects - see <a href="#prereq_algs">Section 2.2</a></td>
@@ -720,25 +706,81 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">capSpecs</td>
-      <td class="left">The capabilities of a particular RSA mode</td>
-      <td class="left">an array of objects specific to the mode being specified</td>
-      <td class="left">array</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">modeSpecs</td>
-      <td class="left">The RSA mode and its capabilities</td>
-      <td class="left">an object with "mode" and "capSpecs" properties</td>
+      <td class="left">keyGen</td>
+      <td class="left">The RSA KeyGen mode and its capabilities</td>
+      <td class="left">an object defining KeyGen capabilities, see <a href="#mode_keyGen">Section 2.4.1</a></td>
       <td class="left">object</td>
-      <td class="left">No</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">sigGen</td>
+      <td class="left">The RSA SigGen mode and its capabilities</td>
+      <td class="left">an object defining SigGen capabilities, see <a href="#mode_sigGen">Section 2.4.2</a></td>
+      <td class="left">object</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">sigVer</td>
+      <td class="left">The RSA SigVer mode and its capabilities</td>
+      <td class="left">an object defining SigVer capabilities, see <a href="#mode_sigVer">Section 2.4.3</a></td>
+      <td class="left">object</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">legacySigVer</td>
+      <td class="left">The RSA Legacy SigVer mode and its capabilities</td>
+      <td class="left">an object defining Legacy SigVer capabilities, see <a href="#mode_legacySigVer">Section 2.4.4</a></td>
+      <td class="left">object</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">componentSigPrim</td>
+      <td class="left">The RSA component SigPrim mode and its capabilities</td>
+      <td class="left">an object defining component SigPrim capabilities, see <a href="#mode_componentSigPrimitive">Section 2.4.5</a></td>
+      <td class="left">object</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">componentDecPrim</td>
+      <td class="left">The RSA component DecPrim mode and its capabilities</td>
+      <td class="left">an object defining component DecPrim capabilities, see <a href="#mode_componentDecPrimitive">Section 2.4.6</a></td>
+      <td class="left">object</td>
+      <td class="left">Yes</td>
     </tr>
     <tr>
       <td class="left"/>
@@ -749,18 +791,18 @@
     </tr>
     <tr>
       <td class="left">algSpecs</td>
-      <td class="left">Array of modeSpecs</td>
-      <td class="left">array of modeSpecs objects, each identified uniquely by the "mode" property</td>
+      <td class="left">Array of modes</td>
+      <td class="left">array of mode objects, each identified uniquely by the "mode" property</td>
       <td class="left">See <a href="#algs_table">Table 1</a> and <a href="#supported_mods">Section 2.4</a></td>
       <td class="left">No</td>
     </tr>
   </tbody>
 </table>
 <h1 id="rfc.section.2.4"><a href="#rfc.section.2.4">2.4.</a> <a href="#supported_mods" id="supported_mods">Supported RSA Modes Capabilities</a></h1>
-<p id="rfc.section.2.4.p.1">The RSA mode capabilities are advertised as arrays of JSON objects within the 'modeSpecs' value of the ACVP registration message - see <a href="#caps_table">Table 3</a>. The 'modeSpecs' value is an array, where each array element is an array of individual JSON objects corresponding to a particular RSA mode defined in this section.  The 'modeSpecs' value is part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.p.1">The RSA mode capabilities are advertised as arrays of JSON objects within the self-named value of the ACVP registration message - see <a href="#caps_table">Table 3</a>. Each object is an array, where each array element is an array of individual JSON objects corresponding to a particular RSA mode defined in this section.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.p.2">Each RSA mode capabilities are advertised as an array of self-contained JSON objects.</p>
 <h1 id="rfc.section.2.4.1"><a href="#rfc.section.2.4.1">2.4.1.</a> <a href="#mode_keyGen" id="mode_keyGen">The keyGen Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.1.p.1">The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.1.p.1">The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'keyGen' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.1.p.2">Each RSA keyGen mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.1.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.1.1"><a href="#rfc.section.2.4.1.1">2.4.1.1.</a> <a href="#mode_keyGenProvPrim" id="mode_keyGenProvPrim">keyGen With Provable Primes or Provable Primes with Conditions Capabilities</a></h1>
@@ -998,7 +1040,7 @@
       <td class="left">mode</td>
       <td class="left">The mode to be validated</td>
       <td class="left">value</td>
-      <td class="left">"keyGen", see <a href="#algs_table">Table 1</a></td>
+      <td class="left">"keyGen", see<a href="#algs_table">Table 1</a></td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1009,11 +1051,39 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">fixedPubExp</td>
-      <td class="left">Supports fixed public key exponent e</td>
+      <td class="left">randPQ</td>
+      <td class="left">Key Generation mode to be validated. Random P and Q primes generated as (see <a href="#FIPS186-4">[FIPS186-4]</a>): provable primes (Appendix B.3.2); probable primes (Appendix B.3.3); provable primes with conditions (Appendix B.3.4); provable/probable primes with conditions (Appendix B.3.5); probable primes with conditions (Appendix B.3.6)</td>
+      <td class="left">value</td>
+      <td class="left">"B.3.2", "B.3.3", "B.3.4", "B.3.5", or "B.3.6"</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">infoGeneratedByServer</td>
+      <td class="left">This flag indicates that the server is responsible for generating inputs for Key Generation tests</td>
       <td class="left">value</td>
       <td class="left">true or false</td>
-      <td class="left">Yes</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">pubExp</td>
+      <td class="left">Supports fixed or random public key exponent e</td>
+      <td class="left">value</td>
+      <td class="left">"fixed" or "random"</td>
+      <td class="left">No</td>
     </tr>
     <tr>
       <td class="left"/>
@@ -1024,7 +1094,7 @@
     </tr>
     <tr>
       <td class="left">fixedPubExpVal</td>
-      <td class="left">The value of the public key exponent e in hex</td>
+      <td class="left">The value of the public key exponent e in hex if "pubExp" is "fixed"</td>
       <td class="left">value</td>
       <td class="left">hex</td>
       <td class="left">Yes</td>
@@ -1037,38 +1107,10 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">randPubExp</td>
-      <td class="left">Supports random public key exponent e</td>
-      <td class="left">value</td>
-      <td class="left">true or false</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">randPQ</td>
-      <td class="left">Random P and Q primes generated as (see <a href="#FIPS186-4">[FIPS186-4]</a>): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</td>
-      <td class="left">value</td>
-      <td class="left">{1, 2, 3, 4, 5}</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">capProvPrimes</td>
-      <td class="left">Capabilities for all supported moduli and hash algorithms (see <a href="#keyGenProvPrim_modulitable">Table 4</a>)</td>
+      <td class="left">Capabilities for all supported moduli and hash algorithms (see <a href="#keyGenProvPrim_modulitable">Table 4</a>) for provable primes (Appendix B.3.2) and provable primes with conditions (Appendix B.3.4).</td>
       <td class="left">array</td>
-      <td class="left"/>
+      <td class="left">See <a href="#keyGenProvPrim_modulitable">Table 4</a>.</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1079,10 +1121,10 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">modProbPrime</td>
-      <td class="left">See <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
+      <td class="left">capProbPrimes</td>
+      <td class="left">Capabilities for all supported moduli and hash algorithms for probable primes (Appendix B.3.3) and probable primes with conditions (Appendix B.3.6).</td>
       <td class="left">array</td>
-      <td class="left">see <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
+      <td class="left">See <a href="#keyGenProbPrim_modulitable">Table 5</a>.</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1093,20 +1135,20 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">primeTest</td>
-      <td class="left">See <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
-      <td class="left">value</td>
-      <td class="left">see <a href="#keyGenProbPrim_modulitable">Table 5</a></td>
+      <td class="left">capProvProbPrimes</td>
+      <td class="left">Capabilities for all supported moduli and hash algorithms for provable and probable primes with conditions (Appendix B.3.5).</td>
+      <td class="left">array</td>
+      <td class="left">See <a href="#keyGenProvProbPrimWithCond">Table 6</a>.</td>
       <td class="left">Yes</td>
     </tr>
   </tbody>
 </table>
 <h1 id="rfc.section.2.4.2"><a href="#rfc.section.2.4.2">2.4.2.</a> <a href="#mode_sigGen" id="mode_sigGen">The sigGen Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.2.p.1">The RSA sigGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.2.p.1">The RSA sigGen mode capabilities are advertised as an array of JSON objects within the array of 'sigGen' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.2.p.2">Each RSA sigGen mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.2.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.2.1"><a href="#rfc.section.2.4.2.1">2.4.2.1.</a> <a href="#mode_sigGenCap" id="mode_sigGenCap">sigGen Capabilities</a></h1>
-<p id="rfc.section.2.4.2.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.2.1.p.1">The following signature generation capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.8"/>
 <div id="sigGenRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1136,7 +1178,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">modRSASigGen</td>
+      <td class="left">modulo</td>
       <td class="left">supported RSA moduli for signature generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {2048, 3072, 4096}</td>
@@ -1150,7 +1192,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">hashSigGen</td>
+      <td class="left">hashAlg</td>
       <td class="left">supported hash algorithms for signature generation - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
@@ -1164,7 +1206,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">saltSigGen</td>
+      <td class="left">saltLen</td>
       <td class="left">supported salt lengths for PKCS1PSS signature generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
       <td class="left">array</td>
       <td class="left">array of values for each hash algorithm used subject to the constraint in the note below.</td>
@@ -1174,11 +1216,11 @@
 </table>
 <p id="rfc.section.2.4.2.1.p.2">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.3"><a href="#rfc.section.2.4.3">2.4.3.</a> <a href="#mode_sigVer" id="mode_sigVer">The sigVer Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.3.p.1">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.3.p.1">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'sigVer' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.3.p.2">Each RSA sigVer mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.3.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.3.1"><a href="#rfc.section.2.4.3.1">2.4.3.1.</a> <a href="#mode_sigVerCap" id="mode_sigVerCap">sigVer Capabilities</a></h1>
-<p id="rfc.section.2.4.3.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.3.1.p.1">The following signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.9"/>
 <div id="sigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1208,7 +1250,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">modRSASigVer</td>
+      <td class="left">modulo</td>
       <td class="left">supported RSA moduli for signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {2048, 3072, 4096}</td>
@@ -1222,7 +1264,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">hashSigVer</td>
+      <td class="left">hashAlg</td>
       <td class="left">supported hash algorithms for signature verification - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
@@ -1236,7 +1278,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">saltSigVer</td>
+      <td class="left">saltLen</td>
       <td class="left">supported salt lengths for PKCS1PSS signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
       <td class="left">array</td>
       <td class="left">array of values for each hash algorithm used subject to the constraint in the note below.</td>
@@ -1246,12 +1288,10 @@
 </table>
 <p id="rfc.section.2.4.3.1.p.2">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.4"><a href="#rfc.section.2.4.4">2.4.4.</a> <a href="#mode_legacySigVer" id="mode_legacySigVer">The legacySigVer Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.4.p.1">The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.4.p.1">The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'legacySigVer' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.4.p.2">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
-<p id="rfc.section.2.4.4.p.3">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.4.p.4">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
-<p id="rfc.section.2.4.4.p.5">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
-<p id="rfc.section.2.4.4.p.6">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.4.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
+<p id="rfc.section.2.4.4.p.4">The following legacy signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.10"/>
 <div id="legacySigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1281,7 +1321,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">modLegacyRSASigVer</td>
+      <td class="left">modulo</td>
       <td class="left">supported RSA moduli for signature verification - see <a href="#SP800-131A">[SP800-131A]</a></td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {1024, 1536, 2048, 3072, 4096}</td>
@@ -1295,7 +1335,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">hashLegacySigVer</td>
+      <td class="left">hashAlg</td>
       <td class="left">supported hash algorithms for signature verification - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-1", "SHA-256", "SHA-384", "SHA-512"}</td>
@@ -1309,7 +1349,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">saltLegacySigVer</td>
+      <td class="left">saltLen</td>
       <td class="left">supported salt lengths for PKCS1PSS signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
       <td class="left">array</td>
       <td class="left">array of values for each hash algorithm used subject to the constraint in the note below.</td>
@@ -1317,16 +1357,16 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.2.4.4.p.7">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
+<p id="rfc.section.2.4.4.p.5">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.5"><a href="#rfc.section.2.4.5">2.4.5.</a> <a href="#mode_componentSigPrimitive" id="mode_componentSigPrimitive">The componentSigPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.5.p.1">The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <a href="#RFC3447">[RFC3447]</a>) is advertised as a JSON object within the array of 'modeSpecs' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server.  Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability.  See <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for 'msg' and 'n'.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.5.p.2">Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</p>
+<p id="rfc.section.2.4.5.p.1">The RSA componentSigPrim mode capability (otherwise known as RSASP1 in <a href="#RFC3447">[RFC3447]</a>) is advertised as a JSON object within the array of 'componentSigPrim' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server.  Only 2048-bit RSA keys are allowed for this capability.  See <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for 'msg' and 'n'.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.5.p.2">Each RSA componentSigPrim mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.2.4.6"><a href="#rfc.section.2.4.6">2.4.6.</a> <a href="#mode_componentDecPrimitive" id="mode_componentDecPrimitive">The componentDecPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
+<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrim mode capability is advertised a JSON object within the array of 'componentDecPrim' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
 <p id="rfc.section.2.4.6.p.2">In testing, only 'msg' is supplied by the ACVP server.  The client is responsible for generating RSA key pairs of modulus 'n', private key 'd', and calculates 's'.  Only 2048-bit RSA keys are allowed for this capability. See <a href="#app-testcomponentdecprimitive-ex">Appendix B.6</a> for additional details on constraints for 'msg' and 'n'. The client provides the public exponent 'e', modulus 'n', the private key 'd' and the computed result 's' in its response to the ACVP - see <a href="#app-componentdec-results-ex">Appendix C.6</a> .  The client must first check if  '0 &lt; msg &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 'msg' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.6.p.3">Each RSA componentDecPrimitive mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
-<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm, such as Hash_DRBG, etc.  This section describes the JSON schema for a test vector set used with DRBG algorithms.</p>
+<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm mode, such as RSA Key Generation where the algorithm is "RSA" and the mode is "KeyGen".  If a registration comes in requesting multiple modes of RSA, multiple test vector sets will be returned. This section describes the JSON schema for a test vector set used with RSA algorithms.</p>
 <p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
 <div id="rfc.table.11"/>
 <div id="vs_top_table"/>
@@ -1371,6 +1411,16 @@
       <td class="left"/>
     </tr>
     <tr>
+      <td class="left">mode</td>
+      <td class="left">The RSA mode tested. See <a href="#supported_algs">Section 2.1</a> for possible values.</td>
+      <td class="left">value</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
       <td class="left">testGroups</td>
       <td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs">Section 3.1</a></td>
       <td class="left">array</td>
@@ -1393,18 +1443,6 @@
   </thead>
   <tbody>
     <tr>
-      <td class="left">mode</td>
-      <td class="left">The RSA algorithm mode used for the test vectors.  See <a href="#supported_algs">Section 2.1</a> for possible values.</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">randPQ</td>
       <td class="left">RSA prime generation method - see <a href="#keyGen_table">Table 7</a></td>
       <td class="left">value</td>
@@ -1417,9 +1455,21 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">modRSA</td>
+      <td class="left">modulo</td>
       <td class="left">RSA modulus</td>
       <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">testType</td>
+      <td class="left">The test type for the test group</td>
+      <td class="left">Either "AFT" (algorithm functional test), "KAT" (known answer test), or "GDT" (generated data test).</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1443,7 +1493,7 @@
     <tr>
       <td class="left">primeTest</td>
       <td class="left">Miller-Rabin constraint from Table C.2 or C.3</td>
-      <td class="left">value</td>
+      <td class="left">"tblC2" or "tblC3"</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1455,7 +1505,7 @@
     <tr>
       <td class="left">pubExp</td>
       <td class="left">Fixed or random public exponent</td>
-      <td class="left">hex value or "random"</td>
+      <td class="left">"fixed" or "random"</td>
       <td class="left">Yes</td>
     </tr>
     <tr>
@@ -1473,11 +1523,11 @@
   </tbody>
 </table>
 <h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a></h1>
-<p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each RSA test vector.</p>
+<p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each RSA test vector under the KeyGen mode. If the value "infoGeneratedByServer" is false, the test case will only consist of a "tcId", unless "B.3.3" is included. Under this prime generation method, the test case will always consist of a series of test cases with only "tcId". If both "B.3.3" and "random" "pubExp" are enabled (regardless of "infoGeneratedByServer"), then there will be an additional test group of known answer tests (KATs) which includes test cases with only "tcId", "pRand", "qRand", and "e".</p>
 <div id="rfc.table.13"/>
-<div id="vs_tc_table"/>
+<div id="vs_tc_table_kg"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>RSA Test Case JSON Object</caption>
+  <caption>RSA Test Case JSON Object for Key Generation</caption>
   <thead>
     <tr>
       <th class="left">JSON Value</th>
@@ -1536,6 +1586,196 @@
       <td class="left"/>
     </tr>
     <tr>
+      <td class="left">xP1</td>
+      <td class="left">the prime factor p1 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">seed</td>
+      <td class="left">the seed used in prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, or B3.5</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">bitlen1</td>
+      <td class="left">the length of p1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B3.5 or the length of xP1 for B.3.6</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">bitlen2</td>
+      <td class="left">the length of p2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B.3.5 or the length of xP2 for B.3.6</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">bitlen3</td>
+      <td class="left">the length of q1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ1 for B.3.6</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">bitlen4</td>
+      <td class="left">the length of q2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ2 for B.3.6</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">primeSeedP2</td>
+      <td class="left">the prime seed used for p2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">primeSeedQ1</td>
+      <td class="left">the prime seed used for q1 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">primeSeedQ2</td>
+      <td class="left">the prime seed used for q2 for prime generation according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">xP2</td>
+      <td class="left">the prime factor p2 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">xP</td>
+      <td class="left">the random number used in Step 3 of the algorithm in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.9 to generate the prime P, if applicable</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">xQ1</td>
+      <td class="left">the prime factor q1 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">xQ2</td>
+      <td class="left">the prime factor q2 for Primes with Conditions - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">xQ</td>
+      <td class="left">the random number used in Step 3 of the algorithm in <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix C.9 to generate the prime Q, if applicable</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.3.2.p.2">The following table describes the JSON elements for each RSA test vector under the SigGen or SigVer mode.</p>
+<div id="rfc.table.14"/>
+<div id="vs_tc_table_sig"/>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <caption>RSA Test Case JSON Object for Signature Generation or Verification</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">tcId</td>
+      <td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
       <td class="left">msg</td>
       <td class="left">the message to be signed</td>
       <td class="left">hex value</td>
@@ -1543,9 +1783,67 @@
     </tr>
   </tbody>
 </table>
+<p id="rfc.section.3.2.p.3">The following table describes the JSON elements for each RSA test vector under the componentSigPrim or componentDecPrim modes.</p>
+<div id="rfc.table.15"/>
+<div id="vs_tc_table_comp"/>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <caption>RSA Test Case JSON Object for Component Signature Primitive or Component Decryption Primitive modes</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">tcId</td>
+      <td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">msg</td>
+      <td class="left">the message to be signed or decrypted</td>
+      <td class="left">hex value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">d</td>
+      <td class="left">the private exponent</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">n</td>
+      <td class="left">the modulus value</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+  </tbody>
+</table>
 <h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a></h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.14"/>
+<div id="rfc.table.16"/>
 <div id="vr_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>Vector Set Response JSON Object</caption>
@@ -1584,8 +1882,8 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.4.p.2">The following table describes the JSON elements for the response to a RSA test vector.</p>
-<div id="rfc.table.15"/>
+<p id="rfc.section.4.p.2">The following table describes the JSON elements for the response to a RSA test vector. The client can send private keys using the standard format or the Chinese Remainder Theorem (CRT) format. If the value of "infoGeneratedByServer" is true then the client does not need to send back values generated by the server.</p>
+<div id="rfc.table.17"/>
 <div id="vs_tr_keyGen_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <caption>RSA Test Case Results JSON Object</caption>
@@ -1875,6 +2173,42 @@
       <td class="left"/>
     </tr>
     <tr>
+      <td class="left">dmp1</td>
+      <td class="left">the private exponent d modulo p - 1. This is only applicable when representing the private key using CRT</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">dmq1</td>
+      <td class="left">the private exponent d modulo q - 1. This is only applicable when representing the prvate key using CRT</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">iqmp</td>
+      <td class="left">the private prime factor q, inverted modulo p, (q^-1 mod p). This is only applicable when representing the private key using CRT</td>
+      <td class="left">hex value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
       <td class="left">s</td>
       <td class="left">the digital signature value</td>
       <td class="left">hex value</td>
@@ -1889,6 +2223,18 @@
     <tr>
       <td class="left">sigResult</td>
       <td class="left">the result from the digital signature verirfication</td>
+      <td class="left">"pass"/"fail"</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">compResult</td>
+      <td class="left">the result from either the componentSigPrim mode or the componentDecPrim mode</td>
       <td class="left">"pass"/"fail"</td>
       <td class="left">Yes</td>
     </tr>
@@ -1949,27 +2295,23 @@
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
-      "infoGeneratedByServer": true,
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-              "mode": "keyGen",
-              "capSpecs" :  {
-                      "fixedPubExp" : true,
-                      "fixedPubExpVal" : "010001",
-                      "randPQ" : 1,
-                      "capProvPrime" : 
-                            [
-                                {   "modulo" : 2048,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 3072,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 4096,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                            ]
-                      }
-                }
-          }
+         "keyGen" : [{
+              "fixedPubExp" : "fixed",
+              "fixedPubExpVal" : "010001",
+              "randPQ" : "B.3.2",
+              "infoGeneratedByServer": true
+              "capProvPrime" : 
+                    [
+                        {   "modulo" : 2048,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                        {   "modulo" : 3072,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                        {   "modulo" : 4096,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+                    ]
+              }]
       ]
    }
 </pre>
@@ -1979,7 +2321,6 @@
 <pre>
    {
     "algorithm":"RSA",
-    "infoGeneratedByServer": true,
     "prereqVals":[
       {
         "algorithm":"DRBG",
@@ -1991,24 +2332,18 @@
       }
     ],
     "algSpecs":[
-      {
-        "modeSpecs": {
-          "mode":"keyGen",
-          "capSpecs": {
-            "fixedPubExp": true,
-            "fixedPubExpVal":"010001",
-            "randPQ": 2,
-            "capProbPrime":[{
-              "modulo": 2048,
-              "primeTest":["tblC2"]
-            },
-            {
-              "modulo": 3072,
-              "primeTest":["tblC2", "tblC3"]
-            }]
-          }
-        }
-      }
+        "keyGen": [{
+          "fixedPubExp": "random",
+          "randPQ": "B.3.3",
+          "capProbPrime":[{
+            "modulo": 2048,
+            "primeTest":["tblC2"]
+          },
+          {
+            "modulo": 3072,
+            "primeTest":["tblC2", "tblC3"]
+          }]
+        }]
     ]
   }
 </pre>
@@ -2018,16 +2353,14 @@
 <pre>
    {
       "algorithm": "RSA",
-      "infoGeneratedByServer": false,
        "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-           "mode": "keyGen",
-           "capSpecs" : {
-               "fixedPubExp" : true,
+         "keyGen": [{
+               "fixedPubExp" : "fixed",
                "fixedPubExpVal" : "010001",
-               "randPQ" : 4,
+               "randPQ" : "B.3.5",
+               "infoGeneratedByServer": true
                "capsProvProbPrime" : 
                     [
                         {"modulo" : 2048,
@@ -2040,9 +2373,7 @@
                          "hashAlg" : ["SHA-512"],
                          "primeTest": ["tblC3"]},
                     ]
-              }
-          }
-        }
+              }]
       ]
    }
 </pre>
@@ -2054,54 +2385,45 @@
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "X9.31",
-                  "capSigType" :
-                  [
-                      {"modRSASigGen" : 2048,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 3072,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 4096,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-        }},
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "PKCS1v1.5",
-                  "capSigType" :
-                  [
-                      {"modRSASigGen" : 2048,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 3072,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 4096,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-         }},
-        {"modeSpecs" : {
-            "mode": "sigGen",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                [
-                    { "modRSASigGen" : 2048,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]},
-                    { "modRSASigGen" : 3072,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]},
-                    { "modRSASigGen" : 4096,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]}
+         "sigGen" : [{
+              "sigType" : "X9.31",
+              "capSigType" :
+              [
+                  {"modulo" : 2048,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 3072,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 4096,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+        },
+        {
+              "sigType" : "PKCS1v1.5",
+              "capSigType" :
+              [
+                  {"modulo" : 2048,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 3072,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 4096,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+         },
+         {
+              "sigType" : "PKCS1PSS",
+              "capSigType" :
+              [
+                  { "modulo" : 2048,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]}
                 ]
-            }
-         }}
+            }]
       ]
    }
 </pre>
@@ -2113,71 +2435,56 @@
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" : 
       [
-        {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-               
-                 "sigType" : "X9.31",
-                 "capSigType" :
-                [
-                  {"modRSASigVer" : 2048,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 4096,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
-               ]
-            }
-          }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1v1.5",
-                 "capSigType" :
-                [
-                  {"modRSASigVer" : 2048,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 4096,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
-                ]
-            }
-         }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                  [
-                    { "modRSASigVer" : 2048,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]},
-                    { "modRSASigVer" : 3072,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]},
-                    { "modRSASigVer" : 4096,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]}
-                 ]
-            }
-       }}
-    ]
+        "sigVer" : [{
+             "sigType" : "X9.31",
+             "capSigType" :
+             [
+               {"modulo" : 2048,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+               {"modulo" : 3072,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+               {"modulo" : 4096,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+             ]
+          },
+          {
+             "sigType" : "PKCS1v1.5",
+             "capSigType" :
+             [
+                {"modulo" : 2048,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                {"modulo" : 3072,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                {"modulo" : 4096,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+           },
+           {
+              "sigType" : "PKCS1PSS",
+              "capSigType" :
+              [
+                 { "modulo" : 2048,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]},
+                 { "modulo" : 3072,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]},
+                 { "modulo" : 4096,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]}
+              ]
+           }]
+      ]
    }
 </pre>
 <h1 id="rfc.appendix.A.4"><a href="#rfc.appendix.A.4">A.4.</a> <a href="#app-cap-legacysigverex" id="app-cap-legacysigverex">Example RSA legacySigVer Capabilities JSON Objects</a></h1>
-<p id="rfc.section.A.4.p.1">The format and structure of the RSA legacySigVer capabilities JSON objects follow very closely those of the RSA sigVer capabilties JSON objects with the obvious changes from modRSASigVer, hashSigVer and saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer and the corresponding parameter ranges adjustments.</p>
+<p id="rfc.section.A.4.p.1">The format and structure of the RSA legacySigVer capabilities JSON objects follows very closely those of the RSA sigVer capabilties JSON objects with the obvious changes from modulo, hashAlg and saltLen to the corresponding parameters.</p>
 <h1 id="rfc.appendix.A.5"><a href="#rfc.appendix.A.5">A.5.</a> <a href="#app-cap-componentsigverex" id="app-cap-componentsigverex">Example componentSigPrimitive Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.5.p.1">The following is an example JSON object advertising support for RSA componentSigPrimitive according to <a href="#FIPS186-4">[FIPS186-4]</a>.</p>
 <pre>
    {
       "algorithm": "RSA",
-      "algSpecs" : 
-      [
-       {"modeSpecs" : {
-           "mode": "componentSigPrimitive"
-         }}
-      ]
+      "algSpecs" : ["componentSigPrim"]
    }
 </pre>
 <h1 id="rfc.appendix.A.6"><a href="#rfc.appendix.A.6">A.6.</a> <a href="#app-cap-componentdecverex" id="app-cap-componentdecverex">Example componentDecPrimitive Capabilities JSON Objects</a></h1>
@@ -2186,12 +2493,7 @@
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" : 
-      [
-        {"modeSpecs" : {
-            "mode": "componentDecPrimitive"
-         }}
-      ]
+      "algSpecs" : ["componentDecPrimitive"]
    }
 </pre>
 <h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-testVect-ex" id="app-testVect-ex">Example Test Vectors JSON Objects</a></h1>
@@ -2200,16 +2502,17 @@
 <pre>
 
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1133,
       "algorithm": "RSA",
-      "infoGeneratedByServer": false,
       "testGroups" : [
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 1,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.2",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -2222,9 +2525,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 1,
-                "modRSA" : 3072,
+                "randPQ": "B.3.2",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -2237,9 +2542,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 3,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.4",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -2252,9 +2559,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 3,
-                "modRSA" : 3072,
+                "randPQ": "B.3.4",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -2267,9 +2576,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 4,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.5",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -2282,9 +2593,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 4,
-                "modRSA" : 3072,
+                "randPQ": "B.3.5",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -2297,9 +2610,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 5,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -2312,9 +2627,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 5,
-                "modRSA" : 3072,
+                "randPQ": "B.3.6",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -2327,10 +2644,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "modRSA" : 2048,
+                 "modulo" : 2048,
                  "tests" : [
                     {
                       "tcId" : 1119,
@@ -2349,8 +2667,9 @@
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
                  "modRSA" : 3072,
                  "tests" : [
@@ -2364,8 +2683,9 @@
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
                  "modRSA" : 2048,
                  "tests" : [
@@ -2386,8 +2706,9 @@
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
                  "modRSA" : 3072,
                  "tests" : [
@@ -2398,32 +2719,224 @@
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
-             }
+             },
+             {
+                "mode": "keyGen",
+                "testType": "GDT",
+                "pubExp": "random",
+                "randPQ": "B.3.3",
+                "modulo" : 2048,
+                "tests": [
+                  {
+                    "tcId": 1159,
+                  },
+                  {
+                    "tcId": 1160,
+                  }
+                ]
+              }
      ]
    }
  ]
 </pre>
-<p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table">Table 15</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the server validates that this pair matches the requirements.</p>
+<p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table">Table 17</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd', or CRT form) and the server validates that this pair matches the requirements.</p>
+<p id="rfc.section.B.1.p.2">The following is an example for when "infoGeneratedByServer" is set to true. Note when "randPQ" is "B.3.3", there is no difference and is omitted from this example.</p>
+<pre>
+
+ [
+   { "acvVersion": "0.4" },
+   { "vsId": 1133,
+      "algorithm": "RSA",
+      "testGroups" : [
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.2",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1111,
+              			  "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
+              			  "e" : "10000021"
+              			},
+              			{
+              			  "tcId" : 1112,
+              			  "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
+              			  "e" : "10000021"
+              			}
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.4",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1113,
+              			  "e" : "10000021",
+              			  "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
+              			  "bitlen1" : 312,
+              			  "bitlen2" : 145,
+              			  "bitlen3" : 144,
+              			  "bitlen4" : 338
+              			},
+              			{
+              			  "tcId" : 1114,
+              			  "e" : "10000021",
+              			  "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
+              			  "bitlen1" : 320,
+              			  "bitlen2" : 159,
+              			  "bitlen3" : 192,
+              			  "bitlen4" : 222
+              			}
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.5",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1115,
+              			  "e" : "10000021",
+              			  "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
+              			  "bitlen1" : 504,
+              			  "bitlen2" : 238,
+              			  "bitlen3" : 440,
+              			  "bitlen4" : 185
+              			},
+              			{
+              			  "tcId" : 1116,
+              			  "e" : "10000021",
+              			  "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
+              			  "bitlen1" : 448,
+              			  "bitlen2" : 281,
+              			  "bitlen3" : 240,
+              			  "bitlen4" : 469
+              			}
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1117,
+              			  "e" : "10000021",
+              			  "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
+              			  "bitlen1" : 232,
+              			  "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
+              			  "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
+              			  "bitlen2" : 220,
+              			  "p2" : "baf57f053b1f2a46705d9be799f90f28b800de871d88c95f24bf659",
+              			  "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
+              			  "primeSeedQ1" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc373fa",
+              			  "bitlen3" : 336,
+              			  "q1" : "bfbf1abfc1fb9b7e21342139053e7b05f56e664594419bbdcb14bb959ab66cf10e99a0d38f560a22cb33",
+              			  "primeSeedQ2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37484",
+              			  "bitlen4" : 141,
+              			  "q2" : "15e35869eb4f8dac49e317f09e3be3627c1d",
+              			  "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291"
+              			},
+              			{
+              			 "tcId" : 1118,
+              			 "e" : "10000021",
+              			 "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
+              			 "bitlen1" : 272,
+              			 "p1" : "e43dc77ad0bbe2090a7d99a490f0b37188603691ebd453ef987e8358eee34be2def9",
+              			 "primeSeedP2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805cf1",
+              			 "bitlen2" : 205,
+              			 "p2" : "18dd5b6a27ca680f10764a0e2f49ffd384b650948aa6ba175f07",
+              			 "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
+              			 "primeSeedQ1" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805e76",
+              			 "bitlen3" : 296,
+              			 "q1" : "bd76411ab7c1edb6873e76e5edc7b920b75cf8e2e1152010e6c34df592f8c3cd948212ca05",
+              			 "primeSeedQ2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805f9c",
+              			 "bitlen4" : 157,
+              			 "q2" : "123e72d9c914cde1b11d233a985f37f0769d2227",
+              			 "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05"
+              			}
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "testType": "KAT"
+                "pubExp": "random",
+                "randPQ": "B.3.3",
+                "modulo" : 2048,
+                "primeTest" : "tblC2"
+                "tests": [
+              			{
+              			  "tcId" : 1119,
+              			  "e" : "df28ab",
+              			  "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+              			  "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+              			},
+              			{
+              			  "tcId" : 1120,
+              			  "e" : "85a4cf",
+              			  "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+              			  "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+              			}
+                ]
+              },
+              {
+          			"mode": "keyGen",
+          			"testType": "GDT",
+          			"pubExp": "random",
+          			"randPQ": "B.3.3",
+          			"primeTest": "tblC2",
+          			"modRSA": 2048,
+          			"tests": [
+          			    {
+          			      "tcId": 1125
+          			    },
+          			    {
+          			      "tcId": 1126
+          			    }
+          			]
+          		}
+     ]
+   }
+ ]
+</pre>
 <h1 id="rfc.appendix.B.2"><a href="#rfc.appendix.B.2">B.2.</a> <a href="#app-testVectsigGen-ex" id="app-testVectsigGen-ex">Example Test Vectors for sigGen JSON Objects</a></h1>
 <pre>
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
                       "tcId" : 1165,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
                       "tcId" : 1166,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
                     }
@@ -2431,17 +2944,18 @@
              },
               {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1167,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
                       "tcId" : 1168,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
@@ -2449,18 +2963,19 @@
              },
              {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
                       "tcId" : 1169,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "saltLen" : 20,
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
                     {
                       "tcId" : 1170,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-512",
                       "saltLen" : 62,
                       "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
@@ -2474,17 +2989,18 @@
 <h1 id="rfc.appendix.B.3"><a href="#rfc.appendix.B.3">B.3.</a> <a href="#app-testVectsigVer-ex" id="app-testVectsigVer-ex">Example Test Vectors for sigVer JSON Objects</a></h1>
 <pre>
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
                       "tcId" : 1174,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
                       "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -2493,7 +3009,7 @@
                     },
                     {
                       "tcId" : 1175,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
                       "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
@@ -2504,11 +3020,12 @@
              },
               {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1176,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
                       "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
@@ -2517,7 +3034,7 @@
                     },
                     {
                       "tcId" : 1177,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
                       "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
@@ -2528,11 +3045,12 @@
              },
              {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
                       "tcId" : 1178,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
                       "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
@@ -2541,7 +3059,7 @@
                     },
                     {
                       "tcId" : 1179,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
                       "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
@@ -2561,12 +3079,13 @@
 <h1 id="rfc.appendix.B.5"><a href="#rfc.appendix.B.5">B.5.</a> <a href="#app-testcomponentsigprimitive-ex" id="app-testcomponentsigprimitive-ex">Example Test Vectors for componentSigPrimitive JSON Objects</a></h1>
 <pre>
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentSigPrimitive",
+                 "mode": "componentSigPrim",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -2590,12 +3109,13 @@
 <h1 id="rfc.appendix.B.6"><a href="#rfc.appendix.B.6">B.6.</a> <a href="#app-testcomponentdecprimitive-ex" id="app-testcomponentdecprimitive-ex">Example Test Vectors for componentDecPrimitive JSON Objects</a></h1>
 <pre>
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
+                 "mode": "componentDecPrim",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -2617,7 +3137,7 @@
 <p id="rfc.section.C.1.p.1">The following is a example JSON object for RSA keyGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
              [
-                { "acvVersion": "0.3" },
+                { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "testResults": [
                     {
@@ -2894,7 +3414,7 @@
 <p id="rfc.section.C.2.p.1">The following is a example JSON object for RSA sigGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
              [
-                  { "acvVersion": "0.3" },
+                  { "acvVersion": "0.4" },
                   { "vsId": 1163,
                     "testResults": [
                     {
@@ -2953,7 +3473,7 @@
 <p id="rfc.section.C.3.p.1">The following is a example JSON object for RSA sigVer test results sent from the crypto module to the ACVP server.</p>
 <pre>
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
@@ -3009,12 +3529,12 @@
 <p id="rfc.section.C.5.p.1">The following is a example JSON object for RSA componentSigPrimitive test results sent from the crypto module to the ACVP server.</p>
 <pre>
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentSigPrimitive",
+                 "mode": "componentSigPrim",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -3034,12 +3554,12 @@
 <p id="rfc.section.C.6.p.1">The following is a example JSON object for RSA componentDecPrimitive test results sent from the crypto module to the ACVP server.</p>
 <pre>
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
+                 "mode": "componentDecPrim",
                  "tests" : [
                     {
                       "tcId" : 1196,

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -71,41 +71,41 @@ Table of Contents
        2.4.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   7
          2.4.1.1.  keyGen With Provable Primes or Provable Primes
                    with Conditions Capabilities  . . . . . . . . . .   7
-         2.4.1.2.  keyGen With Probable Primes Capabilities  . . . .   8
+         2.4.1.2.  keyGen With Probable Primes Capabilities  . . . .   9
          2.4.1.3.  keyGen With Both Provable and Probable Primes
-                   With Conditions . . . . . . . . . . . . . . . . .  10
-         2.4.1.4.  keyGen Full Set Of Capabilities . . . . . . . . .  11
-       2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  12
-         2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  13
-       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  14
-         2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  14
-       2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  16
-       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  18
-       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  18
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  18
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  19
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  20
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  21
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  25
-   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  26
+                   With Conditions . . . . . . . . . . . . . . . . .  11
+         2.4.1.4.  keyGen Full Set Of Capabilities . . . . . . . . .  12
+       2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  15
+         2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  15
+       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  16
+         2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  17
+       2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  18
+       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  19
+       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  20
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  20
+     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  21
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  22
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  25
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  30
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  30
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  30
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  31
+   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  31
      A.1.  Example keyGen with Provable Primes and Provable Primes
-           with Conditions Capabilities JSON Objects . . . . . . . .  26
+           with Conditions Capabilities JSON Objects . . . . . . . .  31
        A.1.1.  Example keyGen with Probable Primes Capabilities JSON
-               Object  . . . . . . . . . . . . . . . . . . . . . . .  27
+               Object  . . . . . . . . . . . . . . . . . . . . . . .  32
        A.1.2.  Example keyGen with Provable Conditional Primes with
-               Probable Factors Capabilities JSON Object . . . . . .  28
-     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  29
-     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  30
-     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  32
-     A.5.  Example componentSigPrimitive Capabilities JSON Objects .  32
-     A.6.  Example componentDecPrimitive Capabilities JSON Objects .  32
-   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  33
-     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  33
-     B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  37
-     B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  39
+               Probable Factors Capabilities JSON Object . . . . . .  33
+     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  34
+     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  36
+     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  38
+     A.5.  Example componentSigPrimitive Capabilities JSON Objects .  38
+     A.6.  Example componentDecPrimitive Capabilities JSON Objects .  38
+   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  38
+     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  38
+     B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  47
+     B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  49
 
 
 
@@ -114,19 +114,19 @@ Vassilev                Expires November 2, 2017                [Page 2]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-     B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  41
+     B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  51
      B.5.  Example Test Vectors for componentSigPrimitive JSON
-           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  41
+           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  51
      B.6.  Example Test Vectors for componentDecPrimitive JSON
-           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  41
-   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  42
-     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  42
-     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  48
-     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  49
-     C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  50
-     C.5.  Example componentSigPrimitive Test Results JSON Objects .  51
-     C.6.  Example componentDecPrimitive Test Results JSON Objects .  51
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  52
+           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  52
+   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  52
+     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  52
+     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  58
+     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  59
+     C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  61
+     C.5.  Example componentSigPrimitive Test Results JSON Objects .  61
+     C.6.  Example componentDecPrimitive Test Results JSON Objects .  61
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  62
 
 1.  Introduction
 
@@ -185,16 +185,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following RSA algorithm modes may be advertised by the ACVP
    compliant crypto module:
 
-            +----------------------+-------------------------+
-            | JSON algorithm value | JSON mode value         |
-            +----------------------+-------------------------+
-            | "RSA"                | "keyGen"                |
-            |                      | "sigGen"                |
-            |                      | "sigVer"                |
-            |                      | "legacySigVer"          |
-            |                      | "componentSigPrimitive" |
-            |                      | "componentDecPrimitive" |
-            +----------------------+-------------------------+
+               +----------------------+--------------------+
+               | JSON algorithm value | JSON mode value    |
+               +----------------------+--------------------+
+               | "RSA"                | "keyGen"           |
+               |                      | "sigGen"           |
+               |                      | "sigVer"           |
+               |                      | "legacySigVer"     |
+               |                      | "componentSigPrim" |
+               |                      | "componentDecPrim" |
+               +----------------------+--------------------+
 
             Table 1: Supported RSA Algorithm Modes JSON Values
 
@@ -266,14 +266,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    object.  The following JSON values are used for RSA algorithm
    capabilities:
 
-   +-------------------+-----------+------------+------------+---------+
-   | JSON Value        | Descripti | JSON type  | Valid      | Optiona |
-   |                   | on        |            | Values     | l       |
-   +-------------------+-----------+------------+------------+---------+
-   | algorithm         | The RSA   | value      | "RSA"      | No      |
-   |                   | algorithm |            |            |         |
-   |                   | to be     |            |            |         |
-   |                   | validated |            |            |         |
+   +----------------+------------+-------------+------------+----------+
+   | JSON Value     | Descriptio | JSON type   | Valid      | Optional |
+   |                | n          |             | Values     |          |
+   +----------------+------------+-------------+------------+----------+
+   | algorithm      | The RSA    | value       | "RSA"      | No       |
+   |                | algorithm  |             |            |          |
+   |                | to be      |             |            |          |
+   |                | validated  |             |            |          |
 
 
 
@@ -282,54 +282,54 @@ Vassilev                Expires November 2, 2017                [Page 5]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |                   |           |            |            |         |
-   | infoGeneratedBySe | This flag | value      | true or    | Yes     |
-   | rver              | indicates |            | false      |         |
-   |                   | that the  |            |            |         |
-   |                   | server is |            |            |         |
-   |                   | responsib |            |            |         |
-   |                   | le for ge |            |            |         |
-   |                   | nerating  |            |            |         |
-   |                   | inputs    |            |            |         |
-   |                   | for Key G |            |            |         |
-   |                   | eneration |            |            |         |
-   |                   | tests     |            |            |         |
-   |                   |           |            |            |         |
-   | prereqVals        | The prere | array of p | array      | No      |
-   |                   | quisite   | rereqAlgVa |            |         |
-   |                   | algorithm | l objects  |            |         |
-   |                   | validatio | - see      |            |         |
-   |                   | ns        | Section    |            |         |
-   |                   |           | 2.2        |            |         |
-   |                   |           |            |            |         |
-   | capSpecs          | The capab | an array   | array      | No      |
-   |                   | ilities   | of objects |            |         |
-   |                   | of a part | specific   |            |         |
-   |                   | icular    | to the     |            |         |
-   |                   | RSA mode  | mode being |            |         |
-   |                   |           | specified  |            |         |
-   |                   |           |            |            |         |
-   | modeSpecs         | The RSA   | an object  | object     | No      |
-   |                   | mode and  | with       |            |         |
-   |                   | its capab | "mode" and |            |         |
-   |                   | ilities   | "capSpecs" |            |         |
-   |                   |           | properties |            |         |
-   |                   |           |            |            |         |
-   | algSpecs          | Array of  | array of   | See Table  | No      |
-   |                   | modeSpecs | modeSpecs  | 1 and      |         |
-   |                   |           | objects,   | Section    |         |
-   |                   |           | each       | 2.4        |         |
-   |                   |           | identified |            |         |
-   |                   |           | uniquely   |            |         |
-   |                   |           | by the     |            |         |
-   |                   |           | "mode"     |            |         |
-   |                   |           | property   |            |         |
-   +-------------------+-----------+------------+------------+---------+
-
-              Table 3: RSA Algorithm Capabilities JSON Values
-
-
-
+   |                |            |             |            |          |
+   | prereqVals     | The prereq | array of pr | array      | No       |
+   |                | uisite     | ereqAlgVal  |            |          |
+   |                | algorithm  | objects -   |            |          |
+   |                | validation | see Section |            |          |
+   |                | s          | 2.2         |            |          |
+   |                |            |             |            |          |
+   | keyGen         | The RSA    | an object   | object     | Yes      |
+   |                | KeyGen     | defining    |            |          |
+   |                | mode and   | KeyGen capa |            |          |
+   |                | its capabi | bilities,   |            |          |
+   |                | lities     | see Section |            |          |
+   |                |            | 2.4.1       |            |          |
+   |                |            |             |            |          |
+   | sigGen         | The RSA    | an object   | object     | Yes      |
+   |                | SigGen     | defining    |            |          |
+   |                | mode and   | SigGen capa |            |          |
+   |                | its capabi | bilities,   |            |          |
+   |                | lities     | see Section |            |          |
+   |                |            | 2.4.2       |            |          |
+   |                |            |             |            |          |
+   | sigVer         | The RSA    | an object   | object     | Yes      |
+   |                | SigVer     | defining    |            |          |
+   |                | mode and   | SigVer capa |            |          |
+   |                | its capabi | bilities,   |            |          |
+   |                | lities     | see Section |            |          |
+   |                |            | 2.4.3       |            |          |
+   |                |            |             |            |          |
+   | legacySigVer   | The RSA    | an object   | object     | Yes      |
+   |                | Legacy     | defining    |            |          |
+   |                | SigVer     | Legacy      |            |          |
+   |                | mode and   | SigVer capa |            |          |
+   |                | its capabi | bilities,   |            |          |
+   |                | lities     | see Section |            |          |
+   |                |            | 2.4.4       |            |          |
+   |                |            |             |            |          |
+   | componentSigPr | The RSA    | an object   | object     | Yes      |
+   | im             | component  | defining    |            |          |
+   |                | SigPrim    | component   |            |          |
+   |                | mode and   | SigPrim cap |            |          |
+   |                | its capabi | abilities,  |            |          |
+   |                | lities     | see Section |            |          |
+   |                |            | 2.4.5       |            |          |
+   |                |            |             |            |          |
+   | componentDecPr | The RSA    | an object   | object     | Yes      |
+   | im             | component  | defining    |            |          |
+   |                | DecPrim    | component   |            |          |
+   |                | mode and   | DecPrim cap |            |          |
 
 
 
@@ -338,16 +338,30 @@ Vassilev                Expires November 2, 2017                [Page 6]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+   |                | its capabi | abilities,  |            |          |
+   |                | lities     | see Section |            |          |
+   |                |            | 2.4.6       |            |          |
+   |                |            |             |            |          |
+   | algSpecs       | Array of   | array of    | See Table  | No       |
+   |                | modes      | mode        | 1 and      |          |
+   |                |            | objects,    | Section    |          |
+   |                |            | each        | 2.4        |          |
+   |                |            | identified  |            |          |
+   |                |            | uniquely by |            |          |
+   |                |            | the "mode"  |            |          |
+   |                |            | property    |            |          |
+   +----------------+------------+-------------+------------+----------+
+
+              Table 3: RSA Algorithm Capabilities JSON Values
+
 2.4.  Supported RSA Modes Capabilities
 
    The RSA mode capabilities are advertised as arrays of JSON objects
-   within the 'modeSpecs' value of the ACVP registration message - see
-   Table 3.  The 'modeSpecs' value is an array, where each array element
-   is an array of individual JSON objects corresponding to a particular
-   RSA mode defined in this section.  The 'modeSpecs' value is part of
-   the 'capability_exchange' element of the ACVP JSON registration
-   message.  See the ACVP specification for details on the registration
-   message.
+   within the self-named value of the ACVP registration message - see
+   Table 3.  Each object is an array, where each array element is an
+   array of individual JSON objects corresponding to a particular RSA
+   mode defined in this section.  See the ACVP specification for details
+   on the registration message.
 
    Each RSA mode capabilities are advertised as an array of self-
    contained JSON objects.
@@ -355,10 +369,10 @@ Internet-Draft                RSA Alg JSON                      May 2017
 2.4.1.  The keyGen Mode Capabilities
 
    The RSA keyGen mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
+   objects within the array of 'keyGen' value of the ACVP registration
+   message, as part of the 'capability_exchange' element of the ACVP
+   JSON registration message.  See the ACVP specification for details on
+   the registration message.
 
    Each RSA keyGen mode capability is advertised as a self-contained
    JSON object.
@@ -373,6 +387,13 @@ Internet-Draft                RSA Alg JSON                      May 2017
    with conditions capabilities may be advertised by the ACVP compliant
    crypto module:
 
+
+
+Vassilev                Expires November 2, 2017                [Page 7]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    +-------------+-------------+-----------+----------------+----------+
    | JSON value  | Description | JSON type | Valid values   | Optional |
    +-------------+-------------+-----------+----------------+----------+
@@ -386,14 +407,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | 186-4],     |           |                |          |
    |             | Appendix    |           |                |          |
    |             | B.3.2 or    |           |                |          |
-
-
-
-Vassilev                Expires November 2, 2017                [Page 7]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | Appendix    |           |                |          |
    |             | B.3.4       |           |                |          |
    |             |             |           |                |          |
@@ -429,6 +442,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | prime with  |           |                |          |
    |             | conditions  |           |                |          |
    |             | generation  |           |                |          |
+
+
+
+Vassilev                Expires November 2, 2017                [Page 8]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    +-------------+-------------+-----------+----------------+----------+
 
     Table 4: Supported RSA keyGen moduli and hash options for provable
@@ -445,7 +466,42 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires November 2, 2017                [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017                [Page 9]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -501,7 +557,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires November 2, 2017                [Page 9]
+Vassilev                Expires November 2, 2017               [Page 10]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -557,7 +613,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires November 2, 2017               [Page 10]
+Vassilev                Expires November 2, 2017               [Page 11]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -593,79 +649,23 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
-   +----------------+-------------------+-------+-----------+----------+
-   | JSON Value     | Description       | JSON  | Valid     | Optional |
-   |                |                   | type  | Values    |          |
-   +----------------+-------------------+-------+-----------+----------+
-   | mode           | The mode to be    | value | "keyGen", | No       |
-   |                | validated         |       | see Table |          |
-   |                |                   |       | 1         |          |
-   |                |                   |       |           |          |
-   | fixedPubExp    | Supports fixed    | value | true or   | Yes      |
-   |                | public key        |       | false     |          |
-   |                | exponent e        |       |           |          |
-   |                |                   |       |           |          |
-   | fixedPubExpVal | The value of the  | value | hex       | Yes      |
-   |                | public key        |       |           |          |
-   |                | exponent e in hex |       |           |          |
-   |                |                   |       |           |          |
-   | randPubExp     | Supports random   | value | true or   | Yes      |
-
-
-
-Vassilev                Expires November 2, 2017               [Page 11]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-   |                | public key        |       | false     |          |
-   |                | exponent e        |       |           |          |
-   |                |                   |       |           |          |
-   | randPQ         | Random P and Q    | value | {1, 2, 3, | Yes      |
-   |                | primes generated  |       | 4, 5}     |          |
-   |                | as (see           |       |           |          |
-   |                | [FIPS186-4]): 1 - |       |           |          |
-   |                | provable primes   |       |           |          |
-   |                | (Appendix B.3.2); |       |           |          |
-   |                | 2 - probable      |       |           |          |
-   |                | primes (Appendix  |       |           |          |
-   |                | B.3.3); 3 -       |       |           |          |
-   |                | provable primes   |       |           |          |
-   |                | (Appendix B.3.4); |       |           |          |
-   |                | 4 -               |       |           |          |
-   |                | provable/probable |       |           |          |
-   |                | primes (Appendix  |       |           |          |
-   |                | B.3.5); 5 -       |       |           |          |
-   |                | probable primes   |       |           |          |
-   |                | (Appendix B.3.6)  |       |           |          |
-   |                |                   |       |           |          |
-   | capProvPrimes  | Capabilities for  | array |           | Yes      |
-   |                | all supported     |       |           |          |
-   |                | moduli and hash   |       |           |          |
-   |                | algorithms (see   |       |           |          |
-   |                | Table 4)          |       |           |          |
-   |                |                   |       |           |          |
-   | modProbPrime   | See Table 5       | array | see Table | Yes      |
-   |                |                   |       | 5         |          |
-   |                |                   |       |           |          |
-   | primeTest      | See Table 5       | value | see Table | Yes      |
-   |                |                   |       | 5         |          |
-   +----------------+-------------------+-------+-----------+----------+
-
-               Table 7: RSA keyGen Capabilities JSON Values
-
-2.4.2.  The sigGen Mode Capabilities
-
-   The RSA sigGen mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
-
-   Each RSA sigGen mode capability is advertised as a self-contained
-   JSON object.
-
-
+   +--------------------+----------------+-------+-----------+---------+
+   | JSON Value         | Description    | JSON  | Valid     | Optiona |
+   |                    |                | type  | Values    | l       |
+   +--------------------+----------------+-------+-----------+---------+
+   | mode               | The mode to be | value | "keyGen", | No      |
+   |                    | validated      |       | seeTable  |         |
+   |                    |                |       | 1         |         |
+   |                    |                |       |           |         |
+   | randPQ             | Key Generation | value | "B.3.2",  | No      |
+   |                    | mode to be     |       | "B.3.3",  |         |
+   |                    | validated.     |       | "B.3.4",  |         |
+   |                    | Random P and Q |       | "B.3.5",  |         |
+   |                    | primes         |       | or        |         |
+   |                    | generated as   |       | "B.3.6"   |         |
+   |                    | (see           |       |           |         |
+   |                    | [FIPS186-4]):  |       |           |         |
+   |                    | provable       |       |           |         |
 
 
 
@@ -674,54 +674,54 @@ Vassilev                Expires November 2, 2017               [Page 12]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   The following subsections define the capabilities that may be
-   advertised by the ACVP compliant crypto modules.
-
-2.4.2.1.  sigGen Capabilities
-
-   The following key generation with provable primes capabilities may be
-   advertised by the ACVP compliant crypto module:
-
-   +--------------+----------------+-------+----------------+----------+
-   | JSON value   | Description    | JSON  | Valid values   | Optional |
-   |              |                | type  |                |          |
-   +--------------+----------------+-------+----------------+----------+
-   | sigType      | supported RSA  | array | any non-empty  | No       |
-   |              | signature      |       | subset of      |          |
-   |              | types  - see   |       | {"X9.31",      |          |
-   |              | [FIPS186-4],   |       | "PKCS1v1.5",   |          |
-   |              | Section 5      |       | "PKCS1PSS"}    |          |
-   |              |                |       |                |          |
-   | modRSASigGen | supported RSA  | array | any non-empty  | No       |
-   |              | moduli for     |       | subset of      |          |
-   |              | signature      |       | {2048, 3072,   |          |
-   |              | generation -   |       | 4096}          |          |
-   |              | see            |       |                |          |
-   |              | [FIPS186-4],   |       |                |          |
-   |              | Section 5      |       |                |          |
-   |              |                |       |                |          |
-   | hashSigGen   | supported hash | array | any non-empty  | No       |
-   |              | algorithms for |       | subset of      |          |
-   |              | signature      |       | {"SHA-224",    |          |
-   |              | generation -   |       | "SHA-256",     |          |
-   |              | see            |       | "SHA-384",     |          |
-   |              | [SP800-131A],  |       | "SHA-512",     |          |
-   |              | Section 9      |       | "SHA-512/224", |          |
-   |              |                |       | "SHA-512/256"} |          |
-   |              |                |       |                |          |
-   | saltSigGen   | supported salt | array | array of       | Yes      |
-   |              | lengths for    |       | values for     |          |
-   |              | PKCS1PSS       |       | each hash      |          |
-   |              | signature      |       | algorithm used |          |
-   |              | generation -   |       | subject to the |          |
-   |              | see            |       | constraint in  |          |
-   |              | [FIPS186-4],   |       | the note       |          |
-   |              | Section 5.5.   |       | below.         |          |
-   |              | See also note  |       |                |          |
-   |              | below.         |       |                |          |
-   +--------------+----------------+-------+----------------+----------+
-
-     Table 8: Supported RSA sigGen moduli and hash options JSON Values
+   |                    | primes         |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.2);        |       |           |         |
+   |                    | probable       |       |           |         |
+   |                    | primes         |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.3);        |       |           |         |
+   |                    | provable       |       |           |         |
+   |                    | primes with    |       |           |         |
+   |                    | conditions     |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.4); provab |       |           |         |
+   |                    | le/probable    |       |           |         |
+   |                    | primes with    |       |           |         |
+   |                    | conditions     |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.5);        |       |           |         |
+   |                    | probable       |       |           |         |
+   |                    | primes with    |       |           |         |
+   |                    | conditions     |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.6)         |       |           |         |
+   |                    |                |       |           |         |
+   | infoGeneratedBySer | This flag      | value | true or   | No      |
+   | ver                | indicates that |       | false     |         |
+   |                    | the server is  |       |           |         |
+   |                    | responsible    |       |           |         |
+   |                    | for generating |       |           |         |
+   |                    | inputs for Key |       |           |         |
+   |                    | Generation     |       |           |         |
+   |                    | tests          |       |           |         |
+   |                    |                |       |           |         |
+   | pubExp             | Supports fixed | value | "fixed"   | No      |
+   |                    | or random      |       | or        |         |
+   |                    | public key     |       | "random"  |         |
+   |                    | exponent e     |       |           |         |
+   |                    |                |       |           |         |
+   | fixedPubExpVal     | The value of   | value | hex       | Yes     |
+   |                    | the public key |       |           |         |
+   |                    | exponent e in  |       |           |         |
+   |                    | hex if         |       |           |         |
+   |                    | "pubExp" is    |       |           |         |
+   |                    | "fixed"        |       |           |         |
+   |                    |                |       |           |         |
+   | capProvPrimes      | Capabilities   | array | See Table | Yes     |
+   |                    | for all        |       | 4.        |         |
+   |                    | supported      |       |           |         |
+   |                    | moduli and     |       |           |         |
 
 
 
@@ -730,50 +730,50 @@ Vassilev                Expires November 2, 2017               [Page 13]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   Note: the salt length for each hash algorithm used in PKCS1PSS
-   signature generation is between 0 and the length of the corresponding
-   hash function output block (in bytes), the end points included.
+   |                    | hash           |       |           |         |
+   |                    | algorithms     |       |           |         |
+   |                    | (see Table 4)  |       |           |         |
+   |                    | for provable   |       |           |         |
+   |                    | primes         |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.2) and     |       |           |         |
+   |                    | provable       |       |           |         |
+   |                    | primes with    |       |           |         |
+   |                    | conditions     |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.4).        |       |           |         |
+   |                    |                |       |           |         |
+   | capProbPrimes      | Capabilities   | array | See Table | Yes     |
+   |                    | for all        |       | 5.        |         |
+   |                    | supported      |       |           |         |
+   |                    | moduli and     |       |           |         |
+   |                    | hash           |       |           |         |
+   |                    | algorithms for |       |           |         |
+   |                    | probable       |       |           |         |
+   |                    | primes         |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.3) and     |       |           |         |
+   |                    | probable       |       |           |         |
+   |                    | primes with    |       |           |         |
+   |                    | conditions     |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.6).        |       |           |         |
+   |                    |                |       |           |         |
+   | capProvProbPrimes  | Capabilities   | array | See Table | Yes     |
+   |                    | for all        |       | 6.        |         |
+   |                    | supported      |       |           |         |
+   |                    | moduli and     |       |           |         |
+   |                    | hash           |       |           |         |
+   |                    | algorithms for |       |           |         |
+   |                    | provable and   |       |           |         |
+   |                    | probable       |       |           |         |
+   |                    | primes with    |       |           |         |
+   |                    | conditions     |       |           |         |
+   |                    | (Appendix      |       |           |         |
+   |                    | B.3.5).        |       |           |         |
+   +--------------------+----------------+-------+-----------+---------+
 
-2.4.3.  The sigVer Mode Capabilities
-
-   The RSA sigVer mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
-
-   Each RSA sigVer mode capability is advertised as a self-contained
-   JSON object.
-
-   The following subsections define the capabilities that may be
-   advertised by the ACVP compliant crypto modules.
-
-2.4.3.1.  sigVer Capabilities
-
-   The following key generation with provable primes capabilities may be
-   advertised by the ACVP compliant crypto module:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+               Table 7: RSA keyGen Capabilities JSON Values
 
 
 
@@ -786,50 +786,50 @@ Vassilev                Expires November 2, 2017               [Page 14]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +--------------+----------------+-------+----------------+----------+
-   | JSON value   | Description    | JSON  | Valid values   | Optional |
-   |              |                | type  |                |          |
-   +--------------+----------------+-------+----------------+----------+
-   | sigType      | supported RSA  | array | any non-empty  | No       |
-   |              | signature      |       | subset of      |          |
-   |              | types  - see   |       | {"X9.31",      |          |
-   |              | [FIPS186-4],   |       | "PKCS1v1.5",   |          |
-   |              | Section 5      |       | "PKCS1PSS"}    |          |
-   |              |                |       |                |          |
-   | modRSASigVer | supported RSA  | array | any non-empty  | No       |
-   |              | moduli for     |       | subset of      |          |
-   |              | signature      |       | {2048, 3072,   |          |
-   |              | verification - |       | 4096}          |          |
-   |              | see            |       |                |          |
-   |              | [FIPS186-4],   |       |                |          |
-   |              | Section 5      |       |                |          |
-   |              |                |       |                |          |
-   | hashSigVer   | supported hash | array | any non-empty  | No       |
-   |              | algorithms for |       | subset of      |          |
-   |              | signature      |       | {"SHA-224",    |          |
-   |              | verification - |       | "SHA-256",     |          |
-   |              | see            |       | "SHA-384",     |          |
-   |              | [SP800-131A],  |       | "SHA-512",     |          |
-   |              | Section 9      |       | "SHA-512/224", |          |
-   |              |                |       | "SHA-512/256"} |          |
-   |              |                |       |                |          |
-   | saltSigVer   | supported salt | array | array of       | Yes      |
-   |              | lengths for    |       | values for     |          |
-   |              | PKCS1PSS       |       | each hash      |          |
-   |              | signature      |       | algorithm used |          |
-   |              | verification - |       | subject to the |          |
-   |              | see            |       | constraint in  |          |
-   |              | [FIPS186-4],   |       | the note       |          |
-   |              | Section 5.5.   |       | below.         |          |
-   |              | See also note  |       |                |          |
-   |              | below.         |       |                |          |
-   +--------------+----------------+-------+----------------+----------+
+2.4.2.  The sigGen Mode Capabilities
 
-     Table 9: Supported RSA sigVer moduli and hash options JSON Values
+   The RSA sigGen mode capabilities are advertised as an array of JSON
+   objects within the array of 'sigGen' value of the ACVP registration
+   message, as part of the 'capability_exchange' element of the ACVP
+   JSON registration message.  See the ACVP specification for details on
+   the registration message.
 
-   Note: the salt length for each hash algorithm used in PKCS1PSS
-   signature generation is between 0 and the length of the corresponding
-   hash function output block (in bytes), the end points included.
+   Each RSA sigGen mode capability is advertised as a self-contained
+   JSON object.
+
+   The following subsections define the capabilities that may be
+   advertised by the ACVP compliant crypto modules.
+
+2.4.2.1.  sigGen Capabilities
+
+   The following signature generation capabilities may be advertised by
+   the ACVP compliant crypto module:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -842,20 +842,127 @@ Vassilev                Expires November 2, 2017               [Page 15]
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+  +---------+--------------------+-------+------------------+----------+
+  | JSON    | Description        | JSON  | Valid values     | Optional |
+  | value   |                    | type  |                  |          |
+  +---------+--------------------+-------+------------------+----------+
+  | sigType | supported RSA      | array | any non-empty    | No       |
+  |         | signature types  - |       | subset of        |          |
+  |         | see [FIPS186-4],   |       | {"X9.31",        |          |
+  |         | Section 5          |       | "PKCS1v1.5",     |          |
+  |         |                    |       | "PKCS1PSS"}      |          |
+  |         |                    |       |                  |          |
+  | modulo  | supported RSA      | array | any non-empty    | No       |
+  |         | moduli for         |       | subset of {2048, |          |
+  |         | signature          |       | 3072, 4096}      |          |
+  |         | generation - see   |       |                  |          |
+  |         | [FIPS186-4],       |       |                  |          |
+  |         | Section 5          |       |                  |          |
+  |         |                    |       |                  |          |
+  | hashAlg | supported hash     | array | any non-empty    | No       |
+  |         | algorithms for     |       | subset of        |          |
+  |         | signature          |       | {"SHA-224",      |          |
+  |         | generation - see   |       | "SHA-256",       |          |
+  |         | [SP800-131A],      |       | "SHA-384",       |          |
+  |         | Section 9          |       | "SHA-512",       |          |
+  |         |                    |       | "SHA-512/224",   |          |
+  |         |                    |       | "SHA-512/256"}   |          |
+  |         |                    |       |                  |          |
+  | saltLen | supported salt     | array | array of values  | Yes      |
+  |         | lengths for        |       | for each hash    |          |
+  |         | PKCS1PSS signature |       | algorithm used   |          |
+  |         | generation - see   |       | subject to the   |          |
+  |         | [FIPS186-4],       |       | constraint in    |          |
+  |         | Section 5.5. See   |       | the note below.  |          |
+  |         | also note below.   |       |                  |          |
+  +---------+--------------------+-------+------------------+----------+
+
+     Table 8: Supported RSA sigGen moduli and hash options JSON Values
+
+   Note: the salt length for each hash algorithm used in PKCS1PSS
+   signature generation is between 0 and the length of the corresponding
+   hash function output block (in bytes), the end points included.
+
+2.4.3.  The sigVer Mode Capabilities
+
+   The RSA sigVer mode capabilities are advertised as an array of JSON
+   objects within the array of 'sigVer' value of the ACVP registration
+   message, as part of the 'capability_exchange' element of the ACVP
+   JSON registration message.  See the ACVP specification for details on
+   the registration message.
+
+
+
+Vassilev                Expires November 2, 2017               [Page 16]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   Each RSA sigVer mode capability is advertised as a self-contained
+   JSON object.
+
+   The following subsections define the capabilities that may be
+   advertised by the ACVP compliant crypto modules.
+
+2.4.3.1.  sigVer Capabilities
+
+   The following signature verification capabilities may be advertised
+   by the ACVP compliant crypto module:
+
+  +---------+--------------------+-------+------------------+----------+
+  | JSON    | Description        | JSON  | Valid values     | Optional |
+  | value   |                    | type  |                  |          |
+  +---------+--------------------+-------+------------------+----------+
+  | sigType | supported RSA      | array | any non-empty    | No       |
+  |         | signature types  - |       | subset of        |          |
+  |         | see [FIPS186-4],   |       | {"X9.31",        |          |
+  |         | Section 5          |       | "PKCS1v1.5",     |          |
+  |         |                    |       | "PKCS1PSS"}      |          |
+  |         |                    |       |                  |          |
+  | modulo  | supported RSA      | array | any non-empty    | No       |
+  |         | moduli for         |       | subset of {2048, |          |
+  |         | signature          |       | 3072, 4096}      |          |
+  |         | verification - see |       |                  |          |
+  |         | [FIPS186-4],       |       |                  |          |
+  |         | Section 5          |       |                  |          |
+  |         |                    |       |                  |          |
+  | hashAlg | supported hash     | array | any non-empty    | No       |
+  |         | algorithms for     |       | subset of        |          |
+  |         | signature          |       | {"SHA-224",      |          |
+  |         | verification - see |       | "SHA-256",       |          |
+  |         | [SP800-131A],      |       | "SHA-384",       |          |
+  |         | Section 9          |       | "SHA-512",       |          |
+  |         |                    |       | "SHA-512/224",   |          |
+  |         |                    |       | "SHA-512/256"}   |          |
+  |         |                    |       |                  |          |
+  | saltLen | supported salt     | array | array of values  | Yes      |
+  |         | lengths for        |       | for each hash    |          |
+  |         | PKCS1PSS signature |       | algorithm used   |          |
+  |         | verification - see |       | subject to the   |          |
+  |         | [FIPS186-4],       |       | constraint in    |          |
+  |         | Section 5.5. See   |       | the note below.  |          |
+  |         | also note below.   |       |                  |          |
+  +---------+--------------------+-------+------------------+----------+
+
+     Table 9: Supported RSA sigVer moduli and hash options JSON Values
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 17]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   Note: the salt length for each hash algorithm used in PKCS1PSS
+   signature generation is between 0 and the length of the corresponding
+   hash function output block (in bytes), the end points included.
+
 2.4.4.  The legacySigVer Mode Capabilities
 
    The RSA legacySigVer mode capabilities are advertised as an array of
-   JSON objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
-
-   Each RSA legacySigVer mode capability is advertised as a self-
-   contained JSON object.
-
-   The RSA sigVer mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
+   JSON objects within the array of 'legacySigVer' value of the ACVP
+   registration message, as part of the 'capability_exchange' element of
    the ACVP JSON registration message.  See the ACVP specification for
    details on the registration message.
 
@@ -865,7 +972,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
 
-   The following key generation with provable primes capabilities may be
+   The following legacy signature verification capabilities may be
    advertised by the ACVP compliant crypto module:
 
 
@@ -893,51 +1000,47 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires November 2, 2017               [Page 16]
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 18]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +------------------+--------------+-------+--------------+----------+
-   | JSON value       | Description  | JSON  | Valid values | Optional |
-   |                  |              | type  |              |          |
-   +------------------+--------------+-------+--------------+----------+
-   | sigType          | supported    | array | any non-     | No       |
-   |                  | legacy RSA   |       | empty subset |          |
-   |                  | signature    |       | of {"X9.31", |          |
-   |                  | types  - see |       | "PKCS1v1.5", |          |
-   |                  | [SP800-131A] |       | "PKCS1PSS"}  |          |
-   |                  | , Section 5  |       |              |          |
-   |                  |              |       |              |          |
-   | modLegacyRSASigV | supported    | array | any non-     | No       |
-   | er               | RSA moduli   |       | empty subset |          |
-   |                  | for          |       | of {1024,    |          |
-   |                  | signature    |       | 1536, 2048,  |          |
-   |                  | verification |       | 3072, 4096}  |          |
-   |                  | - see        |       |              |          |
-   |                  | [SP800-131A] |       |              |          |
-   |                  |              |       |              |          |
-   | hashLegacySigVer | supported    | array | any non-     | No       |
-   |                  | hash         |       | empty subset |          |
-   |                  | algorithms   |       | of {"SHA-1", |          |
-   |                  | for          |       | "SHA-256",   |          |
-   |                  | signature    |       | "SHA-384",   |          |
-   |                  | verification |       | "SHA-512"}   |          |
-   |                  | - see [SP800 |       |              |          |
-   |                  | -131A],      |       |              |          |
-   |                  | Section 9    |       |              |          |
-   |                  |              |       |              |          |
-   | saltLegacySigVer | supported    | array | array of     | Yes      |
-   |                  | salt lengths |       | values for   |          |
-   |                  | for PKCS1PSS |       | each hash    |          |
-   |                  | signature    |       | algorithm    |          |
-   |                  | verification |       | used subject |          |
-   |                  | - see        |       | to the       |          |
-   |                  | [FIPS186-4], |       | constraint   |          |
-   |                  | Section 5.5. |       | in the note  |          |
-   |                  | See also     |       | below.       |          |
-   |                  | note below.  |       |              |          |
-   +------------------+--------------+-------+--------------+----------+
+   +---------+--------------------+-------+-----------------+----------+
+   | JSON    | Description        | JSON  | Valid values    | Optional |
+   | value   |                    | type  |                 |          |
+   +---------+--------------------+-------+-----------------+----------+
+   | sigType | supported legacy   | array | any non-empty   | No       |
+   |         | RSA signature      |       | subset of       |          |
+   |         | types  - see       |       | {"X9.31",       |          |
+   |         | [SP800-131A],      |       | "PKCS1v1.5",    |          |
+   |         | Section 5          |       | "PKCS1PSS"}     |          |
+   |         |                    |       |                 |          |
+   | modulo  | supported RSA      | array | any non-empty   | No       |
+   |         | moduli for         |       | subset of       |          |
+   |         | signature          |       | {1024, 1536,    |          |
+   |         | verification - see |       | 2048, 3072,     |          |
+   |         | [SP800-131A]       |       | 4096}           |          |
+   |         |                    |       |                 |          |
+   | hashAlg | supported hash     | array | any non-empty   | No       |
+   |         | algorithms for     |       | subset of       |          |
+   |         | signature          |       | {"SHA-1",       |          |
+   |         | verification - see |       | "SHA-256",      |          |
+   |         | [SP800-131A],      |       | "SHA-384",      |          |
+   |         | Section 9          |       | "SHA-512"}      |          |
+   |         |                    |       |                 |          |
+   | saltLen | supported salt     | array | array of values | Yes      |
+   |         | lengths for        |       | for each hash   |          |
+   |         | PKCS1PSS signature |       | algorithm used  |          |
+   |         | verification - see |       | subject to the  |          |
+   |         | [FIPS186-4],       |       | constraint in   |          |
+   |         | Section 5.5. See   |       | the note below. |          |
+   |         | also note below.   |       |                 |          |
+   +---------+--------------------+-------+-----------------+----------+
 
      Table 10: Supported RSA legacySigVer moduli and hash options JSON
                                   Values
@@ -946,37 +1049,36 @@ Internet-Draft                RSA Alg JSON                      May 2017
    signature generation is between 0 and the length of the corresponding
    hash function output block (in bytes), the end points included.
 
+2.4.5.  The componentSigPrimitive Mode Capabilities
+
+   The RSA componentSigPrim mode capability (otherwise known as RSASP1
+   in [RFC3447]) is advertised as a JSON object within the array of
+   'componentSigPrim' value of the ACVP registration message, as part of
+   the 'capability_exchange' element of the ACVP JSON registration
+   message.  In this mode, the only tested capability is the correct
+   expontiation 's = msg^d mod n', where 'msg' is a message between '0'
+   and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all
 
 
 
-Vassilev                Expires November 2, 2017               [Page 17]
+Vassilev                Expires November 2, 2017               [Page 19]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-2.4.5.  The componentSigPrimitive Mode Capabilities
+   supplied by the testing ACVP server.  Only 2048-bit RSA keys are
+   allowed for this capability.  See Appendix B.5 for additional details
+   on constraints for 'msg' and 'n'.  See the ACVP specification for
+   details on the registration message.
 
-   The RSA componentSigPrimitive mode capability (otherwise known as
-   RSASP1 in [RFC3447]) is advertised as a JSON object within the array
-   of 'modeSpecs' value of the ACVP registration message, as part of the
-   'capability_exchange' element of the ACVP JSON registration message.
-   In this mode, the only tested capability is the correct expontiation
-   's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1',
-   'd' is the private exponent and 'n' is the modulus, all supplied by
-   the testing ACVP server.  Only 2048-bit RSA keys are allowed for this
-   capability.  There are no properties specified for this capability.
-   See Appendix B.5 for additional details on constraints for 'msg' and
-   'n'.  See the ACVP specification for details on the registration
-   message.
-
-   Each RSA componentSigPrimitive mode capability is advertised as a
-   self-contained JSON object.
+   Each RSA componentSigPrim mode capability is advertised as a self-
+   contained JSON object.
 
 2.4.6.  The componentDecPrimitive Mode Capabilities
 
-   The RSA componentDecPrimitive mode capability is advertised a JSON
-   object within the array of 'modeSpecs' value of the ACVP registration
-   message. as part of the 'capability_exchange' element of the ACVP
+   The RSA componentDecPrim mode capability is advertised a JSON object
+   within the array of 'componentDecPrim' value of the ACVP registration
+   message, as part of the 'capability_exchange' element of the ACVP
    JSON registration message.  In this mode, the only tested capability
    is the correct expontiation 's = msg^d mod n', where 'msg' is a
    message, 'd' is the private exponent and ''n is the modulus.  See
@@ -1002,21 +1104,24 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
    typical ACVP validation session would require multiple test vector
+   sets to be downloaded and processed by the ACVP client.  Each test
+   vector set represents an individual algorithm mode, such as RSA Key
+   Generation where the algorithm is "RSA" and the mode is "KeyGen".  If
+   a registration comes in requesting multiple modes of RSA, multiple
+   test vector sets will be returned.  This section describes the JSON
+   schema for a test vector set used with RSA algorithms.
+
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
 
 
 
-Vassilev                Expires November 2, 2017               [Page 18]
+
+Vassilev                Expires November 2, 2017               [Page 20]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   sets to be downloaded and processed by the ACVP client.  Each test
-   vector set represents an individual algorithm, such as Hash_DRBG,
-   etc.  This section describes the JSON schema for a test vector set
-   used with DRBG algorithms.
-
-   The test vector set JSON schema is a multi-level hierarchy that
-   contains meta data for the entire vector set as well as individual
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
 
@@ -1030,6 +1135,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |            |                                              |       |
    | algorithm  | The RSA algorithm used for the test vectors. | value |
    |            | See Section 2.1 for possible values.         |       |
+   |            |                                              |       |
+   | mode       | The RSA mode tested. See Section 2.1 for     | value |
+   |            | possible values.                             |       |
    |            |                                              |       |
    | testGroups | Array of test group JSON objects, which are  | array |
    |            | defined in Section 3.1                       |       |
@@ -1061,37 +1169,50 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires November 2, 2017               [Page 19]
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 21]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +-----------+--------------------------------+-----------+----------+
-   | JSON      | Description                    | JSON type | Optional |
-   | Value     |                                |           |          |
-   +-----------+--------------------------------+-----------+----------+
-   | mode      | The RSA algorithm mode used    | value     | No       |
-   |           | for the test vectors.  See     |           |          |
-   |           | Section 2.1 for possible       |           |          |
-   |           | values.                        |           |          |
-   |           |                                |           |          |
-   | randPQ    | RSA prime generation method -  | value     | Yes      |
-   |           | see Table 7                    |           |          |
-   |           |                                |           |          |
-   | modRSA    | RSA modulus                    | value     | No       |
-   |           |                                |           |          |
-   | hashAlg   | the hash algorithm             | value     | Yes      |
-   |           |                                |           |          |
-   | primeTest | Miller-Rabin constraint from   | value     | Yes      |
-   |           | Table C.2 or C.3               |           |          |
-   |           |                                |           |          |
-   | pubExp    | Fixed or random public         | hex value | Yes      |
-   |           | exponent                       | or        |          |
-   |           |                                | "random"  |          |
-   |           |                                |           |          |
-   | sigType   | The type of digital signature  | value     | Yes      |
-   |           | algorithm - see  Table 8       |           |          |
-   +-----------+--------------------------------+-----------+----------+
+   +-----------+----------------+---------------------------+----------+
+   | JSON      | Description    | JSON type                 | Optional |
+   | Value     |                |                           |          |
+   +-----------+----------------+---------------------------+----------+
+   | randPQ    | RSA prime      | value                     | Yes      |
+   |           | generation     |                           |          |
+   |           | method - see   |                           |          |
+   |           | Table 7        |                           |          |
+   |           |                |                           |          |
+   | modulo    | RSA modulus    | value                     | No       |
+   |           |                |                           |          |
+   | testType  | The test type  | Either "AFT" (algorithm   | No       |
+   |           | for the test   | functional test), "KAT"   |          |
+   |           | group          | (known answer test), or   |          |
+   |           |                | "GDT" (generated data     |          |
+   |           |                | test).                    |          |
+   |           |                |                           |          |
+   | hashAlg   | the hash       | value                     | Yes      |
+   |           | algorithm      |                           |          |
+   |           |                |                           |          |
+   | primeTest | Miller-Rabin   | "tblC2" or "tblC3"        | Yes      |
+   |           | constraint     |                           |          |
+   |           | from Table C.2 |                           |          |
+   |           | or C.3         |                           |          |
+   |           |                |                           |          |
+   | pubExp    | Fixed or       | "fixed" or "random"       | Yes      |
+   |           | random public  |                           |          |
+   |           | exponent       |                           |          |
+   |           |                |                           |          |
+   | sigType   | The type of    | value                     | Yes      |
+   |           | digital        |                           |          |
+   |           | signature      |                           |          |
+   |           | algorithm -    |                           |          |
+   |           | see  Table 8   |                           |          |
+   +-----------+----------------+---------------------------+----------+
 
                      Table 12: Test Group JSON Object
 
@@ -1100,51 +1221,172 @@ Internet-Draft                RSA Alg JSON                      May 2017
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
-   elements for each RSA test vector.
+   elements for each RSA test vector under the KeyGen mode.  If the
+   value "infoGeneratedByServer" is false, the test case will only
+   consist of a "tcId", unless "B.3.3" is included.  Under this prime
+   generation method, the test case will always consist of a series of
+   test cases with only "tcId".  If both "B.3.3" and "random" "pubExp"
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 20]
+Vassilev                Expires November 2, 2017               [Page 22]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +-------+----------------------------------------+-------+----------+
-   | JSON  | Description                            | JSON  | Optional |
-   | Value |                                        | type  |          |
-   +-------+----------------------------------------+-------+----------+
-   | tcId  | Numeric identifier for the test case,  | value | No       |
-   |       | unique across the entire vector set.   |       |          |
-   |       |                                        |       |          |
-   | e     | the public exponent                    | hex   | Yes      |
-   |       |                                        | value |          |
-   |       |                                        |       |          |
-   | pRand | the random for P, testing probable     | hex   | Yes      |
-   |       | primes according to [FIPS186-4],       | value |          |
-   |       | Appendix B.3.3                         |       |          |
-   |       |                                        |       |          |
-   | qRand | the random for Q, if applicable,       | hex   | Yes      |
-   |       | testing probable primes according to   | value |          |
-   |       | [FIPS186-4], Appendix B.3.3            |       |          |
-   |       |                                        |       |          |
-   | msg   | the message to be signed               | hex   | Yes      |
-   |       |                                        | value |          |
-   +-------+----------------------------------------+-------+----------+
+   are enabled (regardless of "infoGeneratedByServer"), then there will
+   be an additional test group of known answer tests (KATs) which
+   includes test cases with only "tcId", "pRand", "qRand", and "e".
 
-                    Table 13: RSA Test Case JSON Object
+   +-------------+----------------------------------+-------+----------+
+   | JSON Value  | Description                      | JSON  | Optional |
+   |             |                                  | type  |          |
+   +-------------+----------------------------------+-------+----------+
+   | tcId        | Numeric identifier for the test  | value | No       |
+   |             | case, unique across the entire   |       |          |
+   |             | vector set.                      |       |          |
+   |             |                                  |       |          |
+   | e           | the public exponent              | hex   | Yes      |
+   |             |                                  | value |          |
+   |             |                                  |       |          |
+   | pRand       | the random for P, testing        | hex   | Yes      |
+   |             | probable primes according to     | value |          |
+   |             | [FIPS186-4], Appendix B.3.3      |       |          |
+   |             |                                  |       |          |
+   | qRand       | the random for Q, if applicable, | hex   | Yes      |
+   |             | testing probable primes          | value |          |
+   |             | according to [FIPS186-4],        |       |          |
+   |             | Appendix B.3.3                   |       |          |
+   |             |                                  |       |          |
+   | xP1         | the prime factor p1 for Primes   | hex   | Yes      |
+   |             | with Conditions - see            | value |          |
+   |             | [FIPS186-4], Appendix B.3.3,     |       |          |
+   |             | B.3.4, or B.3.5, if applicable   |       |          |
+   |             |                                  |       |          |
+   | seed        | the seed used in prime           | hex   | Yes      |
+   |             | generation according to          | value |          |
+   |             | [FIPS186-4], Appendix B.3.2,     |       |          |
+   |             | B.3.4, or B3.5                   |       |          |
+   |             |                                  |       |          |
+   | bitlen1     | the length of p1 for prime       | hex   | Yes      |
+   |             | generation according to          | value |          |
+   |             | [FIPS186-4], Appendix B.3.2,     |       |          |
+   |             | B.3.4, B3.5 or the length of xP1 |       |          |
+   |             | for B.3.6                        |       |          |
+   |             |                                  |       |          |
+   | bitlen2     | the length of p2 for prime       | hex   | Yes      |
+   |             | generation according to          | value |          |
+   |             | [FIPS186-4], Appendix B.3.2,     |       |          |
+   |             | B.3.4, B.3.5 or the length of    |       |          |
+   |             | xP2 for B.3.6                    |       |          |
+   |             |                                  |       |          |
+   | bitlen3     | the length of q1 for prime       | hex   | Yes      |
+   |             | generation according to          | value |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 23]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   |             | [FIPS186-4], Appendix B.3.2,     |       |          |
+   |             | B.3.4, B.3.5 or the length of    |       |          |
+   |             | xQ1 for B.3.6                    |       |          |
+   |             |                                  |       |          |
+   | bitlen4     | the length of q2 for prime       | hex   | Yes      |
+   |             | generation according to          | value |          |
+   |             | [FIPS186-4], Appendix B.3.2,     |       |          |
+   |             | B.3.4, B.3.5 or the length of    |       |          |
+   |             | xQ2 for B.3.6                    |       |          |
+   |             |                                  |       |          |
+   | primeSeedP2 | the prime seed used for p2 for   | hex   | Yes      |
+   |             | prime generation according to    | value |          |
+   |             | [FIPS186-4], Appendix B.3.5      |       |          |
+   |             |                                  |       |          |
+   | primeSeedQ1 | the prime seed used for q1 for   | hex   | Yes      |
+   |             | prime generation according to    | value |          |
+   |             | [FIPS186-4], Appendix B.3.5      |       |          |
+   |             |                                  |       |          |
+   | primeSeedQ2 | the prime seed used for q2 for   | hex   | Yes      |
+   |             | prime generation according to    | value |          |
+   |             | [FIPS186-4], Appendix B.3.5      |       |          |
+   |             |                                  |       |          |
+   | xP2         | the prime factor p2 for Primes   | hex   | Yes      |
+   |             | with Conditions - see            | value |          |
+   |             | [FIPS186-4], Appendix B.3.3,     |       |          |
+   |             | B.3.4, or B.3.5, if applicable   |       |          |
+   |             |                                  |       |          |
+   | xP          | the random number used in Step 3 | hex   | Yes      |
+   |             | of the algorithm in [FIPS186-4], | value |          |
+   |             | Appendix C.9 to generate the     |       |          |
+   |             | prime P, if applicable           |       |          |
+   |             |                                  |       |          |
+   | xQ1         | the prime factor q1 for Primes   | hex   | Yes      |
+   |             | with Conditions - see            | value |          |
+   |             | [FIPS186-4], Appendix B.3.3,     |       |          |
+   |             | B.3.4, or B.3.5, if applicable   |       |          |
+   |             |                                  |       |          |
+   | xQ2         | the prime factor q2 for Primes   | hex   | Yes      |
+   |             | with Conditions - see            | value |          |
+   |             | [FIPS186-4], Appendix B.3.3,     |       |          |
+   |             | B.3.4, or B.3.5, if applicable   |       |          |
+   |             |                                  |       |          |
+   | xQ          | the random number used in Step 3 | hex   | Yes      |
+   |             | of the algorithm in [FIPS186-4], | value |          |
+   |             | Appendix C.9 to generate the     |       |          |
+   |             | prime Q, if applicable           |       |          |
+   +-------------+----------------------------------+-------+----------+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 24]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+          Table 13: RSA Test Case JSON Object for Key Generation
+
+   The following table describes the JSON elements for each RSA test
+   vector under the SigGen or SigVer mode.
+
+   +--------+---------------------------------------+-------+----------+
+   | JSON   | Description                           | JSON  | Optional |
+   | Value  |                                       | type  |          |
+   +--------+---------------------------------------+-------+----------+
+   | tcId   | Numeric identifier for the test case, | value | No       |
+   |        | unique across the entire vector set.  |       |          |
+   |        |                                       |       |          |
+   | msg    | the message to be signed              | hex   | Yes      |
+   |        |                                       | value |          |
+   +--------+---------------------------------------+-------+----------+
+
+      Table 14: RSA Test Case JSON Object for Signature Generation or
+                               Verification
+
+   The following table describes the JSON elements for each RSA test
+   vector under the componentSigPrim or componentDecPrim modes.
+
+   +--------+---------------------------------------+-------+----------+
+   | JSON   | Description                           | JSON  | Optional |
+   | Value  |                                       | type  |          |
+   +--------+---------------------------------------+-------+----------+
+   | tcId   | Numeric identifier for the test case, | value | No       |
+   |        | unique across the entire vector set.  |       |          |
+   |        |                                       |       |          |
+   | msg    | the message to be signed or decrypted | hex   | No       |
+   |        |                                       | value |          |
+   |        |                                       |       |          |
+   | d      | the private exponent                  | hex   | Yes      |
+   |        |                                       | value |          |
+   |        |                                       |       |          |
+   | n      | the modulus value                     | hex   | Yes      |
+   |        |                                       | value |          |
+   +--------+---------------------------------------+-------+----------+
+
+   Table 15: RSA Test Case JSON Object for Component Signature Primitive
+                  or Component Decryption Primitive modes
 
 4.  Test Vector Responses
 
@@ -1152,6 +1394,13 @@ Internet-Draft                RSA Alg JSON                      May 2017
    send the response vectors back to the ACVP server.  The following
    table describes the JSON object that represents a vector set
    response.
+
+
+
+Vassilev                Expires November 2, 2017               [Page 25]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    +-------------+---------------------------------------------+-------+
    | JSON Value  | Description                                 | JSON  |
@@ -1167,19 +1416,13 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | JSON schema as defined in Section 3.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 14: Vector Set Response JSON Object
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 21]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
+                 Table 16: Vector Set Response JSON Object
 
    The following table describes the JSON elements for the response to a
-   RSA test vector.
+   RSA test vector.  The client can send private keys using the standard
+   format or the Chinese Remainder Theorem (CRT) format.  If the value
+   of "infoGeneratedByServer" is true then the client does not need to
+   send back values generated by the server.
 
    +-------------+--------------------+---------------------+----------+
    | JSON Value  | Description        | JSON type           | Optional |
@@ -1207,6 +1450,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             |                    |                     |          |
    | primeResult | the verdict on the | "prime"/"composite" | Yes      |
    |             | primality testing  |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 26]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    |             | for the supplied   |                     |          |
    |             | pRand/qRand        |                     |          |
    |             | combination, see   |                     |          |
@@ -1226,14 +1477,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
-
-
-
-Vassilev                Expires November 2, 2017               [Page 22]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | B.3.4, or B3.5     |                     |          |
    |             |                    |                     |          |
    | bitlen1     | the length of p1   | hex value           | Yes      |
@@ -1263,6 +1506,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.2,    |                     |          |
    |             | B.3.4, B.3.5 or    |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 27]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    |             | the length of xQ1  |                     |          |
    |             | for B.3.6          |                     |          |
    |             |                    |                     |          |
@@ -1282,14 +1533,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | according to       |                     |          |
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.5     |                     |          |
-
-
-
-Vassilev                Expires November 2, 2017               [Page 23]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             |                    |                     |          |
    | primeSeedQ1 | the prime seed     | hex value           | Yes      |
    |             | used for q1 for    |                     |          |
@@ -1319,6 +1562,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix C.9 to    |                     |          |
    |             | generate the prime |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 28]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    |             | P, if applicable   |                     |          |
    |             |                    |                     |          |
    | p           | the private prime  | hex value           | Yes      |
@@ -1338,14 +1589,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | [FIPS186-4],       |                     |          |
    |             | Appendix B.3.3,    |                     |          |
    |             | B.3.4, or B.3.5,   |                     |          |
-
-
-
-Vassilev                Expires November 2, 2017               [Page 24]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | if applicable      |                     |          |
    |             |                    |                     |          |
    | xQ          | the random number  | hex value           | Yes      |
@@ -1364,6 +1607,39 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | d           | the private        | hex value           | Yes      |
    |             | exponent d         |                     |          |
    |             |                    |                     |          |
+   | dmp1        | the private        | hex value           | Yes      |
+   |             | exponent d modulo  |                     |          |
+   |             | p - 1. This is     |                     |          |
+   |             | only applicable    |                     |          |
+   |             | when representing  |                     |          |
+   |             | the private key    |                     |          |
+   |             | using CRT          |                     |          |
+   |             |                    |                     |          |
+   | dmq1        | the private        | hex value           | Yes      |
+   |             | exponent d modulo  |                     |          |
+   |             | q - 1. This is     |                     |          |
+
+
+
+Vassilev                Expires November 2, 2017               [Page 29]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   |             | only applicable    |                     |          |
+   |             | when representing  |                     |          |
+   |             | the prvate key     |                     |          |
+   |             | using CRT          |                     |          |
+   |             |                    |                     |          |
+   | iqmp        | the private prime  | hex value           | Yes      |
+   |             | factor q, inverted |                     |          |
+   |             | modulo p, (q^-1    |                     |          |
+   |             | mod p). This is    |                     |          |
+   |             | only applicable    |                     |          |
+   |             | when representing  |                     |          |
+   |             | the private key    |                     |          |
+   |             | using CRT          |                     |          |
+   |             |                    |                     |          |
    | s           | the digital        | hex value           | Yes      |
    |             | signature value    |                     |          |
    |             |                    |                     |          |
@@ -1371,9 +1647,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | the digital        |                     |          |
    |             | signature          |                     |          |
    |             | verirfication      |                     |          |
+   |             |                    |                     |          |
+   | compResult  | the result from    | "pass"/"fail"       | Yes      |
+   |             | either the         |                     |          |
+   |             | componentSigPrim   |                     |          |
+   |             | mode or the        |                     |          |
+   |             | componentDecPrim   |                     |          |
+   |             | mode               |                     |          |
    +-------------+--------------------+---------------------+----------+
 
-                Table 15: RSA Test Case Results JSON Object
+                Table 17: RSA Test Case Results JSON Object
 
 5.  Acknowledgements
 
@@ -1387,9 +1670,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    Security considerations are addressed by the ACVP specification.
 
-8.  Normative References
-
-   [ACVP]     NIST, "ACVP Specification", 2016.
 
 
 
@@ -1397,10 +1677,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev                Expires November 2, 2017               [Page 25]
+Vassilev                Expires November 2, 2017               [Page 30]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
+
+8.  Normative References
+
+   [ACVP]     NIST, "ACVP Specification", 2016.
 
    [FIPS186-4]
               NIST, "FIPS PUB 186-4 Digital Signature Standard", July
@@ -1449,11 +1733,7 @@ A.1.  Example keyGen with Provable Primes and Provable Primes with
 
 
 
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 26]
+Vassilev                Expires November 2, 2017               [Page 31]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -1461,27 +1741,23 @@ Internet-Draft                RSA Alg JSON                      May 2017
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
-      "infoGeneratedByServer": true,
       "algSpecs" :
       [
-         {"modeSpecs" : {
-              "mode": "keyGen",
-              "capSpecs" :  {
-                      "fixedPubExp" : true,
-                      "fixedPubExpVal" : "010001",
-                      "randPQ" : 1,
-                      "capProvPrime" :
-                            [
-                                {   "modulo" : 2048,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 3072,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 4096,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                            ]
-                      }
-                }
-          }
+         "keyGen" : [{
+              "fixedPubExp" : "fixed",
+              "fixedPubExpVal" : "010001",
+              "randPQ" : "B.3.2",
+              "infoGeneratedByServer": true
+              "capProvPrime" :
+                    [
+                        {   "modulo" : 2048,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                        {   "modulo" : 3072,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                        {   "modulo" : 4096,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+                    ]
+              }]
       ]
    }
 
@@ -1509,14 +1785,17 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
 
 
 
-Vassilev                Expires November 2, 2017               [Page 27]
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 32]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
       {
        "algorithm":"RSA",
-       "infoGeneratedByServer": true,
        "prereqVals":[
          {
            "algorithm":"DRBG",
@@ -1528,24 +1807,18 @@ Internet-Draft                RSA Alg JSON                      May 2017
          }
        ],
        "algSpecs":[
-         {
-           "modeSpecs": {
-             "mode":"keyGen",
-             "capSpecs": {
-               "fixedPubExp": true,
-               "fixedPubExpVal":"010001",
-               "randPQ": 2,
-               "capProbPrime":[{
-                 "modulo": 2048,
-                 "primeTest":["tblC2"]
-               },
-               {
-                 "modulo": 3072,
-                 "primeTest":["tblC2", "tblC3"]
-               }]
-             }
-           }
-         }
+           "keyGen": [{
+             "fixedPubExp": "random",
+             "randPQ": "B.3.3",
+             "capProbPrime":[{
+               "modulo": 2048,
+               "primeTest":["tblC2"]
+             },
+             {
+               "modulo": 3072,
+               "primeTest":["tblC2", "tblC3"]
+             }]
+           }]
        ]
      }
 
@@ -1565,23 +1838,28 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
 
 
 
-Vassilev                Expires November 2, 2017               [Page 28]
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 33]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
    {
       "algorithm": "RSA",
-      "infoGeneratedByServer": false,
        "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" :
       [
-         {"modeSpecs" : {
-           "mode": "keyGen",
-           "capSpecs" : {
-               "fixedPubExp" : true,
+         "keyGen": [{
+               "fixedPubExp" : "fixed",
                "fixedPubExpVal" : "010001",
-               "randPQ" : 4,
+               "randPQ" : "B.3.5",
+               "infoGeneratedByServer": true
                "capsProvProbPrime" :
                     [
                         {"modulo" : 2048,
@@ -1594,9 +1872,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
                          "hashAlg" : ["SHA-512"],
                          "primeTest": ["tblC3"]},
                     ]
-              }
-          }
-        }
+              }]
       ]
    }
 
@@ -1605,69 +1881,86 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
    The following is an example JSON object advertising support for RSA
    sigGen according to [FIPS186-4].
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 34]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" :
       [
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "X9.31",
-                  "capSigType" :
-                  [
-                      {"modRSASigGen" : 2048,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
+         "sigGen" : [{
+              "sigType" : "X9.31",
+              "capSigType" :
+              [
+                  {"modulo" : 2048,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 3072,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 4096,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+        },
+        {
+              "sigType" : "PKCS1v1.5",
+              "capSigType" :
+              [
+                  {"modulo" : 2048,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 3072,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 4096,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+         },
+         {
+              "sigType" : "PKCS1PSS",
+              "capSigType" :
+              [
+                  { "modulo" : 2048,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]}
+                ]
+            }]
+      ]
+   }
 
 
 
-Vassilev                Expires November 2, 2017               [Page 29]
+
+
+Vassilev                Expires November 2, 2017               [Page 35]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
-
-                      {"modRSASigGen" : 3072,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 4096,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-        }},
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "PKCS1v1.5",
-                  "capSigType" :
-                  [
-                      {"modRSASigGen" : 2048,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 3072,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 4096,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-         }},
-        {"modeSpecs" : {
-            "mode": "sigGen",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                [
-                    { "modRSASigGen" : 2048,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]},
-                    { "modRSASigGen" : 3072,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]},
-                    { "modRSASigGen" : 4096,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]}
-                ]
-            }
-         }}
-      ]
-   }
 
 A.3.  Example RSA sigVer Capabilities JSON Objects
 
@@ -1677,7 +1970,50 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
 
 
 
-Vassilev                Expires November 2, 2017               [Page 30]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 36]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -1687,73 +2023,63 @@ Internet-Draft                RSA Alg JSON                      May 2017
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" :
       [
-        {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-
-                 "sigType" : "X9.31",
-                 "capSigType" :
-                [
-                  {"modRSASigVer" : 2048,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 4096,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
-               ]
-            }
-          }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1v1.5",
-                 "capSigType" :
-                [
-                  {"modRSASigVer" : 2048,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 4096,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
-                ]
-            }
-         }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                  [
-                    { "modRSASigVer" : 2048,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]},
-                    { "modRSASigVer" : 3072,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]},
+        "sigVer" : [{
+             "sigType" : "X9.31",
+             "capSigType" :
+             [
+               {"modulo" : 2048,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+               {"modulo" : 3072,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+               {"modulo" : 4096,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+             ]
+          },
+          {
+             "sigType" : "PKCS1v1.5",
+             "capSigType" :
+             [
+                {"modulo" : 2048,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                {"modulo" : 3072,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                {"modulo" : 4096,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+           },
+           {
+              "sigType" : "PKCS1PSS",
+              "capSigType" :
+              [
+                 { "modulo" : 2048,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]},
+                 { "modulo" : 3072,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]},
+                 { "modulo" : 4096,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]}
+              ]
+           }]
+      ]
+   }
 
 
 
-Vassilev                Expires November 2, 2017               [Page 31]
+
+
+Vassilev                Expires November 2, 2017               [Page 37]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                    { "modRSASigVer" : 4096,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]}
-                 ]
-            }
-       }}
-    ]
-   }
-
 A.4.  Example RSA legacySigVer Capabilities JSON Objects
 
    The format and structure of the RSA legacySigVer capabilities JSON
-   objects follow very closely those of the RSA sigVer capabilties JSON
-   objects with the obvious changes from modRSASigVer, hashSigVer and
-   saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer
-   and the corresponding parameter ranges adjustments.
+   objects follows very closely those of the RSA sigVer capabilties JSON
+   objects with the obvious changes from modulo, hashAlg and saltLen to
+   the corresponding parameters.
 
 A.5.  Example componentSigPrimitive Capabilities JSON Objects
 
@@ -1762,12 +2088,7 @@ A.5.  Example componentSigPrimitive Capabilities JSON Objects
 
       {
          "algorithm": "RSA",
-         "algSpecs" :
-         [
-          {"modeSpecs" : {
-              "mode": "componentSigPrimitive"
-            }}
-         ]
+         "algSpecs" : ["componentSigPrim"]
       }
 
 A.6.  Example componentDecPrimitive Capabilities JSON Objects
@@ -1778,21 +2099,8 @@ A.6.  Example componentDecPrimitive Capabilities JSON Objects
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" :
-      [
-        {"modeSpecs" : {
-            "mode": "componentDecPrimitive"
-         }}
-      ]
+      "algSpecs" : ["componentDecPrimitive"]
    }
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 32]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 Appendix B.  Example Test Vectors JSON Objects
 
@@ -1803,16 +2111,25 @@ B.1.  Example Test Vectors for keyGen JSON Objects
 
 
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1133,
       "algorithm": "RSA",
-      "infoGeneratedByServer": false,
       "testGroups" : [
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 1,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.2",
+                 "modulo" : 2048,
+
+
+
+Vassilev                Expires November 2, 2017               [Page 38]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1825,9 +2142,11 @@ B.1.  Example Test Vectors for keyGen JSON Objects
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 1,
-                "modRSA" : 3072,
+                "randPQ": "B.3.2",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1840,17 +2159,11 @@ B.1.  Example Test Vectors for keyGen JSON Objects
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 3,
-
-
-
-Vassilev                Expires November 2, 2017               [Page 33]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.4",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1863,9 +2176,19 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
+
+
+
+Vassilev                Expires November 2, 2017               [Page 39]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                 "pubExp": "random",
-                "randPQ": 3,
-                "modRSA" : 3072,
+                "randPQ": "B.3.4",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1878,9 +2201,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 4,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.5",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1893,19 +2218,13 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 4,
-                "modRSA" : 3072,
+                "randPQ": "B.3.5",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
-
-
-
-Vassilev                Expires November 2, 2017               [Page 34]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                   {
                     "tcId": 1155,
                   },
@@ -1915,10 +2234,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
                 ]
               },
              {
+
+
+
+Vassilev                Expires November 2, 2017               [Page 40]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 5,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1931,9 +2260,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 5,
-                "modRSA" : 3072,
+                "randPQ": "B.3.6",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1946,26 +2277,27 @@ Internet-Draft                RSA Alg JSON                      May 2017
               },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "modRSA" : 2048,
+                 "modulo" : 2048,
                  "tests" : [
                     {
                       "tcId" : 1119,
                       "e" : "df28ab",
-
-
-
-Vassilev                Expires November 2, 2017               [Page 35]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
                       "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                     },
                     {
+
+
+
+Vassilev                Expires November 2, 2017               [Page 41]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "tcId" : 1120,
                       "e" : "85a4cf",
                       "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
@@ -1976,8 +2308,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
                  "modRSA" : 3072,
                  "tests" : [
@@ -1991,8 +2324,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
                  "modRSA" : 2048,
                  "tests" : [
@@ -2010,19 +2344,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
                     }
                  ]
+             },
+             {
 
 
 
-Vassilev                Expires November 2, 2017               [Page 36]
+Vassilev                Expires November 2, 2017               [Page 42]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-             },
-             {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
                  "modRSA" : 3072,
                  "tests" : [
@@ -2033,7 +2368,22 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
-             }
+             },
+             {
+                "mode": "keyGen",
+                "testType": "GDT",
+                "pubExp": "random",
+                "randPQ": "B.3.3",
+                "modulo" : 2048,
+                "tests": [
+                  {
+                    "tcId": 1159,
+                  },
+                  {
+                    "tcId": 1160,
+                  }
+                ]
+              }
      ]
    }
  ]
@@ -2042,43 +2392,255 @@ Internet-Draft                RSA Alg JSON                      May 2017
    This means the client is responsible for providing the details by
    running an instance of the appropriate Key Generation method for each
    test.  The information returned should match all applicable data in
-   Table 15.  For Key Generation method 2 (Appendix B.3.3 [FIPS186-4])
+   Table 17.  For Key Generation method 2 (Appendix B.3.3 [FIPS186-4])
    if the public exponent is random, there are two test types.  One is a
    known answer test (KAT) provided by the server resulting in a
    "pass"/"fail" response determining if the input forms a valid key
    pair.  The other, which exists for a fixed public exponent as well,
    asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and
-   'd') and the server validates that this pair matches the
+   'd', or CRT form) and the server validates that this pair matches the
    requirements.
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 43]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   The following is an example for when "infoGeneratedByServer" is set
+   to true.  Note when "randPQ" is "B.3.3", there is no difference and
+   is omitted from this example.
+
+
+ [
+   { "acvVersion": "0.4" },
+   { "vsId": 1133,
+      "algorithm": "RSA",
+      "testGroups" : [
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.2",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                                {
+                                  "tcId" : 1111,
+                                  "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
+                                  "e" : "10000021"
+                                },
+                                {
+                                  "tcId" : 1112,
+                                  "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
+                                  "e" : "10000021"
+                                }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.4",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                                {
+                                  "tcId" : 1113,
+                                  "e" : "10000021",
+                                  "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
+                                  "bitlen1" : 312,
+                                  "bitlen2" : 145,
+                                  "bitlen3" : 144,
+                                  "bitlen4" : 338
+
+
+
+Vassilev                Expires November 2, 2017               [Page 44]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+                                },
+                                {
+                                  "tcId" : 1114,
+                                  "e" : "10000021",
+                                  "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
+                                  "bitlen1" : 320,
+                                  "bitlen2" : 159,
+                                  "bitlen3" : 192,
+                                  "bitlen4" : 222
+                                }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.5",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                                {
+                                  "tcId" : 1115,
+                                  "e" : "10000021",
+                                  "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
+                                  "bitlen1" : 504,
+                                  "bitlen2" : 238,
+                                  "bitlen3" : 440,
+                                  "bitlen4" : 185
+                                },
+                                {
+                                  "tcId" : 1116,
+                                  "e" : "10000021",
+                                  "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
+                                  "bitlen1" : 448,
+                                  "bitlen2" : 281,
+                                  "bitlen3" : 240,
+                                  "bitlen4" : 469
+                                }
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
+
+
+
+Vassilev                Expires November 2, 2017               [Page 45]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+                                {
+                                  "tcId" : 1117,
+                                  "e" : "10000021",
+                                  "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
+                                  "bitlen1" : 232,
+                                  "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
+                                  "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
+                                  "bitlen2" : 220,
+                                  "p2" : "baf57f053b1f2a46705d9be799f90f28b800de871d88c95f24bf659",
+                                  "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
+                                  "primeSeedQ1" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc373fa",
+                                  "bitlen3" : 336,
+                                  "q1" : "bfbf1abfc1fb9b7e21342139053e7b05f56e664594419bbdcb14bb959ab66cf10e99a0d38f560a22cb33",
+                                  "primeSeedQ2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37484",
+                                  "bitlen4" : 141,
+                                  "q2" : "15e35869eb4f8dac49e317f09e3be3627c1d",
+                                  "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291"
+                                },
+                                {
+                                 "tcId" : 1118,
+                                 "e" : "10000021",
+                                 "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
+                                 "bitlen1" : 272,
+                                 "p1" : "e43dc77ad0bbe2090a7d99a490f0b37188603691ebd453ef987e8358eee34be2def9",
+                                 "primeSeedP2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805cf1",
+                                 "bitlen2" : 205,
+                                 "p2" : "18dd5b6a27ca680f10764a0e2f49ffd384b650948aa6ba175f07",
+                                 "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
+                                 "primeSeedQ1" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805e76",
+                                 "bitlen3" : 296,
+                                 "q1" : "bd76411ab7c1edb6873e76e5edc7b920b75cf8e2e1152010e6c34df592f8c3cd948212ca05",
+                                 "primeSeedQ2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805f9c",
+                                 "bitlen4" : 157,
+                                 "q2" : "123e72d9c914cde1b11d233a985f37f0769d2227",
+                                 "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05"
+                                }
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "testType": "KAT"
+                "pubExp": "random",
+                "randPQ": "B.3.3",
+                "modulo" : 2048,
+                "primeTest" : "tblC2"
+                "tests": [
+
+
+
+Vassilev                Expires November 2, 2017               [Page 46]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+                                {
+                                  "tcId" : 1119,
+                                  "e" : "df28ab",
+                                  "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                                  "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+                                },
+                                {
+                                  "tcId" : 1120,
+                                  "e" : "85a4cf",
+                                  "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                                  "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+                                }
+                ]
+              },
+              {
+                                "mode": "keyGen",
+                                "testType": "GDT",
+                                "pubExp": "random",
+                                "randPQ": "B.3.3",
+                                "primeTest": "tblC2",
+                                "modRSA": 2048,
+                                "tests": [
+                                    {
+                                      "tcId": 1125
+                                    },
+                                    {
+                                      "tcId": 1126
+                                    }
+                                ]
+                        }
+     ]
+   }
+ ]
 
 B.2.  Example Test Vectors for sigGen JSON Objects
 
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
                       "tcId" : 1165,
-                      "modRSA" : 2048,
-                      "hashAlg" : "SHA-256",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 37]
+Vassilev                Expires November 2, 2017               [Page 47]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "modulo" : 2048,
+                      "hashAlg" : "SHA-256",
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
                       "tcId" : 1166,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
                     }
@@ -2086,17 +2648,18 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
               {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1167,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
                       "tcId" : 1168,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
@@ -2104,32 +2667,33 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
                       "tcId" : 1169,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "saltLen" : 20,
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
                     {
                       "tcId" : 1170,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-512",
                       "saltLen" : 62,
-                      "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
-                    }
-                 ]
-             }
 
 
 
-Vassilev                Expires November 2, 2017               [Page 38]
+Vassilev                Expires November 2, 2017               [Page 48]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
+                    }
+                 ]
+             }
        ]
     }
   ]
@@ -2137,17 +2701,18 @@ Internet-Draft                RSA Alg JSON                      May 2017
 B.3.  Example Test Vectors for sigVer JSON Objects
 
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
                       "tcId" : 1174,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
                       "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -2156,7 +2721,7 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                     },
                     {
                       "tcId" : 1175,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
                       "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
@@ -2167,28 +2732,29 @@ B.3.  Example Test Vectors for sigVer JSON Objects
              },
               {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1176,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
+
+
+
+Vassilev                Expires November 2, 2017               [Page 49]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
                       "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
                       "msg" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
                       "s" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
                     },
-
-
-
-Vassilev                Expires November 2, 2017               [Page 39]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                     {
                       "tcId" : 1177,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
                       "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
@@ -2199,11 +2765,12 @@ Internet-Draft                RSA Alg JSON                      May 2017
              },
              {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
                       "tcId" : 1178,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
                       "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
@@ -2212,7 +2779,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     },
                     {
                       "tcId" : 1179,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
                       "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
@@ -2226,21 +2793,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
   ]
 
 
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 50]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    Note: The ACVP server does retain additional context for each test
    vector sent to the client in order to verify the results when
    submitted for validation.  These may include the public key n, the
    public exponent e, the private key d for each test.  Note also that
    each test for which msg is not between 0 and n - 1 should fail.
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 40]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 B.4.  Example Test Vectors for legacySigVer JSON Objects
 
@@ -2250,12 +2816,13 @@ B.4.  Example Test Vectors for legacySigVer JSON Objects
 B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
 
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentSigPrimitive",
+                 "mode": "componentSigPrim",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -2282,29 +2849,25 @@ B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
    that each test for which 'msg' is not between '0' and 'n - 1' should
    fail.
 
-B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
 
 
 
 
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 41]
+Vassilev                Expires November 2, 2017               [Page 51]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
+
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
+                 "mode": "componentDecPrim",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -2335,7 +2898,7 @@ C.1.  Example keyGen Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
              [
-                { "acvVersion": "0.3" },
+                { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "testResults": [
                     {
@@ -2343,17 +2906,17 @@ C.1.  Example keyGen Test Results JSON Objects
                       "e" : "10000021",
                       "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
                       "bitlen1" : 312,
-                      "bitlen2" : 145,
-                      "bitlen3" : 144,
-                      "bitlen4" : 338,
 
 
 
-Vassilev                Expires November 2, 2017               [Page 42]
+Vassilev                Expires November 2, 2017               [Page 52]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "bitlen2" : 145,
+                      "bitlen3" : 144,
+                      "bitlen4" : 338,
                       "p" : "e2ab16d3026db341223bcef7f05b61d1682da54b0e2314f8eac9652752d6aa89ad65417e2c7f7b2824555a17c8c854ecbbc44c80c10c5ba132c3992f30308459b3afaee8f00ca318cd39a478c93dc1fa13268842ce88b2d5aeacbb4ac7638db6501eed3cedca65b777e910f701207cf96a81e46c418c3fdc493c02f708b2bacb",
                       "q" : "d13c3209bbc1bfa27c96688cbb325e8ce8d609efde1cc2417a578354c7bd248fb89eca31599d6b5b0d69a832bd2fafaacf3e9c3b71484328059dff1a7af54b003fee84f64f34e31ade0689f26fbc181443b7af3d8043657ddceefc1ff3160543825de3fe8f33fce4bf5d1c10357919c31729f8c0476f6b2fb6f405c875f06609",
                       "n" : "b942fa09a727ab488f8bc2d29b89814345dc96e7df9dc7188b7be6be7dc473869c914f612f5aa6b450a17ffc07b42db7b80d2ce88be1953e80ebff92f4aa12fb7fa9b9b258f249d876d69c1976df63a362d1a820f2cff4c88ae2a5fc3b607e7d62a4e60dcd9185929fcc1c931dea94147c03adfa41bf1e72d09376e4dbebaf44df6ec492530d9eb910970f45e41107ea313dccb11567e0832674335639b136b851d19e397be3f1681c72b62bc8defae88e02fe7e67ee56191cb874a53fc115652337277d3aea969adbba4a22d3d8840844cbe48b556895d06d0c7b3cd2c9fcc9a86ec93ca00ea5916090948820fd07f0b22a42f829d9bd1fcfa044ac6a057323",
@@ -2399,17 +2962,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "cf02aaaca392f5d21e80ac8e954ccc3eb738155b9ca03d96c1c7506b6593e97954e0b97eed739e6cd0eff08fe66e1584926d8d6ab9d6c686f99f758fec24627071a0f9164096b93c2693e296d2707f392ada019d010459b0783918f8f104423e2dfdcd418194144bde4b9fbbc766dc892bf9154803d41e8a295e2fd280592e4388dd78d792f96654da3268421553fa101f5e334b5149a6bd6857705ae9b5fbe4f80f2334fffec4a168a63c47d927d54e33571590f4450e005adb54c4a290f52141a7a502007a3508c6fad932f04e5b469cbab7228f69c34e89b5b4e7378fc82a9f1dd2132bceceb447dfd8a14679dd9df39194e4190b6d5fa79e2abe140abc4cc6cd428ed04c1bdb14cf51bd9133119138b1cee3bb1649bedb2e86c810010006e611237a901e3e404ca78c551253979c587a92440e11c2b742e87bea09a93fa2b1ed6cbf66907d3005a572b20055cc4870bce35d78b51f7b22ba37ff7f8af05dc2d0d6c743d95ac0a5e0eabf5be061991bb2fb505555589c5c5a0cd3b575d15"
                     },
                     {
-                      "tcId" : 1115,
-                      "e" : "10000021",
-                      "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 43]
+Vassilev                Expires November 2, 2017               [Page 53]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "tcId" : 1115,
+                      "e" : "10000021",
+                      "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
                       "bitlen1" : 232,
                       "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
                       "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
@@ -2455,17 +3018,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "10000021",
                       "seed" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddbbc",
                       "bitlen1" : 512,
-                      "p1" : "e50610fd8a3b4f132e5c8d5904e0995b4e3782fa606593f1a80c4284920df7f14d310fab60d78bf97d2ad51472f2dc784e14f2f49734cc06ed299ecfd4764f51",
-                      "primeSeedP2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddc59",
-                      "bitlen2" : 196,
 
 
 
-Vassilev                Expires November 2, 2017               [Page 44]
+Vassilev                Expires November 2, 2017               [Page 54]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "p1" : "e50610fd8a3b4f132e5c8d5904e0995b4e3782fa606593f1a80c4284920df7f14d310fab60d78bf97d2ad51472f2dc784e14f2f49734cc06ed299ecfd4764f51",
+                      "primeSeedP2" : "6710f90af3479a276ee2f1500d444c944e48da1d5425b4afc64b058e509ddc59",
+                      "bitlen2" : 196,
                       "p2" : "f974675ade75f0e11d66247a498fda86ec29e0c3a84052bbb",
                       "xP" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e306705e39d2b621027353b4873898b36b3fe86ab203dee10260058ce77f13d315ea1dcc0b717ffe906bfb05f251f3e9d678c585917176e127ece648c788f28b05607d4f71e113842e289b0de45bed72b7e591ea55ae5750ebe86a8",
                       "p" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e3092a9dfd7697a29e1c6952f0d71a7381d0bd64c4ac6102f54ae43b21f7d399583f86f6192717188b913ed16c1422d5fe5df0a407b1de9a05e178e4f47cdb3532866e2fcf36e57616f3473c5c967fa6703847d90ddfe0b822f24e9",
@@ -2511,17 +3074,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "bitlen2" : 195,
                       "xP2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f0f",
                       "p2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f45",
-                      "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
-                      "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
-                      "bitlen3" : 352,
 
 
 
-Vassilev                Expires November 2, 2017               [Page 45]
+Vassilev                Expires November 2, 2017               [Page 55]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
+                      "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
+                      "bitlen3" : 352,
                       "xQ1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd810093026606fd",
                       "q1" : "7468d10e69a14b00ec128f7dd19f6f7317bcf96a97989cd5a9051b3ca75268362acf3918cd81009302660959",
                       "bitlen4" : 142,
@@ -2567,17 +3130,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "tcId" : 1147,
                       "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
                       "e" : "10000021",
-                      "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
-                      "q" : "be7263212933d452800cf89edbad8e01a79eeab335bc8a4ff375173f29542f6cc14551432f2c715cf8f9b9852c6cf15fb5eae3a5895154c5c83c28ee1a5dd8ae12a963af318c0ce398cefd324c1099240367cd961e081d41884d812f48d5735d15348a8638ac700519874e6d82300bebd050273a69c4ca59ef61f17f239fe17d4dc7092d64a986fba02dcee818b62be6587ad56ff6c92627eff9e2ac767b1a9799f8108b1be9613b2a07b0a5512b8b3aaa300c586678a08cd13f22d20e5d4b95",
-                      "n" : "969cc8d2bf6bce77575d8d3d62ffca22fbe43d0572ab27a7070b4324bd39a74e6adcf2cc69baeaa0af404512273702959f2393aff9375e58d1460e74f514a6f0887a8f607b0fa8e12682d76b663ae82716072e4d15722e70b2dc0fa0c73729393889e6c7b130311f47a27a988a098bf390a956be56648840c781b1cf82484df708821a53a6c9c0d64f23ea499ec274e5c31e78f702ffa21aa87da832f2e12300c389be1d965764acf2cae1ace36493cae1776513c1c30637f8dd98bcde0083224d5e65a7695d5f05b707ae40dec91d34f41df9094814f0f20154356232b54df9b40a31421e015cb47968a4ca77629b2493cb74054c30517e92606967aa3d14ce12260995d3d0243502192940b6d552b1015e5ac16f756f2152bf259c5a72468783f87a92e371a2f9a9c829f4397fc59e9b874a7a3222bfb2207cabbef0f3949d4871fbae9deb742ed9eae8a1baeb6088d92f904a132234ef6fc3e8b170904d56e276436135e3abe67054c139699e37601e44f3dc6b73a6935793f062de998049",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 46]
+Vassilev                Expires November 2, 2017               [Page 56]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
+                      "q" : "be7263212933d452800cf89edbad8e01a79eeab335bc8a4ff375173f29542f6cc14551432f2c715cf8f9b9852c6cf15fb5eae3a5895154c5c83c28ee1a5dd8ae12a963af318c0ce398cefd324c1099240367cd961e081d41884d812f48d5735d15348a8638ac700519874e6d82300bebd050273a69c4ca59ef61f17f239fe17d4dc7092d64a986fba02dcee818b62be6587ad56ff6c92627eff9e2ac767b1a9799f8108b1be9613b2a07b0a5512b8b3aaa300c586678a08cd13f22d20e5d4b95",
+                      "n" : "969cc8d2bf6bce77575d8d3d62ffca22fbe43d0572ab27a7070b4324bd39a74e6adcf2cc69baeaa0af404512273702959f2393aff9375e58d1460e74f514a6f0887a8f607b0fa8e12682d76b663ae82716072e4d15722e70b2dc0fa0c73729393889e6c7b130311f47a27a988a098bf390a956be56648840c781b1cf82484df708821a53a6c9c0d64f23ea499ec274e5c31e78f702ffa21aa87da832f2e12300c389be1d965764acf2cae1ace36493cae1776513c1c30637f8dd98bcde0083224d5e65a7695d5f05b707ae40dec91d34f41df9094814f0f20154356232b54df9b40a31421e015cb47968a4ca77629b2493cb74054c30517e92606967aa3d14ce12260995d3d0243502192940b6d552b1015e5ac16f756f2152bf259c5a72468783f87a92e371a2f9a9c829f4397fc59e9b874a7a3222bfb2207cabbef0f3949d4871fbae9deb742ed9eae8a1baeb6088d92f904a132234ef6fc3e8b170904d56e276436135e3abe67054c139699e37601e44f3dc6b73a6935793f062de998049",
                       "d" : "79815d367f924ba3509d3d4870cc729a82dc6dfb001e551baac15ff2ed77efdc6a00e628f29aabe062b5226a2e2689d26c82e8021958eda5fe0581f3bad0479942ec03bee965d79204c822d6c4e5cb82814419acd38a8779afae03b4a95ded204198bc2d68ee124cb5d2cbc68bc3621450168f55a9b9f2787b1cafb0328ceb9c0bc4e81d23bc155af9a172b18dac8f493f6753571b2f13cf56d7d93ac9d191dbfb7a2b6c6e795c2387722ee48d9bbf8fabd0fe58b3502a6a3173901057ae04bdd1f69cea58c38f9ac88c90427d8d3c60afd50dea9d98b669f8a052c7c26415885d70df8eb36fabd5d9fcde1a9cea5c4118f16af672fadb56f43e2fedf3b33ab4c0d6763b497d73164b778a1638af9c8e87e71cf64ed368c978179a2d7bfb2086ce8fd1ab6f3263603a71d0dc70fa5c56c6c0f233447bf4c93fb03c8e85ddbb204142e4414f0a1f35746c7f106931e25a1fe6a5f865b93d679ccd7742519b29803ed34ca40321c7e38fdeeed68195860b8157f14365a587ca58e1c5c7c46c9c1"
                     },
                     {
@@ -2623,17 +3186,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                   {
                     "tcId" : 1130,
                       "e" : "e66d81",
-                      "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
-                      "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
-                      "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 47]
+Vassilev                Expires November 2, 2017               [Page 57]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                      "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
+                      "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
+                      "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
                       "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
                    },
                    {
@@ -2662,7 +3225,7 @@ C.2.  Example sigGen Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
              [
-                  { "acvVersion": "0.3" },
+                  { "acvVersion": "0.4" },
                   { "vsId": 1163,
                     "testResults": [
                     {
@@ -2679,17 +3242,17 @@ C.2.  Example sigGen Test Results JSON Objects
                     }
                  ]
              }
-              {
-                 "mode": "sigGen",
-                 "sigType" : "PKCS1v1.5",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 48]
+Vassilev                Expires November 2, 2017               [Page 58]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+              {
+                 "mode": "sigGen",
+                 "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1167,
@@ -2731,21 +3294,21 @@ C.3.  Example sigVer Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
     [
-       { "acvVersion": "0.3" },
+       { "acvVersion": "0.4" },
        { "vsId": 1173,
          "algorithm": "RSA",
          "testGroups" : [
-                {
-                    "mode": "sigVer",
-                    "sigType" : "X9.31",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 49]
+Vassilev                Expires November 2, 2017               [Page 59]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
+                {
+                    "mode": "sigVer",
+                    "sigType" : "X9.31",
                     "tests" : [
                        {
                          "tcId" : 1174,
@@ -2789,18 +3352,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
        }
      ]
 
+
+
+
+
+
+Vassilev                Expires November 2, 2017               [Page 60]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
 C.4.  Example legacySigVer Test Results JSON Objects
 
    The format and structure of the RSA legacySigVer Test Results JSON
    Objects are identical to those of the RSA sigVer Test Results JSON
    Objects.
-
-
-
-Vassilev                Expires November 2, 2017               [Page 50]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 C.5.  Example componentSigPrimitive Test Results JSON Objects
 
@@ -2808,12 +3374,12 @@ C.5.  Example componentSigPrimitive Test Results JSON Objects
    test results sent from the crypto module to the ACVP server.
 
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentSigPrimitive",
+                 "mode": "componentSigPrim",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -2847,24 +3413,18 @@ C.6.  Example componentDecPrimitive Test Results JSON Objects
 
 
 
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 51]
+Vassilev                Expires November 2, 2017               [Page 61]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
+                 "mode": "componentDecPrim",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -2909,4 +3469,4 @@ Author's Address
 
 
 
-Vassilev                Expires November 2, 2017               [Page 52]
+Vassilev                Expires November 2, 2017               [Page 62]

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -153,9 +153,9 @@
           <c/>
           <c>"legacySigVer"</c>
           <c/>
-          <c>"componentSigPrimitive"</c>
+          <c>"componentSigPrim"</c>
           <c/>
-          <c>"componentDecPrimitive"</c>
+          <c>"componentDecPrim"</c>
           </texttable>
 	</section>
 	<section anchor="prereq_algs" title="Required Prerequisite Algorithms for RSA Mode Validations">
@@ -233,16 +233,6 @@
           <c/>
           <c/>
           <c/>
-          <c>infoGeneratedByServer</c>
-          <c>This flag indicates that the server is responsible for generating inputs for Key Generation tests</c>
-          <c>value</c>
-          <c>true or false</c>
-          <c>Yes</c>
-          <c/>
-          <c/>
-          <c/>
-          <c/>
-          <c/>
           <c>prereqVals</c>
 	       <c>The prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects - see <xref target="prereq_algs"/></c>
@@ -253,44 +243,83 @@
           <c/>
           <c/>
           <c/>
-          <c>capSpecs</c>
-	       <c>The capabilities of a particular RSA mode</c>
-          <c>an array of objects specific to the mode being specified</c>
-          <c>array</c>
-          <c>No</c>
-         <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/>
-         <c>modeSpecs</c>
-	       <c>The RSA mode and its capabilities</c>
-          <c>an object with "mode" and "capSpecs" properties</c>
+         <c>keyGen</c>
+	       <c>The RSA KeyGen mode and its capabilities</c>
+          <c>an object defining KeyGen capabilities, see <xref target="mode_keyGen"/></c>
           <c>object</c>
-          <c>No</c>
+          <c>Yes</c>
          <c/>
          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>sigGen</c>
+          <c>The RSA SigGen mode and its capabilities</c>
+          <c>an object defining SigGen capabilities, see <xref target="mode_sigGen"/></c>
+          <c>object</c>
+          <c>Yes</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>sigVer</c>
+          <c>The RSA SigVer mode and its capabilities</c>
+          <c>an object defining SigVer capabilities, see <xref target="mode_sigVer"/></c>
+          <c>object</c>
+          <c>Yes</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>legacySigVer</c>
+          <c>The RSA Legacy SigVer mode and its capabilities</c>
+          <c>an object defining Legacy SigVer capabilities, see <xref target="mode_legacySigVer"/></c>
+          <c>object</c>
+          <c>Yes</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>componentSigPrim</c>
+          <c>The RSA component SigPrim mode and its capabilities</c>
+          <c>an object defining component SigPrim capabilities, see <xref target="mode_componentSigPrimitive"/></c>
+          <c>object</c>
+          <c>Yes</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>componentDecPrim</c>
+          <c>The RSA component DecPrim mode and its capabilities</c>
+          <c>an object defining component DecPrim capabilities, see <xref target="mode_componentDecPrimitive"/></c>
+          <c>object</c>
+          <c>Yes</c>
+          <c/>
+          <c/>
           <c/>
           <c/>
           <c/>
          <c>algSpecs</c>
-	       <c>Array of modeSpecs</c>
-          <c>array of modeSpecs objects, each identified uniquely by the "mode" property</c>
+	       <c>Array of modes</c>
+          <c>array of mode objects, each identified uniquely by the "mode" property</c>
           <c>See <xref target="algs_table"/> and <xref target="supported_mods"/></c>
           <c>No</c>          
           </texttable>    
    </section>
 	<section anchor="supported_mods" title="Supported RSA Modes Capabilities">
-    <t>The RSA mode capabilities are advertised as arrays of JSON objects within the 'modeSpecs'
-	value of the ACVP registration message - see <xref target="caps_table"/>. The 'modeSpecs' value is an array, where each
-	array element is an array of individual JSON objects corresponding to a particular RSA mode defined in this section.  The 'modeSpecs'
-	value is part of the 'capability_exchange' element of the ACVP JSON registration message.
+    <t>The RSA mode capabilities are advertised as arrays of JSON objects within the self-named
+	value of the ACVP registration message - see <xref target="caps_table"/>. Each object is an array, where each
+	array element is an array of individual JSON objects corresponding to a particular RSA mode defined in this section.  
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA mode capabilities are advertised as an array of self-contained JSON objects.</t>
 	<section anchor="mode_keyGen" title="The keyGen Mode Capabilities">
-	  <t>The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	  <t>The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'keyGen'
+	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA keyGen mode capability is advertised as a self-contained JSON object.</t>
@@ -451,27 +480,49 @@
           <ttcol align="left">Valid Values</ttcol>
           <ttcol align="left">Optional</ttcol>
           <c>mode</c>
-          <c>The mode to be validated</c>
+	         <c>The mode to be validated</c>
           <c>value</c>
-          <c>"keyGen", see <xref target="algs_table"/></c>
+	         <c>"keyGen", see<xref target="algs_table"/></c>
           <c>No</c> 
          <c/>
          <c/>
           <c/>
           <c/>
           <c/>
-          <c>fixedPubExp</c>
-	       <c>Supports fixed public key exponent e</c>
+	         <c>randPQ</c>
+	         <c>Key Generation mode to be validated. Random P and Q primes generated as (see <xref target="FIPS186-4"/>): provable primes (Appendix B.3.2); 
+	           probable primes (Appendix B.3.3); provable primes with conditions (Appendix B.3.4); 
+	           provable/probable primes with conditions (Appendix B.3.5); probable primes with conditions (Appendix B.3.6)</c>
+	         <c>value</c>
+	         <c>"B.3.2", "B.3.3", "B.3.4", "B.3.5", or "B.3.6"</c>
+	         <c>No</c> 
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c>infoGeneratedByServer</c>
+	         <c>This flag indicates that the server is responsible for generating inputs for Key Generation tests</c>
+	         <c>value</c>
+	         <c>true or false</c>
+	         <c>No</c>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c/>
+          <c>pubExp</c>
+	       <c>Supports fixed or random public key exponent e</c>
           <c>value</c>
-          <c>true or false</c>
-          <c>Yes</c>
+          <c>"fixed" or "random"</c>
+          <c>No</c>
          <c/>
          <c/>
           <c/>
           <c/>
           <c/>
            <c>fixedPubExpVal</c>
-	       <c>The value of the public key exponent e in hex</c>
+	       <c>The value of the public key exponent e in hex if "pubExp" is "fixed"</c>
           <c>value</c>
           <c>hex</c>
           <c>Yes</c>
@@ -480,63 +531,46 @@
           <c/>
           <c/>
           <c/>
-          <c>randPubExp</c>
-          <c>Supports random public key exponent e</c>
-          <c>value</c>
-          <c>true or false</c>
-          <c>Yes</c>
-          <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/> 
-          <c>randPQ</c>
-          <c>Random P and Q primes generated as (see <xref target="FIPS186-4"/>): 1 - provable primes (Appendix B.3.2); 2 - probable primes (Appendix B.3.3); 3 - provable primes (Appendix B.3.4); 4 - provable/probable primes (Appendix B.3.5); 5 - probable primes (Appendix B.3.6)</c>
-          <c>value</c>
-          <c>{1, 2, 3, 4, 5}</c>
-          <c>Yes</c>
-          <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/>
           <c>capProvPrimes</c>
-          <c>Capabilities for all supported moduli and hash algorithms (see <xref target="keyGenProvPrim_modulitable"/>)</c>
+          <c>Capabilities for all supported moduli and hash algorithms (see <xref target="keyGenProvPrim_modulitable"/>) 
+            for provable primes (Appendix B.3.2) and provable primes with conditions (Appendix B.3.4).</c>
           <c>array</c>
-          <c/>
+	         <c>See <xref target="keyGenProvPrim_modulitable"/>.</c>
           <c>Yes</c>
           <c/>
          <c/>
           <c/>
           <c/>
           <c/>
-          <c>modProbPrime</c>
-          <c>See <xref target="keyGenProbPrim_modulitable"/></c>
-          <c>array</c>
-          <c>see <xref target="keyGenProbPrim_modulitable"/></c>
-          <c>Yes</c>
-          <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/>
-          <c>primeTest</c>
-          <c>See <xref target="keyGenProbPrim_modulitable"/></c>
-          <c>value</c>
-          <c>see <xref target="keyGenProbPrim_modulitable"/></c>
-          <c>Yes</c>
+	         <c>capProbPrimes</c>
+	         <c>Capabilities for all supported moduli and hash algorithms 
+	           for probable primes (Appendix B.3.3) and probable primes with conditions (Appendix B.3.6).</c>
+	         <c>array</c>
+	         <c>See <xref target="keyGenProbPrim_modulitable"/>.</c>
+	         <c>Yes</c>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c/>
+	         <c>capProvProbPrimes</c>
+	         <c>Capabilities for all supported moduli and hash algorithms  
+	           for provable and probable primes with conditions (Appendix B.3.5).</c>
+	         <c>array</c>
+	         <c>See <xref target="keyGenProvProbPrimWithCond"/>.</c>
+	         <c>Yes</c>
           </texttable>
           </section>
 	</section>
 	<section anchor="mode_sigGen" title="The sigGen Mode Capabilities">
-	  <t>The RSA sigGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	  <t>The RSA sigGen mode capabilities are advertised as an array of JSON objects within the array of 'sigGen'
+	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA sigGen mode capability is advertised as a self-contained JSON object.</t>
 	 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_sigGenCap" title="sigGen Capabilities">
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
+          <t>The following signature generation capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="sigGenRSAMod" title="Supported RSA sigGen moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -553,7 +587,7 @@
           <c/>
           <c/>
           <c/>
-          <c>modRSASigGen</c>
+          <c>modulo</c>
           <c>supported RSA moduli for signature generation - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
           <c>any non-empty subset of {2048, 3072, 4096}</c>
@@ -563,7 +597,7 @@
           <c/>
           <c/>
           <c/>
-          <c>hashSigGen</c>
+          <c>hashAlg</c>
           <c>supported hash algorithms for signature generation - see <xref target="SP800-131A"/>, Section 9</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
@@ -573,7 +607,7 @@
           <c/>
           <c/>
           <c/>
-          <c>saltSigGen</c>
+          <c>saltLen</c>
           <c>supported salt lengths for PKCS1PSS signature generation - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
           <c>array</c>
           <c>array of values for each hash algorithm used subject to the constraint in the note below.</c>
@@ -583,14 +617,14 @@
           </section>
 	</section>
 		<section anchor="mode_sigVer" title="The sigVer Mode Capabilities">
-	  <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	  <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'sigVer'
+	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA sigVer mode capability is advertised as a self-contained JSON object.</t>
 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_sigVerCap" title="sigVer Capabilities">
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
+          <t>The following signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="sigVerRSAMod" title="Supported RSA sigVer moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -607,7 +641,7 @@
           <c/>
           <c/>
           <c/>
-          <c>modRSASigVer</c>
+          <c>modulo</c>
           <c>supported RSA moduli for signature verification - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
           <c>any non-empty subset of {2048, 3072, 4096}</c>
@@ -617,7 +651,7 @@
           <c/>
           <c/>
           <c/>
-          <c>hashSigVer</c>
+          <c>hashAlg</c>
           <c>supported hash algorithms for signature verification - see <xref target="SP800-131A"/>, Section 9</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
@@ -627,7 +661,7 @@
           <c/>
           <c/>
           <c/>
-          <c>saltSigVer</c>
+          <c>saltLen</c>
           <c>supported salt lengths for PKCS1PSS signature verification - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
           <c>array</c>
           <c>array of values for each hash algorithm used subject to the constraint in the note below.</c>
@@ -637,18 +671,13 @@
           </section>
 	</section>
 		<section anchor="mode_legacySigVer" title="The legacySigVer Mode Capabilities">
-	  <t>The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
-	See the ACVP specification for details on the registration message.</t>
-
-	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</t>
-	 <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	  <t>The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'legacySigVer'
+	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</t>
 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
+          <t>The following legacy signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="legacySigVerRSAMod" title="Supported RSA legacySigVer moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -665,7 +694,7 @@
           <c/>
           <c/>
           <c/>
-          <c>modLegacyRSASigVer</c>
+          <c>modulo</c>
           <c>supported RSA moduli for signature verification - see <xref target="SP800-131A"/></c>
           <c>array</c>
           <c>any non-empty subset of {1024, 1536, 2048, 3072, 4096}</c>
@@ -675,7 +704,7 @@
           <c/>
           <c/>
           <c/>
-          <c>hashLegacySigVer</c>
+          <c>hashAlg</c>
           <c>supported hash algorithms for signature verification - see <xref target="SP800-131A"/>, Section 9</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-1", "SHA-256", "SHA-384", "SHA-512"}</c>
@@ -685,7 +714,7 @@
           <c/>
           <c/>
           <c/>
-          <c>saltLegacySigVer</c>
+          <c>saltLen</c>
           <c>supported salt lengths for PKCS1PSS signature verification - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
           <c>array</c>
           <c>array of values for each hash algorithm used subject to the constraint in the note below.</c>
@@ -694,18 +723,18 @@
           <t>Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</t>
 	</section>
 	<section anchor="mode_componentSigPrimitive" title="The componentSigPrimitive Mode Capabilities">
-	  <t>The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <xref target="RFC3447"/>) is advertised as a JSON object within the array of 'modeSpecs'
+	  <t>The RSA componentSigPrim mode capability (otherwise known as RSASP1 in <xref target="RFC3447"/>) is advertised as a JSON object within the array of 'componentSigPrim'
 	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
 	is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server. 
-	Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability. 
+	Only 2048-bit RSA keys are allowed for this capability. 
 	See <xref target="app-testcomponentsigprimitive-ex"/> for additional details on constraints for 'msg' and 'n'.
 	See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</t>
+	<t>Each RSA componentSigPrim mode capability is advertised as a self-contained JSON object.</t>
 	</section>
 	<section anchor="mode_componentDecPrimitive" title="The componentDecPrimitive Mode Capabilities">
-<t>The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
+	  <t>The RSA componentDecPrim mode capability is advertised a JSON object within the array of 'componentDecPrim'
+	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
 	is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <xref target="SP800-56B"/>, Section 7.1.2 for details.</t>
 	
 	<t>In testing, only 'msg' is supplied by the ACVP server. 
@@ -725,8 +754,9 @@
 	<t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to
 	    the ACVP server for validation.  A typical ACVP validation session would require multiple test vector
 	    sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual
-	    algorithm, such as Hash_DRBG, etc.  This section
-	describes the JSON schema for a test vector set used with DRBG algorithms.</t>
+	    algorithm mode, such as RSA Key Generation where the algorithm is "RSA" and the mode is "KeyGen". 
+	    If a registration comes in requesting multiple modes of RSA, multiple test vector sets will be returned. This section
+	describes the JSON schema for a test vector set used with RSA algorithms.</t>
 
 	<t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire
 	vector set as well as individual test vectors to be processed by the ACVP client.  The following table
@@ -749,14 +779,18 @@
 <c/>
 <c/>
 <c/>
-
 	  <c>algorithm</c>
 	  <c>The RSA algorithm used for the test vectors.  See <xref target="supported_algs"/> for possible values.</c>
           <c>value</c>
 <c/>
 <c/>
 <c/>
-          
+    <c>mode</c>
+	  <c>The RSA mode tested. See <xref target="supported_algs"/> for possible values.</c>
+	  <c>value</c>
+	  <c/>
+	  <c/>
+	  <c/>
 	  <c>testGroups</c>
 	  <c>Array of test group JSON objects, which are defined in <xref target="tgjs"/></c>
           <c>array</c>
@@ -773,25 +807,25 @@
 		<ttcol align="left">Description</ttcol>
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
-		<c>mode</c>
-	  <c>The RSA algorithm mode used for the test vectors.  See <xref target="supported_algs"/> for possible values.</c>
-   <c>value</c>
-   <c>No</c>
-   <c/>
-   <c/>
-   <c/>
-   <c/>
-    <c>randPQ</c>
-    <c>RSA prime generation method - see <xref target="keyGen_table"/></c>
-    <c>value</c>
-    <c>Yes</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-    <c>modRSA</c>
+	  <c>randPQ</c>
+	  <c>RSA prime generation method - see <xref target="keyGen_table"/></c>
+	  <c>value</c>
+	  <c>Yes</c>
+	      <c/>
+	      <c/>
+	      <c/>
+	      <c/>
+    <c>modulo</c>
     <c>RSA modulus</c>
     <c>value</c>
+    <c>No</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
+    <c>testType</c>
+    <c>The test type for the test group</c>
+    <c>Either "AFT" (algorithm functional test), "KAT" (known answer test), or "GDT" (generated data test).</c>
     <c>No</c>
     <c/>
     <c/>
@@ -807,7 +841,7 @@
     <c/>
 		<c>primeTest</c>
 		<c>Miller-Rabin constraint from Table C.2 or C.3</c>
-		<c>value</c>
+		<c>"tblC2" or "tblC3"</c>
     <c>Yes</c>
     <c/>
 		<c/>
@@ -815,17 +849,16 @@
 		<c/>
     <c>pubExp</c>
 		<c>Fixed or random public exponent</c>
-		<c>hex value or "random"</c>
+		<c>"fixed" or "random"</c>
     <c>Yes</c>
     <c/>
 		<c/>
 		<c/>
 		<c/>
-    <c>sigType</c>
-		<c>The type of digital signature algorithm - see  <xref target="sigGenRSAMod"/></c>
-		<c>value</c>
-    <c>Yes</c>
-
+	  <c>sigType</c>		
+	  <c>The type of digital signature algorithm - see  <xref target="sigGenRSAMod"/></c>		
+	  <c>value</c>		
+	   <c>Yes</c>
 	    </texttable>
 
 	</section>
@@ -833,50 +866,217 @@
 	<section title="Test Case JSON Schema" anchor="tvjs">
 	    <t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
 		that represents a single test vector to be processed by the ACVP client.  The following table describes
-	    the JSON elements for each RSA test vector.</t>
-	    <texttable anchor="vs_tc_table" title="RSA Test Case JSON Object">
+	    the JSON elements for each RSA test vector under the KeyGen mode. If the value "infoGeneratedByServer" is false,
+	    the test case will only consist of a "tcId", unless "B.3.3" is included. Under this prime generation method,
+	    the test case will always consist of a series of test cases with only "tcId". If both "B.3.3" and "random" "pubExp"
+	    are enabled (regardless of "infoGeneratedByServer"), then there will be an additional test group of known answer 
+	    tests (KATs) which includes test cases with only "tcId", "pRand", "qRand", and "e".</t>
+	  
+	  <texttable anchor="vs_tc_table_kg" title="RSA Test Case JSON Object for Key Generation">
+	    <ttcol align="left">JSON Value</ttcol>
+	    <ttcol align="left">Description</ttcol>
+	    <ttcol align="left">JSON type</ttcol>
+	    <ttcol align="left">Optional</ttcol>
+	    
+	    <c>tcId</c>
+	    <c>Numeric identifier for the test case, unique across the entire vector set.</c>
+	    <c>value</c>
+	    <c>No</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>e</c>
+	    <c>the public exponent</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>pRand</c>
+	    <c>the random for P, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>qRand</c>
+	    <c>the random for Q, if applicable, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>xP1</c>
+	    <c>the prime factor p1 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>seed</c>
+	    <c>the seed used in prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, or B3.5</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>bitlen1</c>
+	    <c>the length of p1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B3.5 or the length of xP1 for B.3.6</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>bitlen2</c>
+	    <c>the length of p2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B.3.5 or the length of xP2 for B.3.6</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>bitlen3</c>
+	    <c>the length of q1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ1 for B.3.6</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>bitlen4</c>
+	    <c>the length of q2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.2, B.3.4, B.3.5 or the length of xQ2 for B.3.6</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>primeSeedP2</c>
+	    <c>the prime seed used for p2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.5</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>primeSeedQ1</c>
+	    <c>the prime seed used for q1 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.5</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>primeSeedQ2</c>
+	    <c>the prime seed used for q2 for prime generation according to <xref target="FIPS186-4"/>, Appendix B.3.5</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>xP2</c>
+	    <c>the prime factor p2 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>xP</c>
+	    <c>the random number used in Step 3 of the algorithm in <xref target="FIPS186-4"/>, Appendix C.9 to generate the prime P, if applicable</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>xQ1</c>
+	    <c>the prime factor q1 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>xQ2</c>
+	    <c>the prime factor q2 for Primes with Conditions - see <xref target="FIPS186-4"/>, Appendix B.3.3, B.3.4, or B.3.5, if applicable</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>xQ</c>
+	    <c>the random number used in Step 3 of the algorithm in <xref target="FIPS186-4"/>, Appendix C.9 to generate the prime Q, if applicable</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	  </texttable>
+	  
+	  <t>The following table describes the JSON elements for each RSA test vector under the SigGen or SigVer mode.</t>
+	    <texttable anchor="vs_tc_table_sig" title="RSA Test Case JSON Object for Signature Generation or Verification">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
 
-		<c>tcId</c>
-		<c>Numeric identifier for the test case, unique across the entire vector set.</c>
-		<c>value</c>
-		<c>No</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-    <c>e</c>
-    <c>the public exponent</c>
-    <c>hex value</c>
-    <c>Yes</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>pRand</c>
-    <c>the random for P, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
-    <c>hex value</c>
-    <c>Yes</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>qRand</c>
-	      <c>the random for Q, if applicable, testing probable primes according to <xref target="FIPS186-4"/>, Appendix B.3.3 </c>
-    <c>hex value</c>
-    <c>Yes</c>
-		<c/>
-		<c/>
-		<c/>
-		<c/>
+    <c>tcId</c>
+    <c>Numeric identifier for the test case, unique across the entire vector set.</c>
+    <c>value</c>
+    <c>No</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
     <c>msg</c>
     <c>the message to be signed</c>
     <c>hex value</c>
     <c>Yes</c>
     </texttable>
+	  
+	  <t>The following table describes the JSON elements for each RSA test vector under the componentSigPrim or componentDecPrim modes.</t>
+	  <texttable anchor="vs_tc_table_comp" title="RSA Test Case JSON Object for Component Signature Primitive or Component Decryption Primitive modes">
+	    <ttcol align="left">JSON Value</ttcol>
+	    <ttcol align="left">Description</ttcol>
+	    <ttcol align="left">JSON type</ttcol>
+	    <ttcol align="left">Optional</ttcol>
+	    
+	    <c>tcId</c>
+	    <c>Numeric identifier for the test case, unique across the entire vector set.</c>
+	    <c>value</c>
+	    <c>No</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>msg</c>
+	    <c>the message to be signed or decrypted</c>
+	    <c>hex value</c>
+	    <c>No</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>d</c>
+	    <c>the private exponent</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c/>
+	    <c>n</c>
+	    <c>the modulus value</c>
+	    <c>hex value</c>
+	    <c>Yes</c>
+	  </texttable>
 	</section>
     </section>
 
@@ -907,7 +1107,9 @@
           <c>array</c>
 	</texttable>
 	
-	  <t>The following table describes the JSON elements for the response to a RSA test vector.</t>
+	  <t>The following table describes the JSON elements for the response to a RSA test vector. The client can send 
+	    private keys using the standard format or the Chinese Remainder Theorem (CRT) format. If the value of "infoGeneratedByServer" is true
+	  then the client does not need to send back values generated by the server.</t>
 	    <texttable anchor="vs_tr_keyGen_table" title="RSA Test Case Results JSON Object">
 		<ttcol align="left">JSON Value</ttcol>
 		<ttcol align="left">Description</ttcol>
@@ -1098,6 +1300,30 @@
 		<c/>
 		<c/>
 		<c/>
+    <c>dmp1</c>
+    <c>the private exponent d modulo p - 1. This is only applicable when representing the private key using CRT</c>
+    <c>hex value</c>
+    <c>Yes</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
+    <c>dmq1</c>
+    <c>the private exponent d modulo q - 1. This is only applicable when representing the prvate key using CRT</c>
+    <c>hex value</c>
+    <c>Yes</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
+    <c>iqmp</c>
+    <c>the private prime factor q, inverted modulo p, (q^-1 mod p). This is only applicable when representing the private key using CRT</c>
+    <c>hex value</c>
+    <c>Yes</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
 		<c>s</c>
     <c>the digital signature value</c>
     <c>hex value</c>
@@ -1110,6 +1336,14 @@
     <c>the result from the digital signature verirfication</c>
     <c>"pass"/"fail"</c>
     <c>Yes</c>
+	      <c/>
+	      <c/>
+	      <c/>
+	      <c/>
+	  <c>compResult</c>
+	  <c>the result from either the componentSigPrim mode or the componentDecPrim mode</c>
+	  <c>"pass"/"fail"</c>
+	  <c>Yes</c>
 	    </texttable>
     </section>
 
@@ -1206,27 +1440,23 @@
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
-      "infoGeneratedByServer": true,
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-              "mode": "keyGen",
-              "capSpecs" :  {
-                      "fixedPubExp" : true,
-                      "fixedPubExpVal" : "010001",
-                      "randPQ" : 1,
-                      "capProvPrime" : 
-                            [
-                                {   "modulo" : 2048,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 3072,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 4096,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                            ]
-                      }
-                }
-          }
+         "keyGen" : [{
+              "fixedPubExp" : "fixed",
+              "fixedPubExpVal" : "010001",
+              "randPQ" : "B.3.2",
+              "infoGeneratedByServer": true
+              "capProvPrime" : 
+                    [
+                        {   "modulo" : 2048,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                        {   "modulo" : 3072,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                        {   "modulo" : 4096,
+                            "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+                    ]
+              }]
       ]
    }
 ]]></artwork>
@@ -1239,7 +1469,6 @@
         <artwork><![CDATA[
    {
     "algorithm":"RSA",
-    "infoGeneratedByServer": true,
     "prereqVals":[
       {
         "algorithm":"DRBG",
@@ -1251,24 +1480,18 @@
       }
     ],
     "algSpecs":[
-      {
-        "modeSpecs": {
-          "mode":"keyGen",
-          "capSpecs": {
-            "fixedPubExp": true,
-            "fixedPubExpVal":"010001",
-            "randPQ": 2,
-            "capProbPrime":[{
-              "modulo": 2048,
-              "primeTest":["tblC2"]
-            },
-            {
-              "modulo": 3072,
-              "primeTest":["tblC2", "tblC3"]
-            }]
-          }
-        }
-      }
+        "keyGen": [{
+          "fixedPubExp": "random",
+          "randPQ": "B.3.3",
+          "capProbPrime":[{
+            "modulo": 2048,
+            "primeTest":["tblC2"]
+          },
+          {
+            "modulo": 3072,
+            "primeTest":["tblC2", "tblC3"]
+          }]
+        }]
     ]
   }
 ]]></artwork>
@@ -1283,16 +1506,14 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
-      "infoGeneratedByServer": false,
        "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-           "mode": "keyGen",
-           "capSpecs" : {
-               "fixedPubExp" : true,
+         "keyGen": [{
+               "fixedPubExp" : "fixed",
                "fixedPubExpVal" : "010001",
-               "randPQ" : 4,
+               "randPQ" : "B.3.5",
+               "infoGeneratedByServer": true
                "capsProvProbPrime" : 
                     [
                         {"modulo" : 2048,
@@ -1305,9 +1526,7 @@
                          "hashAlg" : ["SHA-512"],
                          "primeTest": ["tblC3"]},
                     ]
-              }
-          }
-        }
+              }]
       ]
    }
 ]]></artwork>
@@ -1323,54 +1542,45 @@
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "X9.31",
-                  "capSigType" :
-                  [
-                      {"modRSASigGen" : 2048,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 3072,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 4096,
-                        "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-        }},
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "PKCS1v1.5",
-                  "capSigType" :
-                  [
-                      {"modRSASigGen" : 2048,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 3072,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modRSASigGen" : 4096,
-                       "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-         }},
-        {"modeSpecs" : {
-            "mode": "sigGen",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                [
-                    { "modRSASigGen" : 2048,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]},
-                    { "modRSASigGen" : 3072,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]},
-                    { "modRSASigGen" : 4096,
-                      "hashSigGen" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigGen" : [28, 32, 64]}
+         "sigGen" : [{
+              "sigType" : "X9.31",
+              "capSigType" :
+              [
+                  {"modulo" : 2048,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 3072,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 4096,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+        },
+        {
+              "sigType" : "PKCS1v1.5",
+              "capSigType" :
+              [
+                  {"modulo" : 2048,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 3072,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  {"modulo" : 4096,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+         },
+         {
+              "sigType" : "PKCS1PSS",
+              "capSigType" :
+              [
+                  { "modulo" : 2048,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                    "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                    "saltLen" : [28, 32, 64]}
                 ]
-            }
-         }}
+            }]
       ]
    }
 ]]></artwork>
@@ -1385,62 +1595,53 @@
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" : 
       [
-        {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-               
-                 "sigType" : "X9.31",
-                 "capSigType" :
-                [
-                  {"modRSASigVer" : 2048,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 4096,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
-               ]
-            }
-          }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1v1.5",
-                 "capSigType" :
-                [
-                  {"modRSASigVer" : 2048,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modRSASigVer" : 4096,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]}
-                ]
-            }
-         }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                  [
-                    { "modRSASigVer" : 2048,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]},
-                    { "modRSASigVer" : 3072,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]},
-                    { "modRSASigVer" : 4096,
-                      "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltSigVer" : [28, 32, 64]}
-                 ]
-            }
-       }}
-    ]
+        "sigVer" : [{
+             "sigType" : "X9.31",
+             "capSigType" :
+             [
+               {"modulo" : 2048,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+               {"modulo" : 3072,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+               {"modulo" : 4096,
+                "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+             ]
+          },
+          {
+             "sigType" : "PKCS1v1.5",
+             "capSigType" :
+             [
+                {"modulo" : 2048,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                {"modulo" : 3072,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]},
+                {"modulo" : 4096,
+                 "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"]}
+              ]
+           },
+           {
+              "sigType" : "PKCS1PSS",
+              "capSigType" :
+              [
+                 { "modulo" : 2048,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]},
+                 { "modulo" : 3072,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]},
+                 { "modulo" : 4096,
+                   "hashAlg" : ["SHA-224", "SHA-256", "SHA-512"],
+                   "saltLen" : [28, 32, 64]}
+              ]
+           }]
+      ]
    }
 ]]></artwork>
     </figure>
     </section>
         <section anchor="app-cap-legacysigverex" title="Example RSA legacySigVer Capabilities JSON Objects">
-      <t>The format and structure of the RSA legacySigVer capabilities JSON objects follow very closely those of the RSA sigVer capabilties JSON objects with the obvious changes from modRSASigVer, hashSigVer and saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer and the corresponding parameter ranges adjustments.</t>
+      <t>The format and structure of the RSA legacySigVer capabilities JSON objects follows very closely those of the RSA sigVer
+        capabilties JSON objects with the obvious changes from modulo, hashAlg and saltLen to the corresponding parameters.</t>
 </section>
     <section anchor="app-cap-componentsigverex" title="Example componentSigPrimitive Capabilities JSON Objects">
       <t>The following is an example JSON object advertising support for RSA componentSigPrimitive according to <xref target="FIPS186-4"/>.</t>
@@ -1448,12 +1649,7 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
-      "algSpecs" : 
-      [
-       {"modeSpecs" : {
-           "mode": "componentSigPrimitive"
-         }}
-      ]
+      "algSpecs" : ["componentSigPrim"]
    }
 ]]></artwork>
     </figure>
@@ -1465,12 +1661,7 @@
    {
       "algorithm": "RSA",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" : 
-      [
-        {"modeSpecs" : {
-            "mode": "componentDecPrimitive"
-         }}
-      ]
+      "algSpecs" : ["componentDecPrimitive"]
    }
 ]]></artwork>
     </figure>
@@ -1483,16 +1674,17 @@
     <artwork><![CDATA[
 
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1133,
       "algorithm": "RSA",
-      "infoGeneratedByServer": false,
       "testGroups" : [
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 1,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.2",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1505,9 +1697,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 1,
-                "modRSA" : 3072,
+                "randPQ": "B.3.2",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1520,9 +1714,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 3,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.4",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1535,9 +1731,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 3,
-                "modRSA" : 3072,
+                "randPQ": "B.3.4",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1550,9 +1748,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 4,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.5",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1565,9 +1765,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 4,
-                "modRSA" : 3072,
+                "randPQ": "B.3.5",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1580,9 +1782,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": false,
                  "pubExp" : "random",
-                 "randPQ" : 5,
-                 "modRSA" : 2048,
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
                  "hashAlg" : "SHA-256"
                  "tests" : [
                     {
@@ -1595,9 +1799,11 @@
              },
              {
                 "mode": "keyGen",
+                "testType": "AFT",
+                "infoGeneratedByServer": false,
                 "pubExp": "random",
-                "randPQ": 5,
-                "modRSA" : 3072,
+                "randPQ": "B.3.6",
+                "modulo" : 3072,
                 "hashAlg" : "SHA-256"
                 "tests": [
                   {
@@ -1610,10 +1816,11 @@
               },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "modRSA" : 2048,
+                 "modulo" : 2048,
                  "tests" : [
                     {
                       "tcId" : 1119,
@@ -1632,8 +1839,9 @@
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
                  "modRSA" : 3072,
                  "tests" : [
@@ -1647,8 +1855,9 @@
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
                  "modRSA" : 2048,
                  "tests" : [
@@ -1669,8 +1878,9 @@
              },
              {
                  "mode": "keyGen",
+                 "testType": "KAT",
                  "pubExp" : "random",
-                 "randPQ" : 2,
+                 "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
                  "modRSA" : 3072,
                  "tests" : [
@@ -1681,7 +1891,22 @@
                       "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
-             }
+             },
+             {
+                "mode": "keyGen",
+                "testType": "GDT",
+                "pubExp": "random",
+                "randPQ": "B.3.3",
+                "modulo" : 2048,
+                "tests": [
+                  {
+                    "tcId": 1159,
+                  },
+                  {
+                    "tcId": 1160,
+                  }
+                ]
+              }
      ]
    }
  ]
@@ -1690,30 +1915,210 @@
     <t>Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate
       Key Generation method for each test. The information returned should match all applicable data in <xref target="vs_tr_keyGen_table"/>. For Key Generation method 2 (Appendix
     B.3.3 <xref target="FIPS186-4"/>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" 
-    response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd')
-    and the server validates that this pair matches the requirements.</t>
+    response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs 
+    ('e', 'p', 'q', 'n', and 'd', or CRT form) and the server validates that this pair matches the requirements.</t>
+       
+     <t>The following is an example for when "infoGeneratedByServer" is set to true. Note when "randPQ" is "B.3.3", there is no difference and is omitted from this example.</t>
+       <figure>
+         <artwork><![CDATA[
+
+ [
+   { "acvVersion": "0.4" },
+   { "vsId": 1133,
+      "algorithm": "RSA",
+      "testGroups" : [
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.2",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1111,
+              			  "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
+              			  "e" : "10000021"
+              			},
+              			{
+              			  "tcId" : 1112,
+              			  "seed" : "45406f8f889763b751c841880a5fdeec82446c08c896b5f5d70edb8d",
+              			  "e" : "10000021"
+              			}
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.4",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1113,
+              			  "e" : "10000021",
+              			  "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
+              			  "bitlen1" : 312,
+              			  "bitlen2" : 145,
+              			  "bitlen3" : 144,
+              			  "bitlen4" : 338
+              			},
+              			{
+              			  "tcId" : 1114,
+              			  "e" : "10000021",
+              			  "seed" : "4f317e61d35e6f7dc19d038b9da897e64c3e7706b49d30ab2dda32ef",
+              			  "bitlen1" : 320,
+              			  "bitlen2" : 159,
+              			  "bitlen3" : 192,
+              			  "bitlen4" : 222
+              			}
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.5",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1115,
+              			  "e" : "10000021",
+              			  "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
+              			  "bitlen1" : 504,
+              			  "bitlen2" : 238,
+              			  "bitlen3" : 440,
+              			  "bitlen4" : 185
+              			},
+              			{
+              			  "tcId" : 1116,
+              			  "e" : "10000021",
+              			  "seed" : "3bbc67c71012c63e563580555acb96023106a8d5247d6b27d2b20475681bdcb",
+              			  "bitlen1" : 448,
+              			  "bitlen2" : 281,
+              			  "bitlen3" : 240,
+              			  "bitlen4" : 469
+              			}
+                 ]
+             },
+             {
+                 "mode": "keyGen",
+                 "testType": "AFT",
+                 "infoGeneratedByServer": true,
+                 "pubExp" : "random",
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA-256"
+                 "tests" : [
+              			{
+              			  "tcId" : 1117,
+              			  "e" : "10000021",
+              			  "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
+              			  "bitlen1" : 232,
+              			  "p1" : "dee2f4524cb1368264a88ed326c8e105dc3d566147b05a8e82295bf015",
+              			  "primeSeedP2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37342",
+              			  "bitlen2" : 220,
+              			  "p2" : "baf57f053b1f2a46705d9be799f90f28b800de871d88c95f24bf659",
+              			  "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
+              			  "primeSeedQ1" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc373fa",
+              			  "bitlen3" : 336,
+              			  "q1" : "bfbf1abfc1fb9b7e21342139053e7b05f56e664594419bbdcb14bb959ab66cf10e99a0d38f560a22cb33",
+              			  "primeSeedQ2" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37484",
+              			  "bitlen4" : 141,
+              			  "q2" : "15e35869eb4f8dac49e317f09e3be3627c1d",
+              			  "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291"
+              			},
+              			{
+              			 "tcId" : 1118,
+              			 "e" : "10000021",
+              			 "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
+              			 "bitlen1" : 272,
+              			 "p1" : "e43dc77ad0bbe2090a7d99a490f0b37188603691ebd453ef987e8358eee34be2def9",
+              			 "primeSeedP2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805cf1",
+              			 "bitlen2" : 205,
+              			 "p2" : "18dd5b6a27ca680f10764a0e2f49ffd384b650948aa6ba175f07",
+              			 "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
+              			 "primeSeedQ1" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805e76",
+              			 "bitlen3" : 296,
+              			 "q1" : "bd76411ab7c1edb6873e76e5edc7b920b75cf8e2e1152010e6c34df592f8c3cd948212ca05",
+              			 "primeSeedQ2" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805f9c",
+              			 "bitlen4" : 157,
+              			 "q2" : "123e72d9c914cde1b11d233a985f37f0769d2227",
+              			 "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05"
+              			}
+                 ]
+             },
+             {
+                "mode": "keyGen",
+                "testType": "KAT"
+                "pubExp": "random",
+                "randPQ": "B.3.3",
+                "modulo" : 2048,
+                "primeTest" : "tblC2"
+                "tests": [
+              			{
+              			  "tcId" : 1119,
+              			  "e" : "df28ab",
+              			  "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+              			  "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+              			},
+              			{
+              			  "tcId" : 1120,
+              			  "e" : "85a4cf",
+              			  "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+              			  "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+              			}
+                ]
+              },
+              {
+          			"mode": "keyGen",
+          			"testType": "GDT",
+          			"pubExp": "random",
+          			"randPQ": "B.3.3",
+          			"primeTest": "tblC2",
+          			"modRSA": 2048,
+          			"tests": [
+          			    {
+          			      "tcId": 1125
+          			    },
+          			    {
+          			      "tcId": 1126
+          			    }
+          			]
+          		}
+     ]
+   }
+ ]
+]]></artwork>
+       </figure>
     </section>
 <section anchor="app-testVectsigGen-ex" title="Example Test Vectors for sigGen JSON Objects">
     <figure>
     <artwork><![CDATA[
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
                       "tcId" : 1165,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
                     },
                     {
                       "tcId" : 1166,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
                     }
@@ -1721,17 +2126,18 @@
              },
               {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1167,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "msg" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
                     },
                     {
                       "tcId" : 1168,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "msg" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
@@ -1739,18 +2145,19 @@
              },
              {
                  "mode": "sigGen",
+                 "testType": "AFT",
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
                       "tcId" : 1169,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "saltLen" : 20,
                       "msg" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
                     },
                     {
                       "tcId" : 1170,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-512",
                       "saltLen" : 62,
                       "msg" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
@@ -1767,17 +2174,18 @@
     <figure>
     <artwork><![CDATA[
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
              {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "X9.31",
                  "tests" : [
                     {
                       "tcId" : 1174,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "166f67",
                       "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -1786,7 +2194,7 @@
                     },
                     {
                       "tcId" : 1175,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "89ca09",
                       "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
@@ -1797,11 +2205,12 @@
              },
               {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "PKCS1v1.5",
                  "tests" : [
                     {
                       "tcId" : 1176,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "49d2a1",
                       "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
@@ -1810,7 +2219,7 @@
                     },
                     {
                       "tcId" : 1177,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-256",
                       "e" : "ac6db1",
                       "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
@@ -1821,11 +2230,12 @@
              },
              {
                  "mode": "sigVer",
+                 "testType": "AFT",
                  "sigType" : "PKCS1PSS",
                  "tests" : [
                     {
                       "tcId" : 1178,
-                      "modRSA" : 2048,
+                      "modulo" : 2048,
                       "hashAlg" : "SHA-256",
                       "e" : "10e43f",
                       "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
@@ -1834,7 +2244,7 @@
                     },
                     {
                       "tcId" : 1179,
-                      "modRSA" : 3072,
+                      "modulo" : 3072,
                       "hashAlg" : "SHA-512",
                       "e" : "fe3079",
                       "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
@@ -1859,12 +2269,13 @@
     <figure>
     <artwork><![CDATA[
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentSigPrimitive",
+                 "mode": "componentSigPrim",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -1892,12 +2303,13 @@
     <figure>
     <artwork><![CDATA[
  [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
+                 "mode": "componentDecPrim",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -1924,7 +2336,7 @@
             <figure>
         <artwork><![CDATA[
              [
-                { "acvVersion": "0.3" },
+                { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "testResults": [
                     {
@@ -2204,7 +2616,7 @@
             <figure>
         <artwork><![CDATA[
              [
-                  { "acvVersion": "0.3" },
+                  { "acvVersion": "0.4" },
                   { "vsId": 1163,
                     "testResults": [
                     {
@@ -2266,7 +2678,7 @@
             <figure>
         <artwork><![CDATA[
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1173,
       "algorithm": "RSA",
       "testGroups" : [
@@ -2326,12 +2738,12 @@
             <figure>
         <artwork><![CDATA[
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1193,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentSigPrimitive",
+                 "mode": "componentSigPrim",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -2354,12 +2766,12 @@
             <figure>
         <artwork><![CDATA[
  [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1194,
       "algorithm": "RSA",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
+                 "mode": "componentDecPrim",
                  "tests" : [
                     {
                       "tcId" : 1196,


### PR DESCRIPTION
This addresses the concerns of the previous branch. Algorithm is separate from mode, but the JSON that defines the mode is made simpler to work with. #167 

Also allows clients to use both CRT format for passing around private key information and the standard format. This is optional and left up to the client.  #168 
