### PR TITLE
Mac aes changes

### DIFF
--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -1075,7 +1075,20 @@
                 "macLen": [ 160 ]
             }
             </pre>
-<p id="rfc.section.A.p.2">The following is an example JSON object advertising support for CMAC-TDES.</p>
+<p id="rfc.section.A.p.2">The following is an example JSON object advertising support for CMAC-AES-128.</p>
+<pre>
+
+
+            {
+                "algorithm": "CMAC-AES-128",
+                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+		                {"algorithm" : "TDES", "valValue" : "123456"}],
+                "direction" : [ "gen", "ver" ],
+		            "macLen" : [ 64],
+		            "msgLen" : [ 0 ]
+            }
+            </pre>
+<p id="rfc.section.A.p.3">The following is an example JSON object advertising support for CMAC-TDES.</p>
 <pre>
 
 
@@ -1120,7 +1133,59 @@
                 }
              ]
             </pre>
-<p id="rfc.section.B.p.2">The following is an example JSON object for CMAC test vectors sent from the ACVP server to the crypto module.</p>
+<p id="rfc.section.B.p.2">The following is an example JSON object for CMAC-AES-128 test vectors sent from the ACVP server to the crypto module.</p>
+<pre>
+[{
+  "acvVersion": "0.4"
+},
+	{
+		"vsId": 3500,
+		"algorithm": "CMAC-AES-128",
+		"testGroups": [{
+			"testType": "AFT",
+			"direction": "gen",
+			"keyLen": 128,
+			"msgLen": 0,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 2750,
+					"key": "f28effca41cb11819a81eb3ebf3b7e83",
+					"msg": ""
+				},
+				{
+					"tcId": 2751,
+					"key": "ab566f4af532efc8bc56555fe07696fd",
+					"msg": ""
+				},
+				}
+			]
+		},
+		{
+			"testType": "AFT",
+			"direction": "ver",
+			"keyLen": 127,
+			"msgLen": 0,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 2752,
+					"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+					"msg": ""
+					"mac": "2eef1e38fcc7c568"
+				},
+				{
+					"tcId": 2753,
+					"key": "eb87fb7a5fb60caecb9b23564befe513",
+					"msg": ""
+					"mac": "cafecafecafecafe"
+				}
+			]
+		}    
+    {
+    }]
+	}
+]
+            </pre>
+<p id="rfc.section.B.p.3">The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
 [{
   "acvVersion": "0.4"
@@ -1152,7 +1217,7 @@
 		},
 {
 			"testType": "AFT",
-			"direction": "gen",
+			"direction": "ver",
 			"keyLen": 3,
 			"msgLen": 0,
 			"macLen": 40,
@@ -1201,7 +1266,33 @@
                 }
              ]
             </pre>
-<p id="rfc.section.C.p.2">The following is an example JSON object for CMAC test results sent from the crypto module to the ACVP server.</p>
+<p id="rfc.section.C.p.2">The following is an example JSON object for CMAC-AES-128 test results sent from the crypto module to the ACVP server.</p>
+<pre>
+              [
+                  { "acvVersion": "0.4" },
+                  { "vsId": 3500,
+                    "testResults": [
+                        {
+                            "tcId": 2750,
+                            "mac": "e77145f0d6c77ad5"
+                        },
+                       {
+                            "tcId": 2751,
+                            "mac": "6b078f7e53b6d183"
+                       },
+                       {
+                            "tcId": 2752,
+                            "result": "pass"
+                       },
+                       {
+                            "tcId": 2753,
+                            "result": "fail"
+                       },
+                    ]
+                }
+             ]
+            </pre>
+<p id="rfc.section.C.p.3">The following is an example JSON object for CMAC-TDES test results sent from the crypto module to the ACVP server.</p>
 <pre>
               [
                   { "acvVersion": "0.4" },

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -1084,8 +1084,8 @@
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-		            "macLen" : [ 64],
-		            "msgLen" : [ 0 ]
+                "macLen" : [ 64 ],
+                "msgLen" : [ 0 ]
             }
             </pre>
 <p id="rfc.section.A.p.3">The following is an example JSON object advertising support for CMAC-TDES.</p>
@@ -1097,8 +1097,8 @@
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-		            "macLen" : [ 8, 64],
-		            "msgLen" : [ 0, 256, 120, 248, 320 ]
+                "macLen" : [ 8, 64 ],
+                "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
             </pre>
 <h1 id="rfc.appendix.B">
@@ -1106,38 +1106,39 @@
 </h1>
 <p id="rfc.section.B.p.1">The following is an example JSON object for HMAC test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
-              [
-                { "acvVersion": "0.4" },
-                { "vsId": 1565,
-                  "algorithm": "HMAC-SHA-1",
-                  "testGroups": [
-                    {
-                      "testType": "AFT",
-                      "keyLen": 256,
-                      "msgLen": 160,
-                      "macLen" : 80,
-                      "tests": [
-                        {
-                          "tcId": 2172,
-                          "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-                          "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-                        },
-                        {
-                          "tcId": 2173,
-                          "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-                          "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-                        }
-                      ]
-                    }
-                  ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 1565,
+		"algorithm": "HMAC-SHA-1",
+		"testGroups": [{
+			"testType": "AFT",
+			"keyLen": 256,
+			"msgLen": 160,
+			"macLen": 80,
+			"tests": [{
+					"tcId": 2172,
+					"key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
+					"msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
+				},
+				{
+					"tcId": 2173,
+					"key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
+					"msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
+				}
+			]
+		}]
+	}
+]
             </pre>
 <p id="rfc.section.B.p.2">The following is an example JSON object for CMAC-AES-128 test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
-[{
-  "acvVersion": "0.4"
-},
+[
+	{
+		"acvVersion": "0.4"
+	},
 	{
 		"vsId": 3500,
 		"algorithm": "CMAC-AES-128",
@@ -1156,91 +1157,88 @@
 					"tcId": 2751,
 					"key": "ab566f4af532efc8bc56555fe07696fd",
 					"msg": ""
-				},
 				}
 			]
-		},
-		{
-			"testType": "AFT",
-			"direction": "ver",
-			"keyLen": 127,
-			"msgLen": 0,
-			"macLen": 64,
-			"tests": [{
-					"tcId": 2752,
-					"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-					"msg": ""
-					"mac": "2eef1e38fcc7c568"
-				},
-				{
-					"tcId": 2753,
-					"key": "eb87fb7a5fb60caecb9b23564befe513",
-					"msg": ""
-					"mac": "cafecafecafecafe"
-				}
-			]
-		}    
-    {
-    }]
+		}]
+	},
+	{
+		"testType": "AFT",
+		"direction": "ver",
+		"keyLen": 127,
+		"msgLen": 0,
+		"macLen": 64,
+		"tests": [{
+				"tcId": 2752,
+				"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+				"msg": "",
+				"mac": "2eef1e38fcc7c568"
+			},
+			{
+				"tcId": 2753,
+				"key": "eb87fb7a5fb60caecb9b23564befe513",
+				"msg": "",
+				"mac": "cafecafecafecafe"
+			}
+		]
 	}
 ]
             </pre>
 <p id="rfc.section.B.p.3">The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
