### PR TITLE
Move "mode" back into testGroups for Vector Set Response, fix json typos and minor text typos.

### DIFF
--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -12,28 +12,6 @@
 	  a {
 	  text-decoration: none;
 	  }
-      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
-      a.info {
-          /* This is the key. */
-          position: relative;
-          z-index: 24;
-          text-decoration: none;
-      }
-      a.info:hover {
-          z-index: 25;
-          color: #FFF; background-color: #900;
-      }
-      a.info span { display: none; }
-      a.info:hover span.info {
-          /* The span will display just on :hover state. */
-          display: block;
-          position: absolute;
-          font-size: smaller;
-          top: 2em; left: -5em; width: 15em;
-          padding: 2px; border: 1px solid #333;
-          color: #900; background-color: #EEE;
-          text-align: left;
-      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -346,7 +324,7 @@
 		   content: "December 2010"; 
 	  } 
 	  @top-center {
-		   content: "Abbreviated Title";
+		   content: "Abbreviated Title";3
 	  } 
 	  @bottom-left {
 		   content: "Doe"; 
@@ -428,10 +406,10 @@
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.4.0 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
-  <meta name="dct.creator" content="Vassilev, A., Ed." />
+  <meta name="dct.creator" content="Vassilev, A.V., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.4" />
   <meta name="dct.issued" scheme="ISO8601" content="2017-5" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  " />
@@ -446,7 +424,7 @@
     
     	<tr>
   <td class="left">TBD</td>
-  <td class="right">A. Vassilev, Ed.</td>
+  <td class="right">A.V. Vassilev, Ed.</td>
 </tr>
 <tr>
   <td class="left">Internet-Draft</td>
@@ -457,7 +435,7 @@
   <td class="right">May 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: November 2, 2017</td>
+  <td class="left">Expires: November 02, 2017</td>
   <td class="right"></td>
 </tr>
 
@@ -478,7 +456,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on November 2, 2017.</p>
+<p>This Internet-Draft will expire on November 02, 2017.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -491,57 +469,57 @@
   <ul class="toc">
 
   	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
-<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a></li>
+<li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a></li>
 <li>1.2.   <a href="#rfc.section.1.2">Testing scope</a></li>
-</ul><li>2.   <a href="#rfc.section.2">Capabilities Registration</a></li>
-<ul><li>2.1.   <a href="#rfc.section.2.1">Supported RSA Algorithm modes</a></li>
+<li>2.   <a href="#rfc.section.2">Capabilities Registration</a></li>
+<li>2.1.   <a href="#rfc.section.2.1">Supported RSA Algorithm modes</a></li>
 <li>2.2.   <a href="#rfc.section.2.2">Required Prerequisite Algorithms for RSA Mode Validations</a></li>
 <li>2.3.   <a href="#rfc.section.2.3">Supported RSA Capabilities</a></li>
 <li>2.4.   <a href="#rfc.section.2.4">Supported RSA Modes Capabilities</a></li>
-<ul><li>2.4.1.   <a href="#rfc.section.2.4.1">The keyGen Mode Capabilities</a></li>
-<ul><li>2.4.1.1.   <a href="#rfc.section.2.4.1.1">keyGen With Provable Primes or Provable Primes with Conditions Capabilities</a></li>
+<li>2.4.1.   <a href="#rfc.section.2.4.1">The keyGen Mode Capabilities</a></li>
+<li>2.4.1.1.   <a href="#rfc.section.2.4.1.1">keyGen With Provable Primes or Provable Primes with Conditions Capabilities</a></li>
 <li>2.4.1.2.   <a href="#rfc.section.2.4.1.2">keyGen With Probable Primes Capabilities</a></li>
 <li>2.4.1.3.   <a href="#rfc.section.2.4.1.3">keyGen With Both Provable and Probable Primes With Conditions</a></li>
 <li>2.4.1.4.   <a href="#rfc.section.2.4.1.4">keyGen Full Set Of Capabilities</a></li>
-</ul><li>2.4.2.   <a href="#rfc.section.2.4.2">The sigGen Mode Capabilities</a></li>
-<ul><li>2.4.2.1.   <a href="#rfc.section.2.4.2.1">sigGen Capabilities</a></li>
-</ul><li>2.4.3.   <a href="#rfc.section.2.4.3">The sigVer Mode Capabilities</a></li>
-<ul><li>2.4.3.1.   <a href="#rfc.section.2.4.3.1">sigVer Capabilities</a></li>
-</ul><li>2.4.4.   <a href="#rfc.section.2.4.4">The legacySigVer Mode Capabilities</a></li>
+<li>2.4.2.   <a href="#rfc.section.2.4.2">The sigGen Mode Capabilities</a></li>
+<li>2.4.2.1.   <a href="#rfc.section.2.4.2.1">sigGen Capabilities</a></li>
+<li>2.4.3.   <a href="#rfc.section.2.4.3">The sigVer Mode Capabilities</a></li>
+<li>2.4.3.1.   <a href="#rfc.section.2.4.3.1">sigVer Capabilities</a></li>
+<li>2.4.4.   <a href="#rfc.section.2.4.4">The legacySigVer Mode Capabilities</a></li>
 <li>2.4.5.   <a href="#rfc.section.2.4.5">The componentSigPrimitive Mode Capabilities</a></li>
 <li>2.4.6.   <a href="#rfc.section.2.4.6">The componentDecPrimitive Mode Capabilities</a></li>
-</ul></ul><li>3.   <a href="#rfc.section.3">Test Vectors</a></li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a></li>
+<li>3.   <a href="#rfc.section.3">Test Vectors</a></li>
+<li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a></li>
 <li>3.2.   <a href="#rfc.section.3.2">Test Case JSON Schema</a></li>
-</ul><li>4.   <a href="#rfc.section.4">Test Vector Responses</a></li>
+<li>4.   <a href="#rfc.section.4">Test Vector Responses</a></li>
 <li>5.   <a href="#rfc.section.5">Acknowledgements</a></li>
 <li>6.   <a href="#rfc.section.6">IANA Considerations</a></li>
 <li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
 <li>8.   <a href="#rfc.references">Normative References</a></li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Example RSA Capabilities JSON Objects</a></li>
-<ul><li>A.1.   <a href="#rfc.appendix.A.1">Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects</a></li>
-<ul><li>A.1.1.   <a href="#rfc.appendix.A.1.1">Example keyGen with Probable Primes Capabilities JSON Object</a></li>
+<li>A.1.   <a href="#rfc.appendix.A.1">Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects</a></li>
+<li>A.1.1.   <a href="#rfc.appendix.A.1.1">Example keyGen with Probable Primes Capabilities JSON Object</a></li>
 <li>A.1.2.   <a href="#rfc.appendix.A.1.2">Example keyGen with Provable Conditional Primes with Probable Factors Capabilities JSON Object</a></li>
-</ul><li>A.2.   <a href="#rfc.appendix.A.2">Example RSA sigGen Capabilities JSON Objects</a></li>
+<li>A.2.   <a href="#rfc.appendix.A.2">Example RSA sigGen Capabilities JSON Objects</a></li>
 <li>A.3.   <a href="#rfc.appendix.A.3">Example RSA sigVer Capabilities JSON Objects</a></li>
 <li>A.4.   <a href="#rfc.appendix.A.4">Example RSA legacySigVer Capabilities JSON Objects</a></li>
 <li>A.5.   <a href="#rfc.appendix.A.5">Example componentSigPrimitive Capabilities JSON Objects</a></li>
 <li>A.6.   <a href="#rfc.appendix.A.6">Example componentDecPrimitive Capabilities JSON Objects</a></li>
-</ul><li>Appendix B.   <a href="#rfc.appendix.B">Example Test Vectors JSON Objects</a></li>
-<ul><li>B.1.   <a href="#rfc.appendix.B.1">Example Test Vectors for keyGen JSON Objects</a></li>
+<li>Appendix B.   <a href="#rfc.appendix.B">Example Test Vectors JSON Objects</a></li>
+<li>B.1.   <a href="#rfc.appendix.B.1">Example Test Vectors for keyGen JSON Objects</a></li>
 <li>B.2.   <a href="#rfc.appendix.B.2">Example Test Vectors for sigGen JSON Objects</a></li>
 <li>B.3.   <a href="#rfc.appendix.B.3">Example Test Vectors for sigVer JSON Objects</a></li>
 <li>B.4.   <a href="#rfc.appendix.B.4">Example Test Vectors for legacySigVer JSON Objects</a></li>
 <li>B.5.   <a href="#rfc.appendix.B.5">Example Test Vectors for componentSigPrimitive JSON Objects</a></li>
 <li>B.6.   <a href="#rfc.appendix.B.6">Example Test Vectors for componentDecPrimitive JSON Objects</a></li>
-</ul><li>Appendix C.   <a href="#rfc.appendix.C">Example Test Results JSON Objects</a></li>
-<ul><li>C.1.   <a href="#rfc.appendix.C.1">Example keyGen Test Results JSON Objects</a></li>
+<li>Appendix C.   <a href="#rfc.appendix.C">Example Test Results JSON Objects</a></li>
+<li>C.1.   <a href="#rfc.appendix.C.1">Example keyGen Test Results JSON Objects</a></li>
 <li>C.2.   <a href="#rfc.appendix.C.2">Example sigGen Test Results JSON Objects</a></li>
 <li>C.3.   <a href="#rfc.appendix.C.3">Example sigVer Test Results JSON Objects</a></li>
 <li>C.4.   <a href="#rfc.appendix.C.4">Example legacySigVer Test Results JSON Objects</a></li>
 <li>C.5.   <a href="#rfc.appendix.C.5">Example componentSigPrimitive Test Results JSON Objects</a></li>
 <li>C.6.   <a href="#rfc.appendix.C.6">Example componentDecPrimitive Test Results JSON Objects</a></li>
-</ul><li><a href="#rfc.authors">Author's Address</a></li>
+<li><a href="#rfc.authors">Author's Address</a></li>
 
 
   </ul>
@@ -594,7 +572,7 @@
   </tbody>
 </table>
 <h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for RSA Mode Validations</a></h1>
-<p id="rfc.section.2.2.p.1">Each RSA Mode implementation relies on other cryptographic primitives (algorithms) - see <a href="#FIPS186-4">[FIPS186-4]</a>.  For example, a keyGen implementation uses underlying DRBG and hash algorithms. In some case, a single RSA Mode implementation may use several primitives of the same type.  For example, two different DRBG implementations may be used in the keyGen algorithms in Appendix B.3.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, one in step 4.2 and another in step 5.2.  Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<p id="rfc.section.2.2.p.1">Each RSA Mode implementation relies on other cryptographic primitives (algorithms) - see <a href="#FIPS186-4">[FIPS186-4]</a>.  For example, a keyGen implementation uses underlying DRBG and hash algorithms. In some cases, a single RSA Mode implementation may use several primitives of the same type.  For example, two different DRBG implementations may be used in the keyGen algorithms in Appendix B.3.3 in <a href="#FIPS186-4">[FIPS186-4]</a>, one in step 4.2 and another in step 5.2.  Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
 <div id="rfc.table.2"/>
 <div id="prereqs_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -736,7 +714,7 @@
     <tr>
       <td class="left">algSpecs</td>
       <td class="left">Array of modeSpecs</td>
-      <td class="left">array of modeSpecs objects, each identified uniquely by the "mode" property</td>
+      <td class="left">array of modeSpecs objects, each identified uniquely by the "mode" and required properties</td>
       <td class="left">See <a href="#algs_table">Table 1</a> and <a href="#supported_mods">Section 2.4</a></td>
       <td class="left">No</td>
     </tr>
@@ -1078,7 +1056,7 @@
 <p id="rfc.section.2.4.2.p.2">Each RSA sigGen mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.2.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.2.1"><a href="#rfc.section.2.4.2.1">2.4.2.1.</a> <a href="#mode_sigGenCap" id="mode_sigGenCap">sigGen Capabilities</a></h1>
-<p id="rfc.section.2.4.2.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.2.1.p.1">The following RSA signature generation capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.8"/>
 <div id="sigGenRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1146,11 +1124,11 @@
 </table>
 <p id="rfc.section.2.4.2.1.p.2">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.3"><a href="#rfc.section.2.4.3">2.4.3.</a> <a href="#mode_sigVer" id="mode_sigVer">The sigVer Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.3.p.1">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.3.p.1">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.3.p.2">Each RSA sigVer mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.3.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.3.1"><a href="#rfc.section.2.4.3.1">2.4.3.1.</a> <a href="#mode_sigVerCap" id="mode_sigVerCap">sigVer Capabilities</a></h1>
-<p id="rfc.section.2.4.3.1.p.1">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.3.1.p.1">The following RSA signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.9"/>
 <div id="sigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1220,10 +1198,10 @@
 <h1 id="rfc.section.2.4.4"><a href="#rfc.section.2.4.4">2.4.4.</a> <a href="#mode_legacySigVer" id="mode_legacySigVer">The legacySigVer Mode Capabilities</a></h1>
 <p id="rfc.section.2.4.4.p.1">The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.4.p.2">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
-<p id="rfc.section.2.4.4.p.3">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.4.p.3">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.4.p.4">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.4.p.5">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
-<p id="rfc.section.2.4.4.p.6">The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.4.p.6">The following RSA legacy signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.10"/>
 <div id="legacySigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1294,7 +1272,7 @@
 <p id="rfc.section.2.4.5.p.1">The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <a href="#RFC3447">[RFC3447]</a>) is advertised as a JSON object within the array of 'modeSpecs' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server.  Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability.  See <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for 'msg' and 'n'.  See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.5.p.2">Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.2.4.6"><a href="#rfc.section.2.4.6">2.4.6.</a> <a href="#mode_componentDecPrimitive" id="mode_componentDecPrimitive">The componentDecPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
+<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
 <p id="rfc.section.2.4.6.p.2">In testing, only 'msg' is supplied by the ACVP server.  The client is responsible for generating RSA key pairs of modulus 'n', private key 'd', and calculates 's'.  Only 2048-bit RSA keys are allowed for this capability. See <a href="#app-testcomponentdecprimitive-ex">Appendix B.6</a> for additional details on constraints for 'msg' and 'n'. The client provides the public exponent 'e', modulus 'n', the private key 'd' and the computed result 's' in its response to the ACVP - see <a href="#app-componentdec-results-ex">Appendix C.6</a> .  The client must first check if  '0 &lt; msg &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 'msg' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.</p>
 <p id="rfc.section.2.4.6.p.3">Each RSA componentDecPrimitive mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
@@ -1343,11 +1321,6 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">mode</td>
-      <td class="left">The RSA mode.</td>
-      <td class="left">"KeyGen", "SigGen", or "SigVer"</td>
-    </tr>
-    <tr>
       <td class="left"/>
       <td class="left"/>
       <td class="left"/>
@@ -1374,6 +1347,18 @@
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td class="left">mode</td>
+      <td class="left">The RSA mode.</td>
+      <td class="left">"KeyGen", "SigGen", or "SigVer"</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
     <tr>
       <td class="left">modulo</td>
       <td class="left">RSA modulus</td>
@@ -1779,18 +1764,6 @@
   <tbody>
     <tr>
       <td class="reference">
-        <b id="ACVP">[ACVP]</b>
-      </td>
-      <td class="top"><a>NIST</a>, "<a>ACVP Specification</a>", 2016.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="FIPS186-4">[FIPS186-4]</b>
-      </td>
-      <td class="top"><a>NIST</a>, "<a href="http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf">FIPS PUB 186-4 Digital Signature Standard</a>", July 2013.</td>
-    </tr>
-    <tr>
-      <td class="reference">
         <b id="RFC2119">[RFC2119]</b>
       </td>
       <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
@@ -1803,15 +1776,27 @@
     </tr>
     <tr>
       <td class="reference">
+        <b id="ACVP">[ACVP]</b>
+      </td>
+      <td class="top"><a>NIST</a>, "<a>ACVP Specification</a>", 2016.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="FIPS186-4">[FIPS186-4]</b>
+      </td>
+      <td class="top"><a>NIST</a>, "<a>FIPS PUB 186-4 Digital Signature Standard</a>", July 2013.</td>
+    </tr>
+    <tr>
+      <td class="reference">
         <b id="SP800-131A">[SP800-131A]</b>
       </td>
-      <td class="top"><a title="NIST">Barker, E.</a> and <a title="NIST">A. Roginsky</a>, "<a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths, Revision 1</a>", November 2015.</td>
+      <td class="top"><a title="NIST">Barker, E.</a> and <a title="NIST">A. Roginsky</a>, "<a>Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths, Revision 1</a>", November 2015.</td>
     </tr>
     <tr>
       <td class="reference">
         <b id="SP800-56B">[SP800-56B]</b>
       </td>
-      <td class="top"><a title="NIST">Barker, E.</a>, <a title="NIST">Chen, L.</a> and <a title="NIST">D. Moody</a>, "<a href="http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf">Recommendation for Pair-Wise Key-Esablishment Schems Using Integer Factorization Cryptography, Revision 1</a>", September 2014.</td>
+      <td class="top"><a title="NIST">Barker, E.</a>, <a title="NIST">Chen, L.</a> and <a title="NIST">D. Moody</a>, "<a>Recommendation for Pair-Wise Key-Esablishment Schems Using Integer Factorization Cryptography, Revision 1</a>", September 2014.</td>
     </tr>
   </tbody>
 </table>
@@ -1847,6 +1832,7 @@
       ]
    }
 </pre>
+<p class="figure"></p>
 <p id="rfc.section.A.1.p.2">In order to advertise support for RSA keyGen with provable primes with conditions, the same properties exist, but the 'randPQ' value should be '3' as an integer.</p>
 <h1 id="rfc.appendix.A.1.1"><a href="#rfc.appendix.A.1.1">A.1.1.</a> <a href="#app-ex-keyGenProbPrime" id="app-ex-keyGenProbPrime">Example keyGen with Probable Primes Capabilities JSON Object</a></h1>
 <p id="rfc.section.A.1.1.p.1">The following is an example JSON object advertising support for RSA keyGen with probable primes according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.3. See also <a href="#mode_keyGenFullSet">Section 2.4.1.4</a>.</p>
@@ -1885,6 +1871,7 @@
     ]
   }
 </pre>
+<p class="figure"></p>
 <p id="rfc.section.A.1.1.p.2">In order to advertise support for RSA keyGen with all probable primes with conditions, the same properties exist, but the 'randPQ' value should be '5' as an integer.</p>
 <h1 id="rfc.appendix.A.1.2"><a href="#rfc.appendix.A.1.2">A.1.2.</a> <a href="#app-ex-keyGenProvProbPrime" id="app-ex-keyGenProvProbPrime">Example keyGen with Provable Conditional Primes with Probable Factors Capabilities JSON Object</a></h1>
 <p id="rfc.section.A.1.2.p.1">The following is an example JSON object advertising support for RSA keyGen with primes with conditions according to <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.5. See also <a href="#mode_keyGenFullSet">Section 2.4.1.4</a>.</p>
@@ -1911,7 +1898,7 @@
                          "primeTest": ["tblC2"]},
                        {"modulo" : 4096,
                          "hashAlgs" : ["SHA-512"],
-                         "primeTest": ["tblC3"]},
+                         "primeTest": ["tblC3"]}
                     ]
               }
           }
@@ -1919,6 +1906,7 @@
       ]
    }
 </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.A.2"><a href="#rfc.appendix.A.2">A.2.</a> <a href="#app-cap-siggenex" id="app-cap-siggenex">Example RSA sigGen Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.2.p.1">The following is an example JSON object advertising support for RSA sigGen according to <a href="#FIPS186-4">[FIPS186-4]</a>.</p>
 <pre>
@@ -1978,6 +1966,7 @@
       ]
    }
 </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.A.3"><a href="#rfc.appendix.A.3">A.3.</a> <a href="#app-cap-sigverex" id="app-cap-sigverex">Example RSA sigVer Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.3.p.1">The following is an example JSON object advertising support for RSA sigVer according to <a href="#FIPS186-4">[FIPS186-4]</a>.</p>
 <pre>
@@ -2038,6 +2027,7 @@
     ]
    }
 </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.A.4"><a href="#rfc.appendix.A.4">A.4.</a> <a href="#app-cap-legacysigverex" id="app-cap-legacysigverex">Example RSA legacySigVer Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.4.p.1">The format and structure of the RSA legacySigVer capabilities JSON objects follow very closely those of the RSA sigVer capabilties JSON objects with the obvious changes from moduloSigVer, hashSigVer and saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer and the corresponding parameter ranges adjustments.</p>
 <h1 id="rfc.appendix.A.5"><a href="#rfc.appendix.A.5">A.5.</a> <a href="#app-cap-componentsigverex" id="app-cap-componentsigverex">Example componentSigPrimitive Capabilities JSON Objects</a></h1>
@@ -2053,6 +2043,7 @@
       ]
    }
 </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.A.6"><a href="#rfc.appendix.A.6">A.6.</a> <a href="#app-cap-componentdecverex" id="app-cap-componentdecverex">Example componentDecPrimitive Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.6.p.1">The following is an example JSON object advertising support for RSA componentDecPrimitive according to <a href="#SP800-56B">[SP800-56B]</a>.</p>
 <pre>
@@ -2067,6 +2058,7 @@
       ]
    }
 </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-testVect-ex" id="app-testVect-ex">Example Test Vectors JSON Objects</a></h1>
 <p id="rfc.section.B.p.1">This appendix contains example JSON objects for test vectors sent from the ACVP server to the crypto module.</p>
 <h1 id="rfc.appendix.B.1"><a href="#rfc.appendix.B.1">B.1.</a> <a href="#app-testVectProvProvPrime-ex" id="app-testVectProvProvPrime-ex">Example Test Vectors for keyGen JSON Objects</a></h1>
@@ -2075,130 +2067,138 @@
  [
    { "acvVersion": "0.4" },
    { "vsId": 1133,
-      "algorithm": "RSA",
-      "mode": "keyGen",
-      "testGroups" : [
+     "algorithm": "RSA",
+     "testGroups" : [
              {           
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.2",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1145,
+                      "tcId" : 1145
                     },
                     {
-                      "tcId" : 1146,
+                      "tcId" : 1146
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.2",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1147,
+                    "tcId": 1147
                   },
                   {
-                    "tcId": 1148,
+                    "tcId": 1148
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.4",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1149,
+                      "tcId" : 1149
                     },
                     {
-                      "tcId" : 1150,
+                      "tcId" : 1150
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1151,
+                    "tcId": 1151
                   },
                   {
-                    "tcId": 1152,
+                    "tcId": 1152
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.5",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1153,
+                      "tcId" : 1153
                     },
                     {
-                      "tcId" : 1154,
+                      "tcId" : 1154
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.5",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1155,
+                    "tcId": 1155
                   },
                   {
-                    "tcId": 1156,
+                    "tcId": 1156
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.6",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1157,
+                      "tcId" : 1157
                     },
                     {
-                      "tcId" : 1158,
+                      "tcId" : 1158
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.6",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1159,
+                    "tcId": 1159
                   },
                   {
-                    "tcId": 1160,
+                    "tcId": 1160
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -2220,6 +2220,7 @@
                  ]
              },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -2234,6 +2235,7 @@
                  ]
              },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -2255,6 +2257,7 @@
                  ]
              },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -2272,6 +2275,7 @@
    }
  ]
 </pre>
+<p class="figure"></p>
 <p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table">Table 15</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the server validates that this pair matches the requirements.</p>
 <h1 id="rfc.appendix.B.2"><a href="#rfc.appendix.B.2">B.2.</a> <a href="#app-testVectsigGen-ex" id="app-testVectsigGen-ex">Example Test Vectors for sigGen JSON Objects</a></h1>
 <pre>
@@ -2279,9 +2283,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
-      "mode": "sigGen",
       "testGroups" : [
              {
+                 "mode": "sigGen",
                  "sigType" : "ANSX9.31",
                  "hashAlg" : "SHA-256",
                  "modulo" : 2048,
@@ -2289,10 +2293,11 @@
                     {
                       "tcId" : 1165,
                       "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
-                    },
+                    }
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType": "ANSX9.31",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -2304,6 +2309,7 @@
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -2311,10 +2317,11 @@
                    {
                      "tcId" : 1167,
                      "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
-                   },
+                   }
                 ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -2326,6 +2333,7 @@
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -2338,6 +2346,7 @@
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -2353,18 +2362,19 @@
     }
   ]
 </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.B.3"><a href="#rfc.appendix.B.3">B.3.</a> <a href="#app-testVectsigVer-ex" id="app-testVectsigVer-ex">Example Test Vectors for sigVer JSON Objects</a></h1>
 <pre>
  [
    { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
-      "mode": "sigVer",
       "testGroups" : [
              {
+                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
-                 "modulo" : 2048,
                  "hashAlg" : "SHA-256",
+                 "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
                  "tests" : [
@@ -2376,6 +2386,7 @@
                  ]
              },
              {
+                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA-256",
@@ -2390,6 +2401,7 @@
                  ]
              },
              {
+                 "mode": "sigVer",
                  "sigType" : "PKCS1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -2400,10 +2412,11 @@
                       "tcId" : 1176,
                       "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
                       "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
-                    },
+                    }
                  ]
              },
              {
+                "mode": "sigVer",
                 "sigType" : "PKCS1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-256",
@@ -2418,6 +2431,7 @@
                  ]
              },
              {
+                 "mode": "sigVer",
                  "sigType" : "PSS",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -2428,10 +2442,11 @@
                       "tcId" : 1178,
                       "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
                       "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
-                    },
+                    }
                  ]
              },
              {
+                "mode": "sigVer",
                 "sigType" : "PSS",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-512",
@@ -2450,6 +2465,7 @@
   ]
 
 </pre>
+<p class="figure"></p>
 <p id="rfc.section.B.3.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation.  These may include the public key n, the public exponent e, the private key d for each test. Note also that each test for which msg is not between 0 and n - 1 should fail.</p>
 <h1 id="rfc.appendix.B.4"><a href="#rfc.appendix.B.4">B.4.</a> <a href="#app-testVectlegacySigVer-ex" id="app-testVectlegacySigVer-ex">Example Test Vectors for legacySigVer JSON Objects</a></h1>
 <p id="rfc.section.B.4.p.1">The format and structure of legacySigVer Test Vector JSON Objects is identical to those for the Test Vectors for sigVer JSON Objects. </p>
@@ -2459,9 +2475,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
-      "mode": "componentSigPrimitive",
       "testGroups" : [
              {           
+                 "mode": "componentSigPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -2481,6 +2497,7 @@
     }
   ]
 </pre>
+<p class="figure"></p>
 <p id="rfc.section.B.5.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key 'n', the public exponent 'e', the private key 'd' for each test.  Note also that each test for which 'msg' is not between '0' and 'n - 1' should fail.</p>
 <h1 id="rfc.appendix.B.6"><a href="#rfc.appendix.B.6">B.6.</a> <a href="#app-testcomponentdecprimitive-ex" id="app-testcomponentdecprimitive-ex">Example Test Vectors for componentDecPrimitive JSON Objects</a></h1>
 <pre>
@@ -2488,9 +2505,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
-      "mode": "componentDecPrimitive",
       "testGroups" : [
              {
+                 "mode": "componentDecPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -2506,6 +2523,7 @@
     }
   ]
 </pre>
+<p class="figure"></p>
 <p id="rfc.section.B.6.p.1">Note: The ACVP server does retain additional context for each test vector sent to the client in order to verify the results when submitted for validation. These may include the public key 'n', the public exponent 'e', the private key 'd' for each test.  Note also that each test for which 'msg' is not between '0' and 'n - 1' should fail.</p>
 <h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Objects</a></h1>
 <h1 id="rfc.appendix.C.1"><a href="#rfc.appendix.C.1">C.1.</a> <a href="#app-keyGen-results-ex" id="app-keyGen-results-ex">Example keyGen Test Results JSON Objects</a></h1>
@@ -2515,7 +2533,6 @@
                 { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "algorithm": "RSA",
-                    "mode": "keyGen",
                     "testResults": [
                     {
                       "tcId" : 1111,
@@ -2571,15 +2588,15 @@
                     },
                     {
                       "tcId" : 1116,
-                     "e" : "10000021",
-                     "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
-                     "bitlens" : [272, 205, 296, 157],
-                     "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
-                     "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
-                     "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
-                     "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
-                     "n" : "b86c87f9aea1aa7b5c253966047466b0ae29fdbacabeb7eaed820b7f87b664749bfaba791d7a0bfd25cbb4251da58fbb2ab9725c2c873f2b545eaa7409f1124e2d84cdb5c71583fc433a2fa44c6e8e006caaadb07b4996a67ee01df45b70bf94dd0f1bd13c60935f012899edde57c9af80ad362440e804767e4837fbf98847e5e33c534fb86601958adea41ed278203e99d717917fe9d719fcefb3b04f0edb4f44831b52f20c5ac410ea96723fe5bc0afb4dc7d3bf617dd3760b396436cf613444b9abcaa82bd7e0f3174df6dbe320616a2bcb774fbc4633ea783dacffd557706f6f64a8821805d40fd627f3deaa99d4da4a4f571fe7332cc219f68682d4d3d3",
-                     "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
+                      "e" : "10000021",
+                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
+                      "bitlens" : [272, 205, 296, 157],
+                      "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
+                      "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
+                      "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
+                      "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
+                      "n" : "b86c87f9aea1aa7b5c253966047466b0ae29fdbacabeb7eaed820b7f87b664749bfaba791d7a0bfd25cbb4251da58fbb2ab9725c2c873f2b545eaa7409f1124e2d84cdb5c71583fc433a2fa44c6e8e006caaadb07b4996a67ee01df45b70bf94dd0f1bd13c60935f012899edde57c9af80ad362440e804767e4837fbf98847e5e33c534fb86601958adea41ed278203e99d717917fe9d719fcefb3b04f0edb4f44831b52f20c5ac410ea96723fe5bc0afb4dc7d3bf617dd3760b396436cf613444b9abcaa82bd7e0f3174df6dbe320616a2bcb774fbc4633ea783dacffd557706f6f64a8821805d40fd627f3deaa99d4da4a4f571fe7332cc219f68682d4d3d3",
+                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
                       "tcId" : 1117,
@@ -2694,7 +2711,7 @@
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "tcId" : 1130,
+                      "tcId" : 1130,
                       "e" : "e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
@@ -2721,55 +2738,45 @@
                 }
              ]
             </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.C.2"><a href="#rfc.appendix.C.2">C.2.</a> <a href="#app-sigGen-results-ex" id="app-sigGen-results-ex">Example sigGen Test Results JSON Objects</a></h1>
 <p id="rfc.section.C.2.p.1">The following is a example JSON object for RSA sigGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1163,
-                    "algorithm": "RSA",
-                    "mode": "sigGen",
-                    "testResults": [
+                { "acvVersion": "0.4" },
+                { "vsId": 1163,
+                  "algorithm": "RSA",
+                  "testResults": [
                     {
                       "tcId" : 1165,
-                      "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "e" : "f3e7af",
+                      "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
-                    }
+                    },
                     {
                       "tcId" : 1166,
-                      "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "e" : "ebda09",
+                      "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
-                    }
-                 ]
-             }
-              {
-                 "sigType" : "PKCS1v1.5",
-                 "tests" : [
+                    },
                     {
                       "tcId" : 1167,
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "signature" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
-                    }
+                    },
                     {
                       "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
                       "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
-                    }
-                 ]
-             }
-             {
-                 "sigType" : "PSS",
-                 "tests" : [
+                    },
                     {
                       "tcId" : 1169,
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "signature" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
-                    }
+                    },
                     {
                       "tcId" : 1170,
                       "e" : "1415a7",
@@ -2780,6 +2787,7 @@
              }
            ]
             </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.C.3"><a href="#rfc.appendix.C.3">C.3.</a> <a href="#app-sigVer-results-ex" id="app-sigVer-results-ex">Example sigVer Test Results JSON Objects</a></h1>
 <p id="rfc.section.C.3.p.1">The following is a example JSON object for RSA sigVer test results sent from the crypto module to the ACVP server.</p>
 <pre>
@@ -2787,106 +2795,83 @@
     { "acvVersion": "0.4" },
     { "vsId": 1173,
       "algorithm": "RSA",
-      "mode": "sigVer",
-      "testGroups" : [
-             {
-                 "sigType" : "ANSX9.31",
-                 "tests" : [
-                    {
-                      "tcId" : 1174,
-                      "sigResult" : "failed"
-                    },
-                    {
-                      "tcId" : 1175,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             },
+      "testResults" : [
               {
-                 "sigType" : "PKCS1v1.5",
-                 "tests" : [
-                    {
-                      "tcId" : 1176,
-                      "sigResult" : "passed"
-                    },
-                    {
-                      "tcId" : 1177,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             },
-             {
-                 "sigType" : "PSS",
-                 "tests" : [
-                    {
-                      "tcId" : 1178,
-                      "sigResult" : "failed"
-                    },
-                    {
-                      "tcId" : 1179,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             }
-       ]
+                "tcId" : 1174,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1175,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1176,
+                "sigResult" : "passed"
+              },
+              {
+                "tcId" : 1177,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1178,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1179,
+                "sigResult" : "failed"
+              }
+        ]
     }
-  ]
+]
             </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.C.4"><a href="#rfc.appendix.C.4">C.4.</a> <a href="#app-legacySigVer-results-ex" id="app-legacySigVer-results-ex">Example legacySigVer Test Results JSON Objects</a></h1>
 <p id="rfc.section.C.4.p.1">The format and structure of the RSA legacySigVer Test Results JSON Objects are identical to those of the RSA sigVer Test Results JSON Objects. </p>
 <h1 id="rfc.appendix.C.5"><a href="#rfc.appendix.C.5">C.5.</a> <a href="#app-componentsig-results-ex" id="app-componentsig-results-ex">Example componentSigPrimitive Test Results JSON Objects</a></h1>
 <p id="rfc.section.C.5.p.1">The following is a example JSON object for RSA componentSigPrimitive test results sent from the crypto module to the ACVP server.</p>
 <pre>
- [
+[
     { "acvVersion": "0.4" },
     { "vsId": 1193,
       "algorithm": "RSA",
-      "mode": "componentSigPrimitive",
-      "testGroups" : [
-             {
-                 "tests" : [
-                    {
-                      "tcId" : 1194,
-                      "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
-                    },
-                    {
-                      "tcId" : 1195,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             }
-       ]
+      "testResults" : [
+                {
+                 "tcId" : 1194,
+                 "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
+                },
+                {
+                 "tcId" : 1195,
+                 "sigResult" : "failed"
+                }
+            ]
     }
-  ]
+]
             </pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.C.6"><a href="#rfc.appendix.C.6">C.6.</a> <a href="#app-componentdec-results-ex" id="app-componentdec-results-ex">Example componentDecPrimitive Test Results JSON Objects</a></h1>
 <p id="rfc.section.C.6.p.1">The following is a example JSON object for RSA componentDecPrimitive test results sent from the crypto module to the ACVP server.</p>
 <pre>
- [
+[
     { "acvVersion": "0.4" },
     { "vsId": 1194,
       "algorithm": "RSA",
-      "mode": "componentDecPrimitive",
-      "testGroups" : [
+      "testResults" : [
              {           
-                 "tests" : [
-                    {
-                      "tcId" : 1196,
-                      "e" : "010001",
-                      "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
-                      "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
-                      "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
-                    },
-                    {
-                      "tcId" : 1197,
-                      "sigResult" : "failed"
-                    }
-                 ]
+                "tcId" : 1196,
+                "e" : "010001",
+                "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
+                "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
+                "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
+             },
+             {
+                "tcId" : 1197,
+                "sigResult" : "failed"
              }
-       ]
+        ]
     }
-  ]
+]
             </pre>
+<p class="figure"></p>
 <h1 id="rfc.authors">
   <a href="#rfc.authors">Author's Address</a>
 </h1>
@@ -2900,7 +2885,7 @@
 	</span>
 	<span class="org vcardline">National Institute of Standards and Technology</span>
 	<span class="adr">
-	  <span class="vcardline">100 Bureau Dr.</span>
+	  <span>100 Bureau Dr.</span>
 
 	  <span class="vcardline">
 		<span class="locality">Gaithersburg</span>,  

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -409,9 +409,9 @@
   <meta name="generator" content="xml2rfc version 2.4.0 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
-  <meta name="dct.creator" content="Vassilev, A.V., Ed." />
+  <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-5" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-8-17" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  " />
   <meta name="description" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  " />
 
@@ -424,7 +424,7 @@
     
     	<tr>
   <td class="left">TBD</td>
-  <td class="right">A.V. Vassilev, Ed.</td>
+  <td class="right">A. Vassilev, Ed.</td>
 </tr>
 <tr>
   <td class="left">Internet-Draft</td>
@@ -432,10 +432,10 @@
 </tr>
 <tr>
   <td class="left">Intended status: Informational</td>
-  <td class="right">May 2017</td>
+  <td class="right">August 17, 2017</td>
 </tr>
 <tr>
-  <td class="left">Expires: November 02, 2017</td>
+  <td class="left">Expires: February 18, 2018</td>
   <td class="right"></td>
 </tr>
 
@@ -456,7 +456,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on November 02, 2017.</p>
+<p>This Internet-Draft will expire on February 18, 2018.</p>
 <h1 id="rfc.copyrightnotice">
   <a href="#rfc.copyrightnotice">Copyright Notice</a>
 </h1>
@@ -546,27 +546,26 @@
   </thead>
   <tbody>
     <tr>
-      <td class="left">"RSA"</td>
       <td class="left">"keyGen"</td>
+      <td class="left"/>
     </tr>
     <tr>
-      <td class="left"/>
       <td class="left">"sigGen"</td>
+      <td class="left"/>
     </tr>
     <tr>
-      <td class="left"/>
       <td class="left">"sigVer"</td>
+      <td class="left"/>
     </tr>
     <tr>
-      <td class="left"/>
       <td class="left">"legacySigVer"</td>
+      <td class="left"/>
     </tr>
     <tr>
-      <td class="left"/>
       <td class="left">"componentSigPrimitive"</td>
+      <td class="left"/>
     </tr>
     <tr>
-      <td class="left"/>
       <td class="left">"componentDecPrimitive"</td>
     </tr>
   </tbody>
@@ -670,6 +669,20 @@
       <td class="left"/>
     </tr>
     <tr>
+      <td class="left">mode</td>
+      <td class="left">The RSA algorithm mode to be validated</td>
+      <td class="left">value</td>
+      <td class="left">"keyGen", "sigGen", "sigVer", "legacySigVer", "componentSigPrimitive", "componentDecPrimitive"</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
       <td class="left">prereqVals</td>
       <td class="left">The prerequisite algorithm validations</td>
       <td class="left">array of prereqAlgVal objects - see <a href="#prereq_algs">Section 2.2</a></td>
@@ -684,48 +697,20 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">capSpecs</td>
-      <td class="left">The capabilities of a particular RSA mode</td>
-      <td class="left">an array of objects specific to the mode being specified</td>
-      <td class="left">array</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">modeSpecs</td>
-      <td class="left">The RSA mode and its capabilities</td>
-      <td class="left">an object with "mode" and "capSpecs" properties</td>
-      <td class="left">object</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
       <td class="left">algSpecs</td>
-      <td class="left">Array of modeSpecs</td>
-      <td class="left">array of modeSpecs objects, each identified uniquely by the "mode" and required properties</td>
-      <td class="left">See <a href="#algs_table">Table 1</a> and <a href="#supported_mods">Section 2.4</a></td>
+      <td class="left">Array of JSON objects</td>
+      <td class="left">array of JSON objects, each with fields pertaining to the global RSA mode indicated above and identified uniquely by the combination of the RSA "mode" and indicated properties</td>
+      <td class="left">See <a href="#algs_table">Table 1</a> and <a href="#supported_modes">Section 2.4</a></td>
       <td class="left">No</td>
     </tr>
   </tbody>
 </table>
-<h1 id="rfc.section.2.4"><a href="#rfc.section.2.4">2.4.</a> <a href="#supported_mods" id="supported_mods">Supported RSA Modes Capabilities</a></h1>
-<p id="rfc.section.2.4.p.1">The RSA mode capabilities are advertised as arrays of JSON objects within the 'modeSpecs' value of the ACVP registration message - see <a href="#caps_table">Table 3</a>. The 'modeSpecs' value is an array, where each array element is an array of individual JSON objects corresponding to a particular RSA mode defined in this section.  The 'modeSpecs' value is part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.p.2">Each RSA mode capabilities are advertised as an array of self-contained JSON objects.</p>
+<h1 id="rfc.section.2.4"><a href="#rfc.section.2.4">2.4.</a> <a href="#supported_modes" id="supported_modes">Supported RSA Modes Capabilities</a></h1>
+<p id="rfc.section.2.4.p.1">The RSA mode capabilities are advertised as JSON objects within the 'algSpecs' value of the ACVP registration message - see <a href="#caps_table">Table 3</a>. The 'algSpecs' value is an array, where each array element is a JSON object corresponding to a particular RSA mode defined in this section.  The 'algSpecs' value is part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.p.2">Each RSA mode's capabilities are advertised as JSON objects.</p>
 <h1 id="rfc.section.2.4.1"><a href="#rfc.section.2.4.1">2.4.1.</a> <a href="#mode_keyGen" id="mode_keyGen">The keyGen Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.1.p.1">The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.1.p.2">Each RSA keyGen mode capability is advertised as a self-contained JSON object.</p>
+<p id="rfc.section.2.4.1.p.1">The RSA keyGen mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.1.p.2">Each RSA keyGen mode capability set is advertised as a self-contained JSON object.</p>
 <p id="rfc.section.2.4.1.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.1.1"><a href="#rfc.section.2.4.1.1">2.4.1.1.</a> <a href="#mode_keyGenProvPrim" id="mode_keyGenProvPrim">keyGen With Provable Primes or Provable Primes with Conditions Capabilities</a></h1>
 <p id="rfc.section.2.4.1.1.p.1">The following key generation with provable primes, or provable primes with conditions capabilities may be advertised by the ACVP compliant crypto module:</p>
@@ -758,7 +743,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">hashAlg</td>
+      <td class="left">hashAlgs</td>
       <td class="left">Supported hash algorithms for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.2 or Appendix B.3.4</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
@@ -774,7 +759,7 @@
     <tr>
       <td class="left">singleCap</td>
       <td class="left">A testable combination of modulus and hash values</td>
-      <td class="left">object with "modulo" and "hashAlg" properties</td>
+      <td class="left">object with "modulo" and "hashAlgs" properties</td>
       <td class="left">see above</td>
       <td class="left">Yes</td>
     </tr>
@@ -892,7 +877,7 @@
       <td class="left"/>
     </tr>
     <tr>
-      <td class="left">hashAlg</td>
+      <td class="left">hashAlgs</td>
       <td class="left">Supported hash algorithms for provable prime generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Appendix B.3.6</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
@@ -922,7 +907,7 @@
     <tr>
       <td class="left">singleCap</td>
       <td class="left">A testable combination of modulus, hash algorithm, and primality test rounds</td>
-      <td class="left">object with "modulo", "hashAlg", and "primeTest" properties</td>
+      <td class="left">object with "modulo", "hashAlgs", and "primeTest" properties</td>
       <td class="left">see above</td>
       <td class="left">Yes</td>
     </tr>
@@ -1052,8 +1037,8 @@
   </tbody>
 </table>
 <h1 id="rfc.section.2.4.2"><a href="#rfc.section.2.4.2">2.4.2.</a> <a href="#mode_sigGen" id="mode_sigGen">The sigGen Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.2.p.1">The RSA sigGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.2.p.2">Each RSA sigGen mode capability is advertised as a self-contained JSON object.</p>
+<p id="rfc.section.2.4.2.p.1">The RSA sigGen mode capabilities are advertised as JSON objects within the 'algSpecs' array as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.2.p.2">Each RSA sigGen mode capability is advertised as a self-contained JSON object consisting of the algorithm, mode, and algSpecs array.  The algSpecs array may contain multiple elements, each pertaining to a sigType that is supported by the client for the RSA mode being advertised.</p>
 <p id="rfc.section.2.4.2.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.2.1"><a href="#rfc.section.2.4.2.1">2.4.2.1.</a> <a href="#mode_sigGenCap" id="mode_sigGenCap">sigGen Capabilities</a></h1>
 <p id="rfc.section.2.4.2.1.p.1">The following RSA signature generation capabilities may be advertised by the ACVP compliant crypto module:</p>
@@ -1074,8 +1059,22 @@
     <tr>
       <td class="left">sigType</td>
       <td class="left">supported RSA signature types  - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
+      <td class="left">value</td>
+      <td class="left">one of {"ANSX9.31", "PKCS1v1.5", "PSS"}</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">capSigType</td>
+      <td class="left">capabilites supported for this sigType  - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"ANSX9.31", "PKCS1v1.5", "PSS"}</td>
+      <td class="left">modulo, hashAlgs, and optionally the saltLens object</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1088,8 +1087,8 @@
     <tr>
       <td class="left">modulo</td>
       <td class="left">supported RSA moduli for signature generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
-      <td class="left">array</td>
-      <td class="left">any non-empty subset of {2048, 3072, 4096}</td>
+      <td class="left">value</td>
+      <td class="left">one of the supported modulo sizes {2048, 3072, 4096}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1101,7 +1100,7 @@
     </tr>
     <tr>
       <td class="left">hashAlgs</td>
-      <td class="left">supported hash algorithms for signature generation - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
+      <td class="left">supported hash algorithms for signature generation for this sigType and modulo - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
       <td class="left">No</td>
@@ -1115,17 +1114,17 @@
     </tr>
     <tr>
       <td class="left">saltLens</td>
-      <td class="left">supported salt lengths for PKCS1PSS signature generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
+      <td class="left">supported salt lengths for PSS signature generation - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
       <td class="left">array</td>
       <td class="left">array of values for each hash algorithm used subject to the constraint in the note below.</td>
       <td class="left">Yes</td>
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.2.4.2.1.p.2">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
+<p id="rfc.section.2.4.2.1.p.2">Note: the salt length for each hash algorithm used in PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.3"><a href="#rfc.section.2.4.3">2.4.3.</a> <a href="#mode_sigVer" id="mode_sigVer">The sigVer Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.3.p.1">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.3.p.2">Each RSA sigVer mode capability is advertised as a self-contained JSON object.</p>
+<p id="rfc.section.2.4.3.p.1">The RSA sigVer mode capabilities are advertised as JSON objects within the array of 'algSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.3.p.2">Each RSA sigVer mode capability is advertised as a self-contained JSON object consisting of the algorithm, mode, and algSpecs array.  The algSpecs array may contain multiple elements, each pertaining to a sigType that is supported by the client for the RSA mode being advertised.</p>
 <p id="rfc.section.2.4.3.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <h1 id="rfc.section.2.4.3.1"><a href="#rfc.section.2.4.3.1">2.4.3.1.</a> <a href="#mode_sigVerCap" id="mode_sigVerCap">sigVer Capabilities</a></h1>
 <p id="rfc.section.2.4.3.1.p.1">The following RSA signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
@@ -1146,8 +1145,22 @@
     <tr>
       <td class="left">sigType</td>
       <td class="left">supported RSA signature types  - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
+      <td class="left">value</td>
+      <td class="left">one of {"ANSX9.31", "PKCS1v1.5", "PSS"}</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">capSigType</td>
+      <td class="left">RSA signature verification parameters  - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"ANSX9.31", "PKCS1v1.5", "PSS"}</td>
+      <td class="left">modulo, hashAlgs, and saltLens (when sigType is PSS)</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1159,9 +1172,9 @@
     </tr>
     <tr>
       <td class="left">modulo</td>
-      <td class="left">supported RSA moduli for signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
-      <td class="left">array</td>
-      <td class="left">any non-empty subset of {2048, 3072, 4096}</td>
+      <td class="left">supported RSA modulo for signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
+      <td class="left">value</td>
+      <td class="left">any one of the supported modulo sizes {2048, 3072, 4096}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1173,7 +1186,7 @@
     </tr>
     <tr>
       <td class="left">hashAlgs</td>
-      <td class="left">supported hash algorithms for signature verification - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
+      <td class="left">supported hash algorithms for this sigType and modulo - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
       <td class="left">array</td>
       <td class="left">any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
       <td class="left">No</td>
@@ -1187,7 +1200,7 @@
     </tr>
     <tr>
       <td class="left">saltLens</td>
-      <td class="left">supported salt lengths for PKCS1PSS signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
+      <td class="left">supported salt lengths for PSS signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
       <td class="left">array</td>
       <td class="left">array of values for each hash algorithm used subject to the constraint in the note below.</td>
       <td class="left">Yes</td>
@@ -1196,12 +1209,9 @@
 </table>
 <p id="rfc.section.2.4.3.1.p.2">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.4"><a href="#rfc.section.2.4.4">2.4.4.</a> <a href="#mode_legacySigVer" id="mode_legacySigVer">The legacySigVer Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.4.p.1">The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.4.p.2">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
-<p id="rfc.section.2.4.4.p.3">The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.4.p.4">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</p>
-<p id="rfc.section.2.4.4.p.5">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
-<p id="rfc.section.2.4.4.p.6">The following RSA legacy signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.2.4.4.p.1">The RSA legacySigVer mode capabilities are advertised as JSON objects within the array of 'algSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.4.4.p.2">Each RSA legacySigVer mode capability is advertised as a self-contained JSON object consisting of the algorithm, mode, and algSpecs array.  The algSpecs array may contain multiple elements, each pertaining to a sigType that is supported by the client for the RSA mode being advertised.</p>
+<p id="rfc.section.2.4.4.p.3">The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</p>
 <div id="rfc.table.10"/>
 <div id="legacySigVerRSAMod"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1218,9 +1228,23 @@
   <tbody>
     <tr>
       <td class="left">sigType</td>
-      <td class="left">supported legacy RSA signature types  - see <a href="#SP800-131A">[SP800-131A]</a>, Section 5</td>
+      <td class="left">supported RSA legacy signature types  - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
+      <td class="left">value</td>
+      <td class="left">one of {"ANSX9.31", "PKCS1v1.5", "PSS"}</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">capSigType</td>
+      <td class="left">RSA legacy signature verification parameters  - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"ANSX9.31", "PKCS1v1.5", "PSS"}</td>
+      <td class="left">modulo, hashAlgs, and saltLens (when sigType is PSS)</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1232,9 +1256,9 @@
     </tr>
     <tr>
       <td class="left">modulo</td>
-      <td class="left">supported RSA moduli for signature verification - see <a href="#SP800-131A">[SP800-131A]</a></td>
-      <td class="left">array</td>
-      <td class="left">any non-empty subset of {1024, 1536, 2048, 3072, 4096}</td>
+      <td class="left">supported RSA modulo for signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5</td>
+      <td class="left">value</td>
+      <td class="left">any one of the supported modulo sizes {2048, 3072, 4096}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1246,9 +1270,9 @@
     </tr>
     <tr>
       <td class="left">hashAlgs</td>
-      <td class="left">supported hash algorithms for signature verification - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
+      <td class="left">supported hash algorithms for this sigType and modulo - see <a href="#SP800-131A">[SP800-131A]</a>, Section 9</td>
       <td class="left">array</td>
-      <td class="left">any non-empty subset of {"SHA-1", "SHA-256", "SHA-384", "SHA-512"}</td>
+      <td class="left">any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</td>
       <td class="left">No</td>
     </tr>
     <tr>
@@ -1260,23 +1284,21 @@
     </tr>
     <tr>
       <td class="left">saltLens</td>
-      <td class="left">supported salt lengths for PKCS1PSS signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
+      <td class="left">supported salt lengths for PSS signature verification - see <a href="#FIPS186-4">[FIPS186-4]</a>, Section 5.5. See also note below.</td>
       <td class="left">array</td>
       <td class="left">array of values for each hash algorithm used subject to the constraint in the note below.</td>
       <td class="left">Yes</td>
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.2.4.4.p.7">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
+<p id="rfc.section.2.4.4.p.4">Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</p>
 <h1 id="rfc.section.2.4.5"><a href="#rfc.section.2.4.5">2.4.5.</a> <a href="#mode_componentSigPrimitive" id="mode_componentSigPrimitive">The componentSigPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.5.p.1">The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <a href="#RFC3447">[RFC3447]</a>) is advertised as a JSON object within the array of 'modeSpecs' value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server.  Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability.  See <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for 'msg' and 'n'.  See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.5.p.2">Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</p>
+<p id="rfc.section.2.4.5.p.1">The RSA componentSigPrimitive mode capabilities (otherwise known as RSASP1 in <a href="#RFC3447">[RFC3447]</a>) are advertised as JSON objects within the array of 'algSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server.  Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability.  See <a href="#app-testcomponentsigprimitive-ex">Appendix B.5</a> for additional details on constraints for 'msg' and 'n'.  See the ACVP specification for details on the registration message.</p>
 <h1 id="rfc.section.2.4.6"><a href="#rfc.section.2.4.6">2.4.6.</a> <a href="#mode_componentDecPrimitive" id="mode_componentDecPrimitive">The componentDecPrimitive Mode Capabilities</a></h1>
-<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
+<p id="rfc.section.2.4.6.p.1">The RSA componentDecPrimitive mode capabilities are advertised as JSON objects within the array of 'algSpecs' as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <a href="#SP800-56B">[SP800-56B]</a>, Section 7.1.2 for details.</p>
 <p id="rfc.section.2.4.6.p.2">In testing, only 'msg' is supplied by the ACVP server.  The client is responsible for generating RSA key pairs of modulus 'n', private key 'd', and calculates 's'.  Only 2048-bit RSA keys are allowed for this capability. See <a href="#app-testcomponentdecprimitive-ex">Appendix B.6</a> for additional details on constraints for 'msg' and 'n'. The client provides the public exponent 'e', modulus 'n', the private key 'd' and the computed result 's' in its response to the ACVP - see <a href="#app-componentdec-results-ex">Appendix C.6</a> .  The client must first check if  '0 &lt; msg &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 'msg' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.</p>
-<p id="rfc.section.2.4.6.p.3">Each RSA componentDecPrimitive mode capability is advertised as a self-contained JSON object.</p>
 <h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
-<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm, such as Hash_DRBG, etc.  This section describes the JSON schema for a test vector set used with DRBG algorithms.</p>
+<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed by the client and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm and mode, such as {"algorithm": "RSA, "mode": "sigGen"}, etc.  This section describes the JSON schema for test vector sets used with the RSA algorithm and modes.</p>
 <p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
 <div id="rfc.table.11"/>
 <div id="vs_top_table"/>
@@ -1807,28 +1829,24 @@
 <pre>
    {
       "algorithm": "RSA",
+      "mode": "keyGen",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-              "mode": "keyGen",
-              "capSpecs" :  {
-                      "pubExp" : "fixed",
-                      "fixedPubExpVal" : "010001",
-                      "infoGeneratedByServer": true,
-                      "randPQ" : "B.3.2",
-                      "capProvPrime" : 
-                            [
-                                {   "modulo" : 2048,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 3072,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 4096,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                            ]
-                      }
-                }
-          }
+         {  "pubExp" : "fixed",
+            "fixedPubExpVal" : "010001",
+            "infoGeneratedByServer": true,
+            "randPQ" : "B.3.2",
+            "capProvPrime" : 
+              [
+                {   "modulo" : 2048,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                {   "modulo" : 3072,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                {   "modulo" : 4096,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+              ]
+         }
       ]
    }
 </pre>
@@ -1839,36 +1857,22 @@
 <pre>
    {
     "algorithm":"RSA",
-    "prereqVals":[
-      {
-        "algorithm":"DRBG",
-        "valValue":"123456"
-      },
-      {
-        "algorithm":"SHA",
-        "valValue":"7890"
-      }
-    ],
-    "algSpecs":[
-      {
-        "modeSpecs": {
-          "mode":"keyGen",
-          "capSpecs": {
-            "pubExp": "fixed",
-            "fixedPubExpVal":"010001",
-            "randPQ": "B.3.3",
-            "capProbPrime":[{
-              "modulo": 2048,
-              "primeTest":["tblC2"]
-            },
-            {
-              "modulo": 3072,
-              "primeTest":["tblC2", "tblC3"]
-            }]
-          }
+    "mode":"keyGen",
+    "prereqVals":[{"algorithm":"DRBG", "valValue":"123456"}, {"algorithm":"SHA", "valValue":"7890"}],
+    "algSpecs":
+    [
+       {  "pubExp": "fixed",
+          "fixedPubExpVal":"010001",
+          "randPQ": "B.3.3",
+          "capProbPrime":
+            [
+              {  "modulo": 2048,
+                 "primeTest":["tblC2"]},
+              {  "modulo": 3072,
+                 "primeTest":["tblC2", "tblC3"]}
+            ]
         }
-      }
-    ]
+     ]
   }
 </pre>
 <p class="figure"></p>
@@ -1878,31 +1882,27 @@
 <pre>
    {
       "algorithm": "RSA",
-       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
+      "mode": "keyGen",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-           "mode": "keyGen",
-           "capSpecs" : {
-               "pubExp" : "fixed",
-               "fixedPubExpVal" : "010001",
-               "infoGeneratedByServer": false,
-               "randPQ" : "B.3.5",
-               "capsProvProbPrime" : 
-                    [
-                        {"modulo" : 2048,
-                         "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
-                         "primeTest": ["tblC2", "tblC3"]},
-                       {"modulo" : 3072,
-                         "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
-                         "primeTest": ["tblC2"]},
-                       {"modulo" : 4096,
-                         "hashAlgs" : ["SHA-512"],
-                         "primeTest": ["tblC3"]}
-                    ]
-              }
-          }
-        }
+         {  "pubExp" : "fixed",
+            "fixedPubExpVal" : "010001",
+            "infoGeneratedByServer": false,
+            "randPQ" : "B.3.5",
+            "capsProvProbPrime" : 
+              [
+                { "modulo" : 2048,
+                  "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                  "primeTest": ["tblC2", "tblC3"]},
+                { "modulo" : 3072,
+                  "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                  "primeTest": ["tblC2"]},
+                { "modulo" : 4096,
+                  "hashAlgs" : ["SHA-512"],
+                  "primeTest": ["tblC3"]}
+              ]
+         }
       ]
    }
 </pre>
@@ -1912,44 +1912,34 @@
 <pre>
    {
       "algorithm": "RSA",
+      "mode": "sigGen",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "ANSX9.31",
-                  "capSigType" :
-                  [
-                      {"modulo" : 2048,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 3072,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 4096,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-        }},
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "PKCS1v1.5",
-                  "capSigType" :
-                  [
-                      {"modulo" : 2048,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 3072,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 4096,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-         }},
-        {"modeSpecs" : {
-            "mode": "sigGen",
-            "capSpecs" : {
-                "sigType" : "PSS",
-                "capSigType" :
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+                [
+                    { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                 ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                    { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                 ]
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
                 [
                     { "modulo" : 2048,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
@@ -1961,8 +1951,7 @@
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]}
                 ]
-            }
-         }}
+         }
       ]
    }
 </pre>
@@ -1972,75 +1961,105 @@
 <pre>
    {
       "algorithm": "RSA",
+      "mode": "sigVer",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" : 
       [
-        {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-               
-                 "sigType" : "ANSX9.31",
-                 "capSigType" :
-                [
-                  {"modulo" : 2048,
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+               [
+                  { "modulo" : 2048,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 3072,
+                  { "modulo" : 3072,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 4096,
+                  { "modulo" : 4096,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
                ]
-            }
-          }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1v1.5",
-                 "capSigType" :
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
                 [
-                  {"modulo" : 2048,
+                  { "modulo" : 2048,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 3072,
+                  { "modulo" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 4096,
+                  { "modulo" : 4096,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
                 ]
-            }
-         }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                  [
-                    { "modulo" : 2048,
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]},
-                    { "modulo" : 3072,
+                  { "modulo" : 3072,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]},
-                    { "modulo" : 4096,
+                  { "modulo" : 4096,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]}
                  ]
-            }
-       }}
-    ]
+          }
+      ]
    }
 </pre>
 <p class="figure"></p>
 <h1 id="rfc.appendix.A.4"><a href="#rfc.appendix.A.4">A.4.</a> <a href="#app-cap-legacysigverex" id="app-cap-legacysigverex">Example RSA legacySigVer Capabilities JSON Objects</a></h1>
-<p id="rfc.section.A.4.p.1">The format and structure of the RSA legacySigVer capabilities JSON objects follow very closely those of the RSA sigVer capabilties JSON objects with the obvious changes from moduloSigVer, hashSigVer and saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer and the corresponding parameter ranges adjustments.</p>
+<p id="rfc.section.A.4.p.1">The following is an example JSON object advertising support for RSA legacySigVer according to <a href="#FIPS186-4">[FIPS186-4]</a>.</p>
+<pre>
+   {
+      "algorithm": "RSA",
+      "mode": "legacySigVer",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
+      "algSpecs" : 
+      [
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+               [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+               ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                ]
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]}
+                 ]
+          }
+      ]
+   }
+</pre>
+<p class="figure"></p>
 <h1 id="rfc.appendix.A.5"><a href="#rfc.appendix.A.5">A.5.</a> <a href="#app-cap-componentsigverex" id="app-cap-componentsigverex">Example componentSigPrimitive Capabilities JSON Objects</a></h1>
 <p id="rfc.section.A.5.p.1">The following is an example JSON object advertising support for RSA componentSigPrimitive according to <a href="#FIPS186-4">[FIPS186-4]</a>.</p>
 <pre>
    {
       "algorithm": "RSA",
-      "algSpecs" : 
-      [
-       {"modeSpecs" : {
-           "mode": "componentSigPrimitive"
-         }}
-      ]
+      "mode": "componentSigPrimitive"
    }
 </pre>
 <p class="figure"></p>
@@ -2049,13 +2068,14 @@
 <pre>
    {
       "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" : 
-      [
-        {"modeSpecs" : {
-            "mode": "componentDecPrimitive"
-         }}
-      ]
+      "mode": "componentDecPrimitive",
+      "prereqVals": 
+        [
+            {"algorithm": "DRBG", "valValue": "123456"}, 
+            {"algorithm": "DRBG", "valValue": "654321"}, 
+            {"algorithm": "SHA", "valValue": "7890"}
+        ],
+      "algSpecs" : [{}]
    }
 </pre>
 <p class="figure"></p>
@@ -2068,9 +2088,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1133,
      "algorithm": "RSA",
+     "mode": "keyGen",
      "testGroups" : [
              {           
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.2",
@@ -2086,7 +2106,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.2",
@@ -2102,7 +2121,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.4",
@@ -2118,7 +2136,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.4",
@@ -2134,7 +2151,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.5",
@@ -2150,7 +2166,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.5",
@@ -2166,7 +2181,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.6",
@@ -2182,7 +2196,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.6",
@@ -2198,7 +2211,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -2220,7 +2232,6 @@
                  ]
              },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -2235,7 +2246,6 @@
                  ]
              },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -2257,7 +2267,6 @@
                  ]
              },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -2271,9 +2280,9 @@
                     }
                  ]
              }
-     ]
-   }
- ]
+         ]
+      }
+   ]
 </pre>
 <p class="figure"></p>
 <p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table">Table 15</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the server validates that this pair matches the requirements.</p>
@@ -2283,9 +2292,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
+      "mode": "sigGen",
       "testGroups" : [
              {
-                 "mode": "sigGen",
                  "sigType" : "ANSX9.31",
                  "hashAlg" : "SHA-256",
                  "modulo" : 2048,
@@ -2297,7 +2306,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType": "ANSX9.31",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -2309,7 +2317,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -2320,8 +2327,7 @@
                    }
                 ]
              },
-             {
-                "mode": "sigGen",
+             {,
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -2333,7 +2339,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -2346,7 +2351,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -2369,9 +2373,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
+      "mode": "sigVer",
       "testGroups" : [
              {
-                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
                  "hashAlg" : "SHA-256",
                  "modulo" : 2048,
@@ -2386,7 +2390,6 @@
                  ]
              },
              {
-                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA-256",
@@ -2401,7 +2404,6 @@
                  ]
              },
              {
-                 "mode": "sigVer",
                  "sigType" : "PKCS1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -2416,7 +2418,6 @@
                  ]
              },
              {
-                "mode": "sigVer",
                 "sigType" : "PKCS1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-256",
@@ -2431,7 +2432,6 @@
                  ]
              },
              {
-                 "mode": "sigVer",
                  "sigType" : "PSS",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -2446,7 +2446,6 @@
                  ]
              },
              {
-                "mode": "sigVer",
                 "sigType" : "PSS",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-512",
@@ -2460,8 +2459,8 @@
                     }
                  ]
              }
-       ]
-    }
+          ]
+      }
   ]
 
 </pre>
@@ -2475,9 +2474,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
+      "mode": "componentSigPrimitive",
       "testGroups" : [
              {           
-                 "mode": "componentSigPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -2493,7 +2492,7 @@
                     }
                  ]
              }
-       ]
+        ]
     }
   ]
 </pre>
@@ -2505,9 +2504,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
+      "mode": "componentDecPrimitive",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -2533,6 +2532,7 @@
                 { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "algorithm": "RSA",
+                    "mode": keyGen,
                     "testResults": [
                     {
                       "tcId" : 1111,
@@ -2746,6 +2746,7 @@
                 { "acvVersion": "0.4" },
                 { "vsId": 1163,
                   "algorithm": "RSA",
+                  "mode": "sigGen",
                   "testResults": [
                     {
                       "tcId" : 1165,
@@ -2795,6 +2796,7 @@
     { "acvVersion": "0.4" },
     { "vsId": 1173,
       "algorithm": "RSA",
+      "mode": "sigVer",
       "testResults" : [
               {
                 "tcId" : 1174,
@@ -2832,8 +2834,9 @@
 <pre>
 [
     { "acvVersion": "0.4" },
-    { "vsId": 1193,
+    { "vsId": 47,
       "algorithm": "RSA",
+      "mode": "componentSigPrimitive",
       "testResults" : [
                 {
                  "tcId" : 1194,
@@ -2853,8 +2856,9 @@
 <pre>
 [
     { "acvVersion": "0.4" },
-    { "vsId": 1194,
+    { "vsId": 48,
       "algorithm": "RSA",
+            "mode": "componentDecPrimitive",
       "testResults" : [
              {           
                 "tcId" : 1196,

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -2,10 +2,10 @@
 
 
 
-TBD                                                     A. Vassilev, Ed.
+TBD                                                   A.V. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
 Intended status: Informational                                  May 2017
-Expires: November 2, 2017
+Expires: November 02, 2017
 
 
             ACVP RSA Algorithm Validation JSON Specification
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 2, 2017.
+   This Internet-Draft will expire on November 02, 2017.
 
 Copyright Notice
 
@@ -49,84 +49,83 @@ Copyright Notice
    the Trust Legal Provisions and are provided without warranty as
    described in the Simplified BSD License.
 
+Table of Contents
 
 
 
-
-Vassilev                Expires November 2, 2017                [Page 1]
+Vassilev               Expires November 02, 2017                [Page 1]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
      1.2.  Testing scope . . . . . . . . . . . . . . . . . . . . . .   3
-   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   4
+   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
      2.1.  Supported RSA Algorithm modes . . . . . . . . . . . . . .   4
      2.2.  Required Prerequisite Algorithms for RSA Mode Validations   4
      2.3.  Supported RSA Capabilities  . . . . . . . . . . . . . . .   5
      2.4.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   6
-       2.4.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   7
+       2.4.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   6
          2.4.1.1.  keyGen With Provable Primes or Provable Primes
                    with Conditions Capabilities  . . . . . . . . . .   7
          2.4.1.2.  keyGen With Probable Primes Capabilities  . . . .   8
          2.4.1.3.  keyGen With Both Provable and Probable Primes
-                   With Conditions . . . . . . . . . . . . . . . . .  10
-         2.4.1.4.  keyGen Full Set Of Capabilities . . . . . . . . .  11
-       2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  13
-         2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  13
-       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  14
-         2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  15
-       2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  16
-       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  17
-       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  18
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  18
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  19
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  20
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  20
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  23
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  24
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  24
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  24
-   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  24
+                   With Conditions . . . . . . . . . . . . . . . . .   9
+         2.4.1.4.  keyGen Full Set Of Capabilities . . . . . . . . .  10
+       2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  12
+         2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  12
+       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  13
+         2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  14
+       2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  15
+       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  16
+       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  16
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  17
+     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  18
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  18
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  19
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  22
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  22
+   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  23
      A.1.  Example keyGen with Provable Primes and Provable Primes
-           with Conditions Capabilities JSON Objects . . . . . . . .  25
+           with Conditions Capabilities JSON Objects . . . . . . . .  23
        A.1.1.  Example keyGen with Probable Primes Capabilities JSON
-               Object  . . . . . . . . . . . . . . . . . . . . . . .  25
+               Object  . . . . . . . . . . . . . . . . . . . . . . .  24
        A.1.2.  Example keyGen with Provable Conditional Primes with
-               Probable Factors Capabilities JSON Object . . . . . .  26
-     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  27
-     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  28
-     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  30
-     A.5.  Example componentSigPrimitive Capabilities JSON Objects .  30
-     A.6.  Example componentDecPrimitive Capabilities JSON Objects .  30
-   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  31
-     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  31
-     B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  35
-     B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  37
+               Probable Factors Capabilities JSON Object . . . . . .  25
+     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  26
+     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  27
+     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  28
+     A.5.  Example componentSigPrimitive Capabilities JSON Objects .  28
+     A.6.  Example componentDecPrimitive Capabilities JSON Objects .  29
+   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  29
+     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  29
+     B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  34
+     B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  36
+     B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  38
 
 
 
-Vassilev                Expires November 2, 2017                [Page 2]
+Vassilev               Expires November 02, 2017                [Page 2]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-     B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  39
      B.5.  Example Test Vectors for componentSigPrimitive JSON
-           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  39
+           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  38
      B.6.  Example Test Vectors for componentDecPrimitive JSON
-           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  40
-   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  41
-     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  41
-     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  46
-     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  47
-     C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  49
-     C.5.  Example componentSigPrimitive Test Results JSON Objects .  49
-     C.6.  Example componentDecPrimitive Test Results JSON Objects .  49
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  50
+           Objects . . . . . . . . . . . . . . . . . . . . . . . . .  39
+   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  39
+     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  39
+     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  44
+     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  45
+     C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  46
+     C.5.  Example componentSigPrimitive Test Results JSON Objects .  46
+     C.6.  Example componentDecPrimitive Test Results JSON Objects .  46
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  47
 
 1.  Introduction
 
@@ -160,17 +159,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
    testing of the five different methods for key generation in
    [FIPS186-4], Appendix B.3.
 
+2.  Capabilities Registration
 
 
 
 
 
-Vassilev                Expires November 2, 2017                [Page 3]
+Vassilev               Expires November 02, 2017                [Page 3]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
-
-2.  Capabilities Registration
 
    ACVP requires cryptographic modules to register their capabilities.
    This allows the cryptographic module to advertise support for
@@ -202,29 +200,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    Each RSA Mode implementation relies on other cryptographic primitives
    (algorithms) - see [FIPS186-4].  For example, a keyGen implementation
-   uses underlying DRBG and hash algorithms.  In some case, a single RSA
-   Mode implementation may use several primitives of the same type.  For
-   example, two different DRBG implementations may be used in the keyGen
-   algorithms in Appendix B.3.3 in [FIPS186-4], one in step 4.2 and
-   another in step 5.2.  Each of these underlying algorithm primitives
-   must be validated, either separately or as part of the same
-   submission.  ACVP provides a mechanism for specifying the required
-   prerequisites:
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017                [Page 4]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
+   uses underlying DRBG and hash algorithms.  In some cases, a single
+   RSA Mode implementation may use several primitives of the same type.
+   For example, two different DRBG implementations may be used in the
+   keyGen algorithms in Appendix B.3.3 in [FIPS186-4], one in step 4.2
+   and another in step 5.2.  Each of these underlying algorithm
+   primitives must be validated, either separately or as part of the
+   same submission.  ACVP provides a mechanism for specifying the
+   required prerequisites:
 
    +--------------+--------------+--------------+-----------+----------+
    | JSON Value   | Description  | JSON type    | Valid     | Optional |
@@ -235,6 +218,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              | algorithm    |              |           |          |
    |              |              |              |           |          |
    | valValue     | algorithm    | value        | actual    | No       |
+
+
+
+Vassilev               Expires November 02, 2017                [Page 4]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    |              | validation   |              | number,   |          |
    |              | number       |              | e.g.      |          |
    |              |              |              | "123456", |          |
@@ -266,58 +257,47 @@ Internet-Draft                RSA Alg JSON                      May 2017
    object.  The following JSON values are used for RSA algorithm
    capabilities:
 
+   +------------+--------------+----------------+-----------+----------+
+   | JSON Value | Description  | JSON type      | Valid     | Optional |
+   |            |              |                | Values    |          |
+   +------------+--------------+----------------+-----------+----------+
+   | algorithm  | The RSA      | value          | "RSA"     | No       |
+   |            | algorithm to |                |           |          |
+   |            | be validated |                |           |          |
+   |            |              |                |           |          |
+   | prereqVals | The          | array of       | array     | No       |
+   |            | prerequisite | prereqAlgVal   |           |          |
+   |            | algorithm    | objects - see  |           |          |
+   |            | validations  | Section 2.2    |           |          |
+   |            |              |                |           |          |
+   | capSpecs   | The          | an array of    | array     | No       |
+   |            | capabilities | objects        |           |          |
+   |            | of a         | specific to    |           |          |
+   |            | particular   | the mode being |           |          |
 
 
 
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017                [Page 5]
+Vassilev               Expires November 02, 2017                [Page 5]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +------------+--------------+--------------+-------------+----------+
-   | JSON Value | Description  | JSON type    | Valid       | Optional |
-   |            |              |              | Values      |          |
-   +------------+--------------+--------------+-------------+----------+
-   | algorithm  | The RSA      | value        | "RSA"       | No       |
-   |            | algorithm to |              |             |          |
-   |            | be validated |              |             |          |
-   |            |              |              |             |          |
-   | prereqVals | The          | array of     | array       | No       |
-   |            | prerequisite | prereqAlgVal |             |          |
-   |            | algorithm    | objects -    |             |          |
-   |            | validations  | see Section  |             |          |
-   |            |              | 2.2          |             |          |
-   |            |              |              |             |          |
-   | capSpecs   | The          | an array of  | array       | No       |
-   |            | capabilities | objects      |             |          |
-   |            | of a         | specific to  |             |          |
-   |            | particular   | the mode     |             |          |
-   |            | RSA mode     | being        |             |          |
-   |            |              | specified    |             |          |
-   |            |              |              |             |          |
-   | modeSpecs  | The RSA mode | an object    | object      | No       |
-   |            | and its      | with "mode"  |             |          |
-   |            | capabilities | and          |             |          |
-   |            |              | "capSpecs"   |             |          |
-   |            |              | properties   |             |          |
-   |            |              |              |             |          |
-   | algSpecs   | Array of     | array of     | See Table 1 | No       |
-   |            | modeSpecs    | modeSpecs    | and Section |          |
-   |            |              | objects,     | 2.4         |          |
-   |            |              | each         |             |          |
-   |            |              | identified   |             |          |
-   |            |              | uniquely by  |             |          |
-   |            |              | the "mode"   |             |          |
-   |            |              | property     |             |          |
-   +------------+--------------+--------------+-------------+----------+
+   |            | RSA mode     | specified      |           |          |
+   |            |              |                |           |          |
+   | modeSpecs  | The RSA mode | an object with | object    | No       |
+   |            | and its      | "mode" and     |           |          |
+   |            | capabilities | "capSpecs"     |           |          |
+   |            |              | properties     |           |          |
+   |            |              |                |           |          |
+   | algSpecs   | Array of     | array of       | See Table | No       |
+   |            | modeSpecs    | modeSpecs      | 1 and     |          |
+   |            |              | objects, each  | Section   |          |
+   |            |              | identified     | 2.4       |          |
+   |            |              | uniquely by    |           |          |
+   |            |              | the "mode" and |           |          |
+   |            |              | required       |           |          |
+   |            |              | properties     |           |          |
+   +------------+--------------+----------------+-----------+----------+
 
               Table 3: RSA Algorithm Capabilities JSON Values
 
@@ -329,15 +309,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    is an array of individual JSON objects corresponding to a particular
    RSA mode defined in this section.  The 'modeSpecs' value is part of
    the 'capability_exchange' element of the ACVP JSON registration
-
-
-
-
-Vassilev                Expires November 2, 2017                [Page 6]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    message.  See the ACVP specification for details on the registration
    message.
 
@@ -348,15 +319,24 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    The RSA keyGen mode capabilities are advertised as an array of JSON
    objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
+   registration message.  as part of the 'capability_exchange' element
+   of the ACVP JSON registration message.  See the ACVP specification
+   for details on the registration message.
 
    Each RSA keyGen mode capability is advertised as a self-contained
    JSON object.
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
+
+
+
+
+
+Vassilev               Expires November 02, 2017                [Page 6]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 2.4.1.1.  keyGen With Provable Primes or Provable Primes with Conditions
           Capabilities
@@ -365,63 +345,61 @@ Internet-Draft                RSA Alg JSON                      May 2017
    with conditions capabilities may be advertised by the ACVP compliant
    crypto module:
 
-   +-------------+-------------+-----------+----------------+----------+
-   | JSON value  | Description | JSON type | Valid values   | Optional |
-   +-------------+-------------+-----------+----------------+----------+
-   | modulo      | Supported   | value     | 2048, 3072, or | Yes      |
-   |             | RSA moduli  |           | 4096           |          |
-   |             | for         |           |                |          |
-   |             | provable    |           |                |          |
-   |             | prime       |           |                |          |
-   |             | generation  |           |                |          |
-   |             | - see [FIPS |           |                |          |
-   |             | 186-4],     |           |                |          |
-   |             | Appendix    |           |                |          |
-   |             | B.3.2 or    |           |                |          |
-   |             | Appendix    |           |                |          |
-   |             | B.3.4       |           |                |          |
-   |             |             |           |                |          |
-   | hashAlg     | Supported   | array     | any non-empty  | Yes      |
-   |             | hash        |           | subset of      |          |
-   |             | algorithms  |           | {"SHA-1",      |          |
-   |             | for         |           | "SHA-224",     |          |
-   |             | provable    |           | "SHA-256",     |          |
+   +--------------+--------------+-----------+---------------+---------+
+   | JSON value   | Description  | JSON type | Valid values  | Optiona |
+   |              |              |           |               | l       |
+   +--------------+--------------+-----------+---------------+---------+
+   | modulo       | Supported    | value     | 2048, 3072,   | Yes     |
+   |              | RSA moduli   |           | or 4096       |         |
+   |              | for provable |           |               |         |
+   |              | prime        |           |               |         |
+   |              | generation - |           |               |         |
+   |              | see          |           |               |         |
+   |              | [FIPS186-4], |           |               |         |
+   |              | Appendix     |           |               |         |
+   |              | B.3.2 or     |           |               |         |
+   |              | Appendix     |           |               |         |
+   |              | B.3.4        |           |               |         |
+   |              |              |           |               |         |
+   | hashAlg      | Supported    | array     | any non-empty | Yes     |
+   |              | hash         |           | subset of     |         |
+   |              | algorithms   |           | {"SHA-1",     |         |
+   |              | for provable |           | "SHA-224",    |         |
+   |              | prime        |           | "SHA-256",    |         |
+   |              | generation - |           | "SHA-384",    |         |
+   |              | see          |           | "SHA-512", "S |         |
+   |              | [FIPS186-4], |           | HA-512/224",  |         |
+   |              | Appendix     |           | "SHA-512/256" |         |
+   |              | B.3.2 or     |           | }             |         |
+   |              | Appendix     |           |               |         |
+   |              | B.3.4        |           |               |         |
+   |              |              |           |               |         |
+   | singleCap    | A testable   | object    | see above     | Yes     |
+   |              | combination  | with      |               |         |
+   |              | of modulus   | "modulo"  |               |         |
+   |              | and hash     | and       |               |         |
+   |              | values       | "hashAlg" |               |         |
+   |              |              | propertie |               |         |
+   |              |              | s         |               |         |
+   |              |              |           |               |         |
+   | capProvPrime | Supported    | array     | "singleCap"   | Yes     |
+   |              | capabilities |           | objects, see  |         |
+   |              | for provable |           | above for     |         |
+   |              | prime        |           | possible      |         |
 
 
 
-Vassilev                Expires November 2, 2017                [Page 7]
+Vassilev               Expires November 02, 2017                [Page 7]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |             | prime       |           | "SHA-384",     |          |
-   |             | generation  |           | "SHA-512",     |          |
-   |             | - see [FIPS |           | "SHA-512/224", |          |
-   |             | 186-4],     |           | "SHA-512/256"} |          |
-   |             | Appendix    |           |                |          |
-   |             | B.3.2 or    |           |                |          |
-   |             | Appendix    |           |                |          |
-   |             | B.3.4       |           |                |          |
-   |             |             |           |                |          |
-   | singleCap   | A testable  | object    | see above      | Yes      |
-   |             | combination | with      |                |          |
-   |             | of modulus  | "modulo"  |                |          |
-   |             | and hash    | and       |                |          |
-   |             | values      | "hashAlg" |                |          |
-   |             |             | propertie |                |          |
-   |             |             | s         |                |          |
-   |             |             |           |                |          |
-   | capProvPrim | Supported c | array     | "singleCap"    | Yes      |
-   | e           | apabilities |           | objects, see   |          |
-   |             | for         |           | above for      |          |
-   |             | provable    |           | possible       |          |
-   |             | prime       |           | values         |          |
-   |             | generation  |           |                |          |
-   |             | or provable |           |                |          |
-   |             | prime with  |           |                |          |
-   |             | conditions  |           |                |          |
-   |             | generation  |           |                |          |
-   +-------------+-------------+-----------+----------------+----------+
+   |              | generation   |           | values        |         |
+   |              | or provable  |           |               |         |
+   |              | prime with   |           |               |         |
+   |              | conditions   |           |               |         |
+   |              | generation   |           |               |         |
+   +--------------+--------------+-----------+---------------+---------+
 
     Table 4: Supported RSA keyGen moduli and hash options for provable
            primes or provable primes with conditions JSON Values
@@ -432,79 +410,59 @@ Internet-Draft                RSA Alg JSON                      May 2017
    with conditions capabilities may be advertised by the ACVP compliant
    crypto module:
 
+   +--------------+--------------+-------------+-----------+-----------+
+   | JSON value   | Description  | JSON type   | Valid     | Optional  |
+   |              |              |             | values    |           |
+   +--------------+--------------+-------------+-----------+-----------+
+   | modulo       | supported    | value       | 2048,     | Yes       |
+   |              | RSA moduli   |             | 3072 or   |           |
+   |              | for probable |             | 4096      |           |
+   |              | prime        |             |           |           |
+   |              | generation - |             |           |           |
+   |              | see          |             |           |           |
+   |              | [FIPS186-4], |             |           |           |
+   |              | Appendix     |             |           |           |
+   |              | B.3.3 or     |             |           |           |
+   |              | Appendix     |             |           |           |
+   |              | B.3.5        |             |           |           |
+   |              |              |             |           |           |
+   | primeTest    | Primality    | array       | any non-  | Yes       |
+   |              | test rounds  |             | empty set |           |
+   |              | of Miller-   |             | of        |           |
+   |              | Rabin from   |             | {"tblC2", |           |
+   |              | Table C.2 or |             | "tblC3"}  |           |
+   |              | Table C.3 in |             |           |           |
+   |              | [FIPS186-4], |             |           |           |
+   |              | Appendix C.3 |             |           |           |
+   |              |              |             |           |           |
+   | singleCap    | A testable   | object with | see above | Yes       |
+   |              | combination  | "modulo"    |           |           |
+   |              | of modulus   | and         |           |           |
+   |              | and          | "primeTest" |           |           |
+   |              | primality    | properties  |           |           |
+   |              | test rounds  |             |           |           |
+   |              |              |             |           |           |
 
 
 
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017                [Page 8]
+Vassilev               Expires November 02, 2017                [Page 8]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   +--------------+---------------+-------------+-----------+----------+
-   | JSON value   | Description   | JSON type   | Valid     | Optional |
-   |              |               |             | values    |          |
-   +--------------+---------------+-------------+-----------+----------+
-   | modulo       | supported RSA | value       | 2048,     | Yes      |
-   |              | moduli for    |             | 3072 or   |          |
-   |              | probable      |             | 4096      |          |
-   |              | prime         |             |           |          |
-   |              | generation -  |             |           |          |
-   |              | see           |             |           |          |
-   |              | [FIPS186-4],  |             |           |          |
-   |              | Appendix      |             |           |          |
-   |              | B.3.3 or      |             |           |          |
-   |              | Appendix      |             |           |          |
-   |              | B.3.5         |             |           |          |
-   |              |               |             |           |          |
-   | primeTest    | Primality     | array       | any non-  | Yes      |
-   |              | test rounds   |             | empty set |          |
-   |              | of Miller-    |             | of        |          |
-   |              | Rabin from    |             | {"tblC2", |          |
-   |              | Table C.2 or  |             | "tblC3"}  |          |
-   |              | Table C.3 in  |             |           |          |
-   |              | [FIPS186-4],  |             |           |          |
-   |              | Appendix C.3  |             |           |          |
-   |              |               |             |           |          |
-   | singleCap    | A testable    | object with | see above | Yes      |
-   |              | combination   | "modulo"    |           |          |
-   |              | of modulus    | and         |           |          |
-   |              | and primality | "primeTest" |           |          |
-   |              | test rounds   | properties  |           |          |
-   |              |               |             |           |          |
-   | capProbPrime | supported     | object with | see above | Yes      |
-   |              | capabilities  | "singleCap" | for       |          |
-   |              | for probable  | properties  | possible  |          |
-   |              | prime         |             | values    |          |
-   |              | generation or |             |           |          |
-   |              | probable      |             |           |          |
-   |              | primes with   |             |           |          |
-   |              | conditions    |             |           |          |
-   |              | generation    |             |           |          |
-   +--------------+---------------+-------------+-----------+----------+
+   | capProbPrime | supported    | object with | see above | Yes       |
+   |              | capabilities | "singleCap" | for       |           |
+   |              | for probable | properties  | possible  |           |
+   |              | prime        |             | values    |           |
+   |              | generation   |             |           |           |
+   |              | or probable  |             |           |           |
+   |              | primes with  |             |           |           |
+   |              | conditions   |             |           |           |
+   |              | generation   |             |           |           |
+   +--------------+--------------+-------------+-----------+-----------+
 
     Table 5: Supported RSA keyGen moduli and primality test options for
       probable primes or probable primes with conditions JSON Values
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017                [Page 9]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 2.4.1.3.  keyGen With Both Provable and Probable Primes With Conditions
 
@@ -512,77 +470,77 @@ Internet-Draft                RSA Alg JSON                      May 2017
    with conditions capabilities may be advertised by the ACVP compliant
    crypto module:
 
-   +---------------+------------+------------+---------------+---------+
-   | JSON value    | Descriptio | JSON type  | Valid values  | Optiona |
-   |               | n          |            |               | l       |
-   +---------------+------------+------------+---------------+---------+
-   | modulo        | supported  | value      | 2048, 3072 or | Yes     |
-   |               | RSA modulo |            | 4096          |         |
-   |               | for        |            |               |         |
-   |               | provable   |            |               |         |
-   |               | primes     |            |               |         |
-   |               | with       |            |               |         |
-   |               | conditions |            |               |         |
-   |               | - see [FIP |            |               |         |
-   |               | S186-4],   |            |               |         |
-   |               | Appendix   |            |               |         |
-   |               | B.3.6      |            |               |         |
-   |               |            |            |               |         |
-   | hashAlg       | Supported  | array      | any non-empty | Yes     |
-   |               | hash       |            | subset of     |         |
-   |               | algorithms |            | {"SHA-1",     |         |
-   |               | for        |            | "SHA-224",    |         |
-   |               | provable   |            | "SHA-256",    |         |
-   |               | prime      |            | "SHA-384",    |         |
-   |               | generation |            | "SHA-512", "S |         |
-   |               | - see [FIP |            | HA-512/224",  |         |
-   |               | S186-4],   |            | "SHA-512/256" |         |
-   |               | Appendix   |            | }             |         |
-   |               | B.3.6      |            |               |         |
-   |               |            |            |               |         |
-   | primeTest     | Primality  | array      | any non-empty | Yes     |
-   |               | test       |            | subset of     |         |
-   |               | rounds of  |            | {"tblC2",     |         |
-   |               | Miller-    |            | "tblC3"}      |         |
-   |               | Rabin from |            |               |         |
-   |               | Table C.2  |            |               |         |
-   |               | or Table   |            |               |         |
-   |               | C.3 in [FI |            |               |         |
-   |               | PS186-4],  |            |               |         |
-   |               | Appendix   |            |               |         |
-   |               | C.3        |            |               |         |
-   |               |            |            |               |         |
-   | singleCap     | A testable | object     | see above     | Yes     |
-   |               | combinatio | with       |               |         |
+   +----------------+------------+-----------+--------------+----------+
+   | JSON value     | Descriptio | JSON type | Valid values | Optional |
+   |                | n          |           |              |          |
+   +----------------+------------+-----------+--------------+----------+
+   | modulo         | supported  | value     | 2048, 3072   | Yes      |
+   |                | RSA modulo |           | or 4096      |          |
+   |                | for        |           |              |          |
+   |                | provable   |           |              |          |
+   |                | primes     |           |              |          |
+   |                | with       |           |              |          |
+   |                | conditions |           |              |          |
+   |                | - see [FIP |           |              |          |
+   |                | S186-4],   |           |              |          |
+   |                | Appendix   |           |              |          |
+   |                | B.3.6      |           |              |          |
+   |                |            |           |              |          |
+   | hashAlg        | Supported  | array     | any non-     | Yes      |
+   |                | hash       |           | empty subset |          |
+   |                | algorithms |           | of {"SHA-1", |          |
+   |                | for        |           | "SHA-224",   |          |
+   |                | provable   |           | "SHA-256",   |          |
+   |                | prime      |           | "SHA-384",   |          |
+   |                | generation |           | "SHA-512", " |          |
+   |                | - see [FIP |           | SHA-512/224" |          |
+   |                | S186-4],   |           | , "SHA-512/2 |          |
+   |                | Appendix   |           | 56"}         |          |
+   |                | B.3.6      |           |              |          |
+   |                |            |           |              |          |
 
 
 
-Vassilev                Expires November 2, 2017               [Page 10]
+Vassilev               Expires November 02, 2017                [Page 9]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |               | n of       | "modulo",  |               |         |
-   |               | modulus,   | "hashAlg", |               |         |
-   |               | hash       | and "prime |               |         |
-   |               | algorithm, | Test"      |               |         |
-   |               | and        | properties |               |         |
-   |               | primality  |            |               |         |
-   |               | test       |            |               |         |
-   |               | rounds     |            |               |         |
-   |               |            |            |               |         |
-   | capProvProbPr | supported  | object     | see above for | Yes     |
-   | ime           | capabiliti | with "sing | possible      |         |
-   |               | es for     | leCap"     | values        |         |
-   |               | both       | properties |               |         |
-   |               | provable   |            |               |         |
-   |               | and        |            |               |         |
-   |               | probable   |            |               |         |
-   |               | primes     |            |               |         |
-   |               | with       |            |               |         |
-   |               | conditions |            |               |         |
-   |               | generation |            |               |         |
-   +---------------+------------+------------+---------------+---------+
+   | primeTest      | Primality  | array     | any non-     | Yes      |
+   |                | test       |           | empty subset |          |
+   |                | rounds of  |           | of {"tblC2", |          |
+   |                | Miller-    |           | "tblC3"}     |          |
+   |                | Rabin from |           |              |          |
+   |                | Table C.2  |           |              |          |
+   |                | or Table   |           |              |          |
+   |                | C.3 in [FI |           |              |          |
+   |                | PS186-4],  |           |              |          |
+   |                | Appendix   |           |              |          |
+   |                | C.3        |           |              |          |
+   |                |            |           |              |          |
+   | singleCap      | A testable | object    | see above    | Yes      |
+   |                | combinatio | with      |              |          |
+   |                | n of       | "modulo", |              |          |
+   |                | modulus,   | "hashAlg" |              |          |
+   |                | hash       | , and "pr |              |          |
+   |                | algorithm, | imeTest"  |              |          |
+   |                | and        | propertie |              |          |
+   |                | primality  | s         |              |          |
+   |                | test       |           |              |          |
+   |                | rounds     |           |              |          |
+   |                |            |           |              |          |
+   | capProvProbPri | supported  | object    | see above    | Yes      |
+   | me             | capabiliti | with "sin | for possible |          |
+   |                | es for     | gleCap" p | values       |          |
+   |                | both       | roperties |              |          |
+   |                | provable   |           |              |          |
+   |                | and        |           |              |          |
+   |                | probable   |           |              |          |
+   |                | primes     |           |              |          |
+   |                | with       |           |              |          |
+   |                | conditions |           |              |          |
+   |                | generation |           |              |          |
+   +----------------+------------+-----------+--------------+----------+
 
    Table 6: Supported RSA keyGen moduli, hash algorithms, and primality
     test options for provable and probable primes with conditions JSON
@@ -593,92 +551,92 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
-   +--------------------+-----------------+------+----------+----------+
-   | JSON Value         | Description     | JSON | Valid    | Optional |
-   |                    |                 | type | Values   |          |
-   +--------------------+-----------------+------+----------+----------+
-   | randPQ             | Key Generation  | valu | "B.3.2", | No       |
-   |                    | mode to be      | e    | "B.3.3", |          |
-   |                    | validated.      |      | "B.3.4", |          |
-   |                    | Random P and Q  |      | "B.3.5", |          |
-   |                    | primes          |      | "B.3.6"  |          |
-   |                    | generated as    |      |          |          |
-   |                    | (see            |      |          |          |
-   |                    | [FIPS186-4]):   |      |          |          |
-   |                    | provable primes |      |          |          |
-   |                    | (Appendix       |      |          |          |
-   |                    | B.3.2);         |      |          |          |
-   |                    | probable primes |      |          |          |
-   |                    | (Appendix       |      |          |          |
+   +---------------------+-----------------+-------+---------+---------+
+   | JSON Value          | Description     | JSON  | Valid   | Optiona |
+   |                     |                 | type  | Values  | l       |
 
 
 
-Vassilev                Expires November 2, 2017               [Page 11]
+Vassilev               Expires November 02, 2017               [Page 10]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |                    | B.3.3);         |      |          |          |
-   |                    | provable primes |      |          |          |
-   |                    | with conditions |      |          |          |
-   |                    | (Appendix       |      |          |          |
-   |                    | B.3.4); provabl |      |          |          |
-   |                    | e/probable      |      |          |          |
-   |                    | primes with     |      |          |          |
-   |                    | conditions      |      |          |          |
-   |                    | (Appendix       |      |          |          |
-   |                    | B.3.5);         |      |          |          |
-   |                    | probable primes |      |          |          |
-   |                    | with conditions |      |          |          |
-   |                    | (Appendix       |      |          |          |
-   |                    | B.3.6)          |      |          |          |
-   |                    |                 |      |          |          |
-   | infoGeneratedBySer | This flag       | valu | true or  | Yes      |
-   | ver                | indicates that  | e    | false    |          |
-   |                    | the server is   |      |          |          |
-   |                    | responsible for |      |          |          |
-   |                    | generating      |      |          |          |
-   |                    | inputs for Key  |      |          |          |
-   |                    | Generation      |      |          |          |
-   |                    | tests. This     |      |          |          |
-   |                    | flag is not     |      |          |          |
-   |                    | relevant to     |      |          |          |
-   |                    | KeyGen mode     |      |          |          |
-   |                    | "B.3.3" Random  |      |          |          |
-   |                    | Probable Primes |      |          |          |
-   |                    |                 |      |          |          |
-   | pubExp             | Supports fixed  | valu | "fixed"  | Yes      |
-   |                    | or random       | e    | or       |          |
-   |                    | public key      |      | "random" |          |
-   |                    | exponent e      |      |          |          |
-   |                    |                 |      |          |          |
-   | fixedPubExpVal     | The value of    | valu | hex      | Yes      |
-   |                    | the public key  | e    |          |          |
-   |                    | exponent e in   |      |          |          |
-   |                    | hex if pubExp   |      |          |          |
-   |                    | is "fixed"      |      |          |          |
-   |                    |                 |      |          |          |
-   | capProvPrimes      | Capabilities    | arra |          | Yes      |
-   |                    | for all         | y    |          |          |
-   |                    | supported       |      |          |          |
-   |                    | moduli and hash |      |          |          |
-   |                    | algorithms (see |      |          |          |
-   |                    | Table 4)        |      |          |          |
-   |                    |                 |      |          |          |
-   | modProbPrime       | See Table 5     | arra | see      | Yes      |
+   +---------------------+-----------------+-------+---------+---------+
+   | randPQ              | Key Generation  | value | "B.3.2" | No      |
+   |                     | mode to be      |       | , "B.3. |         |
+   |                     | validated.      |       | 3", "B. |         |
+   |                     | Random P and Q  |       | 3.4", " |         |
+   |                     | primes          |       | B.3.5", |         |
+   |                     | generated as    |       | "B.3.6" |         |
+   |                     | (see            |       |         |         |
+   |                     | [FIPS186-4]):   |       |         |         |
+   |                     | provable primes |       |         |         |
+   |                     | (Appendix       |       |         |         |
+   |                     | B.3.2);         |       |         |         |
+   |                     | probable primes |       |         |         |
+   |                     | (Appendix       |       |         |         |
+   |                     | B.3.3);         |       |         |         |
+   |                     | provable primes |       |         |         |
+   |                     | with conditions |       |         |         |
+   |                     | (Appendix       |       |         |         |
+   |                     | B.3.4); provabl |       |         |         |
+   |                     | e/probable      |       |         |         |
+   |                     | primes with     |       |         |         |
+   |                     | conditions      |       |         |         |
+   |                     | (Appendix       |       |         |         |
+   |                     | B.3.5);         |       |         |         |
+   |                     | probable primes |       |         |         |
+   |                     | with conditions |       |         |         |
+   |                     | (Appendix       |       |         |         |
+   |                     | B.3.6)          |       |         |         |
+   |                     |                 |       |         |         |
+   | infoGeneratedByServ | This flag       | value | true or | Yes     |
+   | er                  | indicates that  |       | false   |         |
+   |                     | the server is   |       |         |         |
+   |                     | responsible for |       |         |         |
+   |                     | generating      |       |         |         |
+   |                     | inputs for Key  |       |         |         |
+   |                     | Generation      |       |         |         |
+   |                     | tests. This     |       |         |         |
+   |                     | flag is not     |       |         |         |
+   |                     | relevant to     |       |         |         |
+   |                     | KeyGen mode     |       |         |         |
+   |                     | "B.3.3" Random  |       |         |         |
+   |                     | Probable Primes |       |         |         |
+   |                     |                 |       |         |         |
+   | pubExp              | Supports fixed  | value | "fixed" | Yes     |
+   |                     | or random       |       | or "ran |         |
+   |                     | public key      |       | dom"    |         |
+   |                     | exponent e      |       |         |         |
+   |                     |                 |       |         |         |
 
 
 
-Vassilev                Expires November 2, 2017               [Page 12]
+Vassilev               Expires November 02, 2017               [Page 11]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |                    |                 | y    | Table 5  |          |
-   |                    |                 |      |          |          |
-   | primeTest          | See Table 5     | valu | see      | Yes      |
-   |                    |                 | e    | Table 5  |          |
-   +--------------------+-----------------+------+----------+----------+
+   | fixedPubExpVal      | The value of    | value | hex     | Yes     |
+   |                     | the public key  |       |         |         |
+   |                     | exponent e in   |       |         |         |
+   |                     | hex if pubExp   |       |         |         |
+   |                     | is "fixed"      |       |         |         |
+   |                     |                 |       |         |         |
+   | capProvPrimes       | Capabilities    | array |         | Yes     |
+   |                     | for all         |       |         |         |
+   |                     | supported       |       |         |         |
+   |                     | moduli and hash |       |         |         |
+   |                     | algorithms (see |       |         |         |
+   |                     | Table 4)        |       |         |         |
+   |                     |                 |       |         |         |
+   | modProbPrime        | See Table 5     | array | see     | Yes     |
+   |                     |                 |       | Table 5 |         |
+   |                     |                 |       |         |         |
+   | primeTest           | See Table 5     | value | see     | Yes     |
+   |                     |                 |       | Table 5 |         |
+   +---------------------+-----------------+-------+---------+---------+
 
                Table 7: RSA keyGen Capabilities JSON Values
 
@@ -686,9 +644,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    The RSA sigGen mode capabilities are advertised as an array of JSON
    objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
+   registration message.  as part of the 'capability_exchange' element
+   of the ACVP JSON registration message.  See the ACVP specification
+   for details on the registration message.
 
    Each RSA sigGen mode capability is advertised as a self-contained
    JSON object.
@@ -698,72 +656,55 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 2.4.2.1.  sigGen Capabilities
 
-   The following key generation with provable primes capabilities may be
-   advertised by the ACVP compliant crypto module:
+   The following RSA signature generation capabilities may be advertised
+   by the ACVP compliant crypto module:
+
+   +----------+-----------------+--------+------------------+----------+
+   | JSON     | Description     | JSON   | Valid values     | Optional |
+   | value    |                 | type   |                  |          |
+   +----------+-----------------+--------+------------------+----------+
+   | sigType  | supported RSA   | array  | any non-empty    | No       |
+   |          | signature types |        | subset of        |          |
+   |          | - see           |        | {"ANSX9.31",     |          |
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 13]
+Vassilev               Expires November 02, 2017               [Page 12]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
- +----------+--------------------+-------+------------------+----------+
- | JSON     | Description        | JSON  | Valid values     | Optional |
- | value    |                    | type  |                  |          |
- +----------+--------------------+-------+------------------+----------+
- | sigType  | supported RSA      | array | any non-empty    | No       |
- |          | signature types  - |       | subset of        |          |
- |          | see [FIPS186-4],   |       | {"ANSX9.31",     |          |
- |          | Section 5          |       | "PKCS1v1.5",     |          |
- |          |                    |       | "PSS"}           |          |
- |          |                    |       |                  |          |
- | modulo   | supported RSA      | array | any non-empty    | No       |
- |          | moduli for         |       | subset of {2048, |          |
- |          | signature          |       | 3072, 4096}      |          |
- |          | generation - see   |       |                  |          |
- |          | [FIPS186-4],       |       |                  |          |
- |          | Section 5          |       |                  |          |
- |          |                    |       |                  |          |
- | hashAlgs | supported hash     | array | any non-empty    | No       |
- |          | algorithms for     |       | subset of        |          |
- |          | signature          |       | {"SHA-224",      |          |
- |          | generation - see   |       | "SHA-256",       |          |
- |          | [SP800-131A],      |       | "SHA-384",       |          |
- |          | Section 9          |       | "SHA-512",       |          |
- |          |                    |       | "SHA-512/224",   |          |
- |          |                    |       | "SHA-512/256"}   |          |
- |          |                    |       |                  |          |
- | saltLens | supported salt     | array | array of values  | Yes      |
- |          | lengths for        |       | for each hash    |          |
- |          | PKCS1PSS signature |       | algorithm used   |          |
- |          | generation - see   |       | subject to the   |          |
- |          | [FIPS186-4],       |       | constraint in    |          |
- |          | Section 5.5. See   |       | the note below.  |          |
- |          | also note below.   |       |                  |          |
- +----------+--------------------+-------+------------------+----------+
+   |          | [FIPS186-4],    |        | "PKCS1v1.5",     |          |
+   |          | Section 5       |        | "PSS"}           |          |
+   |          |                 |        |                  |          |
+   | modulo   | supported RSA   | array  | any non-empty    | No       |
+   |          | moduli for      |        | subset of {2048, |          |
+   |          | signature       |        | 3072, 4096}      |          |
+   |          | generation -    |        |                  |          |
+   |          | see             |        |                  |          |
+   |          | [FIPS186-4],    |        |                  |          |
+   |          | Section 5       |        |                  |          |
+   |          |                 |        |                  |          |
+   | hashAlgs | supported hash  | array  | any non-empty    | No       |
+   |          | algorithms for  |        | subset of        |          |
+   |          | signature       |        | {"SHA-224",      |          |
+   |          | generation -    |        | "SHA-256",       |          |
+   |          | see             |        | "SHA-384",       |          |
+   |          | [SP800-131A],   |        | "SHA-512",       |          |
+   |          | Section 9       |        | "SHA-512/224",   |          |
+   |          |                 |        | "SHA-512/256"}   |          |
+   |          |                 |        |                  |          |
+   | saltLens | supported salt  | array  | array of values  | Yes      |
+   |          | lengths for     |        | for each hash    |          |
+   |          | PKCS1PSS        |        | algorithm used   |          |
+   |          | signature       |        | subject to the   |          |
+   |          | generation -    |        | constraint in    |          |
+   |          | see             |        | the note below.  |          |
+   |          | [FIPS186-4],    |        |                  |          |
+   |          | Section 5.5.    |        |                  |          |
+   |          | See also note   |        |                  |          |
+   |          | below.          |        |                  |          |
+   +----------+-----------------+--------+------------------+----------+
 
      Table 8: Supported RSA sigGen moduli and hash options JSON Values
 
@@ -774,70 +715,73 @@ Internet-Draft                RSA Alg JSON                      May 2017
 2.4.3.  The sigVer Mode Capabilities
 
    The RSA sigVer mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
-
-
-
-Vassilev                Expires November 2, 2017               [Page 14]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
+   objects within the array of 'modeSpecs' as part of the
+   'capability_exchange' element of the ACVP JSON registration message.
+   See the ACVP specification for details on the registration message.
 
    Each RSA sigVer mode capability is advertised as a self-contained
    JSON object.
+
+
+
+
+Vassilev               Expires November 02, 2017               [Page 13]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
 
 2.4.3.1.  sigVer Capabilities
 
-   The following key generation with provable primes capabilities may be
+   The following RSA signature verification capabilities may be
    advertised by the ACVP compliant crypto module:
 
- +----------+--------------------+-------+------------------+----------+
- | JSON     | Description        | JSON  | Valid values     | Optional |
- | value    |                    | type  |                  |          |
- +----------+--------------------+-------+------------------+----------+
- | sigType  | supported RSA      | array | any non-empty    | No       |
- |          | signature types  - |       | subset of        |          |
- |          | see [FIPS186-4],   |       | {"ANSX9.31",     |          |
- |          | Section 5          |       | "PKCS1v1.5",     |          |
- |          |                    |       | "PSS"}           |          |
- |          |                    |       |                  |          |
- | modulo   | supported RSA      | array | any non-empty    | No       |
- |          | moduli for         |       | subset of {2048, |          |
- |          | signature          |       | 3072, 4096}      |          |
- |          | verification - see |       |                  |          |
- |          | [FIPS186-4],       |       |                  |          |
- |          | Section 5          |       |                  |          |
- |          |                    |       |                  |          |
- | hashAlgs | supported hash     | array | any non-empty    | No       |
- |          | algorithms for     |       | subset of        |          |
- |          | signature          |       | {"SHA-224",      |          |
- |          | verification - see |       | "SHA-256",       |          |
- |          | [SP800-131A],      |       | "SHA-384",       |          |
- |          | Section 9          |       | "SHA-512",       |          |
- |          |                    |       | "SHA-512/224",   |          |
- |          |                    |       | "SHA-512/256"}   |          |
- |          |                    |       |                  |          |
- | saltLens | supported salt     | array | array of values  | Yes      |
- |          | lengths for        |       | for each hash    |          |
- |          | PKCS1PSS signature |       | algorithm used   |          |
- |          | verification - see |       | subject to the   |          |
- |          | [FIPS186-4],       |       | constraint in    |          |
- |          | Section 5.5. See   |       | the note below.  |          |
- |          | also note below.   |       |                  |          |
- +----------+--------------------+-------+------------------+----------+
+   +----------+-----------------+--------+------------------+----------+
+   | JSON     | Description     | JSON   | Valid values     | Optional |
+   | value    |                 | type   |                  |          |
+   +----------+-----------------+--------+------------------+----------+
+   | sigType  | supported RSA   | array  | any non-empty    | No       |
+   |          | signature types |        | subset of        |          |
+   |          | - see           |        | {"ANSX9.31",     |          |
+   |          | [FIPS186-4],    |        | "PKCS1v1.5",     |          |
+   |          | Section 5       |        | "PSS"}           |          |
+   |          |                 |        |                  |          |
+   | modulo   | supported RSA   | array  | any non-empty    | No       |
+   |          | moduli for      |        | subset of {2048, |          |
+   |          | signature       |        | 3072, 4096}      |          |
+   |          | verification -  |        |                  |          |
+   |          | see             |        |                  |          |
+   |          | [FIPS186-4],    |        |                  |          |
+   |          | Section 5       |        |                  |          |
+   |          |                 |        |                  |          |
+   | hashAlgs | supported hash  | array  | any non-empty    | No       |
+   |          | algorithms for  |        | subset of        |          |
+   |          | signature       |        | {"SHA-224",      |          |
+   |          | verification -  |        | "SHA-256",       |          |
+   |          | see             |        | "SHA-384",       |          |
+   |          | [SP800-131A],   |        | "SHA-512",       |          |
+   |          | Section 9       |        | "SHA-512/224",   |          |
+   |          |                 |        | "SHA-512/256"}   |          |
+   |          |                 |        |                  |          |
+   | saltLens | supported salt  | array  | array of values  | Yes      |
+   |          | lengths for     |        | for each hash    |          |
+   |          | PKCS1PSS        |        | algorithm used   |          |
+   |          | signature       |        | subject to the   |          |
+   |          | verification -  |        | constraint in    |          |
+   |          | see             |        | the note below.  |          |
+   |          | [FIPS186-4],    |        |                  |          |
+   |          | Section 5.5.    |        |                  |          |
+   |          | See also note   |        |                  |          |
+   |          | below.          |        |                  |          |
+   +----------+-----------------+--------+------------------+----------+
 
      Table 9: Supported RSA sigVer moduli and hash options JSON Values
 
 
 
-
-Vassilev                Expires November 2, 2017               [Page 15]
+Vassilev               Expires November 02, 2017               [Page 14]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
@@ -850,18 +794,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
    The RSA legacySigVer mode capabilities are advertised as an array of
    JSON objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
+   registration message.  as part of the 'capability_exchange' element
+   of the ACVP JSON registration message.  See the ACVP specification
+   for details on the registration message.
 
    Each RSA legacySigVer mode capability is advertised as a self-
    contained JSON object.
 
    The RSA sigVer mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message. as part of the 'capability_exchange' element of
-   the ACVP JSON registration message.  See the ACVP specification for
-   details on the registration message.
+   objects within the array of 'modeSpecs' as part of the
+   'capability_exchange' element of the ACVP JSON registration message.
+   See the ACVP specification for details on the registration message.
 
    Each RSA legacySigVer mode capability is advertised as a self-
    contained JSON object.
@@ -869,66 +812,49 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
 
-   The following key generation with provable primes capabilities may be
+   The following RSA legacy signature verification capabilities may be
    advertised by the ACVP compliant crypto module:
 
+   +----------+-------------------+--------+----------------+----------+
+   | JSON     | Description       | JSON   | Valid values   | Optional |
+   | value    |                   | type   |                |          |
+   +----------+-------------------+--------+----------------+----------+
+   | sigType  | supported legacy  | array  | any non-empty  | No       |
+   |          | RSA signature     |        | subset of      |          |
+   |          | types  - see      |        | {"ANSX9.31",   |          |
+   |          | [SP800-131A],     |        | "PKCS1v1.5",   |          |
+   |          | Section 5         |        | "PSS"}         |          |
+   |          |                   |        |                |          |
+   | modulo   | supported RSA     | array  | any non-empty  | No       |
+   |          | moduli for        |        | subset of      |          |
+   |          | signature         |        | {1024, 1536,   |          |
+   |          | verification -    |        | 2048, 3072,    |          |
+   |          | see [SP800-131A]  |        | 4096}          |          |
+   |          |                   |        |                |          |
+   | hashAlgs | supported hash    | array  | any non-empty  | No       |
+   |          | algorithms for    |        | subset of      |          |
+   |          | signature         |        | {"SHA-1",      |          |
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 16]
+Vassilev               Expires November 02, 2017               [Page 15]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-  +----------+--------------------+-------+-----------------+----------+
-  | JSON     | Description        | JSON  | Valid values    | Optional |
-  | value    |                    | type  |                 |          |
-  +----------+--------------------+-------+-----------------+----------+
-  | sigType  | supported legacy   | array | any non-empty   | No       |
-  |          | RSA signature      |       | subset of       |          |
-  |          | types  - see       |       | {"ANSX9.31",    |          |
-  |          | [SP800-131A],      |       | "PKCS1v1.5",    |          |
-  |          | Section 5          |       | "PSS"}          |          |
-  |          |                    |       |                 |          |
-  | modulo   | supported RSA      | array | any non-empty   | No       |
-  |          | moduli for         |       | subset of       |          |
-  |          | signature          |       | {1024, 1536,    |          |
-  |          | verification - see |       | 2048, 3072,     |          |
-  |          | [SP800-131A]       |       | 4096}           |          |
-  |          |                    |       |                 |          |
-  | hashAlgs | supported hash     | array | any non-empty   | No       |
-  |          | algorithms for     |       | subset of       |          |
-  |          | signature          |       | {"SHA-1",       |          |
-  |          | verification - see |       | "SHA-256",      |          |
-  |          | [SP800-131A],      |       | "SHA-384",      |          |
-  |          | Section 9          |       | "SHA-512"}      |          |
-  |          |                    |       |                 |          |
-  | saltLens | supported salt     | array | array of values | Yes      |
-  |          | lengths for        |       | for each hash   |          |
-  |          | PKCS1PSS signature |       | algorithm used  |          |
-  |          | verification - see |       | subject to the  |          |
-  |          | [FIPS186-4],       |       | constraint in   |          |
-  |          | Section 5.5. See   |       | the note below. |          |
-  |          | also note below.   |       |                 |          |
-  +----------+--------------------+-------+-----------------+----------+
+   |          | verification -    |        | "SHA-256",     |          |
+   |          | see [SP800-131A], |        | "SHA-384",     |          |
+   |          | Section 9         |        | "SHA-512"}     |          |
+   |          |                   |        |                |          |
+   | saltLens | supported salt    | array  | array of       | Yes      |
+   |          | lengths for       |        | values for     |          |
+   |          | PKCS1PSS          |        | each hash      |          |
+   |          | signature         |        | algorithm used |          |
+   |          | verification -    |        | subject to the |          |
+   |          | see [FIPS186-4],  |        | constraint in  |          |
+   |          | Section 5.5. See  |        | the note       |          |
+   |          | also note below.  |        | below.         |          |
+   +----------+-------------------+--------+----------------+----------+
 
      Table 10: Supported RSA legacySigVer moduli and hash options JSON
                                   Values
@@ -946,14 +872,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    In this mode, the only tested capability is the correct expontiation
    's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1',
    'd' is the private exponent and 'n' is the modulus, all supplied by
-
-
-
-Vassilev                Expires November 2, 2017               [Page 17]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    the testing ACVP server.  Only 2048-bit RSA keys are allowed for this
    capability.  There are no properties specified for this capability.
    See Appendix B.5 for additional details on constraints for 'msg' and
@@ -966,12 +884,19 @@ Internet-Draft                RSA Alg JSON                      May 2017
 2.4.6.  The componentDecPrimitive Mode Capabilities
 
    The RSA componentDecPrimitive mode capability is advertised a JSON
-   object within the array of 'modeSpecs' value of the ACVP registration
-   message. as part of the 'capability_exchange' element of the ACVP
-   JSON registration message.  In this mode, the only tested capability
-   is the correct expontiation 's = msg^d mod n', where 'msg' is a
-   message, 'd' is the private exponent and ''n is the modulus.  See
-   [SP800-56B], Section 7.1.2 for details.
+   object within the array of 'modeSpecs' as part of the
+   'capability_exchange' element of the ACVP JSON registration message.
+   In this mode, the only tested capability is the correct expontiation
+   's = msg^d mod n', where 'msg' is a message, 'd' is the private
+   exponent and ''n is the modulus.  See [SP800-56B], Section 7.1.2 for
+   details.
+
+
+
+Vassilev               Expires November 02, 2017               [Page 16]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    In testing, only 'msg' is supplied by the ACVP server.  The client is
    responsible for generating RSA key pairs of modulus 'n', private key
@@ -1003,33 +928,31 @@ Internet-Draft                RSA Alg JSON                      May 2017
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
 
+   +----------------+---------------------------------------+----------+
+   | JSON Value     | Description                           | JSON     |
+   |                |                                       | type     |
+   +----------------+---------------------------------------+----------+
+   | version        | Protocol version identifier           | value    |
+   |                |                                       |          |
+   | vsId           | Unique numeric identifier for the     | value    |
+   |                | vector set                            |          |
+   |                |                                       |          |
+   | algorithm      | The RSA algorithm used for the test   | "RSA"    |
+   |                | vectors.                              |          |
+   |                |                                       |          |
+   |                |                                       |          |
+   | testGroups     | Array of test group JSON objects,     | array    |
+   |                | which are defined in Section 3.1      |          |
+   +----------------+---------------------------------------+----------+
+
+                     Table 11: Vector Set JSON Object
 
 
-Vassilev                Expires November 2, 2017               [Page 18]
+
+Vassilev               Expires November 02, 2017               [Page 17]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
-
-   +------------+-----------------------------------+------------------+
-   | JSON Value | Description                       | JSON type        |
-   +------------+-----------------------------------+------------------+
-   | version    | Protocol version identifier       | value            |
-   |            |                                   |                  |
-   | vsId       | Unique numeric identifier for the | value            |
-   |            | vector set                        |                  |
-   |            |                                   |                  |
-   | algorithm  | The RSA algorithm used for the    | "RSA"            |
-   |            | test vectors.                     |                  |
-   |            |                                   |                  |
-   | mode       | The RSA mode.                     | "KeyGen",        |
-   |            |                                   | "SigGen", or     |
-   |            |                                   | "SigVer"         |
-   |            |                                   |                  |
-   | testGroups | Array of test group JSON objects, | array            |
-   |            | which are defined in Section 3.1  |                  |
-   +------------+-----------------------------------+------------------+
-
-                     Table 11: Vector Set JSON Object
 
 3.1.  Test Groups JSON Schema
 
@@ -1040,31 +963,26 @@ Internet-Draft                RSA Alg JSON                      May 2017
    applies to all test vectors within the group.  The following table
    describes the RSA JSON elements of the Test Group JSON object.
 
-   +-----------+----------------------------+---------------+----------+
-   | JSON      | Description                | JSON type     | Optional |
-   | Value     |                            |               |          |
-   +-----------+----------------------------+---------------+----------+
-   | modulo    | RSA modulus                | value         | No       |
-   |           |                            |               |          |
-   | hashAlg   | the hash algorithm         | value         | Yes      |
-   |           |                            |               |          |
-   | primeTest | Miller-Rabin constraint    | value         | Yes      |
-   |           | from Table C.2 or C.3      |               |          |
-   |           |                            |               |          |
-   | pubExp    | Fixed or random public     | "fixed" or    | Yes      |
-   |           | exponent                   | "random"      |          |
-   +-----------+----------------------------+---------------+----------+
+   +-------------+----------------------+-----------------+------------+
+   | JSON Value  | Description          | JSON type       | Optional   |
+   +-------------+----------------------+-----------------+------------+
+   | mode        | The RSA mode.        | "KeyGen",       | No         |
+   |             |                      | "SigGen", or    |            |
+   |             |                      | "SigVer"        |            |
+   |             |                      |                 |            |
+   | modulo      | RSA modulus          | value           | No         |
+   |             |                      |                 |            |
+   | hashAlg     | the hash algorithm   | value           | Yes        |
+   |             |                      |                 |            |
+   | primeTest   | Miller-Rabin         | value           | Yes        |
+   |             | constraint from      |                 |            |
+   |             | Table C.2 or C.3     |                 |            |
+   |             |                      |                 |            |
+   | pubExp      | Fixed or random      | "fixed" or      | Yes        |
+   |             | public exponent      | "random"        |            |
+   +-------------+----------------------+-----------------+------------+
 
                      Table 12: Test Group JSON Object
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 19]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 3.2.  Test Case JSON Schema
 
@@ -1073,28 +991,37 @@ Internet-Draft                RSA Alg JSON                      May 2017
    processed by the ACVP client.  The following table describes the JSON
    elements for each RSA test vector.
 
-   +---------+--------------------------------------+-------+----------+
-   | JSON    | Description                          | JSON  | Optional |
-   | Value   |                                      | type  |          |
-   +---------+--------------------------------------+-------+----------+
-   | tcId    | Numeric identifier for the test      | value | No       |
-   |         | case, unique across the entire       |       |          |
-   |         | vector set.                          |       |          |
-   |         |                                      |       |          |
-   | e       | the public exponent                  | hex   | Yes      |
-   |         |                                      | value |          |
-   |         |                                      |       |          |
-   | pRand   | the random for P, testing probable   | hex   | Yes      |
-   |         | primes according to [FIPS186-4],     | value |          |
-   |         | Appendix B.3.3                       |       |          |
-   |         |                                      |       |          |
-   | qRand   | the random for Q, if applicable,     | hex   | Yes      |
-   |         | testing probable primes according to | value |          |
-   |         | [FIPS186-4], Appendix B.3.3          |       |          |
-   |         |                                      |       |          |
-   | message | the message to be signed             | hex   | Yes      |
-   |         |                                      | value |          |
-   +---------+--------------------------------------+-------+----------+
+   +-----------+--------------------------------+---------+------------+
+   | JSON      | Description                    | JSON    | Optional   |
+   | Value     |                                | type    |            |
+   +-----------+--------------------------------+---------+------------+
+   | tcId      | Numeric identifier for the     | value   | No         |
+   |           | test case, unique across the   |         |            |
+   |           | entire vector set.             |         |            |
+   |           |                                |         |            |
+   | e         | the public exponent            | hex     | Yes        |
+   |           |                                | value   |            |
+   |           |                                |         |            |
+
+
+
+Vassilev               Expires November 02, 2017               [Page 18]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   | pRand     | the random for P, testing      | hex     | Yes        |
+   |           | probable primes according to   | value   |            |
+   |           | [FIPS186-4], Appendix B.3.3    |         |            |
+   |           |                                |         |            |
+   | qRand     | the random for Q, if           | hex     | Yes        |
+   |           | applicable, testing probable   | value   |            |
+   |           | primes according to            |         |            |
+   |           | [FIPS186-4], Appendix B.3.3    |         |            |
+   |           |                                |         |            |
+   | message   | the message to be signed       | hex     | Yes        |
+   |           |                                | value   |            |
+   +-----------+--------------------------------+---------+------------+
 
                     Table 13: RSA Test Case JSON Object
 
@@ -1105,190 +1032,172 @@ Internet-Draft                RSA Alg JSON                      May 2017
    table describes the JSON object that represents a vector set
    response.
 
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 20]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-   +-------------+---------------------------------------------+-------+
-   | JSON Value  | Description                                 | JSON  |
-   |             |                                             | type  |
-   +-------------+---------------------------------------------+-------+
-   | version     | Protocol version identifier                 | value |
-   |             |                                             |       |
-   | vsId        | Unique numeric identifier for the vector    | value |
-   |             | set                                         |       |
-   |             |                                             |       |
-   | testResults | Array of JSON objects that represent each   | array |
-   |             | test vector result, which uses the same     |       |
-   |             | JSON schema as defined in Section 3.2       |       |
-   +-------------+---------------------------------------------+-------+
+   +---------------+-----------------------------------------+---------+
+   | JSON Value    | Description                             | JSON    |
+   |               |                                         | type    |
+   +---------------+-----------------------------------------+---------+
+   | version       | Protocol version identifier             | value   |
+   |               |                                         |         |
+   | vsId          | Unique numeric identifier for the       | value   |
+   |               | vector set                              |         |
+   |               |                                         |         |
+   | testResults   | Array of JSON objects that represent    | array   |
+   |               | each test vector result, which uses the |         |
+   |               | same JSON schema as defined in Section  |         |
+   |               | 3.2                                     |         |
+   +---------------+-----------------------------------------+---------+
 
                  Table 14: Vector Set Response JSON Object
 
    The following table describes the JSON elements for the response to a
    RSA test vector.
 
-   +-------------+----------------------+-------------------+----------+
-   | JSON Value  | Description          | JSON type         | Optional |
-   +-------------+----------------------+-------------------+----------+
-   | tcId        | Numeric identifier   | value             | No       |
-   |             | for the test case,   |                   |          |
-   |             | unique across the    |                   |          |
-   |             | entire vector set.   |                   |          |
-   |             |                      |                   |          |
-   | e           | the public exponent  | hex value         | Yes      |
-   |             |                      |                   |          |
-   | pRand       | the random for P,    | hex value         | Yes      |
-   |             | testing probable     |                   |          |
-   |             | primes according to  |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.3       |                   |          |
-   |             |                      |                   |          |
-   | qRand       | the random for Q, if | hex value         | Yes      |
-   |             | applicable, testing  |                   |          |
-   |             | probable primes      |                   |          |
-   |             | according to         |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.3       |                   |          |
-   |             |                      |                   |          |
-   | primeResult | the verdict on the   | "passed"/"failed" | Yes      |
-   |             | prime generation     |                   |          |
-   |             | testing for the      |                   |          |
-   |             | supplied pRand/qRand |                   |          |
-   |             | combination, see     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
+   +-------------+---------------------+-------------------+-----------+
+   | JSON Value  | Description         | JSON type         | Optional  |
+   +-------------+---------------------+-------------------+-----------+
+   | tcId        | Numeric identifier  | value             | No        |
+   |             | for the test case,  |                   |           |
+   |             | unique across the   |                   |           |
 
 
 
-Vassilev                Expires November 2, 2017               [Page 21]
+Vassilev               Expires November 02, 2017               [Page 19]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |             | Appendix B.3.3       |                   |          |
-   |             |                      |                   |          |
-   | seed        | the seed used in     | hex value         | Yes      |
-   |             | prime generation     |                   |          |
-   |             | according to         |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.2,      |                   |          |
-   |             | B.3.4, or B3.5       |                   |          |
-   |             |                      |                   |          |
-   | bitlens     | the length of p1,    | array of ints     | Yes      |
-   |             | p2, q1, and q2 for   |                   |          |
-   |             | prime generation     |                   |          |
-   |             | according to         |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.2,      |                   |          |
-   |             | B.3.4, B3.5 or the   |                   |          |
-   |             | length of xP1, xP2,  |                   |          |
-   |             | xQ1, and xQ2 for     |                   |          |
-   |             | B.3.6                |                   |          |
-   |             |                      |                   |          |
-   | xP1         | the prime factor p1  | hex value         | Yes      |
-   |             | for Primes with      |                   |          |
-   |             | Conditions - see     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.3,      |                   |          |
-   |             | B.3.4, or B.3.5, if  |                   |          |
-   |             | applicable           |                   |          |
-   |             |                      |                   |          |
-   | xP2         | the prime factor p2  | hex value         | Yes      |
-   |             | for Primes with      |                   |          |
-   |             | Conditions - see     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.3,      |                   |          |
-   |             | B.3.4, or B.3.5, if  |                   |          |
-   |             | applicable           |                   |          |
-   |             |                      |                   |          |
-   | xP          | the random number    | hex value         | Yes      |
-   |             | used in Step 3 of    |                   |          |
-   |             | the algorithm in     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix C.9 to      |                   |          |
-   |             | generate the prime   |                   |          |
-   |             | P, if applicable     |                   |          |
-   |             |                      |                   |          |
-   | p           | the private prime    | hex value         | Yes      |
-   |             | factor p             |                   |          |
-   |             |                      |                   |          |
-   | xQ1         | the prime factor q1  | hex value         | Yes      |
+   |             | entire vector set.  |                   |           |
+   |             |                     |                   |           |
+   | e           | the public exponent | hex value         | Yes       |
+   |             |                     |                   |           |
+   | pRand       | the random for P,   | hex value         | Yes       |
+   |             | testing probable    |                   |           |
+   |             | primes according to |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.3      |                   |           |
+   |             |                     |                   |           |
+   | qRand       | the random for Q,   | hex value         | Yes       |
+   |             | if applicable,      |                   |           |
+   |             | testing probable    |                   |           |
+   |             | primes according to |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.3      |                   |           |
+   |             |                     |                   |           |
+   | primeResult | the verdict on the  | "passed"/"failed" | Yes       |
+   |             | prime generation    |                   |           |
+   |             | testing for the     |                   |           |
+   |             | supplied            |                   |           |
+   |             | pRand/qRand         |                   |           |
+   |             | combination, see    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.3      |                   |           |
+   |             |                     |                   |           |
+   | seed        | the seed used in    | hex value         | Yes       |
+   |             | prime generation    |                   |           |
+   |             | according to        |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.2,     |                   |           |
+   |             | B.3.4, or B3.5      |                   |           |
+   |             |                     |                   |           |
+   | bitlens     | the length of p1,   | array of ints     | Yes       |
+   |             | p2, q1, and q2 for  |                   |           |
+   |             | prime generation    |                   |           |
+   |             | according to        |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.2,     |                   |           |
+   |             | B.3.4, B3.5 or the  |                   |           |
+   |             | length of xP1, xP2, |                   |           |
+   |             | xQ1, and xQ2 for    |                   |           |
+   |             | B.3.6               |                   |           |
+   |             |                     |                   |           |
+   | xP1         | the prime factor p1 | hex value         | Yes       |
+   |             | for Primes with     |                   |           |
+   |             | Conditions - see    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
 
 
 
-Vassilev                Expires November 2, 2017               [Page 22]
+Vassilev               Expires November 02, 2017               [Page 20]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   |             | for Primes with      |                   |          |
-   |             | Conditions - see     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.3,      |                   |          |
-   |             | B.3.4, or B.3.5, if  |                   |          |
-   |             | applicable           |                   |          |
-   |             |                      |                   |          |
-   | xQ2         | the prime factor q2  | hex value         | Yes      |
-   |             | for Primes with      |                   |          |
-   |             | Conditions - see     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix B.3.3,      |                   |          |
-   |             | B.3.4, or B.3.5, if  |                   |          |
-   |             | applicable           |                   |          |
-   |             |                      |                   |          |
-   | xQ          | the random number    | hex value         | Yes      |
-   |             | used in Step 3 of    |                   |          |
-   |             | the algorithm in     |                   |          |
-   |             | [FIPS186-4],         |                   |          |
-   |             | Appendix C.9 to      |                   |          |
-   |             | generate the prime   |                   |          |
-   |             | Q, if applicable     |                   |          |
-   |             |                      |                   |          |
-   | q           | the private prime    | hex value         | Yes      |
-   |             | factor q             |                   |          |
-   |             |                      |                   |          |
-   | n           | the modulus          | hex value         | Yes      |
-   |             |                      |                   |          |
-   | d           | the private exponent | hex value         | Yes      |
-   |             | d                    |                   |          |
-   |             |                      |                   |          |
-   | signature   | the digital          | hex value         | Yes      |
-   |             | signature value      |                   |          |
-   |             |                      |                   |          |
-   | sigResult   | the result from the  | "passed"/"failed" | Yes      |
-   |             | digital signature    |                   |          |
-   |             | verirfication        |                   |          |
-   +-------------+----------------------+-------------------+----------+
+   |             | Appendix B.3.3,     |                   |           |
+   |             | B.3.4, or B.3.5, if |                   |           |
+   |             | applicable          |                   |           |
+   |             |                     |                   |           |
+   | xP2         | the prime factor p2 | hex value         | Yes       |
+   |             | for Primes with     |                   |           |
+   |             | Conditions - see    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.3,     |                   |           |
+   |             | B.3.4, or B.3.5, if |                   |           |
+   |             | applicable          |                   |           |
+   |             |                     |                   |           |
+   | xP          | the random number   | hex value         | Yes       |
+   |             | used in Step 3 of   |                   |           |
+   |             | the algorithm in    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix C.9 to     |                   |           |
+   |             | generate the prime  |                   |           |
+   |             | P, if applicable    |                   |           |
+   |             |                     |                   |           |
+   | p           | the private prime   | hex value         | Yes       |
+   |             | factor p            |                   |           |
+   |             |                     |                   |           |
+   | xQ1         | the prime factor q1 | hex value         | Yes       |
+   |             | for Primes with     |                   |           |
+   |             | Conditions - see    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.3,     |                   |           |
+   |             | B.3.4, or B.3.5, if |                   |           |
+   |             | applicable          |                   |           |
+   |             |                     |                   |           |
+   | xQ2         | the prime factor q2 | hex value         | Yes       |
+   |             | for Primes with     |                   |           |
+   |             | Conditions - see    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix B.3.3,     |                   |           |
+   |             | B.3.4, or B.3.5, if |                   |           |
+   |             | applicable          |                   |           |
+   |             |                     |                   |           |
+   | xQ          | the random number   | hex value         | Yes       |
+   |             | used in Step 3 of   |                   |           |
+   |             | the algorithm in    |                   |           |
+   |             | [FIPS186-4],        |                   |           |
+   |             | Appendix C.9 to     |                   |           |
+   |             | generate the prime  |                   |           |
+   |             | Q, if applicable    |                   |           |
+   |             |                     |                   |           |
+   | q           | the private prime   | hex value         | Yes       |
+
+
+
+Vassilev               Expires November 02, 2017               [Page 21]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+   |             | factor q            |                   |           |
+   |             |                     |                   |           |
+   | n           | the modulus         | hex value         | Yes       |
+   |             |                     |                   |           |
+   | d           | the private         | hex value         | Yes       |
+   |             | exponent d          |                   |           |
+   |             |                     |                   |           |
+   | signature   | the digital         | hex value         | Yes       |
+   |             | signature value     |                   |           |
+   |             |                     |                   |           |
+   | sigResult   | the result from the | "passed"/"failed" | Yes       |
+   |             | digital signature   |                   |           |
+   |             | verirfication       |                   |           |
+   +-------------+---------------------+-------------------+-----------+
 
                 Table 15: RSA Test Case Results JSON Object
 
 5.  Acknowledgements
 
    TBD...
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 23]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 6.  IANA Considerations
 
@@ -1308,8 +1217,8 @@ Internet-Draft                RSA Alg JSON                      May 2017
               NIST.FIPS.186-4.pdf>.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997,
+              Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
+              RFC2119, March 1997,
               <http://www.rfc-editor.org/info/rfc2119>.
 
    [RFC3447]  Jonsson, J. and B. Kaliski, "Public-Key Cryptography
@@ -1317,11 +1226,19 @@ Internet-Draft                RSA Alg JSON                      May 2017
               Version 2.1", RFC 3447, DOI 10.17487/RFC3447, February
               2003, <http://www.rfc-editor.org/info/rfc3447>.
 
+
+
+
+Vassilev               Expires November 02, 2017               [Page 22]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
    [SP800-131A]
               Barker, E. and A. Roginsky, "Transitions: Recommendation
               for Transitioning the Use of Cryptographic Algorithms and
-              Key Lengths, Revision 1", November 2015,
-              <http://nvlpubs.nist.gov/nistpubs/SpecialPublications/
+              Key Lengths, Revision 1", November 2015, <http://
+              nvlpubs.nist.gov/nistpubs/SpecialPublications/
               NIST.SP.800-131Ar1.pdf>.
 
    [SP800-56B]
@@ -1337,14 +1254,6 @@ Appendix A.  Example RSA Capabilities JSON Objects
    the verious RSA modes:keyGen, sigGen, sigVer, legacySigVer,
    compRSASP1.  Note that all binary HEX representations are in big-
    endian format.
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 24]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 A.1.  Example keyGen with Provable Primes and Provable Primes with
       Conditions Capabilities JSON Objects
@@ -1373,12 +1282,21 @@ A.1.  Example keyGen with Provable Primes and Provable Primes with
                                     "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
                                 {   "modulo" : 4096,
                                     "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+
+
+
+Vassilev               Expires November 02, 2017               [Page 23]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                             ]
                       }
                 }
           }
       ]
    }
+
 
    In order to advertise support for RSA keyGen with provable primes
    with conditions, the same properties exist, but the 'randPQ' value
@@ -1390,51 +1308,48 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
    keyGen with probable primes according to [FIPS186-4], Appendix B.3.3.
    See also Section 2.4.1.4.
 
+    {
+     "algorithm":"RSA",
+     "prereqVals":[
+       {
+         "algorithm":"DRBG",
+         "valValue":"123456"
+       },
+       {
+         "algorithm":"SHA",
+         "valValue":"7890"
+       }
+     ],
+     "algSpecs":[
+       {
+         "modeSpecs": {
+           "mode":"keyGen",
+           "capSpecs": {
+             "pubExp": "fixed",
+             "fixedPubExpVal":"010001",
+             "randPQ": "B.3.3",
+             "capProbPrime":[{
+               "modulo": 2048,
+               "primeTest":["tblC2"]
+             },
+             {
+               "modulo": 3072,
+               "primeTest":["tblC2", "tblC3"]
+             }]
+           }
+         }
 
 
 
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 25]
+Vassilev               Expires November 02, 2017               [Page 24]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-      {
-       "algorithm":"RSA",
-       "prereqVals":[
-         {
-           "algorithm":"DRBG",
-           "valValue":"123456"
-         },
-         {
-           "algorithm":"SHA",
-           "valValue":"7890"
-         }
-       ],
-       "algSpecs":[
-         {
-           "modeSpecs": {
-             "mode":"keyGen",
-             "capSpecs": {
-               "pubExp": "fixed",
-               "fixedPubExpVal":"010001",
-               "randPQ": "B.3.3",
-               "capProbPrime":[{
-                 "modulo": 2048,
-                 "primeTest":["tblC2"]
-               },
-               {
-                 "modulo": 3072,
-                 "primeTest":["tblC2", "tblC3"]
-               }]
-             }
-           }
-         }
-       ]
-     }
+       }
+     ]
+   }
+
 
    In order to advertise support for RSA keyGen with all probable primes
    with conditions, the same properties exist, but the 'randPQ' value
@@ -1446,17 +1361,6 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
    The following is an example JSON object advertising support for RSA
    keyGen with primes with conditions according to [FIPS186-4],
    Appendix B.3.5.  See also Section 2.4.1.4.
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 26]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
    {
       "algorithm": "RSA",
@@ -1480,13 +1384,23 @@ Internet-Draft                RSA Alg JSON                      May 2017
                          "primeTest": ["tblC2"]},
                        {"modulo" : 4096,
                          "hashAlgs" : ["SHA-512"],
-                         "primeTest": ["tblC3"]},
+                         "primeTest": ["tblC3"]}
                     ]
               }
           }
         }
       ]
    }
+
+
+
+
+
+
+Vassilev               Expires November 02, 2017               [Page 25]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
 A.2.  Example RSA sigGen Capabilities JSON Objects
 
@@ -1506,14 +1420,6 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
                   [
                       {"modulo" : 2048,
                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-
-
-
-Vassilev                Expires November 2, 2017               [Page 27]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       {"modulo" : 3072,
                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
                       {"modulo" : 4096,
@@ -1544,6 +1450,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                 [
                     { "modulo" : 2048,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+
+
+
+Vassilev               Expires November 02, 2017               [Page 26]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "saltLens" : [28, 32, 64]},
                     { "modulo" : 3072,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
@@ -1557,83 +1471,77 @@ Internet-Draft                RSA Alg JSON                      May 2017
       ]
    }
 
+
 A.3.  Example RSA sigVer Capabilities JSON Objects
 
    The following is an example JSON object advertising support for RSA
    sigVer according to [FIPS186-4].
 
+      {
+         "algorithm": "RSA",
+         "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
+         "algSpecs" :
+         [
+           {"modeSpecs" : {
+               "mode": "sigVer",
+               "capSpecs" : {
+
+                    "sigType" : "ANSX9.31",
+                    "capSigType" :
+                   [
+                     {"modulo" : 2048,
+                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                     {"modulo" : 3072,
+                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                     {"modulo" : 4096,
+                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                  ]
+               }
+             }},
+         {"modeSpecs" : {
+               "mode": "sigVer",
+               "capSpecs" : {
+                   "sigType" : "PKCS1v1.5",
+                    "capSigType" :
+                   [
+                     {"modulo" : 2048,
+                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
 
 
 
-Vassilev                Expires November 2, 2017               [Page 28]
+Vassilev               Expires November 02, 2017               [Page 27]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-   {
-      "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" :
-      [
-        {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
+                     {"modulo" : 3072,
+                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
+                     {"modulo" : 4096,
+                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                   ]
+               }
+            }},
+         {"modeSpecs" : {
+               "mode": "sigVer",
+               "capSpecs" : {
+                   "sigType" : "PKCS1PSS",
+                   "capSigType" :
+                     [
+                       { "modulo" : 2048,
+                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                         "saltLens" : [28, 32, 64]},
+                       { "modulo" : 3072,
+                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                         "saltLens" : [28, 32, 64]},
+                       { "modulo" : 4096,
+                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                         "saltLens" : [28, 32, 64]}
+                    ]
+               }
+          }}
+       ]
+      }
 
-                 "sigType" : "ANSX9.31",
-                 "capSigType" :
-                [
-                  {"modulo" : 2048,
-                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 3072,
-                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 4096,
-                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-               ]
-            }
-          }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1v1.5",
-                 "capSigType" :
-                [
-                  {"modulo" : 2048,
-                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 3072,
-                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 4096,
-                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                ]
-            }
-         }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                  [
-                    { "modulo" : 2048,
-                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltLens" : [28, 32, 64]},
-                    { "modulo" : 3072,
-                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltLens" : [28, 32, 64]},
-
-
-
-Vassilev                Expires November 2, 2017               [Page 29]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-                    { "modulo" : 4096,
-                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
-                      "saltLens" : [28, 32, 64]}
-                 ]
-            }
-       }}
-    ]
-   }
 
 A.4.  Example RSA legacySigVer Capabilities JSON Objects
 
@@ -1648,15 +1556,24 @@ A.5.  Example componentSigPrimitive Capabilities JSON Objects
    The following is an example JSON object advertising support for RSA
    componentSigPrimitive according to [FIPS186-4].
 
-      {
-         "algorithm": "RSA",
-         "algSpecs" :
-         [
-          {"modeSpecs" : {
-              "mode": "componentSigPrimitive"
-            }}
-         ]
-      }
+   {
+      "algorithm": "RSA",
+      "algSpecs" :
+      [
+       {"modeSpecs" : {
+           "mode": "componentSigPrimitive"
+
+
+
+Vassilev               Expires November 02, 2017               [Page 28]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
+         }}
+      ]
+   }
+
 
 A.6.  Example componentDecPrimitive Capabilities JSON Objects
 
@@ -1675,13 +1592,6 @@ A.6.  Example componentDecPrimitive Capabilities JSON Objects
    }
 
 
-
-
-Vassilev                Expires November 2, 2017               [Page 30]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
 Appendix B.  Example Test Vectors JSON Objects
 
    This appendix contains example JSON objects for test vectors sent
@@ -1690,237 +1600,255 @@ Appendix B.  Example Test Vectors JSON Objects
 B.1.  Example Test Vectors for keyGen JSON Objects
 
 
- [
-   { "acvVersion": "0.4" },
-   { "vsId": 1133,
-      "algorithm": "RSA",
-      "mode": "keyGen",
-      "testGroups" : [
-             {
-                 "infoGeneratedByServer": false,
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.2",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
-                 "tests" : [
-                    {
-                      "tcId" : 1145,
-                    },
-                    {
-                      "tcId" : 1146,
-                    }
-                 ]
-             },
-             {
-                "infoGeneratedByServer": false,
-                "pubExp": "random",
-                "randPQ": "B.3.2",
-                "modulo" : 3072,
-                "hashAlg" : "SHA-256"
-                "tests": [
-                  {
-                    "tcId": 1147,
-                  },
-                  {
-                    "tcId": 1148,
-                  }
-                ]
-              },
-             {
-                 "infoGeneratedByServer": false,
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.4",
+    [
+      { "acvVersion": "0.4" },
+      { "vsId": 1133,
+        "algorithm": "RSA",
+        "testGroups" : [
+                {
+                    "mode": "keyGen",
+                    "infoGeneratedByServer": false,
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.2",
+                    "modulo" : 2048,
+                    "hashAlg" : "SHA-256",
+                    "tests" : [
+                       {
+                         "tcId" : 1145
+                       },
+                       {
+                         "tcId" : 1146
 
 
 
-Vassilev                Expires November 2, 2017               [Page 31]
+Vassilev               Expires November 02, 2017               [Page 29]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
-                 "tests" : [
-                    {
-                      "tcId" : 1149,
-                    },
-                    {
-                      "tcId" : 1150,
-                    }
-                 ]
-             },
-             {
-                "infoGeneratedByServer": false,
-                "pubExp": "random",
-                "randPQ": "B.3.4",
-                "modulo" : 3072,
-                "hashAlg" : "SHA-256"
-                "tests": [
-                  {
-                    "tcId": 1151,
-                  },
-                  {
-                    "tcId": 1152,
-                  }
-                ]
-              },
-             {
-                 "infoGeneratedByServer": false,
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.5",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
-                 "tests" : [
-                    {
-                      "tcId" : 1153,
-                    },
-                    {
-                      "tcId" : 1154,
-                    }
-                 ]
-             },
-             {
-                "infoGeneratedByServer": false,
-                "pubExp": "random",
-                "randPQ": "B.3.5",
-                "modulo" : 3072,
-                "hashAlg" : "SHA-256"
-                "tests": [
+                       }
+                    ]
+                },
+                {
+                   "mode": "keyGen",
+                   "infoGeneratedByServer": false,
+                   "pubExp": "random",
+                   "randPQ": "B.3.2",
+                   "modulo" : 3072,
+                   "hashAlg" : "SHA-256",
+                   "tests": [
+                     {
+                       "tcId": 1147
+                     },
+                     {
+                       "tcId": 1148
+                     }
+                   ]
+                 },
+                {
+                    "mode": "keyGen",
+                    "infoGeneratedByServer": false,
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.4",
+                    "modulo" : 2048,
+                    "hashAlg" : "SHA-256",
+                    "tests" : [
+                       {
+                         "tcId" : 1149
+                       },
+                       {
+                         "tcId" : 1150
+                       }
+                    ]
+                },
+                {
+                   "mode": "keyGen",
+                   "infoGeneratedByServer": false,
+                   "pubExp": "random",
+                   "randPQ": "B.3.4",
+                   "modulo" : 3072,
+                   "hashAlg" : "SHA-256",
+                   "tests": [
+                     {
+                       "tcId": 1151
+                     },
+                     {
+                       "tcId": 1152
 
 
 
-Vassilev                Expires November 2, 2017               [Page 32]
+Vassilev               Expires November 02, 2017               [Page 30]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                  {
-                    "tcId": 1155,
-                  },
-                  {
-                    "tcId": 1156,
-                  }
-                ]
-              },
-             {
-                 "infoGeneratedByServer": false,
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.6",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
-                 "tests" : [
-                    {
-                      "tcId" : 1157,
-                    },
-                    {
-                      "tcId" : 1158,
-                    }
-                 ]
-             },
-             {
-                "infoGeneratedByServer": false,
-                "pubExp": "random",
-                "randPQ": "B.3.6",
-                "modulo" : 3072,
-                "hashAlg" : "SHA-256"
-                "tests": [
-                  {
-                    "tcId": 1159,
-                  },
-                  {
-                    "tcId": 1160,
-                  }
-                ]
-              },
-             {
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.3",
-                 "primeTest" : "tblC2",
-                 "modulo" : 2048,
-                 "tests" : [
-                    {
-                      "tcId" : 1119,
-                      "e" : "df28ab",
-                      "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                     }
+                   ]
+                 },
+                {
+                    "mode": "keyGen",
+                    "infoGeneratedByServer": false,
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.5",
+                    "modulo" : 2048,
+                    "hashAlg" : "SHA-256",
+                    "tests" : [
+                       {
+                         "tcId" : 1153
+                       },
+                       {
+                         "tcId" : 1154
+                       }
+                    ]
+                },
+                {
+                   "mode": "keyGen",
+                   "infoGeneratedByServer": false,
+                   "pubExp": "random",
+                   "randPQ": "B.3.5",
+                   "modulo" : 3072,
+                   "hashAlg" : "SHA-256",
+                   "tests": [
+                     {
+                       "tcId": 1155
+                     },
+                     {
+                       "tcId": 1156
+                     }
+                   ]
+                 },
+                {
+                    "mode": "keyGen",
+                    "infoGeneratedByServer": false,
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.6",
+                    "modulo" : 2048,
+                    "hashAlg" : "SHA-256",
+                    "tests" : [
+                       {
+                         "tcId" : 1157
+                       },
+                       {
+                         "tcId" : 1158
 
 
 
-Vassilev                Expires November 2, 2017               [Page 33]
+Vassilev               Expires November 02, 2017               [Page 31]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
-                    },
-                    {
-                      "tcId" : 1120,
-                      "e" : "85a4cf",
-                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
-                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+                       }
+                    ]
+                },
+                {
+                   "mode": "keyGen",
+                   "infoGeneratedByServer": false,
+                   "pubExp": "random",
+                   "randPQ": "B.3.6",
+                   "modulo" : 3072,
+                   "hashAlg" : "SHA-256",
+                   "tests": [
+                     {
+                       "tcId": 1159
+                     },
+                     {
+                       "tcId": 1160
+                     }
+                   ]
+                 },
+                {
+                    "mode": "keyGen",
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.3",
+                    "primeTest" : "tblC2",
+                    "modulo" : 2048,
+                    "tests" : [
+                       {
+                         "tcId" : 1119,
+                         "e" : "df28ab",
+                         "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                         "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+                       },
+                       {
+                         "tcId" : 1120,
+                         "e" : "85a4cf",
+                         "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                         "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
 
-                    }
-                 ]
-             },
-             {
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.3",
-                 "primeTest" : "tblC2",
-                 "modulo" : 3072,
-                 "tests" : [
-                    {
-                      "tcId" : 1121,
-                      "e" : "535c97",
-                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
-                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
-                    }
-                 ]
-             },
-             {
-                 "pubExp" : "random",
-                 "randPQ" : "B.3.3",
-                 "primeTest" : "tblC3",
-                 "modulo" : 2048,
-                 "tests" : [
-                    {
-                      "tcId" : 1122,
-                      "e" : "df28ab",
-                      "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
-                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
-                    },
-                    {
-                      "tcId" : 1123,
-                      "e" : "85a4cf",
-                      "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
-                      "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
-
-                    }
-                 ]
-             },
-             {
-                 "pubExp" : "random",
+                       }
+                    ]
+                },
+                {
+                    "mode": "keyGen",
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.3",
+                    "primeTest" : "tblC2",
+                    "modulo" : 3072,
+                    "tests" : [
 
 
 
-Vassilev                Expires November 2, 2017               [Page 34]
+Vassilev               Expires November 02, 2017               [Page 32]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                 "randPQ" : "B.3.3",
-                 "primeTest" : "tblC3",
-                 "modulo" : 3072,
-                 "tests" : [
-                    {
-                      "tcId" : 1124,
-                      "e" : "535c97",
-                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
-                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
-                    }
-                 ]
-             }
-     ]
-   }
- ]
+                       {
+                         "tcId" : 1121,
+                         "e" : "535c97",
+                         "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                         "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
+                       }
+                    ]
+                },
+                {
+                    "mode": "keyGen",
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.3",
+                    "primeTest" : "tblC3",
+                    "modulo" : 2048,
+                    "tests" : [
+                       {
+                         "tcId" : 1122,
+                         "e" : "df28ab",
+                         "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+                         "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+                       },
+                       {
+                         "tcId" : 1123,
+                         "e" : "85a4cf",
+                         "pRand" : "e534f4a4eb86ff9ace08a0b446faf3e20c22a0166057507e4f5f07332d5c0878a50798857d5e9946e3f8ef8a1021481bb0c94631f9ad8427df620ec9ca585cab3082222279f41bc40e2ccdc160dbc410c52662699ae16b27b2c9d2bf14e99083920a448ba4e5d3d11e1ab7777613959c07fb213be26f2cb7ea8a759af082f6c5",
+                         "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
+
+                       }
+                    ]
+                },
+                {
+                    "mode": "keyGen",
+                    "pubExp" : "random",
+                    "randPQ" : "B.3.3",
+                    "primeTest" : "tblC3",
+                    "modulo" : 3072,
+                    "tests" : [
+                       {
+                         "tcId" : 1124,
+                         "e" : "535c97",
+                         "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                         "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
+                       }
+                    ]
+                }
+        ]
+      }
+    ]
+
+
+
+Vassilev               Expires November 02, 2017               [Page 33]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
 
    Note that this example has "infoGeneratedByServer" set to false.
    This means the client is responsible for providing the details by
@@ -1928,220 +1856,229 @@ Internet-Draft                RSA Alg JSON                      May 2017
    test.  The information returned should match all applicable data in
    Table 15.  For Key Generation method 2 (Appendix B.3.3 [FIPS186-4])
    if the public exponent is random, there are two test types.  One is a
-   known answer test (KAT) provided by the server resulting in a
-   "pass"/"fail" response determining if the input forms a valid key
-   pair.  The other, which exists for a fixed public exponent as well,
-   asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and
-   'd') and the server validates that this pair matches the
-   requirements.
+   known answer test (KAT) provided by the server resulting in a "pass"/
+   "fail" response determining if the input forms a valid key pair.  The
+   other, which exists for a fixed public exponent as well, asks the
+   client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the
+   server validates that this pair matches the requirements.
 
 B.2.  Example Test Vectors for sigGen JSON Objects
 
- [
-   { "acvVersion": "0.4" },
-   { "vsId": 1163,
-      "algorithm": "RSA",
-      "mode": "sigGen",
-      "testGroups" : [
-             {
-                 "sigType" : "ANSX9.31",
-                 "hashAlg" : "SHA-256",
-                 "modulo" : 2048,
-                 "tests" : [
-                    {
-                      "tcId" : 1165,
-                      "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
-                    },
-                 ]
-             },
+   [
+     { "acvVersion": "0.4" },
+     { "vsId": 1163,
+        "algorithm": "RSA",
+        "testGroups" : [
+               {
+                   "mode": "sigGen",
+                   "sigType" : "ANSX9.31",
+                   "hashAlg" : "SHA-256",
+                   "modulo" : 2048,
+                   "tests" : [
+                      {
+                        "tcId" : 1165,
+                        "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
+                      }
+                   ]
+               },
+               {
+                  "mode": "sigGen",
+                  "sigType": "ANSX9.31",
+                  "hashAlg" : "SHA-256",
+                  "modulo" : 3072,
+                  "tests": [
+                      {
+                        "tcId" : 1166,
+                        "message" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
+                      }
+                   ]
+               },
+               {
+                  "mode": "sigGen",
+                  "sigType" : "PKCS1v1.5",
+                  "hashAlg" : "SHA-256",
+                  "modulo" : 2048,
 
 
 
-Vassilev                Expires November 2, 2017               [Page 35]
+Vassilev               Expires November 02, 2017               [Page 34]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-             {
-                "sigType": "ANSX9.31",
-                "hashAlg" : "SHA-256",
-                "modulo" : 3072,
-                "tests": [
-                    {
-                      "tcId" : 1166,
-                      "message" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
-                    }
-                 ]
-             },
-             {
-                "sigType" : "PKCS1v1.5",
-                "hashAlg" : "SHA-256",
-                "modulo" : 2048,
-                "tests" : [
-                   {
-                     "tcId" : 1167,
-                     "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
-                   },
-                ]
-             },
-             {
-                "sigType" : "PKCS1v1.5",
-                "hashAlg" : "SHA-256",
-                "modulo" : 3072,
-                "tests" : [
-                    {
-                      "tcId" : 1168,
-                      "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
-                    }
-                 ]
-             },
-             {
-                "sigType" : "PSS",
-                "hashAlg" : "SHA-256",
-                "modulo" : 2048,
-                "tests" : [
-                    {
-                      "tcId" : 1169,
-                      "saltLen" : 20,
-                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
-                    }
-                 ]
-             },
-             {
-                "sigType" : "PSS",
-                "hashAlg" : "SHA-256",
+                  "tests" : [
+                     {
+                       "tcId" : 1167,
+                       "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
+                     }
+                  ]
+               },
+               {
+                  "mode": "sigGen",
+                  "sigType" : "PKCS1v1.5",
+                  "hashAlg" : "SHA-256",
+                  "modulo" : 3072,
+                  "tests" : [
+                      {
+                        "tcId" : 1168,
+                        "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
+                      }
+                   ]
+               },
+               {
+                  "mode": "sigGen",
+                  "sigType" : "PSS",
+                  "hashAlg" : "SHA-256",
+                  "modulo" : 2048,
+                  "tests" : [
+                      {
+                        "tcId" : 1169,
+                        "saltLen" : 20,
+                        "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
+                      }
+                   ]
+               },
+               {
+                  "mode": "sigGen",
+                  "sigType" : "PSS",
+                  "hashAlg" : "SHA-256",
+                  "modulo" : 3072,
+                  "tests" : [
+                      {
+                        "tcId" : 1170,
+                        "saltLen" : 20,
+                        "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
+                      }
+                   ]
+               }
+         ]
+      }
+    ]
 
 
 
-Vassilev                Expires November 2, 2017               [Page 36]
+Vassilev               Expires November 02, 2017               [Page 35]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
-
-                "modulo" : 3072,
-                "tests" : [
-                    {
-                      "tcId" : 1170,
-                      "saltLen" : 20,
-                      "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
-                    }
-                 ]
-             }
-       ]
-    }
-  ]
 
 B.3.  Example Test Vectors for sigVer JSON Objects
 
- [
-   { "acvVersion": "0.4" },
-   { "vsId": 1173,
-      "algorithm": "RSA",
-      "mode": "sigVer",
-      "testGroups" : [
-             {
-                 "sigType" : "ANSX9.31",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256",
-                 "e" : "166f67",
-                 "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
-                 "tests" : [
-                    {
-                      "tcId" : 1174,
-                      "message" : "ff17e5e88ad5cd0dc463ae0b286273b3905271939c60ed70577edef018b9f596a7c7dbf3a1e0ba1b1ed0fe5790495d19ef7d143513ec744d617b9e8da9c78b994fb84fc4a9599e83a9e78f21bc28a0b4f1fdfa4f5e3bf779c0b7e2de61a0fe453f12c9c26ae7812daed1e8d272a6456ae0faab4b46f37ddbbc59324a08ed5681",
-                      "signature" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
-                    }
-                 ]
-             },
-             {
-                 "sigType" : "ANSX9.31",
-                 "modulo" : 3072,
-                 "hashAlg" : "SHA-256",
-                 "e" : "89ca09",
-                 "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
-                 "tests" : [
-                    {
-                      "tcId" : 1175,
-                      "message" : "7cdcd58f9f290bd550c46b61f15b7fe082b8741cba8acedb57685a04b213640496fb2b70520592ec0d8c184b5aa60af80da8f8944cec65e0e9d1c2deef049e337afe17d0ccce94d19e19b6a5b45f8b70b47f05ad387eab1822848fcb302780a7d0ec80f5350b794daa732bb7260e6911214685b1a7c8094bab88a7149d057327",
-                      "signature" : "1c3d10d8b876e2cae5e8210fd2dd53d9b1245b961e69f6fd7759cd27e7a88dd7fc59f517972f4e6a0b480c837bd7d768292f5784ac5f1df692a9699e32d976ebd1a4282af727a5605cbc5b28d8dae834bdcad391282e6bef543bd11a3d72ef984195236043b655217c8cd8bd3247f29afe17ad0af20dc703df5d7ad49af1ff4bb247717dc6335c45e5845d92772c4e4eef5e2efb4a1c45cb2ffe296cecc4474ab81ec17401b4d3c5129a59a40da2ba8c8fa548a0ae8bbe43b1f1f1dbe029e28dc61a762ed2665ac1bbd6eb6aeecf1bca4b450e8df7bed087f7d390733fa477823eaaf59d0bf7a0c7a8150850b413a05237bd253350d5091a12219a35a58a0ef6fc15024f24b9ef2bd7b27ace7bedc30c9f9ecd1e828966cec760e555d019507560c2ba68dc562300460453f937abca74ca25a7de5fa66e4f28fdefb3030126c0f93b8304717c5a28d07ef095069ca9b6925f6e5ad11497b03a2b2c6660485e0e99b13c334084b038a4d81556c5b7c9ed766fd3fb30bf6931e22e94f647f619d4"
-                    }
-                 ]
+    [
+      { "acvVersion": "0.4" },
+      { "vsId": 1173,
+         "algorithm": "RSA",
+         "testGroups" : [
+                {
+                    "mode": "sigVer",
+                    "sigType" : "ANSX9.31",
+                    "hashAlg" : "SHA-256",
+                    "modulo" : 2048,
+                    "e" : "166f67",
+                    "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
+                    "tests" : [
+                       {
+                         "tcId" : 1174,
+                         "message" : "ff17e5e88ad5cd0dc463ae0b286273b3905271939c60ed70577edef018b9f596a7c7dbf3a1e0ba1b1ed0fe5790495d19ef7d143513ec744d617b9e8da9c78b994fb84fc4a9599e83a9e78f21bc28a0b4f1fdfa4f5e3bf779c0b7e2de61a0fe453f12c9c26ae7812daed1e8d272a6456ae0faab4b46f37ddbbc59324a08ed5681",
+                         "signature" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
+                       }
+                    ]
+                },
+                {
+                    "mode": "sigVer",
+                    "sigType" : "ANSX9.31",
+                    "modulo" : 3072,
+                    "hashAlg" : "SHA-256",
+                    "e" : "89ca09",
+                    "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
+                    "tests" : [
+                       {
+                         "tcId" : 1175,
+                         "message" : "7cdcd58f9f290bd550c46b61f15b7fe082b8741cba8acedb57685a04b213640496fb2b70520592ec0d8c184b5aa60af80da8f8944cec65e0e9d1c2deef049e337afe17d0ccce94d19e19b6a5b45f8b70b47f05ad387eab1822848fcb302780a7d0ec80f5350b794daa732bb7260e6911214685b1a7c8094bab88a7149d057327",
+                         "signature" : "1c3d10d8b876e2cae5e8210fd2dd53d9b1245b961e69f6fd7759cd27e7a88dd7fc59f517972f4e6a0b480c837bd7d768292f5784ac5f1df692a9699e32d976ebd1a4282af727a5605cbc5b28d8dae834bdcad391282e6bef543bd11a3d72ef984195236043b655217c8cd8bd3247f29afe17ad0af20dc703df5d7ad49af1ff4bb247717dc6335c45e5845d92772c4e4eef5e2efb4a1c45cb2ffe296cecc4474ab81ec17401b4d3c5129a59a40da2ba8c8fa548a0ae8bbe43b1f1f1dbe029e28dc61a762ed2665ac1bbd6eb6aeecf1bca4b450e8df7bed087f7d390733fa477823eaaf59d0bf7a0c7a8150850b413a05237bd253350d5091a12219a35a58a0ef6fc15024f24b9ef2bd7b27ace7bedc30c9f9ecd1e828966cec760e555d019507560c2ba68dc562300460453f937abca74ca25a7de5fa66e4f28fdefb3030126c0f93b8304717c5a28d07ef095069ca9b6925f6e5ad11497b03a2b2c6660485e0e99b13c334084b038a4d81556c5b7c9ed766fd3fb30bf6931e22e94f647f619d4"
+                       }
+                    ]
+                },
+                {
+                    "mode": "sigVer",
+                    "sigType" : "PKCS1v1.5",
+                    "modulo" : 2048,
+                    "hashAlg" : "SHA-256",
+                    "e" : "49d2a1",
+                    "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
+                    "tests" : [
+                       {
+                         "tcId" : 1176,
+                         "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
 
 
 
-Vassilev                Expires November 2, 2017               [Page 37]
+Vassilev               Expires November 02, 2017               [Page 36]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-             },
-             {
-                 "sigType" : "PKCS1v1.5",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256",
-                 "e" : "49d2a1",
-                 "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
-                 "tests" : [
-                    {
-                      "tcId" : 1176,
-                      "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
-                      "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
-                    },
-                 ]
-             },
-             {
-                "sigType" : "PKCS1v1.5",
-                "modulo" : 3072,
-                "hashAlg" : "SHA-256",
-                "e" : "ac6db1",
-                "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
-                "tests" : [
-                    {
-                      "tcId" : 1177,
-                      "message" : "921961e184a5d9657697e3e65ceb1ed10204ec56e739df0e4f906ee194c9ed27bd9fbc0d514abe3a6e480cb3155debfcc8d9fc815719b334f7500a769488773b68e31b69cd273c824f79f58306692c0c232fc5c0c83415ef1dd59a73a063e9d7bc6ee7bf9e433c8344b3051ed616c9473a90afdde393ee88e9a5849e5f642b43",
-                      "signature" : "55362a6854a7846c4d105dc8a358fd4c02931f117631968457f422939d266682fd705e2091bfd5d1bfb52b4bfad684914489ecdad9038b75c65916a9e967630b16c76656b58404ec11ac46d8684b3e72d4392fb6e7e6c929e43ad4fb6ce6198f241b39e8bcbbc058792dde31b195b91bb14236dcb82c28a5c24d633dd847d1548dd403b3a70149371f46432db1767a00c462758c2298fe9f1f04c2ff4b96858d084ffe5a624cb85c1f9be2a60fed40133b7c571c6c467f46a0f1e48ee6e2e6d65424bf8196b0d927e0fd4141264aa5df4129d52d2fb57b8dac9386a84ecd34ecb1feac3a2b99d055eda977ddf8027f1178348a30e4cb4ecef2291d7f520794018b39f5251fd46d97282ac21f6bce6539d19aa1c21c3c220a2ddb6feed262eceebd753eaf5e0eb98cb3eb7d324a3dac0a415a18b7f36170676e8b9d3e421a6f77046bee6d9591c93f7ef0242f464f15b63132a0aee80949709429b1e76d40d60f79b2a6ab362f12e2cdd0bc66868c80278043e179a36f2815e7916378b0fbdb8e"
-                    }
-                 ]
-             },
-             {
-                 "sigType" : "PSS",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA-256",
-                 "e" : "10e43f",
-                 "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
-                 "tests" : [
-                    {
-                      "tcId" : 1178,
-                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
-                      "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
-                    },
-                 ]
-             },
-             {
-                "sigType" : "PSS",
-                "modulo" : 3072,
-                "hashAlg" : "SHA-512",
-                "e" : "fe3079",
+                         "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
+                       }
+                    ]
+                },
+                {
+                   "mode": "sigVer",
+                   "sigType" : "PKCS1v1.5",
+                   "modulo" : 3072,
+                   "hashAlg" : "SHA-256",
+                   "e" : "ac6db1",
+                   "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
+                   "tests" : [
+                       {
+                         "tcId" : 1177,
+                         "message" : "921961e184a5d9657697e3e65ceb1ed10204ec56e739df0e4f906ee194c9ed27bd9fbc0d514abe3a6e480cb3155debfcc8d9fc815719b334f7500a769488773b68e31b69cd273c824f79f58306692c0c232fc5c0c83415ef1dd59a73a063e9d7bc6ee7bf9e433c8344b3051ed616c9473a90afdde393ee88e9a5849e5f642b43",
+                         "signature" : "55362a6854a7846c4d105dc8a358fd4c02931f117631968457f422939d266682fd705e2091bfd5d1bfb52b4bfad684914489ecdad9038b75c65916a9e967630b16c76656b58404ec11ac46d8684b3e72d4392fb6e7e6c929e43ad4fb6ce6198f241b39e8bcbbc058792dde31b195b91bb14236dcb82c28a5c24d633dd847d1548dd403b3a70149371f46432db1767a00c462758c2298fe9f1f04c2ff4b96858d084ffe5a624cb85c1f9be2a60fed40133b7c571c6c467f46a0f1e48ee6e2e6d65424bf8196b0d927e0fd4141264aa5df4129d52d2fb57b8dac9386a84ecd34ecb1feac3a2b99d055eda977ddf8027f1178348a30e4cb4ecef2291d7f520794018b39f5251fd46d97282ac21f6bce6539d19aa1c21c3c220a2ddb6feed262eceebd753eaf5e0eb98cb3eb7d324a3dac0a415a18b7f36170676e8b9d3e421a6f77046bee6d9591c93f7ef0242f464f15b63132a0aee80949709429b1e76d40d60f79b2a6ab362f12e2cdd0bc66868c80278043e179a36f2815e7916378b0fbdb8e"
+                       }
+                    ]
+                },
+                {
+                    "mode": "sigVer",
+                    "sigType" : "PSS",
+                    "modulo" : 2048,
+                    "hashAlg" : "SHA-256",
+                    "e" : "10e43f",
+                    "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
+                    "tests" : [
+                       {
+                         "tcId" : 1178,
+                         "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
+                         "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
+                       }
+                    ]
+                },
+                {
+                   "mode": "sigVer",
+                   "sigType" : "PSS",
+                   "modulo" : 3072,
+                   "hashAlg" : "SHA-512",
+                   "e" : "fe3079",
+                   "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
+                   "tests" : [
+                       {
+                         "tcId" : 1179,
+                         "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
+                         "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
+                       }
+                    ]
 
 
 
-Vassilev                Expires November 2, 2017               [Page 38]
+Vassilev               Expires November 02, 2017               [Page 37]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-                "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
-                "tests" : [
-                    {
-                      "tcId" : 1179,
-                      "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
-                      "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
-                    }
-                 ]
-             }
-       ]
-    }
-  ]
+                }
+          ]
+       }
+     ]
+
 
 
    Note: The ACVP server does retain additional context for each test
@@ -2157,60 +2094,41 @@ B.4.  Example Test Vectors for legacySigVer JSON Objects
 
 B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
 
+   [
+     { "acvVersion": "0.4" },
+     { "vsId": 1193,
+        "algorithm": "RSA",
+        "testGroups" : [
+               {
+                   "mode": "componentSigPrimitive",
+                   "tests" : [
+                      {
+                        "tcId" : 1194,
+                        "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
+                        "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
+                        "message" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
+                      },
+                      {
+                        "tcId" : 1195,
+                        "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
+                        "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
+                        "message" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
+                      }
+                   ]
+               }
+         ]
+      }
+    ]
 
 
 
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 39]
+Vassilev               Expires November 02, 2017               [Page 38]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
-
- [
-   { "acvVersion": "0.4" },
-   { "vsId": 1193,
-      "algorithm": "RSA",
-      "mode": "componentSigPrimitive",
-      "testGroups" : [
-             {
-                 "tests" : [
-                    {
-                      "tcId" : 1194,
-                      "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
-                      "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
-                      "message" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
-                    },
-                    {
-                      "tcId" : 1195,
-                      "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
-                      "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
-                      "message" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
-                    }
-                 ]
-             }
-       ]
-    }
-  ]
 
    Note: The ACVP server does retain additional context for each test
    vector sent to the client in order to verify the results when
@@ -2221,48 +2139,28 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
 
+   [
+     { "acvVersion": "0.4" },
+     { "vsId": 1194,
+        "algorithm": "RSA",
+        "testGroups" : [
+               {
+                   "mode": "componentDecPrimitive",
+                   "tests" : [
+                      {
+                        "tcId" : 1196,
+                        "message" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
+                      },
+                      {
+                        "tcId" : 1197,
+                        "message" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
+                      }
+                   ]
+               }
+         ]
+      }
+    ]
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 40]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
- [
-   { "acvVersion": "0.4" },
-   { "vsId": 1194,
-      "algorithm": "RSA",
-      "mode": "componentDecPrimitive",
-      "testGroups" : [
-             {
-                 "tests" : [
-                    {
-                      "tcId" : 1196,
-                      "message" : "097e82fec72465e0492e78edf47d050dff2f1a95eb74603dd33aec8a2c8b00a5752c877ba57608ee99ab5b216990720d55e47d1dcbaaeb3224f7ce95b53e0e57d42a5bfc1ff7283fd6313692c513e34e2853be605f82127a50e69140cf523ad21520d5826d5eab47d12d00f5eaf468883843d6cbaad0d175e6875fd189d3571bf2458a92e695b89980e9e65f2b482bb32b8056f8d49644b5ae6d4a3d7b0a543ca8218b6496eac2ef60bbd34eaf6c5b0657e85e2c874612ebfbe2db7bac098ba0986ec63f98dd7dc6c632c2cc73e215deb20f41081e2eba936594ab840e1eda1bf0e01313e2a531b880c138c508090ae2787dd6cf8d6be81b47838071e2d301bc"
-                    },
-                    {
-                      "tcId" : 1197,
-                      "message" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
-                    }
-                 ]
-             }
-       ]
-    }
-  ]
 
    Note: The ACVP server does retain additional context for each test
    vector sent to the client in order to verify the results when
@@ -2280,9 +2178,16 @@ C.1.  Example keyGen Test Results JSON Objects
 
              [
                 { "acvVersion": "0.4" },
+
+
+
+Vassilev               Expires November 02, 2017               [Page 39]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                 { "vsId": 1133,
                     "algorithm": "RSA",
-                    "mode": "keyGen",
                     "testResults": [
                     {
                       "tcId" : 1111,
@@ -2290,14 +2195,6 @@ C.1.  Example keyGen Test Results JSON Objects
                       "seed" : "af152e46b479af86d2eecb2c8e503dc90954866403e4be1d2d716b2a",
                       "bitlens" : [312, 145, 144, 338],
                       "p" : "e2ab16d3026db341223bcef7f05b61d1682da54b0e2314f8eac9652752d6aa89ad65417e2c7f7b2824555a17c8c854ecbbc44c80c10c5ba132c3992f30308459b3afaee8f00ca318cd39a478c93dc1fa13268842ce88b2d5aeacbb4ac7638db6501eed3cedca65b777e910f701207cf96a81e46c418c3fdc493c02f708b2bacb",
-
-
-
-Vassilev                Expires November 2, 2017               [Page 41]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "q" : "d13c3209bbc1bfa27c96688cbb325e8ce8d609efde1cc2417a578354c7bd248fb89eca31599d6b5b0d69a832bd2fafaacf3e9c3b71484328059dff1a7af54b003fee84f64f34e31ade0689f26fbc181443b7af3d8043657ddceefc1ff3160543825de3fe8f33fce4bf5d1c10357919c31729f8c0476f6b2fb6f405c875f06609",
                       "n" : "b942fa09a727ab488f8bc2d29b89814345dc96e7df9dc7188b7be6be7dc473869c914f612f5aa6b450a17ffc07b42db7b80d2ce88be1953e80ebff92f4aa12fb7fa9b9b258f249d876d69c1976df63a362d1a820f2cff4c88ae2a5fc3b607e7d62a4e60dcd9185929fcc1c931dea94147c03adfa41bf1e72d09376e4dbebaf44df6ec492530d9eb910970f45e41107ea313dccb11567e0832674335639b136b851d19e397be3f1681c72b62bc8defae88e02fe7e67ee56191cb874a53fc115652337277d3aea969adbba4a22d3d8840844cbe48b556895d06d0c7b3cd2c9fcc9a86ec93ca00ea5916090948820fd07f0b22a42f829d9bd1fcfa044ac6a057323",
                       "d" : "6b56ee657ebf6a54b35869b02f4e21d3ef0fb479a70309b522a95d955bf966385e770bd9e321bf95eca857ab36b5084ca6f7596255d11a4a49a1547d5b4306be33ff2ec560838565b6c45c6962ff4f8c64752f615c57fbed7d8b961a2e3fad976648feee6bf1d050c812badb0639188f9ff1e0faf4739b74c31ccb7fadd5c67ff4794ef7249b94abab145351aca47f8fe8e0628b7959f91f7eb06ff7a7a7e308365522c9ddc74c62c69662a9d0ee6b4223c66a4f102f4fbd436cab8723a9f416767ab85cd28ffbf5dc60cdf7a51648f3c57ad69d6b07bb77399bbf19c21ad01a9c782951782ac8a46ed8dac939442cbb280fbdc4056e68a5a7565e69c80c849"
@@ -2337,6 +2234,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "10000021",
                       "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
                       "bitlens" : [232, 220, 336, 141],
+
+
+
+Vassilev               Expires November 02, 2017               [Page 40]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
                       "p" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc4cf9e8d26cbe4b9def67b97305763aa17c09c8a939dddcef9fe0cc7773acbb3ef9beff7812132f7d432f9c77af59e95c7613c4cd47cd27a64463",
                       "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291",
@@ -2346,23 +2251,15 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     },
                     {
                       "tcId" : 1116,
-
-
-
-Vassilev                Expires November 2, 2017               [Page 42]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-                     "e" : "10000021",
-                     "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
-                     "bitlens" : [272, 205, 296, 157],
-                     "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
-                     "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
-                     "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
-                     "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
-                     "n" : "b86c87f9aea1aa7b5c253966047466b0ae29fdbacabeb7eaed820b7f87b664749bfaba791d7a0bfd25cbb4251da58fbb2ab9725c2c873f2b545eaa7409f1124e2d84cdb5c71583fc433a2fa44c6e8e006caaadb07b4996a67ee01df45b70bf94dd0f1bd13c60935f012899edde57c9af80ad362440e804767e4837fbf98847e5e33c534fb86601958adea41ed278203e99d717917fe9d719fcefb3b04f0edb4f44831b52f20c5ac410ea96723fe5bc0afb4dc7d3bf617dd3760b396436cf613444b9abcaa82bd7e0f3174df6dbe320616a2bcb774fbc4633ea783dacffd557706f6f64a8821805d40fd627f3deaa99d4da4a4f571fe7332cc219f68682d4d3d3",
-                     "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
+                      "e" : "10000021",
+                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
+                      "bitlens" : [272, 205, 296, 157],
+                      "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
+                      "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
+                      "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
+                      "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
+                      "n" : "b86c87f9aea1aa7b5c253966047466b0ae29fdbacabeb7eaed820b7f87b664749bfaba791d7a0bfd25cbb4251da58fbb2ab9725c2c873f2b545eaa7409f1124e2d84cdb5c71583fc433a2fa44c6e8e006caaadb07b4996a67ee01df45b70bf94dd0f1bd13c60935f012899edde57c9af80ad362440e804767e4837fbf98847e5e33c534fb86601958adea41ed278203e99d717917fe9d719fcefb3b04f0edb4f44831b52f20c5ac410ea96723fe5bc0afb4dc7d3bf617dd3760b396436cf613444b9abcaa82bd7e0f3174df6dbe320616a2bcb774fbc4633ea783dacffd557706f6f64a8821805d40fd627f3deaa99d4da4a4f571fe7332cc219f68682d4d3d3",
+                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
                       "tcId" : 1117,
@@ -2393,6 +2290,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "10000021",
                       "bitlens" : [224, 195, 352, 142],
                       "xP1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d811",
+
+
+
+Vassilev               Expires November 02, 2017               [Page 41]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "xP2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f0f",
                       "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
                       "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
@@ -2402,14 +2307,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "q" : "fa97b510539a102879a78e8ac21b9840468ca6a2e2f16ab4a0f596cd1b36b3cc0d2cffa06173586b21af25b62b3bd9698c3644da4b4e399aed5c7e1cc97d7c2eb3458f49cf455abadffb3f98fc70bcc2f228777fd575cba69133827d17ff7350b4f616fbb54748cd8bc321067fb1c577a8ce25de1bcf03d9818314d01d3191b5",
                       "n" : "bf0d69840d0236aa74eaf8350b1c4b28c5d5d4d9b7e6488a2a0586dfbd535caa8ec5dc97d62dae357e45ed2d64d250a7d86f91ed5e8a06bbf37875971f0d8b8c5318730ba933e55d0b20be31662d889a0e80325291fc2c7e81e6a72298ee6ea6c1f9ca3901ce1a996b66175a4f9b54415da7eda037bd11912a2188ae3cdc237d94b448d9aaa2211811e5bb53226324a3beef7a381647de3fdac1c697a448b9124cb0cd3d0afe48b04878f469e1eabe5a4cc09617e7252392b975a3bc93180e53bfb6b9086586006f9dad5a240b0c7b54ff10048eb8301ce5db704ef8821c4886c62d618ebc0fcd90913f8110085212f08f3c90a119f6178dad4a1b99fd17c765",
                       "d" : "166bed3734b922f074460a0ae1a8fab231668de4a10daa969805338e6e738e9af173e2a5b0cb1cf132c40a0523dea617228cb7ec33779e86d91696a03218d1ee955f05fe9665d6416cca97600f89d30eed460a5638101137bb7e26a3f01ce9724e9570d372c593e6ff837b6eaabb0fc7698cb952a6122ba59f945d4e9b99a00b84dd150ecaa54ed35c280dc046b4af027beaec005a9768d23b38676d2a9d73e3b9c923d30c7e9ae8686815dda971de42fbf96872781231140d04e659c50a9e86bbd4cd9f5f5aa2df5e5e2ff7aa82ecebacb89a9931fa022a0982c42a304a0fad7e5da407be9e9b225664147a6837a05c43d704f4903a7a20f67a360bee822e21"
-
-
-
-Vassilev                Expires November 2, 2017               [Page 43]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                     },
                     {
                       "tcId" : 1137,
@@ -2449,6 +2346,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "primeResult" : "passed"
                     },
                    {
+
+
+
+Vassilev               Expires November 02, 2017               [Page 42]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "tcId" : 1120,
                       "primeResult" : "failed"
                    },
@@ -2458,14 +2363,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                    },
                    {
                       "tcId" : 1122,
-
-
-
-Vassilev                Expires November 2, 2017               [Page 44]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "primeResult" : "failed"
                    },
                    {
@@ -2493,7 +2390,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "tcId" : 1130,
+                      "tcId" : 1130,
                       "e" : "e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
@@ -2505,6 +2402,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
+
+
+
+Vassilev               Expires November 02, 2017               [Page 43]
+
+Internet-Draft                RSA Alg JSON                      May 2017
+
+
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   },
@@ -2514,19 +2419,12 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
-
-
-
-Vassilev                Expires November 2, 2017               [Page 45]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   }
                  ]
                 }
              ]
+
 
 C.2.  Example sigGen Test Results JSON Objects
 
@@ -2534,59 +2432,48 @@ C.2.  Example sigGen Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1163,
-                    "algorithm": "RSA",
-                    "mode": "sigGen",
-                    "testResults": [
+                { "acvVersion": "0.4" },
+                { "vsId": 1163,
+                  "algorithm": "RSA",
+                  "testResults": [
                     {
                       "tcId" : 1165,
-                      "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "e" : "f3e7af",
+                      "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
-                    }
+                    },
                     {
                       "tcId" : 1166,
-                      "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "e" : "ebda09",
+                      "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
-                    }
-                 ]
-             }
-              {
-                 "sigType" : "PKCS1v1.5",
-                 "tests" : [
+                    },
                     {
                       "tcId" : 1167,
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "signature" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
-                    }
+                    },
                     {
                       "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
-                      "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
-                    }
-                 ]
-             }
 
 
 
-Vassilev                Expires November 2, 2017               [Page 46]
+Vassilev               Expires November 02, 2017               [Page 44]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
-             {
-                 "sigType" : "PSS",
-                 "tests" : [
+                      "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
+                    },
                     {
                       "tcId" : 1169,
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "signature" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
-                    }
+                    },
                     {
                       "tcId" : 1170,
                       "e" : "1415a7",
@@ -2597,97 +2484,52 @@ Internet-Draft                RSA Alg JSON                      May 2017
              }
            ]
 
+
 C.3.  Example sigVer Test Results JSON Objects
 
    The following is a example JSON object for RSA sigVer test results
    sent from the crypto module to the ACVP server.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 47]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
     [
        { "acvVersion": "0.4" },
        { "vsId": 1173,
          "algorithm": "RSA",
-         "mode": "sigVer",
-         "testGroups" : [
-                {
-                    "sigType" : "ANSX9.31",
-                    "tests" : [
-                       {
-                         "tcId" : 1174,
-                         "sigResult" : "failed"
-                       },
-                       {
-                         "tcId" : 1175,
-                         "sigResult" : "failed"
-                       }
-                    ]
-                },
+         "testResults" : [
                  {
-                    "sigType" : "PKCS1v1.5",
-                    "tests" : [
-                       {
-                         "tcId" : 1176,
-                         "sigResult" : "passed"
-                       },
-                       {
-                         "tcId" : 1177,
-                         "sigResult" : "failed"
-                       }
-                    ]
-                },
-                {
-                    "sigType" : "PSS",
-                    "tests" : [
-                       {
-                         "tcId" : 1178,
-                         "sigResult" : "failed"
-                       },
-                       {
-                         "tcId" : 1179,
-                         "sigResult" : "failed"
-                       }
-                    ]
-                }
-          ]
-       }
-     ]
+                   "tcId" : 1174,
+                   "sigResult" : "failed"
+                 },
+                 {
+                   "tcId" : 1175,
+                   "sigResult" : "failed"
+                 },
+                 {
+                   "tcId" : 1176,
+                   "sigResult" : "passed"
+                 },
+                 {
+                   "tcId" : 1177,
+                   "sigResult" : "failed"
+                 },
+                 {
+                   "tcId" : 1178,
+                   "sigResult" : "failed"
 
 
 
-Vassilev                Expires November 2, 2017               [Page 48]
+Vassilev               Expires November 02, 2017               [Page 45]
 
 Internet-Draft                RSA Alg JSON                      May 2017
+
+
+                 },
+                 {
+                   "tcId" : 1179,
+                   "sigResult" : "failed"
+                 }
+           ]
+       }
+   ]
 
 
 C.4.  Example legacySigVer Test Results JSON Objects
@@ -2701,75 +2543,57 @@ C.5.  Example componentSigPrimitive Test Results JSON Objects
    The following is a example JSON object for RSA componentSigPrimitive
    test results sent from the crypto module to the ACVP server.
 
- [
-    { "acvVersion": "0.4" },
-    { "vsId": 1193,
-      "algorithm": "RSA",
-      "mode": "componentSigPrimitive",
-      "testGroups" : [
-             {
-                 "tests" : [
-                    {
-                      "tcId" : 1194,
-                      "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
-                    },
-                    {
-                      "tcId" : 1195,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             }
-       ]
-    }
-  ]
+   [
+       { "acvVersion": "0.4" },
+       { "vsId": 1193,
+         "algorithm": "RSA",
+         "testResults" : [
+                   {
+                    "tcId" : 1194,
+                    "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
+                   },
+                   {
+                    "tcId" : 1195,
+                    "sigResult" : "failed"
+                   }
+               ]
+       }
+   ]
+
 
 C.6.  Example componentDecPrimitive Test Results JSON Objects
 
    The following is a example JSON object for RSA componentDecPrimitive
    test results sent from the crypto module to the ACVP server.
 
+   [
+       { "acvVersion": "0.4" },
+       { "vsId": 1194,
+         "algorithm": "RSA",
 
 
 
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires November 2, 2017               [Page 49]
+Vassilev               Expires November 02, 2017               [Page 46]
 
 Internet-Draft                RSA Alg JSON                      May 2017
 
 
- [
-    { "acvVersion": "0.4" },
-    { "vsId": 1194,
-      "algorithm": "RSA",
-      "mode": "componentDecPrimitive",
-      "testGroups" : [
-             {
-                 "tests" : [
-                    {
-                      "tcId" : 1196,
-                      "e" : "010001",
-                      "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
-                      "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
-                      "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
-                    },
-                    {
-                      "tcId" : 1197,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             }
-       ]
-    }
-  ]
+         "testResults" : [
+                {
+                   "tcId" : 1196,
+                   "e" : "010001",
+                   "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
+                   "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
+                   "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
+                },
+                {
+                   "tcId" : 1197,
+                   "sigResult" : "failed"
+                }
+           ]
+       }
+   ]
+
 
 Author's Address
 
@@ -2797,4 +2621,11 @@ Author's Address
 
 
 
-Vassilev                Expires November 2, 2017               [Page 50]
+
+
+
+
+
+
+
+Vassilev               Expires November 02, 2017               [Page 47]

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -2,10 +2,10 @@
 
 
 
-TBD                                                   A.V. Vassilev, Ed.
+TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                                  May 2017
-Expires: November 02, 2017
+Intended status: Informational                           August 17, 2017
+Expires: February 18, 2018
 
 
             ACVP RSA Algorithm Validation JSON Specification
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 02, 2017.
+   This Internet-Draft will expire on February 18, 2018.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-Vassilev               Expires November 02, 2017                [Page 1]
+Vassilev               Expires February 18, 2018                [Page 1]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
 
@@ -76,22 +76,22 @@ Internet-Draft                RSA Alg JSON                      May 2017
          2.4.1.4.  keyGen Full Set Of Capabilities . . . . . . . . .  10
        2.4.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  12
          2.4.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  12
-       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  13
+       2.4.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  14
          2.4.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  14
        2.4.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  15
-       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  16
-       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  16
+       2.4.5.  The componentSigPrimitive Mode Capabilities . . . . .  17
+       2.4.6.  The componentDecPrimitive Mode Capabilities . . . . .  17
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  17
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  18
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  18
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  19
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  22
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  22
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  22
-   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  23
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  19
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  20
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  23
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  23
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  23
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  23
+   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  24
      A.1.  Example keyGen with Provable Primes and Provable Primes
-           with Conditions Capabilities JSON Objects . . . . . . . .  23
+           with Conditions Capabilities JSON Objects . . . . . . . .  24
        A.1.1.  Example keyGen with Probable Primes Capabilities JSON
                Object  . . . . . . . . . . . . . . . . . . . . . . .  24
        A.1.2.  Example keyGen with Provable Conditional Primes with
@@ -99,32 +99,32 @@ Internet-Draft                RSA Alg JSON                      May 2017
      A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  26
      A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  27
      A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  28
-     A.5.  Example componentSigPrimitive Capabilities JSON Objects .  28
+     A.5.  Example componentSigPrimitive Capabilities JSON Objects .  29
      A.6.  Example componentDecPrimitive Capabilities JSON Objects .  29
-   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  29
-     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  29
+   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  30
+     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  30
      B.2.  Example Test Vectors for sigGen JSON Objects  . . . . . .  34
      B.3.  Example Test Vectors for sigVer JSON Objects  . . . . . .  36
      B.4.  Example Test Vectors for legacySigVer JSON Objects  . . .  38
 
 
 
-Vassilev               Expires November 02, 2017                [Page 2]
+Vassilev               Expires February 18, 2018                [Page 2]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
      B.5.  Example Test Vectors for componentSigPrimitive JSON
            Objects . . . . . . . . . . . . . . . . . . . . . . . . .  38
      B.6.  Example Test Vectors for componentDecPrimitive JSON
            Objects . . . . . . . . . . . . . . . . . . . . . . . . .  39
-   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  39
-     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  39
+   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  40
+     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  40
      C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  44
      C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  45
      C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  46
      C.5.  Example componentSigPrimitive Test Results JSON Objects .  46
-     C.6.  Example componentDecPrimitive Test Results JSON Objects .  46
+     C.6.  Example componentDecPrimitive Test Results JSON Objects .  47
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  47
 
 1.  Introduction
@@ -165,9 +165,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev               Expires November 02, 2017                [Page 3]
+Vassilev               Expires February 18, 2018                [Page 3]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
    ACVP requires cryptographic modules to register their capabilities.
@@ -183,16 +183,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following RSA algorithm modes may be advertised by the ACVP
    compliant crypto module:
 
-            +----------------------+-------------------------+
-            | JSON algorithm value | JSON mode value         |
-            +----------------------+-------------------------+
-            | "RSA"                | "keyGen"                |
-            |                      | "sigGen"                |
-            |                      | "sigVer"                |
-            |                      | "legacySigVer"          |
-            |                      | "componentSigPrimitive" |
-            |                      | "componentDecPrimitive" |
-            +----------------------+-------------------------+
+               +-------------------------+-----------------+
+               | JSON algorithm value    | JSON mode value |
+               +-------------------------+-----------------+
+               | "keyGen"                |                 |
+               | "sigGen"                |                 |
+               | "sigVer"                |                 |
+               | "legacySigVer"          |                 |
+               | "componentSigPrimitive" |                 |
+               | "componentDecPrimitive" |
+               +-------------------------+-----------------+
 
             Table 1: Supported RSA Algorithm Modes JSON Values
 
@@ -221,9 +221,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 
 
-Vassilev               Expires November 02, 2017                [Page 4]
+Vassilev               Expires February 18, 2018                [Page 4]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
    |              | validation   |              | number,   |          |
@@ -257,86 +257,92 @@ Internet-Draft                RSA Alg JSON                      May 2017
    object.  The following JSON values are used for RSA algorithm
    capabilities:
 
-   +------------+--------------+----------------+-----------+----------+
-   | JSON Value | Description  | JSON type      | Valid     | Optional |
-   |            |              |                | Values    |          |
-   +------------+--------------+----------------+-----------+----------+
-   | algorithm  | The RSA      | value          | "RSA"     | No       |
-   |            | algorithm to |                |           |          |
-   |            | be validated |                |           |          |
-   |            |              |                |           |          |
-   | prereqVals | The          | array of       | array     | No       |
-   |            | prerequisite | prereqAlgVal   |           |          |
-   |            | algorithm    | objects - see  |           |          |
-   |            | validations  | Section 2.2    |           |          |
-   |            |              |                |           |          |
-   | capSpecs   | The          | an array of    | array     | No       |
-   |            | capabilities | objects        |           |          |
-   |            | of a         | specific to    |           |          |
-   |            | particular   | the mode being |           |          |
+   +----------+------------+------------+---------------------+--------+
+   | JSON     | Descriptio | JSON type  | Valid Values        | Option |
+   | Value    | n          |            |                     | al     |
+   +----------+------------+------------+---------------------+--------+
+   | algorith | The RSA    | value      | "RSA"               | No     |
+   | m        | algorithm  |            |                     |        |
+   |          | to be      |            |                     |        |
+   |          | validated  |            |                     |        |
+   |          |            |            |                     |        |
+   | mode     | The RSA    | value      | "keyGen", "sigGen", | No     |
+   |          | algorithm  |            | "sigVer",           |        |
+   |          | mode to be |            | "legacySigVer", "co |        |
+   |          | validated  |            | mponentSigPrimitive |        |
+   |          |            |            | ", "componentDecPri |        |
+   |          |            |            | mitive"             |        |
+   |          |            |            |                     |        |
+   | prereqVa | The prereq | array of p | array               | No     |
 
 
 
-Vassilev               Expires November 02, 2017                [Page 5]
+Vassilev               Expires February 18, 2018                [Page 5]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
-   |            | RSA mode     | specified      |           |          |
-   |            |              |                |           |          |
-   | modeSpecs  | The RSA mode | an object with | object    | No       |
-   |            | and its      | "mode" and     |           |          |
-   |            | capabilities | "capSpecs"     |           |          |
-   |            |              | properties     |           |          |
-   |            |              |                |           |          |
-   | algSpecs   | Array of     | array of       | See Table | No       |
-   |            | modeSpecs    | modeSpecs      | 1 and     |          |
-   |            |              | objects, each  | Section   |          |
-   |            |              | identified     | 2.4       |          |
-   |            |              | uniquely by    |           |          |
-   |            |              | the "mode" and |           |          |
-   |            |              | required       |           |          |
-   |            |              | properties     |           |          |
-   +------------+--------------+----------------+-----------+----------+
+   | ls       | uisite     | rereqAlgVa |                     |        |
+   |          | algorithm  | l objects  |                     |        |
+   |          | validation | - see      |                     |        |
+   |          | s          | Section    |                     |        |
+   |          |            | 2.2        |                     |        |
+   |          |            |            |                     |        |
+   | algSpecs | Array of   | array of   | See Table 1 and     | No     |
+   |          | JSON       | JSON       | Section 2.4         |        |
+   |          | objects    | objects,   |                     |        |
+   |          |            | each with  |                     |        |
+   |          |            | fields     |                     |        |
+   |          |            | pertaining |                     |        |
+   |          |            | to the     |                     |        |
+   |          |            | global RSA |                     |        |
+   |          |            | mode       |                     |        |
+   |          |            | indicated  |                     |        |
+   |          |            | above and  |                     |        |
+   |          |            | identified |                     |        |
+   |          |            | uniquely   |                     |        |
+   |          |            | by the com |                     |        |
+   |          |            | bination   |                     |        |
+   |          |            | of the RSA |                     |        |
+   |          |            | "mode" and |                     |        |
+   |          |            | indicated  |                     |        |
+   |          |            | properties |                     |        |
+   +----------+------------+------------+---------------------+--------+
 
               Table 3: RSA Algorithm Capabilities JSON Values
 
 2.4.  Supported RSA Modes Capabilities
 
-   The RSA mode capabilities are advertised as arrays of JSON objects
-   within the 'modeSpecs' value of the ACVP registration message - see
-   Table 3.  The 'modeSpecs' value is an array, where each array element
-   is an array of individual JSON objects corresponding to a particular
-   RSA mode defined in this section.  The 'modeSpecs' value is part of
-   the 'capability_exchange' element of the ACVP JSON registration
-   message.  See the ACVP specification for details on the registration
-   message.
+   The RSA mode capabilities are advertised as JSON objects within the
+   'algSpecs' value of the ACVP registration message - see Table 3.  The
+   'algSpecs' value is an array, where each array element is a JSON
+   object corresponding to a particular RSA mode defined in this
+   section.  The 'algSpecs' value is part of the 'capability_exchange'
+   element of the ACVP JSON registration message.  See the ACVP
+   specification for details on the registration message.
 
-   Each RSA mode capabilities are advertised as an array of self-
-   contained JSON objects.
+   Each RSA mode's capabilities are advertised as JSON objects.
 
 2.4.1.  The keyGen Mode Capabilities
 
-   The RSA keyGen mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message.  as part of the 'capability_exchange' element
-   of the ACVP JSON registration message.  See the ACVP specification
-   for details on the registration message.
+   The RSA keyGen mode capabilities are advertised as JSON objects,
+   which are elements of the 'algSpecs' array in the ACVP registration
+   message.  See the ACVP specification for details on the registration
+   message.
 
-   Each RSA keyGen mode capability is advertised as a self-contained
+
+
+
+Vassilev               Expires February 18, 2018                [Page 6]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
+   Each RSA keyGen mode capability set is advertised as a self-contained
    JSON object.
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
-
-
-
-
-
-Vassilev               Expires November 02, 2017                [Page 6]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
 2.4.1.1.  keyGen With Provable Primes or Provable Primes with Conditions
           Capabilities
@@ -361,7 +367,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              | Appendix     |           |               |         |
    |              | B.3.4        |           |               |         |
    |              |              |           |               |         |
-   | hashAlg      | Supported    | array     | any non-empty | Yes     |
+   | hashAlgs     | Supported    | array     | any non-empty | Yes     |
    |              | hash         |           | subset of     |         |
    |              | algorithms   |           | {"SHA-1",     |         |
    |              | for provable |           | "SHA-224",    |         |
@@ -377,23 +383,22 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | singleCap    | A testable   | object    | see above     | Yes     |
    |              | combination  | with      |               |         |
    |              | of modulus   | "modulo"  |               |         |
-   |              | and hash     | and       |               |         |
-   |              | values       | "hashAlg" |               |         |
-   |              |              | propertie |               |         |
-   |              |              | s         |               |         |
+   |              | and hash     | and "hash |               |         |
+   |              | values       | Algs" pro |               |         |
+   |              |              | perties   |               |         |
+
+
+
+Vassilev               Expires February 18, 2018                [Page 7]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    |              |              |           |               |         |
    | capProvPrime | Supported    | array     | "singleCap"   | Yes     |
    |              | capabilities |           | objects, see  |         |
    |              | for provable |           | above for     |         |
    |              | prime        |           | possible      |         |
-
-
-
-Vassilev               Expires November 02, 2017                [Page 7]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |              | generation   |           | values        |         |
    |              | or provable  |           |               |         |
    |              | prime with   |           |               |         |
@@ -437,19 +442,19 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |              |              |             |           |           |
    | singleCap    | A testable   | object with | see above | Yes       |
    |              | combination  | "modulo"    |           |           |
+
+
+
+Vassilev               Expires February 18, 2018                [Page 8]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    |              | of modulus   | and         |           |           |
    |              | and          | "primeTest" |           |           |
    |              | primality    | properties  |           |           |
    |              | test rounds  |             |           |           |
    |              |              |             |           |           |
-
-
-
-Vassilev               Expires November 02, 2017                [Page 8]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    | capProbPrime | supported    | object with | see above | Yes       |
    |              | capabilities | "singleCap" | for       |           |
    |              | for probable | properties  | possible  |           |
@@ -486,26 +491,26 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |                | Appendix   |           |              |          |
    |                | B.3.6      |           |              |          |
    |                |            |           |              |          |
-   | hashAlg        | Supported  | array     | any non-     | Yes      |
+   | hashAlgs       | Supported  | array     | any non-     | Yes      |
    |                | hash       |           | empty subset |          |
    |                | algorithms |           | of {"SHA-1", |          |
    |                | for        |           | "SHA-224",   |          |
    |                | provable   |           | "SHA-256",   |          |
    |                | prime      |           | "SHA-384",   |          |
    |                | generation |           | "SHA-512", " |          |
+
+
+
+Vassilev               Expires February 18, 2018                [Page 9]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    |                | - see [FIP |           | SHA-512/224" |          |
    |                | S186-4],   |           | , "SHA-512/2 |          |
    |                | Appendix   |           | 56"}         |          |
    |                | B.3.6      |           |              |          |
    |                |            |           |              |          |
-
-
-
-Vassilev               Expires November 02, 2017                [Page 9]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    | primeTest      | Primality  | array     | any non-     | Yes      |
    |                | test       |           | empty subset |          |
    |                | rounds of  |           | of {"tblC2", |          |
@@ -521,9 +526,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | singleCap      | A testable | object    | see above    | Yes      |
    |                | combinatio | with      |              |          |
    |                | n of       | "modulo", |              |          |
-   |                | modulus,   | "hashAlg" |              |          |
-   |                | hash       | , and "pr |              |          |
-   |                | algorithm, | imeTest"  |              |          |
+   |                | modulus,   | "hashAlgs |              |          |
+   |                | hash       | ", and "p |              |          |
+   |                | algorithm, | rimeTest" |              |          |
    |                | and        | propertie |              |          |
    |                | primality  | s         |              |          |
    |                | test       |           |              |          |
@@ -548,20 +553,21 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 2.4.1.4.  keyGen Full Set Of Capabilities
 
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 10]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
    +---------------------+-----------------+-------+---------+---------+
    | JSON Value          | Description     | JSON  | Valid   | Optiona |
    |                     |                 | type  | Values  | l       |
-
-
-
-Vassilev               Expires November 02, 2017               [Page 10]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    +---------------------+-----------------+-------+---------+---------+
    | randPQ              | Key Generation  | value | "B.3.2" | No      |
    |                     | mode to be      |       | , "B.3. |         |
@@ -604,20 +610,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |                     | KeyGen mode     |       |         |         |
    |                     | "B.3.3" Random  |       |         |         |
    |                     | Probable Primes |       |         |         |
+
+
+
+Vassilev               Expires February 18, 2018               [Page 11]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    |                     |                 |       |         |         |
    | pubExp              | Supports fixed  | value | "fixed" | Yes     |
    |                     | or random       |       | or "ran |         |
    |                     | public key      |       | dom"    |         |
    |                     | exponent e      |       |         |         |
    |                     |                 |       |         |         |
-
-
-
-Vassilev               Expires November 02, 2017               [Page 11]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    | fixedPubExpVal      | The value of    | value | hex     | Yes     |
    |                     | the public key  |       |         |         |
    |                     | exponent e in   |       |         |         |
@@ -642,14 +648,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 2.4.2.  The sigGen Mode Capabilities
 
-   The RSA sigGen mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' value of the ACVP
-   registration message.  as part of the 'capability_exchange' element
-   of the ACVP JSON registration message.  See the ACVP specification
-   for details on the registration message.
+   The RSA sigGen mode capabilities are advertised as JSON objects
+   within the 'algSpecs' array as part of the 'capability_exchange'
+   element of the ACVP JSON registration message.  See the ACVP
+   specification for details on the registration message.
 
    Each RSA sigGen mode capability is advertised as a self-contained
-   JSON object.
+   JSON object consisting of the algorithm, mode, and algSpecs array.
+   The algSpecs array may contain multiple elements, each pertaining to
+   a sigType that is supported by the client for the RSA mode being
+   advertised.
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
@@ -659,76 +667,85 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following RSA signature generation capabilities may be advertised
    by the ACVP compliant crypto module:
 
-   +----------+-----------------+--------+------------------+----------+
-   | JSON     | Description     | JSON   | Valid values     | Optional |
-   | value    |                 | type   |                  |          |
-   +----------+-----------------+--------+------------------+----------+
-   | sigType  | supported RSA   | array  | any non-empty    | No       |
-   |          | signature types |        | subset of        |          |
-   |          | - see           |        | {"ANSX9.31",     |          |
 
 
-
-Vassilev               Expires November 02, 2017               [Page 12]
+Vassilev               Expires February 18, 2018               [Page 12]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
-   |          | [FIPS186-4],    |        | "PKCS1v1.5",     |          |
-   |          | Section 5       |        | "PSS"}           |          |
-   |          |                 |        |                  |          |
-   | modulo   | supported RSA   | array  | any non-empty    | No       |
-   |          | moduli for      |        | subset of {2048, |          |
-   |          | signature       |        | 3072, 4096}      |          |
-   |          | generation -    |        |                  |          |
-   |          | see             |        |                  |          |
-   |          | [FIPS186-4],    |        |                  |          |
-   |          | Section 5       |        |                  |          |
-   |          |                 |        |                  |          |
-   | hashAlgs | supported hash  | array  | any non-empty    | No       |
-   |          | algorithms for  |        | subset of        |          |
-   |          | signature       |        | {"SHA-224",      |          |
-   |          | generation -    |        | "SHA-256",       |          |
-   |          | see             |        | "SHA-384",       |          |
-   |          | [SP800-131A],   |        | "SHA-512",       |          |
-   |          | Section 9       |        | "SHA-512/224",   |          |
-   |          |                 |        | "SHA-512/256"}   |          |
-   |          |                 |        |                  |          |
-   | saltLens | supported salt  | array  | array of values  | Yes      |
-   |          | lengths for     |        | for each hash    |          |
-   |          | PKCS1PSS        |        | algorithm used   |          |
-   |          | signature       |        | subject to the   |          |
-   |          | generation -    |        | constraint in    |          |
-   |          | see             |        | the note below.  |          |
-   |          | [FIPS186-4],    |        |                  |          |
-   |          | Section 5.5.    |        |                  |          |
-   |          | See also note   |        |                  |          |
-   |          | below.          |        |                  |          |
-   +----------+-----------------+--------+------------------+----------+
+   +------------+-----------------+-------+-----------------+----------+
+   | JSON value | Description     | JSON  | Valid values    | Optional |
+   |            |                 | type  |                 |          |
+   +------------+-----------------+-------+-----------------+----------+
+   | sigType    | supported RSA   | value | one of          | No       |
+   |            | signature types |       | {"ANSX9.31",    |          |
+   |            | - see           |       | "PKCS1v1.5",    |          |
+   |            | [FIPS186-4],    |       | "PSS"}          |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | capSigType | capabilites     | array | modulo,         | No       |
+   |            | supported for   |       | hashAlgs, and   |          |
+   |            | this sigType  - |       | optionally the  |          |
+   |            | see             |       | saltLens object |          |
+   |            | [FIPS186-4],    |       |                 |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | modulo     | supported RSA   | value | one of the      | No       |
+   |            | moduli for      |       | supported       |          |
+   |            | signature       |       | modulo sizes    |          |
+   |            | generation -    |       | {2048, 3072,    |          |
+   |            | see             |       | 4096}           |          |
+   |            | [FIPS186-4],    |       |                 |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | hashAlgs   | supported hash  | array | any non-empty   | No       |
+   |            | algorithms for  |       | subset of       |          |
+   |            | signature       |       | {"SHA-224",     |          |
+   |            | generation for  |       | "SHA-256",      |          |
+   |            | this sigType    |       | "SHA-384",      |          |
+   |            | and modulo -    |       | "SHA-512",      |          |
+   |            | see             |       | "SHA-512/224",  |          |
+   |            | [SP800-131A],   |       | "SHA-512/256"}  |          |
+   |            | Section 9       |       |                 |          |
+   |            |                 |       |                 |          |
+   | saltLens   | supported salt  | array | array of values | Yes      |
+   |            | lengths for PSS |       | for each hash   |          |
+   |            | signature       |       | algorithm used  |          |
+   |            | generation -    |       | subject to the  |          |
+   |            | see             |       | constraint in   |          |
+   |            | [FIPS186-4],    |       | the note below. |          |
+   |            | Section 5.5.    |       |                 |          |
+   |            | See also note   |       |                 |          |
+   |            | below.          |       |                 |          |
+   +------------+-----------------+-------+-----------------+----------+
 
      Table 8: Supported RSA sigGen moduli and hash options JSON Values
 
-   Note: the salt length for each hash algorithm used in PKCS1PSS
-   signature generation is between 0 and the length of the corresponding
-   hash function output block (in bytes), the end points included.
+
+
+
+Vassilev               Expires February 18, 2018               [Page 13]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
+   Note: the salt length for each hash algorithm used in PSS signature
+   generation is between 0 and the length of the corresponding hash
+   function output block (in bytes), the end points included.
 
 2.4.3.  The sigVer Mode Capabilities
 
-   The RSA sigVer mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' as part of the
-   'capability_exchange' element of the ACVP JSON registration message.
-   See the ACVP specification for details on the registration message.
+   The RSA sigVer mode capabilities are advertised as JSON objects
+   within the array of 'algSpecs' as part of the 'capability_exchange'
+   element of the ACVP JSON registration message.  See the ACVP
+   specification for details on the registration message.
 
    Each RSA sigVer mode capability is advertised as a self-contained
-   JSON object.
-
-
-
-
-Vassilev               Expires November 02, 2017               [Page 13]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
+   JSON object consisting of the algorithm, mode, and algSpecs array.
+   The algSpecs array may contain multiple elements, each pertaining to
+   a sigType that is supported by the client for the RSA mode being
+   advertised.
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
@@ -738,53 +755,60 @@ Internet-Draft                RSA Alg JSON                      May 2017
    The following RSA signature verification capabilities may be
    advertised by the ACVP compliant crypto module:
 
-   +----------+-----------------+--------+------------------+----------+
-   | JSON     | Description     | JSON   | Valid values     | Optional |
-   | value    |                 | type   |                  |          |
-   +----------+-----------------+--------+------------------+----------+
-   | sigType  | supported RSA   | array  | any non-empty    | No       |
-   |          | signature types |        | subset of        |          |
-   |          | - see           |        | {"ANSX9.31",     |          |
-   |          | [FIPS186-4],    |        | "PKCS1v1.5",     |          |
-   |          | Section 5       |        | "PSS"}           |          |
-   |          |                 |        |                  |          |
-   | modulo   | supported RSA   | array  | any non-empty    | No       |
-   |          | moduli for      |        | subset of {2048, |          |
-   |          | signature       |        | 3072, 4096}      |          |
-   |          | verification -  |        |                  |          |
-   |          | see             |        |                  |          |
-   |          | [FIPS186-4],    |        |                  |          |
-   |          | Section 5       |        |                  |          |
-   |          |                 |        |                  |          |
-   | hashAlgs | supported hash  | array  | any non-empty    | No       |
-   |          | algorithms for  |        | subset of        |          |
-   |          | signature       |        | {"SHA-224",      |          |
-   |          | verification -  |        | "SHA-256",       |          |
-   |          | see             |        | "SHA-384",       |          |
-   |          | [SP800-131A],   |        | "SHA-512",       |          |
-   |          | Section 9       |        | "SHA-512/224",   |          |
-   |          |                 |        | "SHA-512/256"}   |          |
-   |          |                 |        |                  |          |
-   | saltLens | supported salt  | array  | array of values  | Yes      |
-   |          | lengths for     |        | for each hash    |          |
-   |          | PKCS1PSS        |        | algorithm used   |          |
-   |          | signature       |        | subject to the   |          |
-   |          | verification -  |        | constraint in    |          |
-   |          | see             |        | the note below.  |          |
-   |          | [FIPS186-4],    |        |                  |          |
-   |          | Section 5.5.    |        |                  |          |
-   |          | See also note   |        |                  |          |
-   |          | below.          |        |                  |          |
-   +----------+-----------------+--------+------------------+----------+
+   +------------+-----------------+-------+-----------------+----------+
+   | JSON value | Description     | JSON  | Valid values    | Optional |
+   |            |                 | type  |                 |          |
+   +------------+-----------------+-------+-----------------+----------+
+   | sigType    | supported RSA   | value | one of          | No       |
+   |            | signature types |       | {"ANSX9.31",    |          |
+   |            | - see           |       | "PKCS1v1.5",    |          |
+   |            | [FIPS186-4],    |       | "PSS"}          |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | capSigType | RSA signature   | array | modulo,         | No       |
+   |            | verification    |       | hashAlgs, and   |          |
+   |            | parameters  -   |       | saltLens (when  |          |
+   |            | see             |       | sigType is PSS) |          |
+   |            | [FIPS186-4],    |       |                 |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | modulo     | supported RSA   | value | any one of the  | No       |
+   |            | modulo for      |       | supported       |          |
+   |            | signature       |       | modulo sizes    |          |
+   |            | verification -  |       | {2048, 3072,    |          |
+   |            | see             |       | 4096}           |          |
+   |            | [FIPS186-4],    |       |                 |          |
+
+
+
+Vassilev               Expires February 18, 2018               [Page 14]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | hashAlgs   | supported hash  | array | any non-empty   | No       |
+   |            | algorithms for  |       | subset of       |          |
+   |            | this sigType    |       | {"SHA-224",     |          |
+   |            | and modulo -    |       | "SHA-256",      |          |
+   |            | see             |       | "SHA-384",      |          |
+   |            | [SP800-131A],   |       | "SHA-512",      |          |
+   |            | Section 9       |       | "SHA-512/224",  |          |
+   |            |                 |       | "SHA-512/256"}  |          |
+   |            |                 |       |                 |          |
+   | saltLens   | supported salt  | array | array of values | Yes      |
+   |            | lengths for PSS |       | for each hash   |          |
+   |            | signature       |       | algorithm used  |          |
+   |            | verification -  |       | subject to the  |          |
+   |            | see             |       | constraint in   |          |
+   |            | [FIPS186-4],    |       | the note below. |          |
+   |            | Section 5.5.    |       |                 |          |
+   |            | See also note   |       |                 |          |
+   |            | below.          |       |                 |          |
+   +------------+-----------------+-------+-----------------+----------+
 
      Table 9: Supported RSA sigVer moduli and hash options JSON Values
-
-
-
-Vassilev               Expires November 02, 2017               [Page 14]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
    Note: the salt length for each hash algorithm used in PKCS1PSS
    signature generation is between 0 and the length of the corresponding
@@ -792,72 +816,87 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 2.4.4.  The legacySigVer Mode Capabilities
 
-   The RSA legacySigVer mode capabilities are advertised as an array of
-   JSON objects within the array of 'modeSpecs' value of the ACVP
-   registration message.  as part of the 'capability_exchange' element
-   of the ACVP JSON registration message.  See the ACVP specification
-   for details on the registration message.
+   The RSA legacySigVer mode capabilities are advertised as JSON objects
+   within the array of 'algSpecs' as part of the 'capability_exchange'
+   element of the ACVP JSON registration message.  See the ACVP
+   specification for details on the registration message.
 
    Each RSA legacySigVer mode capability is advertised as a self-
-   contained JSON object.
-
-   The RSA sigVer mode capabilities are advertised as an array of JSON
-   objects within the array of 'modeSpecs' as part of the
-   'capability_exchange' element of the ACVP JSON registration message.
-   See the ACVP specification for details on the registration message.
-
-   Each RSA legacySigVer mode capability is advertised as a self-
-   contained JSON object.
+   contained JSON object consisting of the algorithm, mode, and algSpecs
+   array.  The algSpecs array may contain multiple elements, each
+   pertaining to a sigType that is supported by the client for the RSA
+   mode being advertised.
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
 
-   The following RSA legacy signature verification capabilities may be
-   advertised by the ACVP compliant crypto module:
-
-   +----------+-------------------+--------+----------------+----------+
-   | JSON     | Description       | JSON   | Valid values   | Optional |
-   | value    |                   | type   |                |          |
-   +----------+-------------------+--------+----------------+----------+
-   | sigType  | supported legacy  | array  | any non-empty  | No       |
-   |          | RSA signature     |        | subset of      |          |
-   |          | types  - see      |        | {"ANSX9.31",   |          |
-   |          | [SP800-131A],     |        | "PKCS1v1.5",   |          |
-   |          | Section 5         |        | "PSS"}         |          |
-   |          |                   |        |                |          |
-   | modulo   | supported RSA     | array  | any non-empty  | No       |
-   |          | moduli for        |        | subset of      |          |
-   |          | signature         |        | {1024, 1536,   |          |
-   |          | verification -    |        | 2048, 3072,    |          |
-   |          | see [SP800-131A]  |        | 4096}          |          |
-   |          |                   |        |                |          |
-   | hashAlgs | supported hash    | array  | any non-empty  | No       |
-   |          | algorithms for    |        | subset of      |          |
-   |          | signature         |        | {"SHA-1",      |          |
+   +------------+-----------------+-------+-----------------+----------+
+   | JSON value | Description     | JSON  | Valid values    | Optional |
+   |            |                 | type  |                 |          |
+   +------------+-----------------+-------+-----------------+----------+
 
 
 
-Vassilev               Expires November 02, 2017               [Page 15]
+Vassilev               Expires February 18, 2018               [Page 15]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
-   |          | verification -    |        | "SHA-256",     |          |
-   |          | see [SP800-131A], |        | "SHA-384",     |          |
-   |          | Section 9         |        | "SHA-512"}     |          |
-   |          |                   |        |                |          |
-   | saltLens | supported salt    | array  | array of       | Yes      |
-   |          | lengths for       |        | values for     |          |
-   |          | PKCS1PSS          |        | each hash      |          |
-   |          | signature         |        | algorithm used |          |
-   |          | verification -    |        | subject to the |          |
-   |          | see [FIPS186-4],  |        | constraint in  |          |
-   |          | Section 5.5. See  |        | the note       |          |
-   |          | also note below.  |        | below.         |          |
-   +----------+-------------------+--------+----------------+----------+
+   | sigType    | supported RSA   | value | one of          | No       |
+   |            | legacy          |       | {"ANSX9.31",    |          |
+   |            | signature types |       | "PKCS1v1.5",    |          |
+   |            | - see           |       | "PSS"}          |          |
+   |            | [FIPS186-4],    |       |                 |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | capSigType | RSA legacy      | array | modulo,         | No       |
+   |            | signature       |       | hashAlgs, and   |          |
+   |            | verification    |       | saltLens (when  |          |
+   |            | parameters  -   |       | sigType is PSS) |          |
+   |            | see             |       |                 |          |
+   |            | [FIPS186-4],    |       |                 |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | modulo     | supported RSA   | value | any one of the  | No       |
+   |            | modulo for      |       | supported       |          |
+   |            | signature       |       | modulo sizes    |          |
+   |            | verification -  |       | {2048, 3072,    |          |
+   |            | see             |       | 4096}           |          |
+   |            | [FIPS186-4],    |       |                 |          |
+   |            | Section 5       |       |                 |          |
+   |            |                 |       |                 |          |
+   | hashAlgs   | supported hash  | array | any non-empty   | No       |
+   |            | algorithms for  |       | subset of       |          |
+   |            | this sigType    |       | {"SHA-224",     |          |
+   |            | and modulo -    |       | "SHA-256",      |          |
+   |            | see             |       | "SHA-384",      |          |
+   |            | [SP800-131A],   |       | "SHA-512",      |          |
+   |            | Section 9       |       | "SHA-512/224",  |          |
+   |            |                 |       | "SHA-512/256"}  |          |
+   |            |                 |       |                 |          |
+   | saltLens   | supported salt  | array | array of values | Yes      |
+   |            | lengths for PSS |       | for each hash   |          |
+   |            | signature       |       | algorithm used  |          |
+   |            | verification -  |       | subject to the  |          |
+   |            | see             |       | constraint in   |          |
+   |            | [FIPS186-4],    |       | the note below. |          |
+   |            | Section 5.5.    |       |                 |          |
+   |            | See also note   |       |                 |          |
+   |            | below.          |       |                 |          |
+   +------------+-----------------+-------+-----------------+----------+
 
      Table 10: Supported RSA legacySigVer moduli and hash options JSON
                                   Values
+
+
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 16]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
 
    Note: the salt length for each hash algorithm used in PKCS1PSS
    signature generation is between 0 and the length of the corresponding
@@ -865,38 +904,28 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
 2.4.5.  The componentSigPrimitive Mode Capabilities
 
-   The RSA componentSigPrimitive mode capability (otherwise known as
-   RSASP1 in [RFC3447]) is advertised as a JSON object within the array
-   of 'modeSpecs' value of the ACVP registration message, as part of the
-   'capability_exchange' element of the ACVP JSON registration message.
-   In this mode, the only tested capability is the correct expontiation
-   's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1',
-   'd' is the private exponent and 'n' is the modulus, all supplied by
-   the testing ACVP server.  Only 2048-bit RSA keys are allowed for this
-   capability.  There are no properties specified for this capability.
-   See Appendix B.5 for additional details on constraints for 'msg' and
-   'n'.  See the ACVP specification for details on the registration
-   message.
-
-   Each RSA componentSigPrimitive mode capability is advertised as a
-   self-contained JSON object.
+   The RSA componentSigPrimitive mode capabilities (otherwise known as
+   RSASP1 in [RFC3447]) are advertised as JSON objects within the array
+   of 'algSpecs' as part of the 'capability_exchange' element of the
+   ACVP JSON registration message.  See the ACVP specification for
+   details on the registration message.  In this mode, the only tested
+   capability is the correct expontiation 's = msg^d mod n', where 'msg'
+   is a message between '0' and 'n - 1', 'd' is the private exponent and
+   'n' is the modulus, all supplied by the testing ACVP server.  Only
+   2048-bit RSA keys are allowed for this capability.  There are no
+   properties specified for this capability.  See Appendix B.5 for
+   additional details on constraints for 'msg' and 'n'.  See the ACVP
+   specification for details on the registration message.
 
 2.4.6.  The componentDecPrimitive Mode Capabilities
 
-   The RSA componentDecPrimitive mode capability is advertised a JSON
-   object within the array of 'modeSpecs' as part of the
+   The RSA componentDecPrimitive mode capabilities are advertised as
+   JSON objects within the array of 'algSpecs' as part of the
    'capability_exchange' element of the ACVP JSON registration message.
    In this mode, the only tested capability is the correct expontiation
    's = msg^d mod n', where 'msg' is a message, 'd' is the private
    exponent and ''n is the modulus.  See [SP800-56B], Section 7.1.2 for
    details.
-
-
-
-Vassilev               Expires November 02, 2017               [Page 16]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
 
    In testing, only 'msg' is supplied by the ACVP server.  The client is
    responsible for generating RSA key pairs of modulus 'n', private key
@@ -910,18 +939,24 @@ Internet-Draft                RSA Alg JSON                      May 2017
    for the size of the selected modulus 'n'.  See the ACVP specification
    for details on the registration message.
 
-   Each RSA componentDecPrimitive mode capability is advertised as a
-   self-contained JSON object.
-
 3.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
-   then processed and returned to the ACVP server for validation.  A
-   typical ACVP validation session would require multiple test vector
-   sets to be downloaded and processed by the ACVP client.  Each test
-   vector set represents an individual algorithm, such as Hash_DRBG,
-   etc.  This section describes the JSON schema for a test vector set
-   used with DRBG algorithms.
+   then processed by the client and returned to the ACVP server for
+   validation.  A typical ACVP validation session would require multiple
+   test vector sets to be downloaded and processed by the ACVP client.
+   Each test vector set represents an individual algorithm and mode,
+
+
+
+Vassilev               Expires February 18, 2018               [Page 17]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
+   such as {"algorithm": "RSA, "mode": "sigGen"}, etc.  This section
+   describes the JSON schema for test vector sets used with the RSA
+   algorithm and modes.
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta data for the entire vector set as well as individual
@@ -947,13 +982,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
 
                      Table 11: Vector Set JSON Object
 
-
-
-Vassilev               Expires November 02, 2017               [Page 17]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
 3.1.  Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
@@ -974,6 +1002,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             |                      |                 |            |
    | hashAlg     | the hash algorithm   | value           | Yes        |
    |             |                      |                 |            |
+
+
+
+Vassilev               Expires February 18, 2018               [Page 18]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    | primeTest   | Miller-Rabin         | value           | Yes        |
    |             | constraint from      |                 |            |
    |             | Table C.2 or C.3     |                 |            |
@@ -1002,14 +1038,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | e         | the public exponent            | hex     | Yes        |
    |           |                                | value   |            |
    |           |                                |         |            |
-
-
-
-Vassilev               Expires November 02, 2017               [Page 18]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    | pRand     | the random for P, testing      | hex     | Yes        |
    |           | probable primes according to   | value   |            |
    |           | [FIPS186-4], Appendix B.3.3    |         |            |
@@ -1024,6 +1052,19 @@ Internet-Draft                RSA Alg JSON                      May 2017
    +-----------+--------------------------------+---------+------------+
 
                     Table 13: RSA Test Case JSON Object
+
+
+
+
+
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 19]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
 
 4.  Test Vector Responses
 
@@ -1058,14 +1099,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | tcId        | Numeric identifier  | value             | No        |
    |             | for the test case,  |                   |           |
    |             | unique across the   |                   |           |
-
-
-
-Vassilev               Expires November 02, 2017               [Page 19]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | entire vector set.  |                   |           |
    |             |                     |                   |           |
    | e           | the public exponent | hex value         | Yes       |
@@ -1081,6 +1114,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | testing probable    |                   |           |
    |             | primes according to |                   |           |
    |             | [FIPS186-4],        |                   |           |
+
+
+
+Vassilev               Expires February 18, 2018               [Page 20]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    |             | Appendix B.3.3      |                   |           |
    |             |                     |                   |           |
    | primeResult | the verdict on the  | "passed"/"failed" | Yes       |
@@ -1114,14 +1155,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | for Primes with     |                   |           |
    |             | Conditions - see    |                   |           |
    |             | [FIPS186-4],        |                   |           |
-
-
-
-Vassilev               Expires November 02, 2017               [Page 20]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | Appendix B.3.3,     |                   |           |
    |             | B.3.4, or B.3.5, if |                   |           |
    |             | applicable          |                   |           |
@@ -1137,6 +1170,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    | xP          | the random number   | hex value         | Yes       |
    |             | used in Step 3 of   |                   |           |
    |             | the algorithm in    |                   |           |
+
+
+
+Vassilev               Expires February 18, 2018               [Page 21]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
    |             | [FIPS186-4],        |                   |           |
    |             | Appendix C.9 to     |                   |           |
    |             | generate the prime  |                   |           |
@@ -1170,14 +1211,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | Q, if applicable    |                   |           |
    |             |                     |                   |           |
    | q           | the private prime   | hex value         | Yes       |
-
-
-
-Vassilev               Expires November 02, 2017               [Page 21]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    |             | factor q            |                   |           |
    |             |                     |                   |           |
    | n           | the modulus         | hex value         | Yes       |
@@ -1192,6 +1225,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
    |             | digital signature   |                   |           |
    |             | verirfication       |                   |           |
    +-------------+---------------------+-------------------+-----------+
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 22]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
 
                 Table 15: RSA Test Case Results JSON Object
 
@@ -1226,14 +1267,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
               Version 2.1", RFC 3447, DOI 10.17487/RFC3447, February
               2003, <http://www.rfc-editor.org/info/rfc3447>.
 
-
-
-
-Vassilev               Expires November 02, 2017               [Page 22]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
    [SP800-131A]
               Barker, E. and A. Roginsky, "Transitions: Recommendation
               for Transitioning the Use of Cryptographic Algorithms and
@@ -1247,6 +1280,15 @@ Internet-Draft                RSA Alg JSON                      May 2017
               Factorization Cryptography, Revision 1", September 2014,
               <http://nvlpubs.nist.gov/nistpubs/SpecialPublications/
               NIST.SP.800-56Br1.pdf>.
+
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 23]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
 
 Appendix A.  Example RSA Capabilities JSON Objects
 
@@ -1264,36 +1306,24 @@ A.1.  Example keyGen with Provable Primes and Provable Primes with
 
    {
       "algorithm": "RSA",
+      "mode": "keyGen",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
       "algSpecs" :
       [
-         {"modeSpecs" : {
-              "mode": "keyGen",
-              "capSpecs" :  {
-                      "pubExp" : "fixed",
-                      "fixedPubExpVal" : "010001",
-                      "infoGeneratedByServer": true,
-                      "randPQ" : "B.3.2",
-                      "capProvPrime" :
-                            [
-                                {   "modulo" : 2048,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 3072,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 4096,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-
-
-
-Vassilev               Expires November 02, 2017               [Page 23]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-                            ]
-                      }
-                }
-          }
+         {  "pubExp" : "fixed",
+            "fixedPubExpVal" : "010001",
+            "infoGeneratedByServer": true,
+            "randPQ" : "B.3.2",
+            "capProvPrime" :
+              [
+                {   "modulo" : 2048,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                {   "modulo" : 3072,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                {   "modulo" : 4096,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+              ]
+         }
       ]
    }
 
@@ -1308,46 +1338,32 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
    keyGen with probable primes according to [FIPS186-4], Appendix B.3.3.
    See also Section 2.4.1.4.
 
+
+
+
+Vassilev               Expires February 18, 2018               [Page 24]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
     {
      "algorithm":"RSA",
-     "prereqVals":[
-       {
-         "algorithm":"DRBG",
-         "valValue":"123456"
-       },
-       {
-         "algorithm":"SHA",
-         "valValue":"7890"
-       }
-     ],
-     "algSpecs":[
-       {
-         "modeSpecs": {
-           "mode":"keyGen",
-           "capSpecs": {
-             "pubExp": "fixed",
-             "fixedPubExpVal":"010001",
-             "randPQ": "B.3.3",
-             "capProbPrime":[{
-               "modulo": 2048,
-               "primeTest":["tblC2"]
-             },
-             {
-               "modulo": 3072,
-               "primeTest":["tblC2", "tblC3"]
-             }]
-           }
+     "mode":"keyGen",
+     "prereqVals":[{"algorithm":"DRBG", "valValue":"123456"}, {"algorithm":"SHA", "valValue":"7890"}],
+     "algSpecs":
+     [
+        {  "pubExp": "fixed",
+           "fixedPubExpVal":"010001",
+           "randPQ": "B.3.3",
+           "capProbPrime":
+             [
+               {  "modulo": 2048,
+                  "primeTest":["tblC2"]},
+               {  "modulo": 3072,
+                  "primeTest":["tblC2", "tblC3"]}
+             ]
          }
-
-
-
-Vassilev               Expires November 02, 2017               [Page 24]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-       }
-     ]
+      ]
    }
 
 
@@ -1364,42 +1380,37 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
 
    {
       "algorithm": "RSA",
-       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
+      "mode": "keyGen",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" :
       [
-         {"modeSpecs" : {
-           "mode": "keyGen",
-           "capSpecs" : {
-               "pubExp" : "fixed",
-               "fixedPubExpVal" : "010001",
-               "infoGeneratedByServer": false,
-               "randPQ" : "B.3.5",
-               "capsProvProbPrime" :
-                    [
-                        {"modulo" : 2048,
-                         "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
-                         "primeTest": ["tblC2", "tblC3"]},
-                       {"modulo" : 3072,
-                         "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
-                         "primeTest": ["tblC2"]},
-                       {"modulo" : 4096,
-                         "hashAlgs" : ["SHA-512"],
-                         "primeTest": ["tblC3"]}
-                    ]
-              }
-          }
-        }
+         {  "pubExp" : "fixed",
+            "fixedPubExpVal" : "010001",
+            "infoGeneratedByServer": false,
+            "randPQ" : "B.3.5",
+            "capsProvProbPrime" :
+              [
+                { "modulo" : 2048,
+                  "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                  "primeTest": ["tblC2", "tblC3"]},
+                { "modulo" : 3072,
+
+
+
+Vassilev               Expires February 18, 2018               [Page 25]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
+                  "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                  "primeTest": ["tblC2"]},
+                { "modulo" : 4096,
+                  "hashAlgs" : ["SHA-512"],
+                  "primeTest": ["tblC3"]}
+              ]
+         }
       ]
    }
-
-
-
-
-
-
-Vassilev               Expires November 02, 2017               [Page 25]
-
-Internet-Draft                RSA Alg JSON                      May 2017
 
 
 A.2.  Example RSA sigGen Capabilities JSON Objects
@@ -1409,55 +1420,45 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
 
    {
       "algorithm": "RSA",
+      "mode": "sigGen",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" :
       [
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "ANSX9.31",
-                  "capSigType" :
-                  [
-                      {"modulo" : 2048,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 3072,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 4096,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-        }},
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "PKCS1v1.5",
-                  "capSigType" :
-                  [
-                      {"modulo" : 2048,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 3072,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 4096,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-         }},
-        {"modeSpecs" : {
-            "mode": "sigGen",
-            "capSpecs" : {
-                "sigType" : "PSS",
-                "capSigType" :
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
                 [
                     { "modulo" : 2048,
-                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                 ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                    { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                 ]
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
+                [
+                    { "modulo" : 2048,
 
 
 
-Vassilev               Expires November 02, 2017               [Page 26]
+Vassilev               Expires February 18, 2018               [Page 26]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]},
                     { "modulo" : 3072,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
@@ -1466,8 +1467,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]}
                 ]
-            }
-         }}
+         }
       ]
    }
 
@@ -1477,79 +1477,118 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
    The following is an example JSON object advertising support for RSA
    sigVer according to [FIPS186-4].
 
-      {
-         "algorithm": "RSA",
-         "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-         "algSpecs" :
-         [
-           {"modeSpecs" : {
-               "mode": "sigVer",
-               "capSpecs" : {
+   {
+      "algorithm": "RSA",
+      "mode": "sigVer",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
+      "algSpecs" :
+      [
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+               [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+               ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                ]
+         },
+         {  "sigType" : "PSS",
 
-                    "sigType" : "ANSX9.31",
-                    "capSigType" :
-                   [
-                     {"modulo" : 2048,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                     {"modulo" : 3072,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                     {"modulo" : 4096,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-               }
-             }},
-         {"modeSpecs" : {
-               "mode": "sigVer",
-               "capSpecs" : {
-                   "sigType" : "PKCS1v1.5",
-                    "capSigType" :
-                   [
-                     {"modulo" : 2048,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
 
 
-
-Vassilev               Expires November 02, 2017               [Page 27]
+Vassilev               Expires February 18, 2018               [Page 27]
 
-Internet-Draft                RSA Alg JSON                      May 2017
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
-                     {"modulo" : 3072,
-                       "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                     {"modulo" : 4096,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                   ]
-               }
-            }},
-         {"modeSpecs" : {
-               "mode": "sigVer",
-               "capSpecs" : {
-                   "sigType" : "PKCS1PSS",
-                   "capSigType" :
-                     [
-                       { "modulo" : 2048,
-                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
-                         "saltLens" : [28, 32, 64]},
-                       { "modulo" : 3072,
-                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
-                         "saltLens" : [28, 32, 64]},
-                       { "modulo" : 4096,
-                         "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
-                         "saltLens" : [28, 32, 64]}
-                    ]
-               }
-          }}
-       ]
-      }
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]}
+                 ]
+          }
+      ]
+   }
 
 
 A.4.  Example RSA legacySigVer Capabilities JSON Objects
 
-   The format and structure of the RSA legacySigVer capabilities JSON
-   objects follow very closely those of the RSA sigVer capabilties JSON
-   objects with the obvious changes from moduloSigVer, hashSigVer and
-   saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer
-   and the corresponding parameter ranges adjustments.
+   The following is an example JSON object advertising support for RSA
+   legacySigVer according to [FIPS186-4].
+
+   {
+      "algorithm": "RSA",
+      "mode": "legacySigVer",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
+      "algSpecs" :
+      [
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+               [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+               ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+
+
+
+Vassilev               Expires February 18, 2018               [Page 28]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
+                ]
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]}
+                 ]
+          }
+      ]
+   }
+
 
 A.5.  Example componentSigPrimitive Capabilities JSON Objects
 
@@ -1558,20 +1597,7 @@ A.5.  Example componentSigPrimitive Capabilities JSON Objects
 
    {
       "algorithm": "RSA",
-      "algSpecs" :
-      [
-       {"modeSpecs" : {
-           "mode": "componentSigPrimitive"
-
-
-
-Vassilev               Expires November 02, 2017               [Page 28]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
-         }}
-      ]
+      "mode": "componentSigPrimitive"
    }
 
 
@@ -1582,14 +1608,22 @@ A.6.  Example componentDecPrimitive Capabilities JSON Objects
 
    {
       "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" :
-      [
-        {"modeSpecs" : {
-            "mode": "componentDecPrimitive"
-         }}
-      ]
+      "mode": "componentDecPrimitive",
+      "prereqVals":
+        [
+            {"algorithm": "DRBG", "valValue": "123456"},
+            {"algorithm": "DRBG", "valValue": "654321"},
+            {"algorithm": "SHA", "valValue": "7890"}
+        ],
+      "algSpecs" : [{}]
    }
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 29]
+
+Internet-Draft                RSA Alg JSON                   August 2017
 
 
 Appendix B.  Example Test Vectors JSON Objects
@@ -1604,9 +1638,9 @@ B.1.  Example Test Vectors for keyGen JSON Objects
       { "acvVersion": "0.4" },
       { "vsId": 1133,
         "algorithm": "RSA",
+        "mode": "keyGen",
         "testGroups" : [
                 {
-                    "mode": "keyGen",
                     "infoGeneratedByServer": false,
                     "pubExp" : "random",
                     "randPQ" : "B.3.2",
@@ -1618,19 +1652,10 @@ B.1.  Example Test Vectors for keyGen JSON Objects
                        },
                        {
                          "tcId" : 1146
-
-
-
-Vassilev               Expires November 02, 2017               [Page 29]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                        }
                     ]
                 },
                 {
-                   "mode": "keyGen",
                    "infoGeneratedByServer": false,
                    "pubExp": "random",
                    "randPQ": "B.3.2",
@@ -1646,10 +1671,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                    ]
                  },
                 {
-                    "mode": "keyGen",
                     "infoGeneratedByServer": false,
                     "pubExp" : "random",
                     "randPQ" : "B.3.4",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 30]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                     "modulo" : 2048,
                     "hashAlg" : "SHA-256",
                     "tests" : [
@@ -1662,7 +1694,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                   "mode": "keyGen",
                    "infoGeneratedByServer": false,
                    "pubExp": "random",
                    "randPQ": "B.3.4",
@@ -1674,19 +1705,10 @@ Internet-Draft                RSA Alg JSON                      May 2017
                      },
                      {
                        "tcId": 1152
-
-
-
-Vassilev               Expires November 02, 2017               [Page 30]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                      }
                    ]
                  },
                 {
-                    "mode": "keyGen",
                     "infoGeneratedByServer": false,
                     "pubExp" : "random",
                     "randPQ" : "B.3.5",
@@ -1702,13 +1724,20 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                   "mode": "keyGen",
                    "infoGeneratedByServer": false,
                    "pubExp": "random",
                    "randPQ": "B.3.5",
                    "modulo" : 3072,
                    "hashAlg" : "SHA-256",
                    "tests": [
+
+
+
+Vassilev               Expires February 18, 2018               [Page 31]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                      {
                        "tcId": 1155
                      },
@@ -1718,7 +1747,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                    ]
                  },
                 {
-                    "mode": "keyGen",
                     "infoGeneratedByServer": false,
                     "pubExp" : "random",
                     "randPQ" : "B.3.6",
@@ -1730,19 +1758,10 @@ Internet-Draft                RSA Alg JSON                      May 2017
                        },
                        {
                          "tcId" : 1158
-
-
-
-Vassilev               Expires November 02, 2017               [Page 31]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                        }
                     ]
                 },
                 {
-                   "mode": "keyGen",
                    "infoGeneratedByServer": false,
                    "pubExp": "random",
                    "randPQ": "B.3.6",
@@ -1758,7 +1777,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                    ]
                  },
                 {
-                    "mode": "keyGen",
                     "pubExp" : "random",
                     "randPQ" : "B.3.3",
                     "primeTest" : "tblC2",
@@ -1768,6 +1786,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                          "tcId" : 1119,
                          "e" : "df28ab",
                          "pRand" : "e021757c777288dacfe67cb2e59dc02c70a8cebf56262336592c18dcf466e0a4ed405318ac406bd79eca29183901a557db556dd06f7c6bea175dcb8460b6b1bc05832b01eedf86463238b7cb6643deef66bc4f57bf8ff7ec7c4b8a8af14f478980aabedd42afa530ca47849f0151b7736aa4cd2ff37f322a9034de791ebe3f51",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 32]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                          "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
                        },
                        {
@@ -1780,20 +1806,11 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                    "mode": "keyGen",
                     "pubExp" : "random",
                     "randPQ" : "B.3.3",
                     "primeTest" : "tblC2",
                     "modulo" : 3072,
                     "tests" : [
-
-
-
-Vassilev               Expires November 02, 2017               [Page 32]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                        {
                          "tcId" : 1121,
                          "e" : "535c97",
@@ -1803,7 +1820,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                    "mode": "keyGen",
                     "pubExp" : "random",
                     "randPQ" : "B.3.3",
                     "primeTest" : "tblC3",
@@ -1825,8 +1841,15 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                    "mode": "keyGen",
                     "pubExp" : "random",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 33]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                     "randPQ" : "B.3.3",
                     "primeTest" : "tblC3",
                     "modulo" : 3072,
@@ -1839,15 +1862,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
                        }
                     ]
                 }
-        ]
-      }
-    ]
-
-
-
-Vassilev               Expires November 02, 2017               [Page 33]
-
-Internet-Draft                RSA Alg JSON                      May 2017
+            ]
+         }
+      ]
 
 
    Note that this example has "infoGeneratedByServer" set to false.
@@ -1868,9 +1885,9 @@ B.2.  Example Test Vectors for sigGen JSON Objects
      { "acvVersion": "0.4" },
      { "vsId": 1163,
         "algorithm": "RSA",
+        "mode": "sigGen",
         "testGroups" : [
                {
-                   "mode": "sigGen",
                    "sigType" : "ANSX9.31",
                    "hashAlg" : "SHA-256",
                    "modulo" : 2048,
@@ -1881,8 +1898,15 @@ B.2.  Example Test Vectors for sigGen JSON Objects
                       }
                    ]
                },
+
+
+
+Vassilev               Expires February 18, 2018               [Page 34]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                {
-                  "mode": "sigGen",
                   "sigType": "ANSX9.31",
                   "hashAlg" : "SHA-256",
                   "modulo" : 3072,
@@ -1894,18 +1918,9 @@ B.2.  Example Test Vectors for sigGen JSON Objects
                    ]
                },
                {
-                  "mode": "sigGen",
                   "sigType" : "PKCS1v1.5",
                   "hashAlg" : "SHA-256",
                   "modulo" : 2048,
-
-
-
-Vassilev               Expires November 02, 2017               [Page 34]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                   "tests" : [
                      {
                        "tcId" : 1167,
@@ -1913,8 +1928,7 @@ Internet-Draft                RSA Alg JSON                      May 2017
                      }
                   ]
                },
-               {
-                  "mode": "sigGen",
+               {,
                   "sigType" : "PKCS1v1.5",
                   "hashAlg" : "SHA-256",
                   "modulo" : 3072,
@@ -1926,7 +1940,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                    ]
                },
                {
-                  "mode": "sigGen",
                   "sigType" : "PSS",
                   "hashAlg" : "SHA-256",
                   "modulo" : 2048,
@@ -1939,9 +1952,16 @@ Internet-Draft                RSA Alg JSON                      May 2017
                    ]
                },
                {
-                  "mode": "sigGen",
                   "sigType" : "PSS",
                   "hashAlg" : "SHA-256",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 35]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                   "modulo" : 3072,
                   "tests" : [
                       {
@@ -1956,21 +1976,15 @@ Internet-Draft                RSA Alg JSON                      May 2017
     ]
 
 
-
-Vassilev               Expires November 02, 2017               [Page 35]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
 B.3.  Example Test Vectors for sigVer JSON Objects
 
     [
       { "acvVersion": "0.4" },
       { "vsId": 1173,
          "algorithm": "RSA",
+         "mode": "sigVer",
          "testGroups" : [
                 {
-                    "mode": "sigVer",
                     "sigType" : "ANSX9.31",
                     "hashAlg" : "SHA-256",
                     "modulo" : 2048,
@@ -1985,7 +1999,6 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                     ]
                 },
                 {
-                    "mode": "sigVer",
                     "sigType" : "ANSX9.31",
                     "modulo" : 3072,
                     "hashAlg" : "SHA-256",
@@ -1997,10 +2010,17 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                          "message" : "7cdcd58f9f290bd550c46b61f15b7fe082b8741cba8acedb57685a04b213640496fb2b70520592ec0d8c184b5aa60af80da8f8944cec65e0e9d1c2deef049e337afe17d0ccce94d19e19b6a5b45f8b70b47f05ad387eab1822848fcb302780a7d0ec80f5350b794daa732bb7260e6911214685b1a7c8094bab88a7149d057327",
                          "signature" : "1c3d10d8b876e2cae5e8210fd2dd53d9b1245b961e69f6fd7759cd27e7a88dd7fc59f517972f4e6a0b480c837bd7d768292f5784ac5f1df692a9699e32d976ebd1a4282af727a5605cbc5b28d8dae834bdcad391282e6bef543bd11a3d72ef984195236043b655217c8cd8bd3247f29afe17ad0af20dc703df5d7ad49af1ff4bb247717dc6335c45e5845d92772c4e4eef5e2efb4a1c45cb2ffe296cecc4474ab81ec17401b4d3c5129a59a40da2ba8c8fa548a0ae8bbe43b1f1f1dbe029e28dc61a762ed2665ac1bbd6eb6aeecf1bca4b450e8df7bed087f7d390733fa477823eaaf59d0bf7a0c7a8150850b413a05237bd253350d5091a12219a35a58a0ef6fc15024f24b9ef2bd7b27ace7bedc30c9f9ecd1e828966cec760e555d019507560c2ba68dc562300460453f937abca74ca25a7de5fa66e4f28fdefb3030126c0f93b8304717c5a28d07ef095069ca9b6925f6e5ad11497b03a2b2c6660485e0e99b13c334084b038a4d81556c5b7c9ed766fd3fb30bf6931e22e94f647f619d4"
                        }
+
+
+
+Vassilev               Expires February 18, 2018               [Page 36]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                     ]
                 },
                 {
-                    "mode": "sigVer",
                     "sigType" : "PKCS1v1.5",
                     "modulo" : 2048,
                     "hashAlg" : "SHA-256",
@@ -2010,20 +2030,11 @@ B.3.  Example Test Vectors for sigVer JSON Objects
                        {
                          "tcId" : 1176,
                          "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
-
-
-
-Vassilev               Expires November 02, 2017               [Page 36]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                          "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
                        }
                     ]
                 },
                 {
-                   "mode": "sigVer",
                    "sigType" : "PKCS1v1.5",
                    "modulo" : 3072,
                    "hashAlg" : "SHA-256",
@@ -2038,7 +2049,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                    "mode": "sigVer",
                     "sigType" : "PSS",
                     "modulo" : 2048,
                     "hashAlg" : "SHA-256",
@@ -2053,10 +2063,17 @@ Internet-Draft                RSA Alg JSON                      May 2017
                     ]
                 },
                 {
-                   "mode": "sigVer",
                    "sigType" : "PSS",
                    "modulo" : 3072,
                    "hashAlg" : "SHA-512",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 37]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                    "e" : "fe3079",
                    "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
                    "tests" : [
@@ -2066,17 +2083,9 @@ Internet-Draft                RSA Alg JSON                      May 2017
                          "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
                        }
                     ]
-
-
-
-Vassilev               Expires November 02, 2017               [Page 37]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                 }
-          ]
-       }
+             ]
+         }
      ]
 
 
@@ -2098,9 +2107,9 @@ B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
      { "acvVersion": "0.4" },
      { "vsId": 1193,
         "algorithm": "RSA",
+        "mode": "componentSigPrimitive",
         "testGroups" : [
                {
-                   "mode": "componentSigPrimitive",
                    "tests" : [
                       {
                         "tcId" : 1194,
@@ -2113,21 +2122,20 @@ B.5.  Example Test Vectors for componentSigPrimitive JSON Objects
                         "n" : "9cd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58921",
                         "d" : "0c520729a48d1728adae9901f1c313a79751a4fa73d5c6be0cbb97112013d72191a2070c59dfe3b9ad8016044ca29c6619a5c66f5c2df133efa288605b9f38b1d93b1fa22bf90445383654a4bdbb55dedf99bd49ba79d46b3cd122cf2171ee75f69bca5b2155cd53a0ac9acbd49d2287bea65a9a5f229524325208600d163f5e9ff8f2d22b9478769b8c0636880188126423e03c89c8f55b11225e37ec1f24943b2fee5a9bddcc08ff1cb737466dd62a670801f6b92943a7419f1a00c4bdf8cd643b8edcbd2368ac2a4ada85c36f64ddd18f03e03bae5bb2c068d9b4e03c54c43d3e72e3934c5de642fb1e98a034e421ac2655415a3e3b7a9fa58cd2e2913749",
                         "message" : "ffd5aa3f0c7c787ee38a4fcc203f51e5f49cc562cca3cbce398035efd59556cbb2628ce68b20e436aee80707c2236afc83f0048819f89f5c594db381869d3b61733103ec9cdd75b7370a8d94d99f6d85b05c08ccb4278cf0e6d6e0c15759aac78f5ca74b3c814aa39b18880498543d872a89b641e8bd371703a8f137a55e02136708ec9e97f5cc5f7537becee85ea1ca46a3dae41ff8c4a326bbeda271b24400d3e506f1b4c1e029caebe0dfd1695fa9037c4993fbc2df39bc2a6b597df48493a28b7a5a7aa9ff414c525cf959d291c3a9e823365f2fb9be22c4fd845f813d94f8a49baec0b5784f9176025d60718beb0842e3b36305605998c16d66b3c58abc"
+
+
+
+Vassilev               Expires February 18, 2018               [Page 38]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                       }
                    ]
                }
-         ]
+          ]
       }
     ]
-
-
-
-
-
-
-Vassilev               Expires November 02, 2017               [Page 38]
-
-Internet-Draft                RSA Alg JSON                      May 2017
 
 
    Note: The ACVP server does retain additional context for each test
@@ -2143,9 +2151,9 @@ B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
      { "acvVersion": "0.4" },
      { "vsId": 1194,
         "algorithm": "RSA",
+        "mode": "componentDecPrimitive",
         "testGroups" : [
                {
-                   "mode": "componentDecPrimitive",
                    "tests" : [
                       {
                         "tcId" : 1196,
@@ -2169,6 +2177,15 @@ B.6.  Example Test Vectors for componentDecPrimitive JSON Objects
    that each test for which 'msg' is not between '0' and 'n - 1' should
    fail.
 
+
+
+
+
+Vassilev               Expires February 18, 2018               [Page 39]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
 Appendix C.  Example Test Results JSON Objects
 
 C.1.  Example keyGen Test Results JSON Objects
@@ -2178,16 +2195,9 @@ C.1.  Example keyGen Test Results JSON Objects
 
              [
                 { "acvVersion": "0.4" },
-
-
-
-Vassilev               Expires November 02, 2017               [Page 39]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                 { "vsId": 1133,
                     "algorithm": "RSA",
+                    "mode": keyGen,
                     "testResults": [
                     {
                       "tcId" : 1111,
@@ -2224,6 +2234,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "10000021",
                       "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
                       "bitlens" : [504, 238, 440, 185],
+
+
+
+Vassilev               Expires February 18, 2018               [Page 40]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                       "p" : "b6bbf5a62930f4a89153ff826347d7b49339a5af07d29fbb4120847c914f4a09c98c95070c70c5498520a2e799138cdaaca5c2fe1cd8ef6da799b26af0ac9785bbc790e6b52c32389ef26afd447cc05baf8e6c628832772bce91eb120309332aa8735ce7eb34c640863bb7efc59f70a3d3038359d57b8ba5b009ff7b119aa0c2db32a1edbac51f4bddc1c4dbd3f70e83d43b07c23a4d3859a91f51014e6aec589693e66928c20467fe3c568298b43cb98d8b0f2a7504c19b01759bd4de5c4fad",
                       "q" : "c263d13aded6645ee10683efc4d216e6b51314684c7f3b84cbd59988c14134fd8327d5ee1b436cce2f8648a260f5fda5f9494dd2275ae475676439741aac62587fc2de745b68eb46c59eeee00cbf05f3d911752ba9223e5a0b88390023e79a60d94604b82ac6a51df27699c4b6672e17be555af0673bc2a5573c32ada7158272e08e02efd00d18932cdbd518b4e969b766fefd3f380f31f2180d55dbcbe55b3e6ffb755e07b03800537734c37e8644e66fe64cc7465a9a570e1ec03775cad1fb",
                       "n" : "8ac1b03163ab5e673e5ebfa0328b694a322da0819fd97f7be54f94b805f58a8a2f7ff4e273c98440ba862e7959658ee1c0876a19232bbd4f85c9f20ebb92d031269cf19f0dd46ba28759a452678be7b9c35efb788f3739183b512a56e781bb6a9d42534399b8795e63705c01a742ede7862d6670ca02a02e5c117ac0a6548035be5cfad0da0174c1872d3da8523b3efbf98115d168e74bb4f327661131753593f45550edfda6486dd4dbf870e50367ca1c39e446f3be3b50f197f5f4b3137e950350542e3688330a4e6fd607286f57f5771255ef9f3816658c2ce981132b0303ad34c21208f3c15846f21dbb77daddd4adf5ddcc6d1b828a5a5a6f3c4f85a42f1b51085d2d913e1d105d5565c029efd80d2f8c42701f6e7d51e8bab650c03a98bad191e3f6508d42aff30e6db1ca81228bf044d13eff53bcf6d688b73a423503a8e36808b61ecf499df708c06aae3b441257d154bb5c483bb52f3b0990e47b06b6efdcaa73fb29de1897df0cf8ffb915a35e36ed1011a8a97ffd16ab51105b9f",
@@ -2234,14 +2252,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "10000021",
                       "seed" : "e664bc8c8e09ca232ae38171efc8891085da42fda83463febdc37241",
                       "bitlens" : [232, 220, 336, 141],
-
-
-
-Vassilev               Expires November 02, 2017               [Page 40]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "xP" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc18f9ae081c68ea7903a64f8f25dc431c544ba159470cbed48122b2e28fbf3856d28499a1cebbedf393ef13badd1cbcdc4027f02f6bc3bf27d4e0",
                       "p" : "e7b2b10bb6c975ef794d89b6f6928808ecd87e30bb2e737a8db70edc9e01934d747618274a52b5de36b0493f1fdd0d4f249cb9975e36b51208aa7c09e7f95343810fd089b1cc4cf9e8d26cbe4b9def67b97305763aa17c09c8a939dddcef9fe0cc7773acbb3ef9beff7812132f7d432f9c77af59e95c7613c4cd47cd27a64463",
                       "xQ" : "c3ce8bfcb6fb40bdafd66ae8a1dba8bcd8ccead2071d9d58672f8c5a6f37238fdab83026d5fe992d22d3a60bed9694d97ab4e778acf5d50dda75ed442db502505fe910aed4747b51704d2c2e8a876612d7d5eacfcd787b1a13e46da1ef9c36146d5ed51ad9fcb44a68375dd02edc365dc088bf0ffea14a571c0f93ddbc475291",
@@ -2280,6 +2290,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "bitlens" : [512, 182, 504, 222],
                       "xP" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f16221154aa62d139a67fb09edb0e6dcb091683e4136333b1cc7e9c2b09a8a06a335fd6f318532a068b9fd353ae12a1b57f9da498c6488ce863eb0a115af3ec15f70d4d78f030882a18bc14074a42daf322d2dd4b672c947fa21",
                       "p" : "e028ebb42965be5f3e31aebcfbeee3075ffa41afd99afa2b3ddb9df7327d3113374d27f82e26821976bfad8ccaa81958429685a75f9701144e00e07185ad997579b662b2f8b80dcf25ae491fc8bb05f9824588a38cb8c00ea1c1385bac926521fe5da8ea1bf6f162af6cd818f341cf0f652191e2debdf53eba1ada0b519eb3148708a9a0b36ac4087f7d3c446003111bc8c0db7bee01618f33432d81e3c7cca97e0733c88749f1ebe5e1edad984ecf3bc54651809fb0c5b4eaa45f12fb1155b1",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 41]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                       "xQ" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590d63fbdfb010f463a379e8a78e50ed95ce5c8fa3946970839492654ed0b70b3573354b2937cba400ced3fb1d8b5adfedcf0281fe13ca8b4348d18129afcf68f2bc27210e650d9434b344e2bf942fa03fdc50e4200014753afb998d15d8",
                       "q" : "f65afcf8b413ae69bac0c49def0afebb8304d4d1340a2b8dda19f3b8b0030d8f721fd8756a2d0e0087e058ac7f5eb9b8129f490259028195f2f9b2f2e5ed7bb4188007474f568adee803636c6f7c9729e2c4f001a5f799cb6a821ee267c901a0a9ee590fb74e9213473b3095212d37b0d1e20f93f260bd4ca1937b5eb936451eea0bd93274727a7ebaf6bdce546f0212c6c164eb30d7e139358bd71b16a6e26e6798c0ffbb9769d64a0e7de187b93b3cd102b56123d6a744c8fb3e88b07b62d9",
                       "n" : "d7b6fe640a76037945340c69b7a9179db3f852102a89acb483cd9d571201510e51b217b5de503328bcb2ea43774ca26a7742c3e4d4e079c15b1da25da4b99b50315e0a7123a04eb9c50f98d8c6f86f3c7ea92f536a67c170fc6cc947665dc7549d4a25253c05801a5cba334b72069b21bfc0020697492d562a9e46139dbf810555bd636aeed8c75f20a59ae589951b826787860e72f05c3bb817022d1f2a7f2d191ec8280d2f9db36ae7aa0f283197e72a93dd6f8981d58cbc59db86a3606f6072885fd03d18778be699c1eab0ff4152ae6d69e2bf7ce51df9d639b39fdbb6f79bd0e16835a5d403384f7901fad3883518e72405420fe5c0bdf9988833b3f566460db146a851a96228e4ef6fbefe7f30d22490a7486fab7fdfa8e4afcac2dacfa2fa71a7d8a3a0da60f8fb1f75618cfc0a631593ec729ebc5d58dff2da1728c64b319c70656ce6d1d97ab18c99cdc7bb0148e9cec2a91ff5f2a23052f3502809f29f30b0bb2d637a12a541075f086298bf4b667dbe56a05d6cf5cb79508a6509",
@@ -2290,14 +2308,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "10000021",
                       "bitlens" : [224, 195, 352, 142],
                       "xP1" : "57c9a2986fc7e69e835fd2847ed0a0d6983d8921130628cf86c8d811",
-
-
-
-Vassilev               Expires November 02, 2017               [Page 41]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "xP2" : "7254d6c998a84230ff25531243b8a6d0e05141ca56fba6f0f",
                       "xP" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854c604bae105a7e9bbb65754ce473f9dd76a0401702cf43d82710a847ef80756206d505fff46dbd82be6730efa81dd25ce0455f9287aec",
                       "p" : "c32cccd930ab2c107b3f114930148b501ac1c899de31472dd4a426eb76f1f1a328b17d191c7467b035e7640046bf12c972a91293fc24cbe98236d16487c9504669be7c69e94f7641d854ed236ca30b8bebab4d805b26cc3ddff4b50e462a81a155c6a3f8d8219690a31bd3544aadcab7ecaba73023058d2b7b8ea41f3a68acf1",
@@ -2336,6 +2346,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "tcId" : 1147,
                       "seed" : "6ba71c221702a1a6805c3a421e2af234129b429002f640b9834c41e9479a7f91",
                       "e" : "10000021",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 42]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                       "p" : "ca744f007d67b5e09a4b36e9b1c3edbcac2417c3b37f74da0429c5e85a325cf491eaa0780f6d8ebf24bedea9cc6dd68b6061139b868993d57647ddf2bfa4a52e92e11742866f7eefa262152b2054b5c65cb4c23f7e1ec7d8888a7ca2fea99cba8713642cd4c3f4d24318d841c0f44c82d4f60667ac59282dd2fa859924a38fe5f09c438d1730b7f206af27d7a892a9b93f09272ec333c097c38e029c3f27250b866f7dd3453e287bfbbc4be2af8d561524bb766036c1cb1a88427c4770f854e5",
                       "q" : "be7263212933d452800cf89edbad8e01a79eeab335bc8a4ff375173f29542f6cc14551432f2c715cf8f9b9852c6cf15fb5eae3a5895154c5c83c28ee1a5dd8ae12a963af318c0ce398cefd324c1099240367cd961e081d41884d812f48d5735d15348a8638ac700519874e6d82300bebd050273a69c4ca59ef61f17f239fe17d4dc7092d64a986fba02dcee818b62be6587ad56ff6c92627eff9e2ac767b1a9799f8108b1be9613b2a07b0a5512b8b3aaa300c586678a08cd13f22d20e5d4b95",
                       "n" : "969cc8d2bf6bce77575d8d3d62ffca22fbe43d0572ab27a7070b4324bd39a74e6adcf2cc69baeaa0af404512273702959f2393aff9375e58d1460e74f514a6f0887a8f607b0fa8e12682d76b663ae82716072e4d15722e70b2dc0fa0c73729393889e6c7b130311f47a27a988a098bf390a956be56648840c781b1cf82484df708821a53a6c9c0d64f23ea499ec274e5c31e78f702ffa21aa87da832f2e12300c389be1d965764acf2cae1ace36493cae1776513c1c30637f8dd98bcde0083224d5e65a7695d5f05b707ae40dec91d34f41df9094814f0f20154356232b54df9b40a31421e015cb47968a4ca77629b2493cb74054c30517e92606967aa3d14ce12260995d3d0243502192940b6d552b1015e5ac16f756f2152bf259c5a72468783f87a92e371a2f9a9c829f4397fc59e9b874a7a3222bfb2207cabbef0f3949d4871fbae9deb742ed9eae8a1baeb6088d92f904a132234ef6fc3e8b170904d56e276436135e3abe67054c139699e37601e44f3dc6b73a6935793f062de998049",
@@ -2346,14 +2364,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "primeResult" : "passed"
                     },
                    {
-
-
-
-Vassilev               Expires November 02, 2017               [Page 42]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "tcId" : 1120,
                       "primeResult" : "failed"
                    },
@@ -2392,6 +2402,14 @@ Internet-Draft                RSA Alg JSON                      May 2017
                   {
                       "tcId" : 1130,
                       "e" : "e66d81",
+
+
+
+Vassilev               Expires February 18, 2018               [Page 43]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
                       "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
@@ -2402,14 +2420,6 @@ Internet-Draft                RSA Alg JSON                      May 2017
                       "e" : "535c97",
                       "p" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
                       "q" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5",
-
-
-
-Vassilev               Expires November 02, 2017               [Page 43]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "n" : "ac6a77ebbf9c725ec97311f54cd35a4d98c49582201383cc8caf06de233e8a6498cca81e5705ff67c87874cba0070c94dcf7370a13f44c7bf6f39e1039c0e716f21bb81d238115ce651900c7627086c6bc7047ec8fc9f02713dc7c6cb35342cdd3d026b3e8e73518e657f2e1683532a48bfe3bbd558695860c71fcd44a275e6d41d402d5f050400a3402d3d5d4aaf9787dd79a2d5c90a43fd4cdf43a48d0a52b0b0da5d3b1b59cc2abddbcae0b8b1b02a2e2edbaab934e90309760d699ecb99691d51bbf0674a145e6a35b83a5ad4ac30da41b20527d481d803b2f77ca0b1e1824330687bb3c0a2a6c9eb7395d26585b048fc5de518f3e5c2b961fa93d265c45259f2db3beffe5d1f12e0cc6743f9b24399b7c764d88db093044bbad65829bb61d21b127b87f9054eea09c86b7562d1c173fa73f7280c49c62dd0aa5cbfcf947a5a503b296576eefc0e614cb5918b9f5a6aa54b48bf2e6bc874c9d8c031ee9812f63d2fe883f2f306ad1c555d21f29882af0b4730460bb84aba7172dbce1a449",
                       "d" : "0983777bbe9c98dddf0ea0de97a13e3ed1863a7b8beb62d7a392fc17e891a3e825123e71baf02ca4efc4d8dcc76415fbc99c138fa37c6c414d365d2c5954548f6f88afa3244810090f636911694667ff155281b8311a5028dd8875fb17ad9de058470afc54a9eff622d0f80a04a6eae78a1536cd2cb5b177de39c035fd2bfd0af91b65ca329d279cfccbca6d74973c5ab94b35c040aae61c01692c95fa00d02c2fc72cf5ee48507962bbfcd6c7e5c778ed91fdd80f52900d4e78661a343a2067b6f9c79643ad2856d4c0d49c195a03ef57729234acd9518d3beffa2304e7dcde0fdd8ad2c3d09287b10c32662714077c19f88c04779d926b78eb5ae2b3050634492c7d78fa66b7dd731dd45ca9323707e5c4f41c971c76e53c04403c2254dda635cbb3505a6cb58933a658700a85d5b7a25098680cf3f4c0205b09957e0fae8cf819230e617996fd80ed6d9ae565645b293f12afa4c4076d2ea65bb69af5058ceb5c4b3c684be08acb6021472bd93a37275a1c20fcdf05b27756ba1015d384a3"
                   },
@@ -2435,6 +2445,7 @@ C.2.  Example sigGen Test Results JSON Objects
                 { "acvVersion": "0.4" },
                 { "vsId": 1163,
                   "algorithm": "RSA",
+                  "mode": "sigGen",
                   "testResults": [
                     {
                       "tcId" : 1165,
@@ -2447,6 +2458,14 @@ C.2.  Example sigGen Test Results JSON Objects
                       "e" : "ebda09",
                       "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
+
+
+
+Vassilev               Expires February 18, 2018               [Page 44]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                     },
                     {
                       "tcId" : 1167,
@@ -2458,14 +2477,6 @@ C.2.  Example sigGen Test Results JSON Objects
                       "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
-
-
-
-Vassilev               Expires November 02, 2017               [Page 44]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                       "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
                     },
                     {
@@ -2494,6 +2505,7 @@ C.3.  Example sigVer Test Results JSON Objects
        { "acvVersion": "0.4" },
        { "vsId": 1173,
          "algorithm": "RSA",
+         "mode": "sigVer",
          "testResults" : [
                  {
                    "tcId" : 1174,
@@ -2502,6 +2514,14 @@ C.3.  Example sigVer Test Results JSON Objects
                  {
                    "tcId" : 1175,
                    "sigResult" : "failed"
+
+
+
+Vassilev               Expires February 18, 2018               [Page 45]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
                  },
                  {
                    "tcId" : 1176,
@@ -2514,14 +2534,6 @@ C.3.  Example sigVer Test Results JSON Objects
                  {
                    "tcId" : 1178,
                    "sigResult" : "failed"
-
-
-
-Vassilev               Expires November 02, 2017               [Page 45]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
                  },
                  {
                    "tcId" : 1179,
@@ -2545,8 +2557,9 @@ C.5.  Example componentSigPrimitive Test Results JSON Objects
 
    [
        { "acvVersion": "0.4" },
-       { "vsId": 1193,
+       { "vsId": 47,
          "algorithm": "RSA",
+         "mode": "componentSigPrimitive",
          "testResults" : [
                    {
                     "tcId" : 1194,
@@ -2557,6 +2570,14 @@ C.5.  Example componentSigPrimitive Test Results JSON Objects
                     "sigResult" : "failed"
                    }
                ]
+
+
+
+Vassilev               Expires February 18, 2018               [Page 46]
+
+Internet-Draft                RSA Alg JSON                   August 2017
+
+
        }
    ]
 
@@ -2568,16 +2589,9 @@ C.6.  Example componentDecPrimitive Test Results JSON Objects
 
    [
        { "acvVersion": "0.4" },
-       { "vsId": 1194,
+       { "vsId": 48,
          "algorithm": "RSA",
-
-
-
-Vassilev               Expires November 02, 2017               [Page 46]
-
-Internet-Draft                RSA Alg JSON                      May 2017
-
-
+               "mode": "componentDecPrimitive",
          "testResults" : [
                 {
                    "tcId" : 1196,
@@ -2614,18 +2628,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev               Expires November 02, 2017               [Page 47]
+Vassilev               Expires February 18, 2018               [Page 47]

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -46,7 +46,7 @@
 
     <!-- Another author who claims to be an editor -->
 
-    <author fullname="Apostol Vassilev" initials="A.V." role="editor" surname="Vassilev">
+    <author fullname="Apostol Vassilev" initials="A." role="editor" surname="Vassilev">
       <organization>National Institute of Standards and Technology</organization>
 
       <address>
@@ -70,7 +70,7 @@
       </address>
     </author>
 
-    <date month="May" year="2017"/>
+    <date month="August" year="2017"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -144,7 +144,6 @@
 	    <texttable anchor="algs_table" title="Supported RSA Algorithm Modes JSON Values">
           <ttcol align="left">JSON algorithm value</ttcol>
           <ttcol align="left">JSON mode value</ttcol>
-          <c>"RSA"</c>
           <c>"keyGen"</c>
           <c/>
           <c>"sigGen"</c>
@@ -233,6 +232,16 @@
           <c/>
           <c/>
           <c/>
+          <c>mode</c>
+	  <c>The RSA algorithm mode to be validated</c>
+          <c>value</c>
+          <c>"keyGen", "sigGen", "sigVer", "legacySigVer", "componentSigPrimitive", "componentDecPrimitive"</c>
+          <c>No</c>
+         <c/>
+         <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
 	       <c>The prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects - see <xref target="prereq_algs"/></c>
@@ -243,47 +252,26 @@
           <c/>
           <c/>
           <c/>
-          <c>capSpecs</c>
-	       <c>The capabilities of a particular RSA mode</c>
-          <c>an array of objects specific to the mode being specified</c>
-          <c>array</c>
-          <c>No</c>
-         <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/>
-         <c>modeSpecs</c>
-	       <c>The RSA mode and its capabilities</c>
-          <c>an object with "mode" and "capSpecs" properties</c>
-          <c>object</c>
-          <c>No</c>
-         <c/>
-         <c/>
-          <c/>
-          <c/>
-          <c/>
          <c>algSpecs</c>
-	       <c>Array of modeSpecs</c>
-          <c>array of modeSpecs objects, each identified uniquely by the "mode" and required properties</c>
-          <c>See <xref target="algs_table"/> and <xref target="supported_mods"/></c>
+	       <c>Array of JSON objects</c>
+          <c>array of JSON objects, each with fields pertaining to the global RSA mode indicated above and identified uniquely by the combination of the RSA "mode" and indicated properties</c>
+          <c>See <xref target="algs_table"/> and <xref target="supported_modes"/></c>
           <c>No</c>          
           </texttable>    
    </section>
-	<section anchor="supported_mods" title="Supported RSA Modes Capabilities">
-    <t>The RSA mode capabilities are advertised as arrays of JSON objects within the 'modeSpecs'
-	value of the ACVP registration message - see <xref target="caps_table"/>. The 'modeSpecs' value is an array, where each
-	array element is an array of individual JSON objects corresponding to a particular RSA mode defined in this section.  The 'modeSpecs'
+	<section anchor="supported_modes" title="Supported RSA Modes Capabilities">
+    <t>The RSA mode capabilities are advertised as JSON objects within the 'algSpecs'
+	value of the ACVP registration message - see <xref target="caps_table"/>. The 'algSpecs' value is an array, where each
+	array element is a JSON object corresponding to a particular RSA mode defined in this section.  The 'algSpecs'
 	value is part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA mode capabilities are advertised as an array of self-contained JSON objects.</t>
+	<t>Each RSA mode's capabilities are advertised as JSON objects.</t>
 	<section anchor="mode_keyGen" title="The keyGen Mode Capabilities">
-	  <t>The RSA keyGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
-	See the ACVP specification for details on the registration message.</t>
+	  <t>The RSA keyGen mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array
+	in the ACVP registration message. See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA keyGen mode capability is advertised as a self-contained JSON object.</t>
+	<t>Each RSA keyGen mode capability set is advertised as a self-contained JSON object.</t>
 	
 	    <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_keyGenProvPrim" title="keyGen With Provable Primes or Provable Primes with Conditions Capabilities">
@@ -304,7 +292,7 @@
           <c/>
           <c/>
           <c/>
-          <c>hashAlg</c>
+          <c>hashAlgs</c>
           <c>Supported hash algorithms for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.2 or Appendix B.3.4</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
@@ -316,7 +304,7 @@
           <c/>
           <c>singleCap</c>
           <c>A testable combination of modulus and hash values</c>
-          <c>object with "modulo" and "hashAlg" properties</c>
+          <c>object with "modulo" and "hashAlgs" properties</c>
           <c>see above</c>
           <c>Yes</c>
           <c/>
@@ -395,7 +383,7 @@
 	            <c/>
 	            <c/>
 	            <c/>
-	            <c>hashAlg</c>
+	            <c>hashAlgs</c>
 	            <c>Supported hash algorithms for provable prime generation - see <xref target="FIPS186-4"/>, Appendix B.3.6</c>
 	            <c>array</c>
 	            <c>any non-empty subset of {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
@@ -417,7 +405,7 @@
 	            <c/>
 	            <c>singleCap</c>
 	            <c>A testable combination of modulus, hash algorithm, and primality test rounds</c>
-	            <c>object with "modulo", "hashAlg", and "primeTest" properties</c>
+	            <c>object with "modulo", "hashAlgs", and "primeTest" properties</c>
 	            <c>see above</c>
 	            <c>Yes</c>
 	            <c/>
@@ -511,11 +499,11 @@
           </section>
 	</section>
 	<section anchor="mode_sigGen" title="The sigGen Mode Capabilities">
-	  <t>The RSA sigGen mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	  <t>The RSA sigGen mode capabilities are advertised as JSON objects within the 'algSpecs' array
+	as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA sigGen mode capability is advertised as a self-contained JSON object.</t>
+	<t>Each RSA sigGen mode capability is advertised as a self-contained JSON object consisting of the algorithm, mode, and algSpecs array.  The algSpecs array may contain multiple elements, each pertaining to a sigType that is supported by the client for the RSA mode being advertised.</t>
 	 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_sigGenCap" title="sigGen Capabilities">
           <t>The following RSA signature generation capabilities may be advertised by the ACVP compliant crypto module:</t>
@@ -527,8 +515,18 @@
          <ttcol align="left">Optional</ttcol>
           <c>sigType</c>
           <c>supported RSA signature types  - see <xref target="FIPS186-4"/>, Section 5</c>
+          <c>value</c>
+          <c>one of {"ANSX9.31", "PKCS1v1.5", "PSS"}</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>capSigType</c>
+          <c>capabilites supported for this sigType  - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
-          <c>any non-empty subset of {"ANSX9.31", "PKCS1v1.5", "PSS"}</c>
+          <c>modulo, hashAlgs, and optionally the saltLens object</c>
           <c>No</c>
           <c/>
           <c/>
@@ -537,8 +535,8 @@
           <c/>
           <c>modulo</c>
           <c>supported RSA moduli for signature generation - see <xref target="FIPS186-4"/>, Section 5</c>
-          <c>array</c>
-          <c>any non-empty subset of {2048, 3072, 4096}</c>
+          <c>value</c>
+          <c>one of the supported modulo sizes {2048, 3072, 4096}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -546,7 +544,7 @@
           <c/>
           <c/>
           <c>hashAlgs</c>
-          <c>supported hash algorithms for signature generation - see <xref target="SP800-131A"/>, Section 9</c>
+          <c>supported hash algorithms for signature generation for this sigType and modulo - see <xref target="SP800-131A"/>, Section 9</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
           <c>No</c>
@@ -556,20 +554,20 @@
           <c/>
           <c/>
           <c>saltLens</c>
-          <c>supported salt lengths for PKCS1PSS signature generation - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
+          <c>supported salt lengths for PSS signature generation - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
           <c>array</c>
           <c>array of values for each hash algorithm used subject to the constraint in the note below.</c>
           <c>Yes</c>
           </texttable>
-          <t>Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</t>
+          <t>Note: the salt length for each hash algorithm used in PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</t>
           </section>
 	</section>
 		<section anchor="mode_sigVer" title="The sigVer Mode Capabilities">
-	  <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
+	  <t>The RSA sigVer mode capabilities are advertised as JSON objects within the array of 'algSpecs'
 	as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA sigVer mode capability is advertised as a self-contained JSON object.</t>
+	<t>Each RSA sigVer mode capability is advertised as a self-contained JSON object consisting of the algorithm, mode, and algSpecs array.  The algSpecs array may contain multiple elements, each pertaining to a sigType that is supported by the client for the RSA mode being advertised.</t>
 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_sigVerCap" title="sigVer Capabilities">
           <t>The following RSA signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
@@ -581,8 +579,18 @@
          <ttcol align="left">Optional</ttcol>
           <c>sigType</c>
           <c>supported RSA signature types  - see <xref target="FIPS186-4"/>, Section 5</c>
+          <c>value</c>
+           <c>one of {"ANSX9.31", "PKCS1v1.5", "PSS"}</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>capSigType</c>
+          <c>RSA signature verification parameters  - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
-           <c>any non-empty subset of {"ANSX9.31", "PKCS1v1.5", "PSS"}</c>
+           <c>modulo, hashAlgs, and saltLens (when sigType is PSS)</c>
           <c>No</c>
           <c/>
           <c/>
@@ -590,9 +598,9 @@
           <c/>
           <c/>
           <c>modulo</c>
-          <c>supported RSA moduli for signature verification - see <xref target="FIPS186-4"/>, Section 5</c>
-          <c>array</c>
-          <c>any non-empty subset of {2048, 3072, 4096}</c>
+          <c>supported RSA modulo for signature verification - see <xref target="FIPS186-4"/>, Section 5</c>
+          <c>value</c>
+          <c>any one of the supported modulo sizes {2048, 3072, 4096}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -600,7 +608,7 @@
           <c/>
           <c/>
           <c>hashAlgs</c>
-          <c>supported hash algorithms for signature verification - see <xref target="SP800-131A"/>, Section 9</c>
+          <c>supported hash algorithms for this sigType and modulo - see <xref target="SP800-131A"/>, Section 9</c>
           <c>array</c>
           <c>any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
           <c>No</c>
@@ -610,7 +618,7 @@
           <c/>
           <c/>
           <c>saltLens</c>
-          <c>supported salt lengths for PKCS1PSS signature verification - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
+          <c>supported salt lengths for PSS signature verification - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
           <c>array</c>
           <c>array of values for each hash algorithm used subject to the constraint in the note below.</c>
           <c>Yes</c>
@@ -619,18 +627,12 @@
           </section>
 	</section>
 		<section anchor="mode_legacySigVer" title="The legacySigVer Mode Capabilities">
-	  <t>The RSA legacySigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
-	See the ACVP specification for details on the registration message.</t>
-
-	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</t>
-	 <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
+	  <t>The RSA legacySigVer mode capabilities are advertised as JSON objects within the array of 'algSpecs'
 	as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</t>
+	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object consisting of the algorithm, mode, and algSpecs array.  The algSpecs array may contain multiple elements, each pertaining to a sigType that is supported by the client for the RSA mode being advertised.</t>
 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
-          <t>The following RSA legacy signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="legacySigVerRSAMod" title="Supported RSA legacySigVer moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -638,9 +640,19 @@
          <ttcol align="left">Valid values</ttcol>
          <ttcol align="left">Optional</ttcol>
           <c>sigType</c>
-          <c>supported legacy RSA signature types  - see <xref target="SP800-131A"/>, Section 5</c>
+          <c>supported RSA legacy signature types  - see <xref target="FIPS186-4"/>, Section 5</c>
+          <c>value</c>
+           <c>one of {"ANSX9.31", "PKCS1v1.5", "PSS"}</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>capSigType</c>
+          <c>RSA legacy signature verification parameters  - see <xref target="FIPS186-4"/>, Section 5</c>
           <c>array</c>
-           <c>any non-empty subset of {"ANSX9.31", "PKCS1v1.5", "PSS"}</c>
+           <c>modulo, hashAlgs, and saltLens (when sigType is PSS)</c>
           <c>No</c>
           <c/>
           <c/>
@@ -648,9 +660,9 @@
           <c/>
           <c/>
           <c>modulo</c>
-          <c>supported RSA moduli for signature verification - see <xref target="SP800-131A"/></c>
-          <c>array</c>
-          <c>any non-empty subset of {1024, 1536, 2048, 3072, 4096}</c>
+          <c>supported RSA modulo for signature verification - see <xref target="FIPS186-4"/>, Section 5</c>
+          <c>value</c>
+          <c>any one of the supported modulo sizes {2048, 3072, 4096}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -658,9 +670,9 @@
           <c/>
           <c/>
           <c>hashAlgs</c>
-          <c>supported hash algorithms for signature verification - see <xref target="SP800-131A"/>, Section 9</c>
+          <c>supported hash algorithms for this sigType and modulo - see <xref target="SP800-131A"/>, Section 9</c>
           <c>array</c>
-          <c>any non-empty subset of {"SHA-1", "SHA-256", "SHA-384", "SHA-512"}</c>
+          <c>any non-empty subset of {"SHA-224", "SHA-256", "SHA-384", "SHA-512", "SHA-512/224", "SHA-512/256"}</c>
           <c>No</c>
           <c/>
           <c/>
@@ -668,7 +680,7 @@
           <c/>
           <c/>
           <c>saltLens</c>
-          <c>supported salt lengths for PKCS1PSS signature verification - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
+          <c>supported salt lengths for PSS signature verification - see <xref target="FIPS186-4"/>, Section 5.5. See also note below.</c>
           <c>array</c>
           <c>array of values for each hash algorithm used subject to the constraint in the note below.</c>
           <c>Yes</c>
@@ -676,17 +688,17 @@
           <t>Note: the salt length for each hash algorithm used in PKCS1PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.</t>
 	</section>
 	<section anchor="mode_componentSigPrimitive" title="The componentSigPrimitive Mode Capabilities">
-	  <t>The RSA componentSigPrimitive mode capability (otherwise known as RSASP1 in <xref target="RFC3447"/>) is advertised as a JSON object within the array of 'modeSpecs'
-	value of the ACVP registration message, as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
+	  <t>The RSA componentSigPrimitive mode capabilities (otherwise known as RSASP1 in <xref target="RFC3447"/>) are advertised as JSON objects within the array of 'algSpecs'
+	as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	See the ACVP specification for details on the registration message. In this mode, the only tested capability
 	is the correct expontiation 's = msg^d mod n', where 'msg' is a message between '0' and 'n - 1', 'd' is the private exponent and 'n' is the modulus, all supplied by the testing ACVP server. 
 	Only 2048-bit RSA keys are allowed for this capability. There are no properties specified for this capability. 
 	See <xref target="app-testcomponentsigprimitive-ex"/> for additional details on constraints for 'msg' and 'n'.
 	See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA componentSigPrimitive mode capability is advertised as a self-contained JSON object.</t>
 	</section>
 	<section anchor="mode_componentDecPrimitive" title="The componentDecPrimitive Mode Capabilities">
-<t>The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs'
+<t>The RSA componentDecPrimitive mode capabilities are advertised as JSON objects within the array of 'algSpecs'
 	as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
 	is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <xref target="SP800-56B"/>, Section 7.1.2 for details.</t>
 	
@@ -697,18 +709,16 @@
 	The client must first check if  '0 &lt; msg &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 
 	'msg' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.</t>
 
-	<t>Each RSA componentDecPrimitive mode capability is advertised as a self-contained JSON object.</t>
 	</section>
-		
 </section>   
     </section>
 
     <section anchor="test_vectors" title="Test Vectors">
-	<t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to
+	<t>The ACVP server provides test vectors to the ACVP client, which are then processed by the client and returned to
 	    the ACVP server for validation.  A typical ACVP validation session would require multiple test vector
 	    sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual
-	    algorithm, such as Hash_DRBG, etc.  This section
-	describes the JSON schema for a test vector set used with DRBG algorithms.</t>
+	    algorithm and mode, such as {"algorithm": "RSA, "mode": "sigGen"}, etc.  This section
+	describes the JSON schema for test vector sets used with the RSA algorithm and modes.</t>
 
 	<t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire
 	vector set as well as individual test vectors to be processed by the ACVP client.  The following table
@@ -1124,28 +1134,24 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
+      "mode": "keyGen",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-              "mode": "keyGen",
-              "capSpecs" :  {
-                      "pubExp" : "fixed",
-                      "fixedPubExpVal" : "010001",
-                      "infoGeneratedByServer": true,
-                      "randPQ" : "B.3.2",
-                      "capProvPrime" : 
-                            [
-                                {   "modulo" : 2048,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 3072,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
-                                {   "modulo" : 4096,
-                                    "hashAlg" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
-                            ]
-                      }
-                }
-          }
+         {  "pubExp" : "fixed",
+            "fixedPubExpVal" : "010001",
+            "infoGeneratedByServer": true,
+            "randPQ" : "B.3.2",
+            "capProvPrime" : 
+              [
+                {   "modulo" : 2048,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                {   "modulo" : 3072,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]},
+                {   "modulo" : 4096,
+                    "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"]}
+              ]
+         }
       ]
    }
 ]]></artwork>
@@ -1158,36 +1164,22 @@
         <artwork><![CDATA[
    {
     "algorithm":"RSA",
-    "prereqVals":[
-      {
-        "algorithm":"DRBG",
-        "valValue":"123456"
-      },
-      {
-        "algorithm":"SHA",
-        "valValue":"7890"
-      }
-    ],
-    "algSpecs":[
-      {
-        "modeSpecs": {
-          "mode":"keyGen",
-          "capSpecs": {
-            "pubExp": "fixed",
-            "fixedPubExpVal":"010001",
-            "randPQ": "B.3.3",
-            "capProbPrime":[{
-              "modulo": 2048,
-              "primeTest":["tblC2"]
-            },
-            {
-              "modulo": 3072,
-              "primeTest":["tblC2", "tblC3"]
-            }]
-          }
+    "mode":"keyGen",
+    "prereqVals":[{"algorithm":"DRBG", "valValue":"123456"}, {"algorithm":"SHA", "valValue":"7890"}],
+    "algSpecs":
+    [
+       {  "pubExp": "fixed",
+          "fixedPubExpVal":"010001",
+          "randPQ": "B.3.3",
+          "capProbPrime":
+            [
+              {  "modulo": 2048,
+                 "primeTest":["tblC2"]},
+              {  "modulo": 3072,
+                 "primeTest":["tblC2", "tblC3"]}
+            ]
         }
-      }
-    ]
+     ]
   }
 ]]></artwork>
     </figure>
@@ -1201,31 +1193,27 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
-       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
+      "mode": "keyGen",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-           "mode": "keyGen",
-           "capSpecs" : {
-               "pubExp" : "fixed",
-               "fixedPubExpVal" : "010001",
-               "infoGeneratedByServer": false,
-               "randPQ" : "B.3.5",
-               "capsProvProbPrime" : 
-                    [
-                        {"modulo" : 2048,
-                         "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
-                         "primeTest": ["tblC2", "tblC3"]},
-                       {"modulo" : 3072,
-                         "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
-                         "primeTest": ["tblC2"]},
-                       {"modulo" : 4096,
-                         "hashAlgs" : ["SHA-512"],
-                         "primeTest": ["tblC3"]}
-                    ]
-              }
-          }
-        }
+         {  "pubExp" : "fixed",
+            "fixedPubExpVal" : "010001",
+            "infoGeneratedByServer": false,
+            "randPQ" : "B.3.5",
+            "capsProvProbPrime" : 
+              [
+                { "modulo" : 2048,
+                  "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                  "primeTest": ["tblC2", "tblC3"]},
+                { "modulo" : 3072,
+                  "hashAlgs" : ["SHA-1", "SHA-224", "SHA-256", "SHA-512"],
+                  "primeTest": ["tblC2"]},
+                { "modulo" : 4096,
+                  "hashAlgs" : ["SHA-512"],
+                  "primeTest": ["tblC3"]}
+              ]
+         }
       ]
    }
 ]]></artwork>
@@ -1238,44 +1226,34 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
+      "mode": "sigGen",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "algSpecs" : 
       [
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "ANSX9.31",
-                  "capSigType" :
-                  [
-                      {"modulo" : 2048,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 3072,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 4096,
-                        "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-        }},
-         {"modeSpecs" : {
-               "mode": "sigGen",
-               "capSpecs" : {
-                  "sigType" : "PKCS1v1.5",
-                  "capSigType" :
-                  [
-                      {"modulo" : 2048,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 3072,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                      {"modulo" : 4096,
-                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
-                  ]
-              }
-         }},
-        {"modeSpecs" : {
-            "mode": "sigGen",
-            "capSpecs" : {
-                "sigType" : "PSS",
-                "capSigType" :
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+                [
+                    { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                 ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                    { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                    { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                 ]
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
                 [
                     { "modulo" : 2048,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
@@ -1287,8 +1265,7 @@
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]}
                 ]
-            }
-         }}
+         }
       ]
    }
 ]]></artwork>
@@ -1300,78 +1277,110 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
+      "mode": "sigVer",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "algSpecs" : 
       [
-        {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-               
-                 "sigType" : "ANSX9.31",
-                 "capSigType" :
-                [
-                  {"modulo" : 2048,
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+               [
+                  { "modulo" : 2048,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 3072,
+                  { "modulo" : 3072,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 4096,
+                  { "modulo" : 4096,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
                ]
-            }
-          }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1v1.5",
-                 "capSigType" :
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
                 [
-                  {"modulo" : 2048,
+                  { "modulo" : 2048,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 3072,
+                  { "modulo" : 3072,
                     "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
-                  {"modulo" : 4096,
+                  { "modulo" : 4096,
                     "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
                 ]
-            }
-         }},
-      {"modeSpecs" : {
-            "mode": "sigVer",
-            "capSpecs" : {
-                "sigType" : "PKCS1PSS",
-                "capSigType" :
-                  [
-                    { "modulo" : 2048,
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]},
-                    { "modulo" : 3072,
+                  { "modulo" : 3072,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]},
-                    { "modulo" : 4096,
+                  { "modulo" : 4096,
                       "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
                       "saltLens" : [28, 32, 64]}
                  ]
-            }
-       }}
-    ]
+          }
+      ]
    }
 ]]></artwork>
     </figure>
     </section>
         <section anchor="app-cap-legacysigverex" title="Example RSA legacySigVer Capabilities JSON Objects">
-      <t>The format and structure of the RSA legacySigVer capabilities JSON objects follow very closely those of the RSA sigVer capabilties JSON objects with the obvious changes from moduloSigVer, hashSigVer and saltSigver to modLegacySigVer, hashLegacySigVer, and saltLegacySugVer and the corresponding parameter ranges adjustments.</t>
-</section>
+      <t>The following is an example JSON object advertising support for RSA legacySigVer according to <xref target="FIPS186-4"/>.</t>
+      <figure>
+        <artwork><![CDATA[
+   {
+      "algorithm": "RSA",
+      "mode": "legacySigVer",
+      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
+      "algSpecs" : 
+      [
+         {  "sigType" : "ANSX9.31",
+            "capSigType" :
+               [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+               ]
+         },
+         {  "sigType" : "PKCS1v1.5",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 3072,
+                    "hashSigVer" : ["SHA-224", "SHA-256", "SHA-512"]},
+                  { "modulo" : 4096,
+                    "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"]}
+                ]
+         },
+         {  "sigType" : "PSS",
+            "capSigType" :
+                [
+                  { "modulo" : 2048,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 3072,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]},
+                  { "modulo" : 4096,
+                      "hashAlgs" : ["SHA-224", "SHA-256", "SHA-512"],
+                      "saltLens" : [28, 32, 64]}
+                 ]
+          }
+      ]
+   }
+]]></artwork>
+    </figure>
+    </section>
+
     <section anchor="app-cap-componentsigverex" title="Example componentSigPrimitive Capabilities JSON Objects">
       <t>The following is an example JSON object advertising support for RSA componentSigPrimitive according to <xref target="FIPS186-4"/>.</t>
       <figure>
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
-      "algSpecs" : 
-      [
-       {"modeSpecs" : {
-           "mode": "componentSigPrimitive"
-         }}
-      ]
+      "mode": "componentSigPrimitive"
    }
 ]]></artwork>
     </figure>
@@ -1382,13 +1391,14 @@
         <artwork><![CDATA[
    {
       "algorithm": "RSA",
-      "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
-      "algSpecs" : 
-      [
-        {"modeSpecs" : {
-            "mode": "componentDecPrimitive"
-         }}
-      ]
+      "mode": "componentDecPrimitive",
+      "prereqVals": 
+        [
+            {"algorithm": "DRBG", "valValue": "123456"}, 
+            {"algorithm": "DRBG", "valValue": "654321"}, 
+            {"algorithm": "SHA", "valValue": "7890"}
+        ],
+      "algSpecs" : [{}]
    }
 ]]></artwork>
     </figure>
@@ -1404,9 +1414,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1133,
      "algorithm": "RSA",
+     "mode": "keyGen",
      "testGroups" : [
              {           
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.2",
@@ -1422,7 +1432,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.2",
@@ -1438,7 +1447,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.4",
@@ -1454,7 +1462,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.4",
@@ -1470,7 +1477,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.5",
@@ -1486,7 +1492,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.5",
@@ -1502,7 +1507,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.6",
@@ -1518,7 +1522,6 @@
                  ]
              },
              {
-                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.6",
@@ -1534,7 +1537,6 @@
                 ]
               },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -1556,7 +1558,6 @@
                  ]
              },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -1571,7 +1572,6 @@
                  ]
              },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -1593,7 +1593,6 @@
                  ]
              },
              {
-                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -1607,9 +1606,9 @@
                     }
                  ]
              }
-     ]
-   }
- ]
+         ]
+      }
+   ]
 ]]></artwork>
     </figure>
     <t>Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate
@@ -1625,9 +1624,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
+      "mode": "sigGen",
       "testGroups" : [
              {
-                 "mode": "sigGen",
                  "sigType" : "ANSX9.31",
                  "hashAlg" : "SHA-256",
                  "modulo" : 2048,
@@ -1639,7 +1638,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType": "ANSX9.31",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -1651,7 +1649,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -1662,8 +1659,7 @@
                    }
                 ]
              },
-             {
-                "mode": "sigGen",
+             {,
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -1675,7 +1671,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -1688,7 +1683,6 @@
                  ]
              },
              {
-                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -1713,9 +1707,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
+      "mode": "sigVer",
       "testGroups" : [
              {
-                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
                  "hashAlg" : "SHA-256",
                  "modulo" : 2048,
@@ -1730,7 +1724,6 @@
                  ]
              },
              {
-                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA-256",
@@ -1745,7 +1738,6 @@
                  ]
              },
              {
-                 "mode": "sigVer",
                  "sigType" : "PKCS1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -1760,7 +1752,6 @@
                  ]
              },
              {
-                "mode": "sigVer",
                 "sigType" : "PKCS1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-256",
@@ -1775,7 +1766,6 @@
                  ]
              },
              {
-                 "mode": "sigVer",
                  "sigType" : "PSS",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -1790,7 +1780,6 @@
                  ]
              },
              {
-                "mode": "sigVer",
                 "sigType" : "PSS",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-512",
@@ -1804,8 +1793,8 @@
                     }
                  ]
              }
-       ]
-    }
+          ]
+      }
   ]
 
 ]]></artwork>
@@ -1823,9 +1812,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
+      "mode": "componentSigPrimitive",
       "testGroups" : [
              {           
-                 "mode": "componentSigPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -1841,7 +1830,7 @@
                     }
                  ]
              }
-       ]
+        ]
     }
   ]
 ]]></artwork>
@@ -1856,9 +1845,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
+      "mode": "componentDecPrimitive",
       "testGroups" : [
              {
-                 "mode": "componentDecPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -1888,6 +1877,7 @@
                 { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "algorithm": "RSA",
+                    "mode": keyGen,
                     "testResults": [
                     {
                       "tcId" : 1111,
@@ -2103,6 +2093,7 @@
                 { "acvVersion": "0.4" },
                 { "vsId": 1163,
                   "algorithm": "RSA",
+                  "mode": "sigGen",
                   "testResults": [
                     {
                       "tcId" : 1165,
@@ -2154,6 +2145,7 @@
     { "acvVersion": "0.4" },
     { "vsId": 1173,
       "algorithm": "RSA",
+      "mode": "sigVer",
       "testResults" : [
               {
                 "tcId" : 1174,
@@ -2194,8 +2186,9 @@
         <artwork><![CDATA[
 [
     { "acvVersion": "0.4" },
-    { "vsId": 1193,
+    { "vsId": 47,
       "algorithm": "RSA",
+      "mode": "componentSigPrimitive",
       "testResults" : [
                 {
                  "tcId" : 1194,
@@ -2217,8 +2210,9 @@
         <artwork><![CDATA[
 [
     { "acvVersion": "0.4" },
-    { "vsId": 1194,
+    { "vsId": 48,
       "algorithm": "RSA",
+            "mode": "componentDecPrimitive",
       "testResults" : [
              {           
                 "tcId" : 1196,

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -160,7 +160,7 @@
 	</section>
 	<section anchor="prereq_algs" title="Required Prerequisite Algorithms for RSA Mode Validations">
 	    <t>Each RSA Mode implementation relies on other cryptographic primitives (algorithms) - see <xref target="FIPS186-4"/>. 
-	    For example, a keyGen implementation uses underlying DRBG and hash algorithms. In some case, a single RSA Mode implementation may use several primitives of the same type. 
+	    For example, a keyGen implementation uses underlying DRBG and hash algorithms. In some cases, a single RSA Mode implementation may use several primitives of the same type. 
 	    For example, two different DRBG implementations may be used in the keyGen algorithms in Appendix B.3.3 in <xref target="FIPS186-4"/>, one in step 4.2 and another in step 5.2. 
 	    Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</t>
 	    <texttable anchor="prereqs_table" title="Required RSA Modes Prerequisite Algorithms JSON Values">
@@ -265,7 +265,7 @@
           <c/>
          <c>algSpecs</c>
 	       <c>Array of modeSpecs</c>
-          <c>array of modeSpecs objects, each identified uniquely by the "mode" property</c>
+          <c>array of modeSpecs objects, each identified uniquely by the "mode" and required properties</c>
           <c>See <xref target="algs_table"/> and <xref target="supported_mods"/></c>
           <c>No</c>          
           </texttable>    
@@ -518,7 +518,7 @@
 	<t>Each RSA sigGen mode capability is advertised as a self-contained JSON object.</t>
 	 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_sigGenCap" title="sigGen Capabilities">
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
+          <t>The following RSA signature generation capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="sigGenRSAMod" title="Supported RSA sigGen moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -566,13 +566,13 @@
 	</section>
 		<section anchor="mode_sigVer" title="The sigVer Mode Capabilities">
 	  <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA sigVer mode capability is advertised as a self-contained JSON object.</t>
 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
           <section anchor="mode_sigVerCap" title="sigVer Capabilities">
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
+          <t>The following RSA signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="sigVerRSAMod" title="Supported RSA sigVer moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -625,12 +625,12 @@
 
 	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</t>
 	 <t>The RSA sigVer mode capabilities are advertised as an array of JSON objects within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message.
+	as part of the 'capability_exchange' element of the ACVP JSON registration message.
 	See the ACVP specification for details on the registration message.</t>
 
 	<t>Each RSA legacySigVer mode capability is advertised as a self-contained JSON object.</t>
 <t>The following subsections define the capabilities that may be advertised by the ACVP compliant crypto modules.</t>
-          <t>The following key generation with provable primes capabilities may be advertised by the ACVP compliant crypto module:</t>
+          <t>The following RSA legacy signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
          <texttable anchor="legacySigVerRSAMod" title="Supported RSA legacySigVer moduli and hash options JSON Values ">
           <ttcol align="left">JSON value</ttcol>
           <ttcol align="left">Description</ttcol>
@@ -687,7 +687,7 @@
 	</section>
 	<section anchor="mode_componentDecPrimitive" title="The componentDecPrimitive Mode Capabilities">
 <t>The RSA componentDecPrimitive mode capability is advertised a JSON object within the array of 'modeSpecs'
-	value of the ACVP registration message. as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
+	as part of the 'capability_exchange' element of the ACVP JSON registration message. In this mode, the only tested capability
 	is the correct expontiation 's = msg^d mod n', where 'msg' is a message, 'd' is the private exponent and ''n is the modulus. See <xref target="SP800-56B"/>, Section 7.1.2 for details.</t>
 	
 	<t>In testing, only 'msg' is supplied by the ACVP server. 
@@ -738,9 +738,6 @@
 <c/>
 <c/>
 <c/>
-	  <c>mode</c>
-	  <c>The RSA mode.</c>
-	  <c>"KeyGen", "SigGen", or "SigVer"</c>
 	  <c/>
 	  <c/>
 	  <c/>     
@@ -760,6 +757,14 @@
 		<ttcol align="left">Description</ttcol>
 		<ttcol align="left">JSON type</ttcol>
 		<ttcol align="left">Optional</ttcol>
+	<c>mode</c>
+	<c>The RSA mode.</c>
+	<c>"KeyGen", "SigGen", or "SigVer"</c>
+    <c>No</c>
+    <c/>
+    <c/>
+    <c/>
+    <c/>
     <c>modulo</c>
     <c>RSA modulus</c>
     <c>value</c>
@@ -1216,7 +1221,7 @@
                          "primeTest": ["tblC2"]},
                        {"modulo" : 4096,
                          "hashAlgs" : ["SHA-512"],
-                         "primeTest": ["tblC3"]},
+                         "primeTest": ["tblC3"]}
                     ]
               }
           }
@@ -1398,130 +1403,138 @@
  [
    { "acvVersion": "0.4" },
    { "vsId": 1133,
-      "algorithm": "RSA",
-      "mode": "keyGen",
-      "testGroups" : [
+     "algorithm": "RSA",
+     "testGroups" : [
              {           
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.2",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1145,
+                      "tcId" : 1145
                     },
                     {
-                      "tcId" : 1146,
+                      "tcId" : 1146
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.2",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1147,
+                    "tcId": 1147
                   },
                   {
-                    "tcId": 1148,
+                    "tcId": 1148
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.4",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1149,
+                      "tcId" : 1149
                     },
                     {
-                      "tcId" : 1150,
+                      "tcId" : 1150
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1151,
+                    "tcId": 1151
                   },
                   {
-                    "tcId": 1152,
+                    "tcId": 1152
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.5",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1153,
+                      "tcId" : 1153
                     },
                     {
-                      "tcId" : 1154,
+                      "tcId" : 1154
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.5",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1155,
+                    "tcId": 1155
                   },
                   {
-                    "tcId": 1156,
+                    "tcId": 1156
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "infoGeneratedByServer": false,
                  "pubExp" : "random",
                  "randPQ" : "B.3.6",
                  "modulo" : 2048,
-                 "hashAlg" : "SHA-256"
+                 "hashAlg" : "SHA-256",
                  "tests" : [
                     {
-                      "tcId" : 1157,
+                      "tcId" : 1157
                     },
                     {
-                      "tcId" : 1158,
+                      "tcId" : 1158
                     }
                  ]
              },
              {
+                "mode": "keyGen",
                 "infoGeneratedByServer": false,
                 "pubExp": "random",
                 "randPQ": "B.3.6",
                 "modulo" : 3072,
-                "hashAlg" : "SHA-256"
+                "hashAlg" : "SHA-256",
                 "tests": [
                   {
-                    "tcId": 1159,
+                    "tcId": 1159
                   },
                   {
-                    "tcId": 1160,
+                    "tcId": 1160
                   }
                 ]
               },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -1543,6 +1556,7 @@
                  ]
              },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -1557,6 +1571,7 @@
                  ]
              },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -1578,6 +1593,7 @@
                  ]
              },
              {
+                 "mode": "keyGen",
                  "pubExp" : "random",
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
@@ -1609,9 +1625,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1163,
       "algorithm": "RSA",
-      "mode": "sigGen",
       "testGroups" : [
              {
+                 "mode": "sigGen",
                  "sigType" : "ANSX9.31",
                  "hashAlg" : "SHA-256",
                  "modulo" : 2048,
@@ -1619,10 +1635,11 @@
                     {
                       "tcId" : 1165,
                       "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
-                    },
+                    }
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType": "ANSX9.31",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -1634,6 +1651,7 @@
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -1641,10 +1659,11 @@
                    {
                      "tcId" : 1167,
                      "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
-                   },
+                   }
                 ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PKCS1v1.5",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -1656,6 +1675,7 @@
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 2048,
@@ -1668,6 +1688,7 @@
                  ]
              },
              {
+                "mode": "sigGen",
                 "sigType" : "PSS",
                 "hashAlg" : "SHA-256",
                 "modulo" : 3072,
@@ -1692,12 +1713,12 @@
    { "acvVersion": "0.4" },
    { "vsId": 1173,
       "algorithm": "RSA",
-      "mode": "sigVer",
       "testGroups" : [
              {
+                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
-                 "modulo" : 2048,
                  "hashAlg" : "SHA-256",
+                 "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
                  "tests" : [
@@ -1709,6 +1730,7 @@
                  ]
              },
              {
+                 "mode": "sigVer",
                  "sigType" : "ANSX9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA-256",
@@ -1723,6 +1745,7 @@
                  ]
              },
              {
+                 "mode": "sigVer",
                  "sigType" : "PKCS1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -1733,10 +1756,11 @@
                       "tcId" : 1176,
                       "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
                       "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
-                    },
+                    }
                  ]
              },
              {
+                "mode": "sigVer",
                 "sigType" : "PKCS1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-256",
@@ -1751,6 +1775,7 @@
                  ]
              },
              {
+                 "mode": "sigVer",
                  "sigType" : "PSS",
                  "modulo" : 2048,
                  "hashAlg" : "SHA-256",
@@ -1761,10 +1786,11 @@
                       "tcId" : 1178,
                       "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
                       "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
-                    },
+                    }
                  ]
              },
              {
+                "mode": "sigVer",
                 "sigType" : "PSS",
                 "modulo" : 3072,
                 "hashAlg" : "SHA-512",
@@ -1797,9 +1823,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1193,
       "algorithm": "RSA",
-      "mode": "componentSigPrimitive",
       "testGroups" : [
              {           
+                 "mode": "componentSigPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1194,
@@ -1830,9 +1856,9 @@
    { "acvVersion": "0.4" },
    { "vsId": 1194,
       "algorithm": "RSA",
-      "mode": "componentDecPrimitive",
       "testGroups" : [
              {
+                 "mode": "componentDecPrimitive",
                  "tests" : [
                     {
                       "tcId" : 1196,
@@ -1862,7 +1888,6 @@
                 { "acvVersion": "0.4" },
                 { "vsId": 1133,
                     "algorithm": "RSA",
-                    "mode": "keyGen",
                     "testResults": [
                     {
                       "tcId" : 1111,
@@ -1918,15 +1943,15 @@
                     },
                     {
                       "tcId" : 1116,
-                     "e" : "10000021",
-                     "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
-                     "bitlens" : [272, 205, 296, 157],
-                     "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
-                     "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
-                     "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
-                     "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
-                     "n" : "b86c87f9aea1aa7b5c253966047466b0ae29fdbacabeb7eaed820b7f87b664749bfaba791d7a0bfd25cbb4251da58fbb2ab9725c2c873f2b545eaa7409f1124e2d84cdb5c71583fc433a2fa44c6e8e006caaadb07b4996a67ee01df45b70bf94dd0f1bd13c60935f012899edde57c9af80ad362440e804767e4837fbf98847e5e33c534fb86601958adea41ed278203e99d717917fe9d719fcefb3b04f0edb4f44831b52f20c5ac410ea96723fe5bc0afb4dc7d3bf617dd3760b396436cf613444b9abcaa82bd7e0f3174df6dbe320616a2bcb774fbc4633ea783dacffd557706f6f64a8821805d40fd627f3deaa99d4da4a4f571fe7332cc219f68682d4d3d3",
-                     "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
+                      "e" : "10000021",
+                      "seed" : "242d14906b68f64a8836c27ce91913b042098806d2a8566035805c48",
+                      "bitlens" : [272, 205, 296, 157],
+                      "xP" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a47621780b32308300753bc3047f355228620a8f911dcf16bcd2a0e69ed6a4592f69cf9c8625458bef538e27d59ee4140c78d20ba7a86c4335b71c0499aeb1",
+                      "p" : "f668821d6bb49e9912a731ae34b81d3ed4ef145c20611c5679d8905674bf12110a86647940d29e00b608492fae3363965459642f6c937dda770deb0cc274e42d20a476a8e12548377aa723701a557177e2a9bd6355ef5ccd8e08dcb009137e9c07fcddd38a76d30057d121a8031dad5f5268755312b4f2893fcd6f00664e728b",
+                      "xQ" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c33f3191a1f49adfbf3407e0ad1301606e98001f4e604ddcc21dc8dd2286d641871b4412e76568f8f780e42d83ee8fade1d6d9405115d1c1addec05",
+                      "q" : "bf9a574cd234bc407e59e9177e78a35d7d156fd466f05b9a3aec3242e284ed941c433b0ed69c4fffbc2e661cef93413fceb16096438429ccf48fbad655e3f57c5d2135604c34d8427eab6551ce39b6d480881e0566b9da47b2c13081d106effd4e03b58403f0699fa5adf1015a56d3371e9d69ff22587be9e83befd19ae4b4d9",
+                      "n" : "b86c87f9aea1aa7b5c253966047466b0ae29fdbacabeb7eaed820b7f87b664749bfaba791d7a0bfd25cbb4251da58fbb2ab9725c2c873f2b545eaa7409f1124e2d84cdb5c71583fc433a2fa44c6e8e006caaadb07b4996a67ee01df45b70bf94dd0f1bd13c60935f012899edde57c9af80ad362440e804767e4837fbf98847e5e33c534fb86601958adea41ed278203e99d717917fe9d719fcefb3b04f0edb4f44831b52f20c5ac410ea96723fe5bc0afb4dc7d3bf617dd3760b396436cf613444b9abcaa82bd7e0f3174df6dbe320616a2bcb774fbc4633ea783dacffd557706f6f64a8821805d40fd627f3deaa99d4da4a4f571fe7332cc219f68682d4d3d3",
+                      "d" : "1d26dc09539115a27d95980819d439c5b3f2517f63ed7a66f2382d138027102fcf89fb46c823899e36ee5f07da691ec2f9fbc0e28b1408c179658c9d5d7f114207acf5f0ab17f6bd369e09fcdba00a0851aad795a0ab31f0136a7d9e7a7a781594738cca7838f8cb3b755529c684ca4632adfb6b2b9de2b2b5408f81447e55e79df1197c07e1312980c30cdb9e989697152f0b69fd42e32e2982ccbd6ba40814d63fdf858e82dc4cfe7e4aed2ad6e77af3d977cedfc2900de774c0539901d71802cfa4b28b4e0f747718fcb0bd433a952bca8d1634e3e037f70d2d6135ede9832a4b81f65fd04b5e67182508b44b841e940f16f0e26f1167cfb1ab6b1d62b901"
                     },
                     {
                       "tcId" : 1117,
@@ -2041,7 +2066,7 @@
                       "d" : "1f5201b880a206cb123fb73afc2f266baac9c431afd3c584eb12abd3c6aaa106bc1eb9b034dc7b61803ca7a3a74e371f865de8af27e7d97c5287c9ed91f5c1da02ba44156aa857136685c03256fb9586567fa73a5a17c341d073aae3758fc3676f3fc87bbc2dd684915ec6c3370fa349e2b6bed9e82a8f5fb2ea3bea65a3818968081bdd80f7e046c6b5b8bdac85120d95c243725162cfc9034ae14634d14674e0c0c10f1a5e93af74152d67bf872e039fead73755c8e28f2da34f3b7eb1286deda90e09514a281cb7013a519b93e1b347728fa56543e0c3348d646e67b7f6d2481c41f6c02454cc9e6ed07b1ecf1a44857802191da376bae5027d4c3b0c6473"
                    },
                   {
-                    "tcId" : 1130,
+                      "tcId" : 1130,
                       "e" : "e66d81",
                       "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                       "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
@@ -2075,51 +2100,40 @@
             <figure>
         <artwork><![CDATA[
              [
-                  { "acvVersion": "0.4" },
-                  { "vsId": 1163,
-                    "algorithm": "RSA",
-                    "mode": "sigGen",
-                    "testResults": [
+                { "acvVersion": "0.4" },
+                { "vsId": 1163,
+                  "algorithm": "RSA",
+                  "testResults": [
                     {
                       "tcId" : 1165,
-                      "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "e" : "f3e7af",
+                      "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                       "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
-                    }
+                    },
                     {
                       "tcId" : 1166,
-                      "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "e" : "ebda09",
+                      "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
                       "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c"
-                    }
-                 ]
-             }
-              {
-                 "sigType" : "PKCS1v1.5",
-                 "tests" : [
+                    },
                     {
                       "tcId" : 1167,
                       "e" : "260445",
                       "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
                       "signature" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
-                    }
+                    },
                     {
                       "tcId" : 1168,
                       "e" : "eaf05d",
                       "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
                       "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82"
-                    }
-                 ]
-             }
-             {
-                 "sigType" : "PSS",
-                 "tests" : [
+                    },
                     {
                       "tcId" : 1169,
                       "e" : "86c94f",
                       "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
                       "signature" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc"
-                    }
+                    },
                     {
                       "tcId" : 1170,
                       "e" : "1415a7",
@@ -2140,50 +2154,34 @@
     { "acvVersion": "0.4" },
     { "vsId": 1173,
       "algorithm": "RSA",
-      "mode": "sigVer",
-      "testGroups" : [
-             {
-                 "sigType" : "ANSX9.31",
-                 "tests" : [
-                    {
-                      "tcId" : 1174,
-                      "sigResult" : "failed"
-                    },
-                    {
-                      "tcId" : 1175,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             },
+      "testResults" : [
               {
-                 "sigType" : "PKCS1v1.5",
-                 "tests" : [
-                    {
-                      "tcId" : 1176,
-                      "sigResult" : "passed"
-                    },
-                    {
-                      "tcId" : 1177,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             },
-             {
-                 "sigType" : "PSS",
-                 "tests" : [
-                    {
-                      "tcId" : 1178,
-                      "sigResult" : "failed"
-                    },
-                    {
-                      "tcId" : 1179,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             }
-       ]
+                "tcId" : 1174,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1175,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1176,
+                "sigResult" : "passed"
+              },
+              {
+                "tcId" : 1177,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1178,
+                "sigResult" : "failed"
+              },
+              {
+                "tcId" : 1179,
+                "sigResult" : "failed"
+              }
+        ]
     }
-  ]
+]
             ]]></artwork>
     </figure>
           </section>
@@ -2194,27 +2192,22 @@
       <t>The following is a example JSON object for RSA componentSigPrimitive test results sent from the crypto module to the ACVP server.</t>
             <figure>
         <artwork><![CDATA[
- [
+[
     { "acvVersion": "0.4" },
     { "vsId": 1193,
       "algorithm": "RSA",
-      "mode": "componentSigPrimitive",
-      "testGroups" : [
-             {
-                 "tests" : [
-                    {
-                      "tcId" : 1194,
-                      "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
-                    },
-                    {
-                      "tcId" : 1195,
-                      "sigResult" : "failed"
-                    }
-                 ]
-             }
-       ]
+      "testResults" : [
+                {
+                 "tcId" : 1194,
+                 "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
+                },
+                {
+                 "tcId" : 1195,
+                 "sigResult" : "failed"
+                }
+            ]
     }
-  ]
+]
             ]]></artwork>
     </figure>
           </section>
@@ -2222,30 +2215,25 @@
       <t>The following is a example JSON object for RSA componentDecPrimitive test results sent from the crypto module to the ACVP server.</t>
             <figure>
         <artwork><![CDATA[
- [
+[
     { "acvVersion": "0.4" },
     { "vsId": 1194,
       "algorithm": "RSA",
-      "mode": "componentDecPrimitive",
-      "testGroups" : [
+      "testResults" : [
              {           
-                 "tests" : [
-                    {
-                      "tcId" : 1196,
-                      "e" : "010001",
-                      "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
-                      "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
-                      "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
-                    },
-                    {
-                      "tcId" : 1197,
-                      "sigResult" : "failed"
-                    }
-                 ]
+                "tcId" : 1196,
+                "e" : "010001",
+                "n" : "d0c112f0bee36235d9fe635e895ffb28760e96321c588bd3ed508d165c361f81215ac593b1d67fae791e78fab00ca984ffa85a189b8862cf00d365aa02ac098e9dda175c96241ad39e4bae1829f7fb8df5b49ddcaefbe2c5fb38bda7660a985fe494a7517dc558484a89edc4a374364c1cfd64befed2077b8108e9d1375880c402817d179a4115e76632430b836e77c048f0c43e329386aecf4287c885b5fd3dc39a33309f788a953adb8b643342d5d6991df43fdddbcb8ed733cf342bb60262f202590738d073c204a99ffdef4b8cadc8424f217527fdb09f9d370da7084ac06fe3bf67f6b0f078b6d0324da9d0936e60c96174da5a4e690ac7d6799bfddddd",
+                "d" : "2cde66ea08797aad3cf8fcd63fbc39d15948aad743f8f33afeaddad964c1fc5506bc8a2d83e2a90870ff8ffcbff4c4c5f1a6779104f3145bce5f61a160582668b93c7c5b79e8f23c2c70b34f7dcbcf8d9473791fcb1b98433a0b58d63f6c45128d60b732e08fd779184e5ba4f18603baa9db7bf9426f95cca1b02f03793c2456b979b72d631f9b1b8682bdb0e4e8b75b5d9851a05ef91713320c6de7bc54ad27053c029041779fde5b09159f40f1b65d2cfd3c4b2b82c1009c6549aa506ca63d6f973815d945bb42b172e80896f3b53a4d9d420eb502afa96554dd74e10080d36cfd76e071c4efe8611651493b212e7bf192c12304a249f03ec7b7a4d4948361",
+                "signature" : "a60b879a8fa382fdf4f9040da5f2e9f1700d246724eb5d0c7d0d696bf0b34c414be597d97b6cb478da28676aa944cb18f473e41225b08e22585af5c50673b21fd45f6e675bf248ae78eecb37bab2733e1dc1b6dfd71ef7c0371249601c0a9c76ea343c602b8583622957d3a669cc00088282b39ef95005e4278a3e2cfabbe863ca5ad3d02673f607a5e8c815d8067ddd065e9fd7fa2f045ed777c3d07366573e6aa1973f9810cbc115543568f5a38a3555b5ede680a1cd2b6a86bbd06360d4f7e36f96ba9bb4d5c6386f921135109a2fc417c9ea04e1656191c0af93880af5aad6d8ce194635306a525c5f82e82773e2c7997d66009e6f4e4e2189858751c039"
+             },
+             {
+                "tcId" : 1197,
+                "sigResult" : "failed"
              }
-       ]
+        ]
     }
-  ]
+]
             ]]></artwork>
     </figure>
           </section>          


### PR DESCRIPTION
Changes fall into 3 categories:

1.  Updates to position of "mode" field in json examples to comply with the specification.
2.  Fix all json examples which had misplaced commas or other minor typos.
3.  Fix minor text mis-wordings or cut-and-paste errors.

Brief explanation of repositioning of the mode field:

- mode field is essential to creating vector sets and has been positioned within modeSpecs, within algSpecs for registrations
- the current RSA sub-spec indicates that any mode may be registered in a modeSpecs object
- multiple modeSpec objects may be registered and any mode may be chosen in any modeSpec object according to the current spec
- positioning the "mode" globally at the top level in vector set responses from the server would dictate only one mode per vector set - which is contrary to the spec as noted above.  There has been no requirement to have the same mode in each modeSpec object - so this positioning goes against the current spec.
- preserving one vector set per mode would require parsing down and through each modeSpec at the point of registration and would require parsing each modeSpec object twice (1st for registration and 2nd for creating vector sets) - which will not scale well.
- mode field is not needed in every test results response because the server already has the vector set id and test case id which should allow the testGroup information to be pulled.