-[{
-  "acvVersion": "0.4"
-},
+[
+	{
+		"acvVersion": "0.4"
+	},
 	{
 		"vsId": 1566,
 		"algorithm": "CMAC-TDES",
 		"testGroups": [{
-			"testType": "AFT",
-			"direction": "gen",
-			"keyLen": 3,
-			"msgLen": 0,
-			"macLen": 40,
-			"tests": [{
-					"tcId": 2175,
-					"key": "c479f813ad1a45d5",
-					"key2": "dc43459da4c85e85",
-					"key3": "1cda518af886bf1f",
-					"msg": ""
-				},
-				{
-					"tcId": 2176,
-					"key": "731331866754588f",
-					"key2": "d332ef51e0ce1925",
-					"key3": "d586cba70440f44f",
-					"msg": ""
-				}
-			]
-		},
-{
-			"testType": "AFT",
-			"direction": "ver",
-			"keyLen": 3,
-			"msgLen": 0,
-			"macLen": 40,
-			"tests": [{
-					"tcId": 2177,
-					"key": "d586cba70440f44f",
-					"key2": "d332ef51e0ce1925",
-					"key3": "dc43459da4c85e85",
-					"msg": ""
-					"mac": "cafecafecafecafecafecafecafecafecafecafe"
-				},
-				{
-					"tcId": 2177,
-					"key": "dc43459da4c85e85",
-					"key2": "c479f813ad1a45d5",
-					"key3": "1cda518af886bf1f",
-					"msg": ""
-					"mac": "cafecafecafecafecafecafecafecafecafecafe"
-				}
-			]
-		}    
-    {
-    }]
+				"testType": "AFT",
+				"direction": "gen",
+				"keyLen": 3,
+				"msgLen": 0,
+				"macLen": 40,
+				"tests": [{
+						"tcId": 2175,
+						"key": "c479f813ad1a45d5",
+						"key2": "dc43459da4c85e85",
+						"key3": "1cda518af886bf1f",
+						"msg": ""
+					},
+					{
+						"tcId": 2176,
+						"key": "731331866754588f",
+						"key2": "d332ef51e0ce1925",
+						"key3": "d586cba70440f44f",
+						"msg": ""
+					}
+				]
+			},
+			{
+				"testType": "AFT",
+				"direction": "ver",
+				"keyLen": 3,
+				"msgLen": 0,
+				"macLen": 40,
+				"tests": [{
+						"tcId": 2177,
+						"key": "d586cba70440f44f",
+						"key2": "d332ef51e0ce1925",
+						"key3": "dc43459da4c85e85",
+						"msg": "",
+						"mac": "cafecafecafecafecafecafecafecafecafecafe"
+					},
+					{
+						"tcId": 2177,
+						"key": "dc43459da4c85e85",
+						"key2": "c479f813ad1a45d5",
+						"key3": "1cda518af886bf1f",
+						"msg": "",
+						"mac": "cafecafecafecafecafecafecafecafecafecafe"
+					}
+				]
+			}
+		]
 	}
 ]
             </pre>
@@ -1249,74 +1247,79 @@
 </h1>
 <p id="rfc.section.C.p.1">The following is an example JSON object for HMAC test results sent from the crypto module to the ACVP server.</p>
 <pre>
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1565,
-                    "testResults": [
-                        {
-                            "tcId": 2172,
-                            "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
-                        },
-                       {
-                            "tcId": 2173,
-                            "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-                       },
-                       
-                    ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 1565,
+		"testResults": [{
+				"tcId": 2172,
+				"mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
+			},
+			{
+				"tcId": 2173,
+				"mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
+			}
+		]
+	}
+]
             </pre>
 <p id="rfc.section.C.p.2">The following is an example JSON object for CMAC-AES-128 test results sent from the crypto module to the ACVP server.</p>
 <pre>
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 3500,
-                    "testResults": [
-                        {
-                            "tcId": 2750,
-                            "mac": "e77145f0d6c77ad5"
-                        },
-                       {
-                            "tcId": 2751,
-                            "mac": "6b078f7e53b6d183"
-                       },
-                       {
-                            "tcId": 2752,
-                            "result": "pass"
-                       },
-                       {
-                            "tcId": 2753,
-                            "result": "fail"
-                       },
-                    ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 3500,
+		"testResults": [{
+				"tcId": 2750,
+				"mac": "e77145f0d6c77ad5"
+			},
+			{
+				"tcId": 2751,
+				"mac": "6b078f7e53b6d183"
+			},
+			{
+				"tcId": 2752,
+				"result": "pass"
+			},
+			{
+				"tcId": 2753,
+				"result": "fail"
+			}
+		]
+	}
+]
             </pre>
 <p id="rfc.section.C.p.3">The following is an example JSON object for CMAC-TDES test results sent from the crypto module to the ACVP server.</p>
 <pre>
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1566,
-                    "testResults": [
-                        {
-                            "tcId": 2175,
-                            "mac": "fea01c84a7"
-                        },
-                       {
-                            "tcId": 2176,
-                            "mac": "164bdb8582"
-                       },
-                       {
-                            "tcId": 2177,
-                            "result": "fail"
-                       },
-                       {
-                            "tcId": 2178,
-                            "result": "fail"
-                       },
-                    ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 1566,
+		"testResults": [{
+				"tcId": 2175,
+				"mac": "fea01c84a7"
+			},
+			{
+				"tcId": 2176,
+				"mac": "164bdb8582"
+			},
+			{
+				"tcId": 2177,
+				"result": "fail"
+			},
+			{
+				"tcId": 2178,
+				"result": "fail"
+			}
+		]
+	}
+]
             </pre>
 <h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
 <div class="avoidbreak">

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -607,6 +607,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">direction</td>
+<td class="left">The MAC direction(s) to test. Only applies to CMAC.</td>
+<td class="left">array</td>
+<td class="left">gen, ver</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">keyRange1</td>
 <td class="left">If IUT supports key sizes(KS) less than Block size(BS), enter 2 distinct key sizes. If IUT only supports one KS less than BS, enter a single size in the array and do not pass keyrange2 or keyblock field.</td>
 <td class="left">array</td>
@@ -649,9 +663,16 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">msgLen</td>
+<td class="left">The CMAC message lengths supported.  Min/max/increment and values must be mod 8.</td>
+<td class="left">Domain</td>
+<td class="left">0-524288</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
 <td class="left">macLen</td>
-<td class="left">The supported mac sizes. (range dependent on SHA size)</td>
-<td class="left">array</td>
+<td class="left">The supported mac sizes. Min/max/increment and values must be mod 8. (range dependent on SHA size).</td>
+<td class="left">Domain</td>
 <td class="left">8-524288</td>
 <td class="left">No</td>
 </tr>
@@ -661,13 +682,6 @@
 <td class="left"></td>
 <td class="left"></td>
 <td class="left"></td>
-</tr>
-<tr>
-<td class="left">msgLen</td>
-<td class="left">The CMAC message lengths supported</td>
-<td class="left">array</td>
-<td class="left">0-524288</td>
-<td class="left">Yes</td>
 </tr>
 </tbody>
 </table>
@@ -782,7 +796,19 @@
 <tbody>
 <tr>
 <td class="left">testType</td>
-<td class="left">Test category type (ver or gen for CMAC, gen for HMAC)</td>
+<td class="left">Test category type (AFT)</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The direction of the tests - gen or ver - only applies to CMAC</td>
 <td class="left">value</td>
 <td class="left">No</td>
 </tr>
@@ -1057,8 +1083,9 @@
                 "algorithm": "CMAC-TDES",
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
-		"macLen" : [ 8, 64],
-		"msgLen" : [ 0, 256, 120, 248, 320 ]
+                "direction" : [ "gen", "ver" ],
+		            "macLen" : [ 8, 64],
+		            "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
             </pre>
 <h1 id="rfc.appendix.B">
@@ -1072,7 +1099,7 @@
                   "algorithm": "HMAC-SHA-1",
                   "testGroups": [
                     {
-                      "testType": "gen",
+                      "testType": "AFT",
                       "keyLen": 256,
                       "msgLen": 160,
                       "macLen" : 80,
@@ -1102,7 +1129,8 @@
 		"vsId": 1566,
 		"algorithm": "CMAC-TDES",
 		"testGroups": [{
-			"testType": "gen",
+			"testType": "AFT",
+			"direction": "gen",
 			"keyLen": 3,
 			"msgLen": 0,
 			"macLen": 40,
@@ -1123,7 +1151,8 @@
 			]
 		},
 {
-			"testType": "ver",
+			"testType": "AFT",
+			"direction": "gen",
 			"keyLen": 3,
 			"msgLen": 0,
 			"macLen": 40,
@@ -1133,7 +1162,7 @@
 					"key2": "d332ef51e0ce1925",
 					"key3": "dc43459da4c85e85",
 					"msg": ""
-          "mac": "cafecafecafecafecafecafecafecafecafecafe"
+					"mac": "cafecafecafecafecafecafecafecafecafecafe"
 				},
 				{
 					"tcId": 2177,
@@ -1141,7 +1170,7 @@
 					"key2": "c479f813ad1a45d5",
 					"key3": "1cda518af886bf1f",
 					"msg": ""
-          "mac": "cafecafecafecafecafecafecafecafecafecafe"
+					"mac": "cafecafecafecafecafecafecafecafecafecafe"
 				}
 			]
 		}    

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -70,16 +70,16 @@ Table of Contents
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   7
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   8
    4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   9
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   9
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  10
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  10
      8.2.  Informative References  . . . . . . . . . . . . . . . . .  10
    Appendix A.  Example MAC Capabilities JSON Object . . . . . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  11
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  12
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  14
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  13
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  15
 
 1.  Introduction
 
@@ -175,49 +175,49 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +-----------+----------------+--------------+------------+----------+
-   | JSON      | Description    | JSON type    | Valid      | Optional |
-   | Value     |                |              | Values     |          |
-   +-----------+----------------+--------------+------------+----------+
-   | algorithm | The MAC        | value        | See        | No       |
-   |           | algorithm and  |              | Section    |          |
-   |           | mode to be     |              | 2.3        |          |
-   |           | validated.     |              |            |          |
-   |           |                |              |            |          |
-   | prereqVal | prerequistie   | array of     | See        | No       |
-   | s         | algorithm      | prereqAlgVal | Section    |          |
-   |           | validations,   | objects      | 2.1        |          |
-   |           | See Appendix A |              |            |          |
-   |           | for examples   |              |            |          |
-   |           |                |              |            |          |
-   | keyRange1 | If IUT         | array        | 0-524288   | Yes      |
-   |           | supports key   |              |            |          |
-   |           | sizes(KS) less |              |            |          |
-   |           | than Block     |              |            |          |
-   |           | size(BS),      |              |            |          |
-   |           | enter 2        |              |            |          |
-   |           | distinct key   |              |            |          |
-   |           | sizes. If IUT  |              |            |          |
-   |           | only supports  |              |            |          |
-   |           | one KS less    |              |            |          |
-   |           | than BS, enter |              |            |          |
-   |           | a single size  |              |            |          |
-   |           | in the array   |              |            |          |
-   |           | and do not     |              |            |          |
-   |           | pass keyrange2 |              |            |          |
-   |           | or keyblock    |              |            |          |
-   |           | field.         |              |            |          |
-   |           |                |              |            |          |
-   | keyRange2 | If IUT         | array        | 0-524288   | Yes      |
-   |           | supports key   |              |            |          |
-   |           | sizes(KS)      |              |            |          |
-   |           | greater than   |              |            |          |
-   |           | Block          |              |            |          |
-   |           | size(BS),      |              |            |          |
-   |           | enter 2        |              |            |          |
-   |           | distinct key   |              |            |          |
-   |           | sizes. If IUT  |              |            |          |
-   |           | only supports  |              |            |          |
+   +-----------+-----------------+-------------+------------+----------+
+   | JSON      | Description     | JSON type   | Valid      | Optional |
+   | Value     |                 |             | Values     |          |
+   +-----------+-----------------+-------------+------------+----------+
+   | algorithm | The MAC         | value       | See        | No       |
+   |           | algorithm and   |             | Section    |          |
+   |           | mode to be      |             | 2.3        |          |
+   |           | validated.      |             |            |          |
+   |           |                 |             |            |          |
+   | prereqVal | prerequistie    | array of pr | See        | No       |
+   | s         | algorithm       | ereqAlgVal  | Section    |          |
+   |           | validations,    | objects     | 2.1        |          |
+   |           | See Appendix A  |             |            |          |
+   |           | for examples    |             |            |          |
+   |           |                 |             |            |          |
+   | direction | The MAC         | array       | gen, ver   | No       |
+   |           | direction(s) to |             |            |          |
+   |           | test. Only      |             |            |          |
+   |           | applies to      |             |            |          |
+   |           | CMAC.           |             |            |          |
+   |           |                 |             |            |          |
+   | keyRange1 | If IUT supports | array       | 0-524288   | Yes      |
+   |           | key sizes(KS)   |             |            |          |
+   |           | less than Block |             |            |          |
+   |           | size(BS), enter |             |            |          |
+   |           | 2 distinct key  |             |            |          |
+   |           | sizes. If IUT   |             |            |          |
+   |           | only supports   |             |            |          |
+   |           | one KS less     |             |            |          |
+   |           | than BS, enter  |             |            |          |
+   |           | a single size   |             |            |          |
+   |           | in the array    |             |            |          |
+   |           | and do not pass |             |            |          |
+   |           | keyrange2 or    |             |            |          |
+   |           | keyblock field. |             |            |          |
+   |           |                 |             |            |          |
+   | keyRange2 | If IUT supports | array       | 0-524288   | Yes      |
+   |           | key sizes(KS)   |             |            |          |
+   |           | greater than    |             |            |          |
+   |           | Block size(BS), |             |            |          |
+   |           | enter 2         |             |            |          |
+   |           | distinct key    |             |            |          |
+   |           | sizes. If IUT   |             |            |          |
 
 
 
@@ -226,31 +226,36 @@ Fussell                 Expires December 3, 2016                [Page 4]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |           | one KS greater |              |            |          |
-   |           | than BS, enter |              |            |          |
-   |           | the size in    |              |            |          |
-   |           | the array and  |              |            |          |
-   |           | do not pass    |              |            |          |
-   |           | keyrange1 or   |              |            |          |
-   |           | keyblock       |              |            |          |
-   |           | field.         |              |            |          |
-   |           |                |              |            |          |
-   | keyBlock  | Implementation | boolean      | true/false | Yes      |
-   |           | supports       |              |            |          |
-   |           | keysize equal  |              |            |          |
-   |           | blocksize      |              |            |          |
-   |           |                |              |            |          |
-   | macLen    | The supported  | array        | 8-524288   | No       |
-   |           | mac sizes.     |              |            |          |
-   |           | (range         |              |            |          |
-   |           | dependent on   |              |            |          |
-   |           | SHA size)      |              |            |          |
-   |           |                |              |            |          |
-   | msgLen    | The CMAC       | array        | 0-524288   | Yes      |
-   |           | message        |              |            |          |
-   |           | lengths        |              |            |          |
-   |           | supported      |              |            |          |
-   +-----------+----------------+--------------+------------+----------+
+   |           | only supports   |             |            |          |
+   |           | one KS greater  |             |            |          |
+   |           | than BS, enter  |             |            |          |
+   |           | the size in the |             |            |          |
+   |           | array and do    |             |            |          |
+   |           | not pass        |             |            |          |
+   |           | keyrange1 or    |             |            |          |
+   |           | keyblock field. |             |            |          |
+   |           |                 |             |            |          |
+   | keyBlock  | Implementation  | boolean     | true/false | Yes      |
+   |           | supports        |             |            |          |
+   |           | keysize equal   |             |            |          |
+   |           | blocksize       |             |            |          |
+   |           |                 |             |            |          |
+   | msgLen    | The CMAC        | Domain      | 0-524288   | Yes      |
+   |           | message lengths |             |            |          |
+   |           | supported.  Min |             |            |          |
+   |           | /max/increment  |             |            |          |
+   |           | and values must |             |            |          |
+   |           | be mod 8.       |             |            |          |
+   | macLen    | The supported   | Domain      | 8-524288   | No       |
+   |           | mac sizes. Min/ |             |            |          |
+   |           | max/increment   |             |            |          |
+   |           | and values must |             |            |          |
+   |           | be mod 8.       |             |            |          |
+   |           | (range          |             |            |          |
+   |           | dependent on    |             |            |          |
+   |           | SHA size).      |             |            |          |
+   |           |                 |             |            |          |
+   +-----------+-----------------+-------------+------------+----------+
 
               Table 2: MAC Algorithm Capabilities JSON Values
 
@@ -269,11 +274,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    msgLen for CMAC contains an array of up to 6 values defined by these
    rules:
 
-   o  The smallest message length supported
-
-   o  Two message lengths divisible by block size
-
-   o  Two message lengths NOT divisible by block size
 
 
 
@@ -281,6 +281,12 @@ Fussell                 Expires December 3, 2016                [Page 5]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
+
+   o  The smallest message length supported
+
+   o  Two message lengths divisible by block size
+
+   o  Two message lengths NOT divisible by block size
 
    o  The largest message length supported
 
@@ -324,12 +330,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
    typical ACVP validation session would require multiple test vector
-   sets to be downloaded and processed by the ACVP client.  Each test
-   vector set represents an individual crypto algorithm, such as HMAC-
-   SHA-1, HMAC-SHA2-224, CMAC-AES-128, etc.  This section describes the
-   JSON schema for a test vector set used with HMAC and CMAC crypto
-   algorithms.
-
 
 
 
@@ -337,6 +337,12 @@ Fussell                 Expires December 3, 2016                [Page 6]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
+
+   sets to be downloaded and processed by the ACVP client.  Each test
+   vector set represents an individual crypto algorithm, such as HMAC-
+   SHA-1, HMAC-SHA2-224, CMAC-AES-128, etc.  This section describes the
+   JSON schema for a test vector set used with HMAC and CMAC crypto
+   algorithms.
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta data for the entire vector set as well as individual
@@ -383,35 +389,31 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-
-
-
-
-
 Fussell                 Expires December 3, 2016                [Page 7]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +----------+-------------------------------------+-------+----------+
-   | JSON     | Description                         | JSON  | Optional |
-   | Value    |                                     | type  |          |
-   +----------+-------------------------------------+-------+----------+
-   | testType | Test category type (ver or gen for  | value | No       |
-   |          | CMAC, gen for HMAC)                 |       |          |
-   |          |                                     |       |          |
-   | keyLen   | Length of key in bits to use        | value | No       |
-   |          |                                     |       |          |
-   | msgLen   | Length of message/hash in bits      | value | No       |
-   |          |                                     |       |          |
-   | macLen   | Length of MAC in bits to            | value | No       |
-   |          | generate/verify                     |       |          |
-   |          |                                     |       |          |
-   | tests    | Array of individual test vector     | array | No       |
-   |          | JSON objects, which are defined in  |       |          |
-   |          | Section 3.2                         |       |          |
-   +----------+-------------------------------------+-------+----------+
+   +-----------+------------------------------------+-------+----------+
+   | JSON      | Description                        | JSON  | Optional |
+   | Value     |                                    | type  |          |
+   +-----------+------------------------------------+-------+----------+
+   | testType  | Test category type (AFT)           | value | No       |
+   |           |                                    |       |          |
+   | direction | The direction of the tests - gen   | value | No       |
+   |           | or ver - only applies to CMAC      |       |          |
+   |           |                                    |       |          |
+   | keyLen    | Length of key in bits to use       | value | No       |
+   |           |                                    |       |          |
+   | msgLen    | Length of message/hash in bits     | value | No       |
+   |           |                                    |       |          |
+   | macLen    | Length of MAC in bits to           | value | No       |
+   |           | generate/verify                    |       |          |
+   |           |                                    |       |          |
+   | tests     | Array of individual test vector    | array | No       |
+   |           | JSON objects, which are defined in |       |          |
+   |           | Section 3.2                        |       |          |
+   +-----------+------------------------------------+-------+----------+
 
                       Table 4: Test Group JSON Object
 
@@ -421,6 +423,32 @@ Internet-Draft                Sym Alg JSON                     June 2016
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each secure MAC test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 8]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    +--------+---------------------------------------+-------+----------+
    | JSON   | Description                           | JSON  | Optional |
@@ -441,14 +469,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    +--------+---------------------------------------+-------+----------+
 
                       Table 5: Test Case JSON Object
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 8]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
 4.  Test Vector Responses
 
@@ -479,6 +499,13 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
                  Table 6: Vector Set Response JSON Object
 
+
+
+Fussell                 Expires December 3, 2016                [Page 9]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
 5.  Acknowledgements
 
    TBD...
@@ -496,15 +523,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 8.1.  Normative References
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
-
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 9]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -532,6 +550,18 @@ Appendix A.  Example MAC Capabilities JSON Object
 
 
 
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 10]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
             {
                 "algorithm": "HMAC-SHA2-256",
                 "prereqVals" : [{"algorithm" : "SHA", "valValue" : "123456"}],
@@ -550,22 +580,43 @@ Appendix A.  Example MAC Capabilities JSON Object
                 "algorithm": "CMAC-TDES",
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
                                 {"algorithm" : "TDES", "valValue" : "123456"}],
-                "macLen" : [ 8, 64],
-                "msgLen" : [ 0, 256, 120, 248, 320 ]
+                "direction" : [ "gen", "ver" ],
+                            "macLen" : [ 8, 64],
+                            "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 10]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
 Appendix B.  Example Test Vectors JSON Object
 
    The following is an example JSON object for HMAC test vectors sent
    from the ACVP server to the crypto module.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 11]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
               [
                 { "acvVersion": "0.4" },
@@ -573,7 +624,7 @@ Appendix B.  Example Test Vectors JSON Object
                   "algorithm": "HMAC-SHA-1",
                   "testGroups": [
                     {
-                      "testType": "gen",
+                      "testType": "AFT",
                       "keyLen": 256,
                       "msgLen": 160,
                       "macLen" : 80,
@@ -597,68 +648,70 @@ Appendix B.  Example Test Vectors JSON Object
    The following is an example JSON object for CMAC test vectors sent
    from the ACVP server to the crypto module.
 
-   [{
-     "acvVersion": "0.4"
-   },
-           {
-                   "vsId": 1566,
-                   "algorithm": "CMAC-TDES",
-                   "testGroups": [{
-                           "testType": "gen",
-                           "keyLen": 3,
-                           "msgLen": 0,
-                           "macLen": 40,
-                           "tests": [{
-                                           "tcId": 2175,
+[{
+  "acvVersion": "0.4"
+},
+        {
+                "vsId": 1566,
+                "algorithm": "CMAC-TDES",
+                "testGroups": [{
+                        "testType": "AFT",
+                        "direction": "gen",
+                        "keyLen": 3,
+                        "msgLen": 0,
+                        "macLen": 40,
+                        "tests": [{
+                                        "tcId": 2175,
+                                        "key": "c479f813ad1a45d5",
+                                        "key2": "dc43459da4c85e85",
+                                        "key3": "1cda518af886bf1f",
+                                        "msg": ""
 
 
 
-Fussell                 Expires December 3, 2016               [Page 11]
+Fussell                 Expires December 3, 2016               [Page 12]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                                           "key": "c479f813ad1a45d5",
-                                           "key2": "dc43459da4c85e85",
-                                           "key3": "1cda518af886bf1f",
-                                           "msg": ""
-                                   },
-                                   {
-                                           "tcId": 2176,
-                                           "key": "731331866754588f",
-                                           "key2": "d332ef51e0ce1925",
-                                           "key3": "d586cba70440f44f",
-                                           "msg": ""
-                                   }
-                           ]
-                   },
-   {
-                           "testType": "ver",
-                           "keyLen": 3,
-                           "msgLen": 0,
-                           "macLen": 40,
-                           "tests": [{
-                                           "tcId": 2177,
-                                           "key": "d586cba70440f44f",
-                                           "key2": "d332ef51e0ce1925",
-                                           "key3": "dc43459da4c85e85",
-                                           "msg": ""
-             "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                                   },
-                                   {
-                                           "tcId": 2177,
-                                           "key": "dc43459da4c85e85",
-                                           "key2": "c479f813ad1a45d5",
-                                           "key3": "1cda518af886bf1f",
-                                           "msg": ""
-             "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                                   }
-                           ]
-                   }
-       {
-       }]
-           }
-   ]
+                                },
+                                {
+                                        "tcId": 2176,
+                                        "key": "731331866754588f",
+                                        "key2": "d332ef51e0ce1925",
+                                        "key3": "d586cba70440f44f",
+                                        "msg": ""
+                                }
+                        ]
+                },
+{
+                        "testType": "AFT",
+                        "direction": "gen",
+                        "keyLen": 3,
+                        "msgLen": 0,
+                        "macLen": 40,
+                        "tests": [{
+                                        "tcId": 2177,
+                                        "key": "d586cba70440f44f",
+                                        "key2": "d332ef51e0ce1925",
+                                        "key3": "dc43459da4c85e85",
+                                        "msg": ""
+                                        "mac": "cafecafecafecafecafecafecafecafecafecafe"
+                                },
+                                {
+                                        "tcId": 2177,
+                                        "key": "dc43459da4c85e85",
+                                        "key2": "c479f813ad1a45d5",
+                                        "key3": "1cda518af886bf1f",
+                                        "msg": ""
+                                        "mac": "cafecafecafecafecafecafecafecafecafecafe"
+                                }
+                        ]
+                }
+    {
+    }]
+        }
+]
 
 Appendix C.  Example Test Results JSON Object
 
@@ -669,7 +722,10 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 12]
+
+
+
+Fussell                 Expires December 3, 2016               [Page 13]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -725,7 +781,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 13]
+Fussell                 Expires December 3, 2016               [Page 14]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -781,4 +837,4 @@ Author's Address
 
 
 
-Fussell                 Expires December 3, 2016               [Page 14]
+Fussell                 Expires December 3, 2016               [Page 15]

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -79,7 +79,7 @@ Table of Contents
    Appendix A.  Example MAC Capabilities JSON Object . . . . . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  11
    Appendix C.  Example Test Results JSON Object . . . . . . . . . .  15
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  16
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  17
 
 1.  Introduction
 
@@ -581,8 +581,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
                                 {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-                            "macLen" : [ 64],
-                            "msgLen" : [ 0 ]
+                "macLen" : [ 64 ],
+                "msgLen" : [ 0 ]
             }
 
    The following is an example JSON object advertising support for CMAC-
@@ -595,8 +595,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
                                 {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-                            "macLen" : [ 8, 64],
-                            "msgLen" : [ 0, 256, 120, 248, 320 ]
+                "macLen" : [ 8, 64 ],
+                "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
 
 Appendix B.  Example Test Vectors JSON Object
@@ -618,39 +618,66 @@ Fussell                 Expires December 3, 2016               [Page 11]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-              [
-                { "acvVersion": "0.4" },
-                { "vsId": 1565,
-                  "algorithm": "HMAC-SHA-1",
-                  "testGroups": [
-                    {
-                      "testType": "AFT",
-                      "keyLen": 256,
-                      "msgLen": 160,
-                      "macLen" : 80,
-                      "tests": [
-                        {
-                          "tcId": 2172,
-                          "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-                          "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-                        },
-                        {
-                          "tcId": 2173,
-                          "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-                          "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-                        }
-                      ]
-                    }
-                  ]
-                }
-             ]
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 1565,
+                "algorithm": "HMAC-SHA-1",
+                "testGroups": [{
+                        "testType": "AFT",
+                        "keyLen": 256,
+                        "msgLen": 160,
+                        "macLen": 80,
+                        "tests": [{
+                                        "tcId": 2172,
+                                        "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
+                                        "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
+                                },
+                                {
+                                        "tcId": 2173,
+                                        "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
+                                        "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
+                                }
+                        ]
+                }]
+        }
+]
 
    The following is an example JSON object for CMAC-AES-128 test vectors
    sent from the ACVP server to the crypto module.
 
-[{
-  "acvVersion": "0.4"
-},
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 12]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+[
+        {
+                "acvVersion": "0.4"
+        },
         {
                 "vsId": 3500,
                 "algorithm": "CMAC-AES-128",
@@ -666,62 +693,35 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                         "msg": ""
                                 },
                                 {
-
-
-
-Fussell                 Expires December 3, 2016               [Page 12]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                                         "tcId": 2751,
                                         "key": "ab566f4af532efc8bc56555fe07696fd",
                                         "msg": ""
-                                },
                                 }
                         ]
-                },
-                {
-                        "testType": "AFT",
-                        "direction": "ver",
-                        "keyLen": 127,
-                        "msgLen": 0,
-                        "macLen": 64,
-                        "tests": [{
-                                        "tcId": 2752,
-                                        "key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-                                        "msg": ""
-                                        "mac": "2eef1e38fcc7c568"
-                                },
-                                {
-                                        "tcId": 2753,
-                                        "key": "eb87fb7a5fb60caecb9b23564befe513",
-                                        "msg": ""
-                                        "mac": "cafecafecafecafe"
-                                }
-                        ]
-                }
-    {
-    }]
+                }]
+        },
+        {
+                "testType": "AFT",
+                "direction": "ver",
+                "keyLen": 127,
+                "msgLen": 0,
+                "macLen": 64,
+                "tests": [{
+                                "tcId": 2752,
+                                "key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+                                "msg": "",
+                                "mac": "2eef1e38fcc7c568"
+                        },
+                        {
+                                "tcId": 2753,
+                                "key": "eb87fb7a5fb60caecb9b23564befe513",
+                                "msg": "",
+                                "mac": "cafecafecafecafe"
+                        }
+                ]
         }
 ]
 
-   The following is an example JSON object for CMAC-TDES test vectors
-   sent from the ACVP server to the crypto module.
-
-[{
-  "acvVersion": "0.4"
-},
-        {
-                "vsId": 1566,
-                "algorithm": "CMAC-TDES",
-                "testGroups": [{
-                        "testType": "AFT",
-                        "direction": "gen",
-                        "keyLen": 3,
-                        "msgLen": 0,
-                        "macLen": 40,
-                        "tests": [{
 
 
 
@@ -730,54 +730,54 @@ Fussell                 Expires December 3, 2016               [Page 13]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                                        "tcId": 2175,
-                                        "key": "c479f813ad1a45d5",
-                                        "key2": "dc43459da4c85e85",
-                                        "key3": "1cda518af886bf1f",
-                                        "msg": ""
-                                },
-                                {
-                                        "tcId": 2176,
-                                        "key": "731331866754588f",
-                                        "key2": "d332ef51e0ce1925",
-                                        "key3": "d586cba70440f44f",
-                                        "msg": ""
-                                }
-                        ]
-                },
-{
-                        "testType": "AFT",
-                        "direction": "ver",
-                        "keyLen": 3,
-                        "msgLen": 0,
-                        "macLen": 40,
-                        "tests": [{
-                                        "tcId": 2177,
-                                        "key": "d586cba70440f44f",
-                                        "key2": "d332ef51e0ce1925",
-                                        "key3": "dc43459da4c85e85",
-                                        "msg": ""
-                                        "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                                },
-                                {
-                                        "tcId": 2177,
-                                        "key": "dc43459da4c85e85",
-                                        "key2": "c479f813ad1a45d5",
-                                        "key3": "1cda518af886bf1f",
-                                        "msg": ""
-                                        "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                                }
-                        ]
-                }
-    {
-    }]
-        }
-]
+   The following is an example JSON object for CMAC-TDES test vectors
+   sent from the ACVP server to the crypto module.
 
-
-
-
-
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 1566,
+                "algorithm": "CMAC-TDES",
+                "testGroups": [{
+                                "testType": "AFT",
+                                "direction": "gen",
+                                "keyLen": 3,
+                                "msgLen": 0,
+                                "macLen": 40,
+                                "tests": [{
+                                                "tcId": 2175,
+                                                "key": "c479f813ad1a45d5",
+                                                "key2": "dc43459da4c85e85",
+                                                "key3": "1cda518af886bf1f",
+                                                "msg": ""
+                                        },
+                                        {
+                                                "tcId": 2176,
+                                                "key": "731331866754588f",
+                                                "key2": "d332ef51e0ce1925",
+                                                "key3": "d586cba70440f44f",
+                                                "msg": ""
+                                        }
+                                ]
+                        },
+                        {
+                                "testType": "AFT",
+                                "direction": "ver",
+                                "keyLen": 3,
+                                "msgLen": 0,
+                                "macLen": 40,
+                                "tests": [{
+                                                "tcId": 2177,
+                                                "key": "d586cba70440f44f",
+                                                "key2": "d332ef51e0ce1925",
+                                                "key3": "dc43459da4c85e85",
+                                                "msg": "",
+                                                "mac": "cafecafecafecafecafecafecafecafecafecafe"
+                                        },
+                                        {
+                                                "tcId": 2177,
 
 
 
@@ -786,54 +786,54 @@ Fussell                 Expires December 3, 2016               [Page 14]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                                "key": "dc43459da4c85e85",
+                                                "key2": "c479f813ad1a45d5",
+                                                "key3": "1cda518af886bf1f",
+                                                "msg": "",
+                                                "mac": "cafecafecafecafecafecafecafecafecafecafe"
+                                        }
+                                ]
+                        }
+                ]
+        }
+]
+
 Appendix C.  Example Test Results JSON Object
 
    The following is an example JSON object for HMAC test results sent
    from the crypto module to the ACVP server.
 
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1565,
-                    "testResults": [
-                        {
-                            "tcId": 2172,
-                            "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 1565,
+                "testResults": [{
+                                "tcId": 2172,
+                                "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
                         },
-                       {
-                            "tcId": 2173,
-                            "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-                       },
-
-                    ]
-                }
-             ]
+                        {
+                                "tcId": 2173,
+                                "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
+                        }
+                ]
+        }
+]
 
    The following is an example JSON object for CMAC-AES-128 test results
    sent from the crypto module to the ACVP server.
 
-                 [
-                     { "acvVersion": "0.4" },
-                     { "vsId": 3500,
-                       "testResults": [
-                           {
-                               "tcId": 2750,
-                               "mac": "e77145f0d6c77ad5"
-                           },
-                          {
-                               "tcId": 2751,
-                               "mac": "6b078f7e53b6d183"
-                          },
-                          {
-                               "tcId": 2752,
-                               "result": "pass"
-                          },
-                          {
-                               "tcId": 2753,
-                               "result": "fail"
-                          },
-                       ]
-                   }
-                ]
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -842,32 +842,87 @@ Fussell                 Expires December 3, 2016               [Page 15]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+   [
+           {
+                   "acvVersion": "0.4"
+           },
+           {
+                   "vsId": 3500,
+                   "testResults": [{
+                                   "tcId": 2750,
+                                   "mac": "e77145f0d6c77ad5"
+                           },
+                           {
+                                   "tcId": 2751,
+                                   "mac": "6b078f7e53b6d183"
+                           },
+                           {
+                                   "tcId": 2752,
+                                   "result": "pass"
+                           },
+                           {
+                                   "tcId": 2753,
+                                   "result": "fail"
+                           }
+                   ]
+           }
+   ]
+
    The following is an example JSON object for CMAC-TDES test results
    sent from the crypto module to the ACVP server.
 
-                 [
-                     { "acvVersion": "0.4" },
-                     { "vsId": 1566,
-                       "testResults": [
-                           {
-                               "tcId": 2175,
-                               "mac": "fea01c84a7"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 16]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   [
+           {
+                   "acvVersion": "0.4"
+           },
+           {
+                   "vsId": 1566,
+                   "testResults": [{
+                                   "tcId": 2175,
+                                   "mac": "fea01c84a7"
                            },
-                          {
-                               "tcId": 2176,
-                               "mac": "164bdb8582"
-                          },
-                          {
-                               "tcId": 2177,
-                               "result": "fail"
-                          },
-                          {
-                               "tcId": 2178,
-                               "result": "fail"
-                          },
-                       ]
-                   }
-                ]
+                           {
+                                   "tcId": 2176,
+                                   "mac": "164bdb8582"
+                           },
+                           {
+                                   "tcId": 2177,
+                                   "result": "fail"
+                           },
+                           {
+                                   "tcId": 2178,
+                                   "result": "fail"
+                           }
+                   ]
+           }
+   ]
 
 Author's Address
 
@@ -893,4 +948,5 @@ Author's Address
 
 
 
-Fussell                 Expires December 3, 2016               [Page 16]
+
+Fussell                 Expires December 3, 2016               [Page 17]

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -78,8 +78,8 @@ Table of Contents
      8.2.  Informative References  . . . . . . . . . . . . . . . . .  10
    Appendix A.  Example MAC Capabilities JSON Object . . . . . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  11
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  13
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  15
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  15
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  16
 
 1.  Introduction
 
@@ -572,6 +572,20 @@ Internet-Draft                Sym Alg JSON                     June 2016
             }
 
    The following is an example JSON object advertising support for CMAC-
+   AES-128.
+
+
+
+            {
+                "algorithm": "CMAC-AES-128",
+                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                                {"algorithm" : "TDES", "valValue" : "123456"}],
+                "direction" : [ "gen", "ver" ],
+                            "macLen" : [ 64],
+                            "msgLen" : [ 0 ]
+            }
+
+   The following is an example JSON object advertising support for CMAC-
    TDES.
 
 
@@ -589,20 +603,6 @@ Appendix B.  Example Test Vectors JSON Object
 
    The following is an example JSON object for HMAC test vectors sent
    from the ACVP server to the crypto module.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -645,8 +645,69 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 }
              ]
 
-   The following is an example JSON object for CMAC test vectors sent
-   from the ACVP server to the crypto module.
+   The following is an example JSON object for CMAC-AES-128 test vectors
+   sent from the ACVP server to the crypto module.
+
+[{
+  "acvVersion": "0.4"
+},
+        {
+                "vsId": 3500,
+                "algorithm": "CMAC-AES-128",
+                "testGroups": [{
+                        "testType": "AFT",
+                        "direction": "gen",
+                        "keyLen": 128,
+                        "msgLen": 0,
+                        "macLen": 64,
+                        "tests": [{
+                                        "tcId": 2750,
+                                        "key": "f28effca41cb11819a81eb3ebf3b7e83",
+                                        "msg": ""
+                                },
+                                {
+
+
+
+Fussell                 Expires December 3, 2016               [Page 12]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+                                        "tcId": 2751,
+                                        "key": "ab566f4af532efc8bc56555fe07696fd",
+                                        "msg": ""
+                                },
+                                }
+                        ]
+                },
+                {
+                        "testType": "AFT",
+                        "direction": "ver",
+                        "keyLen": 127,
+                        "msgLen": 0,
+                        "macLen": 64,
+                        "tests": [{
+                                        "tcId": 2752,
+                                        "key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+                                        "msg": ""
+                                        "mac": "2eef1e38fcc7c568"
+                                },
+                                {
+                                        "tcId": 2753,
+                                        "key": "eb87fb7a5fb60caecb9b23564befe513",
+                                        "msg": ""
+                                        "mac": "cafecafecafecafe"
+                                }
+                        ]
+                }
+    {
+    }]
+        }
+]
+
+   The following is an example JSON object for CMAC-TDES test vectors
+   sent from the ACVP server to the crypto module.
 
 [{
   "acvVersion": "0.4"
@@ -661,19 +722,19 @@ Internet-Draft                Sym Alg JSON                     June 2016
                         "msgLen": 0,
                         "macLen": 40,
                         "tests": [{
+
+
+
+Fussell                 Expires December 3, 2016               [Page 13]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                                         "tcId": 2175,
                                         "key": "c479f813ad1a45d5",
                                         "key2": "dc43459da4c85e85",
                                         "key3": "1cda518af886bf1f",
                                         "msg": ""
-
-
-
-Fussell                 Expires December 3, 2016               [Page 12]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                                 },
                                 {
                                         "tcId": 2176,
@@ -686,7 +747,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 },
 {
                         "testType": "AFT",
-                        "direction": "gen",
+                        "direction": "ver",
                         "keyLen": 3,
                         "msgLen": 0,
                         "macLen": 40,
@@ -713,22 +774,22 @@ Internet-Draft                Sym Alg JSON                     June 2016
         }
 ]
 
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 14]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
 Appendix C.  Example Test Results JSON Object
 
    The following is an example JSON object for HMAC test results sent
    from the crypto module to the ACVP server.
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 13]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
               [
                   { "acvVersion": "0.4" },
@@ -747,8 +808,42 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 }
              ]
 
-   The following is an example JSON object for CMAC test results sent
-   from the crypto module to the ACVP server.
+   The following is an example JSON object for CMAC-AES-128 test results
+   sent from the crypto module to the ACVP server.
+
+                 [
+                     { "acvVersion": "0.4" },
+                     { "vsId": 3500,
+                       "testResults": [
+                           {
+                               "tcId": 2750,
+                               "mac": "e77145f0d6c77ad5"
+                           },
+                          {
+                               "tcId": 2751,
+                               "mac": "6b078f7e53b6d183"
+                          },
+                          {
+                               "tcId": 2752,
+                               "result": "pass"
+                          },
+                          {
+                               "tcId": 2753,
+                               "result": "fail"
+                          },
+                       ]
+                   }
+                ]
+
+
+
+Fussell                 Expires December 3, 2016               [Page 15]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   The following is an example JSON object for CMAC-TDES test results
+   sent from the crypto module to the ACVP server.
 
                  [
                      { "acvVersion": "0.4" },
@@ -774,18 +869,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                    }
                 ]
 
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 14]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
 Author's Address
 
    Barry Fussell (editor)
@@ -810,31 +893,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 15]
+Fussell                 Expires December 3, 2016               [Page 16]

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -181,7 +181,7 @@
           <ttcol align="left">Optional</ttcol>
 
           <c>algorithm</c>
-	  <c>The MAC algorithm and mode to be validated.</c>
+	        <c>The MAC algorithm and mode to be validated.</c>
           <c>value</c>
           <c>See <xref target="supported_algs" /></c>
           <c>No</c>
@@ -191,6 +191,13 @@
           <c>prerequistie algorithm validations, See <xref target="app-reg-ex" /> for examples</c>
           <c>array of prereqAlgVal objects</c>
           <c>See <xref target="prereq_algs" /></c>
+          <c>No</c>
+	  <c/><c/><c/><c/><c/>
+
+          <c>direction</c>
+	        <c>The MAC direction(s) to test. Only applies to CMAC.</c>
+          <c>array</c>
+          <c>gen, ver</c>
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
 
@@ -215,18 +222,18 @@
           <c>Yes</c>
 	  <c/><c/><c/><c/><c/>
 
+          <c>msgLen</c>
+	  <c>The CMAC message lengths supported</c>
+          <c>Domain</c>
+          <c>0-524288</c>
+          <c>Yes</c>
+
           <c>macLen</c>
 	  <c>The supported mac sizes. (range dependent on SHA size)</c>
-          <c>array</c>
+          <c>Domain</c>
           <c>8-524288</c>
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
-
-          <c>msgLen</c>
-	  <c>The CMAC message lengths supported</c>
-          <c>array</c>
-          <c>0-524288</c>
-          <c>Yes</c>
 
         </texttable>
 
@@ -322,7 +329,13 @@
 		<ttcol align="left">Optional</ttcol>
 
 		<c>testType</c>
-		<c>Test category type (ver or gen for CMAC, gen for HMAC)</c>
+		<c>Test category type (AFT)</c>
+		<c>value</c>
+		<c>No</c>
+		<c/><c/><c/><c/>
+
+		<c>direction</c>
+		<c>The direction of the tests - gen or ver - only applies to CMAC</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>
@@ -561,8 +574,9 @@
                 "algorithm": "CMAC-TDES",
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
-		"macLen" : [ 8, 64],
-		"msgLen" : [ 0, 256, 120, 248, 320 ]
+                "direction" : [ "gen", "ver" ],
+		            "macLen" : [ 8, 64],
+		            "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
             ]]></artwork>
     </figure>
@@ -577,7 +591,7 @@
                   "algorithm": "HMAC-SHA-1",
                   "testGroups": [
                     {
-                      "testType": "gen",
+                      "testType": "AFT",
                       "keyLen": 256,
                       "msgLen": 160,
                       "macLen" : 80,
@@ -609,7 +623,8 @@
 		"vsId": 1566,
 		"algorithm": "CMAC-TDES",
 		"testGroups": [{
-			"testType": "gen",
+			"testType": "AFT",
+			"direction": "gen",
 			"keyLen": 3,
 			"msgLen": 0,
 			"macLen": 40,
@@ -630,7 +645,8 @@
 			]
 		},
 {
-			"testType": "ver",
+			"testType": "AFT",
+			"direction": "gen",
 			"keyLen": 3,
 			"msgLen": 0,
 			"macLen": 40,
@@ -640,7 +656,7 @@
 					"key2": "d332ef51e0ce1925",
 					"key3": "dc43459da4c85e85",
 					"msg": ""
-          "mac": "cafecafecafecafecafecafecafecafecafecafe"
+					"mac": "cafecafecafecafecafecafecafecafecafecafe"
 				},
 				{
 					"tcId": 2177,
@@ -648,7 +664,7 @@
 					"key2": "c479f813ad1a45d5",
 					"key3": "1cda518af886bf1f",
 					"msg": ""
-          "mac": "cafecafecafecafecafecafecafecafecafecafe"
+					"mac": "cafecafecafecafecafecafecafecafecafecafe"
 				}
 			]
 		}    

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -565,6 +565,21 @@
             }
             ]]></artwork>
     </figure>
+      <t>The following is an example JSON object advertising support for CMAC-AES-128.</t>
+      <figure>
+        <artwork><![CDATA[
+
+
+            {
+                "algorithm": "CMAC-AES-128",
+                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+		                {"algorithm" : "TDES", "valValue" : "123456"}],
+                "direction" : [ "gen", "ver" ],
+		            "macLen" : [ 64],
+		            "msgLen" : [ 0 ]
+            }
+            ]]></artwork>
+    </figure>    
       <t>The following is an example JSON object advertising support for CMAC-TDES.</t>
       <figure>
         <artwork><![CDATA[
@@ -613,7 +628,61 @@
              ]
             ]]></artwork>
        </figure>
-      <t>The following is an example JSON object for CMAC test vectors sent from the ACVP server to the crypto module.</t>
+<t>The following is an example JSON object for CMAC-AES-128 test vectors sent from the ACVP server to the crypto module.</t>
+      <figure>
+        <artwork><![CDATA[
+[{
+  "acvVersion": "0.4"
+},
+	{
+		"vsId": 3500,
+		"algorithm": "CMAC-AES-128",
+		"testGroups": [{
+			"testType": "AFT",
+			"direction": "gen",
+			"keyLen": 128,
+			"msgLen": 0,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 2750,
+					"key": "f28effca41cb11819a81eb3ebf3b7e83",
+					"msg": ""
+				},
+				{
+					"tcId": 2751,
+					"key": "ab566f4af532efc8bc56555fe07696fd",
+					"msg": ""
+				},
+				}
+			]
+		},
+		{
+			"testType": "AFT",
+			"direction": "ver",
+			"keyLen": 127,
+			"msgLen": 0,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 2752,
+					"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+					"msg": ""
+					"mac": "2eef1e38fcc7c568"
+				},
+				{
+					"tcId": 2753,
+					"key": "eb87fb7a5fb60caecb9b23564befe513",
+					"msg": ""
+					"mac": "cafecafecafecafe"
+				}
+			]
+		}    
+    {
+    }]
+	}
+]
+            ]]></artwork>
+    </figure>       
+      <t>The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP server to the crypto module.</t>
       <figure>
         <artwork><![CDATA[
 [{
@@ -646,7 +715,7 @@
 		},
 {
 			"testType": "AFT",
-			"direction": "gen",
+			"direction": "ver",
 			"keyLen": 3,
 			"msgLen": 0,
 			"macLen": 40,
@@ -697,7 +766,35 @@
              ]
             ]]></artwork>
        </figure>
-      <t>The following is an example JSON object for CMAC test results sent from the crypto module to the ACVP server.</t>
+<t>The following is an example JSON object for CMAC-AES-128 test results sent from the crypto module to the ACVP server.</t>
+      <figure>
+        <artwork><![CDATA[
+              [
+                  { "acvVersion": "0.4" },
+                  { "vsId": 3500,
+                    "testResults": [
+                        {
+                            "tcId": 2750,
+                            "mac": "e77145f0d6c77ad5"
+                        },
+                       {
+                            "tcId": 2751,
+                            "mac": "6b078f7e53b6d183"
+                       },
+                       {
+                            "tcId": 2752,
+                            "result": "pass"
+                       },
+                       {
+                            "tcId": 2753,
+                            "result": "fail"
+                       },
+                    ]
+                }
+             ]
+            ]]></artwork>
+    </figure>       
+      <t>The following is an example JSON object for CMAC-TDES test results sent from the crypto module to the ACVP server.</t>
       <figure>
         <artwork><![CDATA[
               [

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -223,13 +223,13 @@
 	  <c/><c/><c/><c/><c/>
 
           <c>msgLen</c>
-	  <c>The CMAC message lengths supported</c>
+	  <c>The CMAC message lengths supported.  Min/max/increment and values must be mod 8.</c>
           <c>Domain</c>
           <c>0-524288</c>
           <c>Yes</c>
 
           <c>macLen</c>
-	  <c>The supported mac sizes. (range dependent on SHA size)</c>
+	  <c>The supported mac sizes. Min/max/increment and values must be mod 8. (range dependent on SHA size).</c>
           <c>Domain</c>
           <c>8-524288</c>
           <c>No</c>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -575,8 +575,8 @@
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-		            "macLen" : [ 64],
-		            "msgLen" : [ 0 ]
+                "macLen" : [ 64 ],
+                "msgLen" : [ 0 ]
             }
             ]]></artwork>
     </figure>    
@@ -590,8 +590,8 @@
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-		            "macLen" : [ 8, 64],
-		            "msgLen" : [ 0, 256, 120, 248, 320 ]
+                "macLen" : [ 8, 64 ],
+                "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
             ]]></artwork>
     </figure>
@@ -600,40 +600,41 @@
       <t>The following is an example JSON object for HMAC test vectors sent from the ACVP server to the crypto module.</t>
       <figure>
         <artwork><![CDATA[
-              [
-                { "acvVersion": "0.4" },
-                { "vsId": 1565,
-                  "algorithm": "HMAC-SHA-1",
-                  "testGroups": [
-                    {
-                      "testType": "AFT",
-                      "keyLen": 256,
-                      "msgLen": 160,
-                      "macLen" : 80,
-                      "tests": [
-                        {
-                          "tcId": 2172,
-                          "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-                          "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-                        },
-                        {
-                          "tcId": 2173,
-                          "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-                          "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-                        }
-                      ]
-                    }
-                  ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 1565,
+		"algorithm": "HMAC-SHA-1",
+		"testGroups": [{
+			"testType": "AFT",
+			"keyLen": 256,
+			"msgLen": 160,
+			"macLen": 80,
+			"tests": [{
+					"tcId": 2172,
+					"key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
+					"msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
+				},
+				{
+					"tcId": 2173,
+					"key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
+					"msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
+				}
+			]
+		}]
+	}
+]
             ]]></artwork>
        </figure>
 <t>The following is an example JSON object for CMAC-AES-128 test vectors sent from the ACVP server to the crypto module.</t>
       <figure>
         <artwork><![CDATA[
-[{
-  "acvVersion": "0.4"
-},
+[
+	{
+		"acvVersion": "0.4"
+	},
 	{
 		"vsId": 3500,
 		"algorithm": "CMAC-AES-128",
@@ -652,32 +653,29 @@
 					"tcId": 2751,
 					"key": "ab566f4af532efc8bc56555fe07696fd",
 					"msg": ""
-				},
 				}
 			]
-		},
-		{
-			"testType": "AFT",
-			"direction": "ver",
-			"keyLen": 127,
-			"msgLen": 0,
-			"macLen": 64,
-			"tests": [{
-					"tcId": 2752,
-					"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-					"msg": ""
-					"mac": "2eef1e38fcc7c568"
-				},
-				{
-					"tcId": 2753,
-					"key": "eb87fb7a5fb60caecb9b23564befe513",
-					"msg": ""
-					"mac": "cafecafecafecafe"
-				}
-			]
-		}    
-    {
-    }]
+		}]
+	},
+	{
+		"testType": "AFT",
+		"direction": "ver",
+		"keyLen": 127,
+		"msgLen": 0,
+		"macLen": 64,
+		"tests": [{
+				"tcId": 2752,
+				"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+				"msg": "",
+				"mac": "2eef1e38fcc7c568"
+			},
+			{
+				"tcId": 2753,
+				"key": "eb87fb7a5fb60caecb9b23564befe513",
+				"msg": "",
+				"mac": "cafecafecafecafe"
+			}
+		]
 	}
 ]
             ]]></artwork>
@@ -685,60 +683,60 @@
       <t>The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP server to the crypto module.</t>
       <figure>
         <artwork><![CDATA[
-[{
-  "acvVersion": "0.4"
-},
+[
+	{
+		"acvVersion": "0.4"
+	},
 	{
 		"vsId": 1566,
 		"algorithm": "CMAC-TDES",
 		"testGroups": [{
-			"testType": "AFT",
-			"direction": "gen",
-			"keyLen": 3,
-			"msgLen": 0,
-			"macLen": 40,
-			"tests": [{
-					"tcId": 2175,
-					"key": "c479f813ad1a45d5",
-					"key2": "dc43459da4c85e85",
-					"key3": "1cda518af886bf1f",
-					"msg": ""
-				},
-				{
-					"tcId": 2176,
-					"key": "731331866754588f",
-					"key2": "d332ef51e0ce1925",
-					"key3": "d586cba70440f44f",
-					"msg": ""
-				}
-			]
-		},
-{
-			"testType": "AFT",
-			"direction": "ver",
-			"keyLen": 3,
-			"msgLen": 0,
-			"macLen": 40,
-			"tests": [{
-					"tcId": 2177,
-					"key": "d586cba70440f44f",
-					"key2": "d332ef51e0ce1925",
-					"key3": "dc43459da4c85e85",
-					"msg": ""
-					"mac": "cafecafecafecafecafecafecafecafecafecafe"
-				},
-				{
-					"tcId": 2177,
-					"key": "dc43459da4c85e85",
-					"key2": "c479f813ad1a45d5",
-					"key3": "1cda518af886bf1f",
-					"msg": ""
-					"mac": "cafecafecafecafecafecafecafecafecafecafe"
-				}
-			]
-		}    
-    {
-    }]
+				"testType": "AFT",
+				"direction": "gen",
+				"keyLen": 3,
+				"msgLen": 0,
+				"macLen": 40,
+				"tests": [{
+						"tcId": 2175,
+						"key": "c479f813ad1a45d5",
+						"key2": "dc43459da4c85e85",
+						"key3": "1cda518af886bf1f",
+						"msg": ""
+					},
+					{
+						"tcId": 2176,
+						"key": "731331866754588f",
+						"key2": "d332ef51e0ce1925",
+						"key3": "d586cba70440f44f",
+						"msg": ""
+					}
+				]
+			},
+			{
+				"testType": "AFT",
+				"direction": "ver",
+				"keyLen": 3,
+				"msgLen": 0,
+				"macLen": 40,
+				"tests": [{
+						"tcId": 2177,
+						"key": "d586cba70440f44f",
+						"key2": "d332ef51e0ce1925",
+						"key3": "dc43459da4c85e85",
+						"msg": "",
+						"mac": "cafecafecafecafecafecafecafecafecafecafe"
+					},
+					{
+						"tcId": 2177,
+						"key": "dc43459da4c85e85",
+						"key2": "c479f813ad1a45d5",
+						"key3": "1cda518af886bf1f",
+						"msg": "",
+						"mac": "cafecafecafecafecafecafecafecafecafecafe"
+					}
+				]
+			}
+		]
 	}
 ]
             ]]></artwork>
@@ -748,78 +746,83 @@
       <t>The following is an example JSON object for HMAC test results sent from the crypto module to the ACVP server.</t>
       <figure>
         <artwork><![CDATA[
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1565,
-                    "testResults": [
-                        {
-                            "tcId": 2172,
-                            "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
-                        },
-                       {
-                            "tcId": 2173,
-                            "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-                       },
-                       
-                    ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 1565,
+		"testResults": [{
+				"tcId": 2172,
+				"mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
+			},
+			{
+				"tcId": 2173,
+				"mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
+			}
+		]
+	}
+]
             ]]></artwork>
        </figure>
 <t>The following is an example JSON object for CMAC-AES-128 test results sent from the crypto module to the ACVP server.</t>
       <figure>
         <artwork><![CDATA[
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 3500,
-                    "testResults": [
-                        {
-                            "tcId": 2750,
-                            "mac": "e77145f0d6c77ad5"
-                        },
-                       {
-                            "tcId": 2751,
-                            "mac": "6b078f7e53b6d183"
-                       },
-                       {
-                            "tcId": 2752,
-                            "result": "pass"
-                       },
-                       {
-                            "tcId": 2753,
-                            "result": "fail"
-                       },
-                    ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 3500,
+		"testResults": [{
+				"tcId": 2750,
+				"mac": "e77145f0d6c77ad5"
+			},
+			{
+				"tcId": 2751,
+				"mac": "6b078f7e53b6d183"
+			},
+			{
+				"tcId": 2752,
+				"result": "pass"
+			},
+			{
+				"tcId": 2753,
+				"result": "fail"
+			}
+		]
+	}
+]
             ]]></artwork>
     </figure>       
       <t>The following is an example JSON object for CMAC-TDES test results sent from the crypto module to the ACVP server.</t>
       <figure>
         <artwork><![CDATA[
-              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1566,
-                    "testResults": [
-                        {
-                            "tcId": 2175,
-                            "mac": "fea01c84a7"
-                        },
-                       {
-                            "tcId": 2176,
-                            "mac": "164bdb8582"
-                       },
-                       {
-                            "tcId": 2177,
-                            "result": "fail"
-                       },
-                       {
-                            "tcId": 2178,
-                            "result": "fail"
-                       },
-                    ]
-                }
-             ]
+[
+	{
+		"acvVersion": "0.4"
+	},
+	{
+		"vsId": 1566,
+		"testResults": [{
+				"tcId": 2175,
+				"mac": "fea01c84a7"
+			},
+			{
+				"tcId": 2176,
+				"mac": "164bdb8582"
+			},
+			{
+				"tcId": 2177,
+				"result": "fail"
+			},
+			{
+				"tcId": 2178,
+				"result": "fail"
+			}
+		]
+	}
+]
             ]]></artwork>
     </figure>
     </section>


### PR DESCRIPTION
Additional CMAC changes 
- Added direction property (gen/ver) for CMAC to more closely mirror symmetric cipher properties.
- TestType changed from gen/ver to "AFT" for consistency.
- Updated property types `macLen` and `msgLen` to utilize the Domain object described in usnistgov@17bef01

