### PR TITLE
Correction to parameter set label and minimum values.

### DIFF
--- a/artifacts/acvp_sub_kas_ffc.html
+++ b/artifacts/acvp_sub_kas_ffc.html
@@ -965,8 +965,8 @@
 <td class="left"></td>
 </tr>
 <tr>
-<td class="left">fb</td>
-<td class="left">The fb parameter set</td>
+<td class="left">fc</td>
+<td class="left">The fc parameter set</td>
 <td class="left">object</td>
 <td class="left">See <a href="#parameter_set_details" class="xref">Section 2.6.2</a>
 </td>
@@ -985,8 +985,8 @@
 <a href="#rfc.section.2.6.2">2.6.2.</a> <a href="#parameter_set_details" id="parameter_set_details">KAS FFC Parameter Set Details</a>
 </h1>
 <p id="rfc.section.2.6.2.p.1">fb/fc changes minimum allowed values on options.</p>
-<p id="rfc.section.2.6.2.p.2">fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112, min macSize - 112</p>
-<p id="rfc.section.2.6.2.p.3">fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min macSize - 128</p>
+<p id="rfc.section.2.6.2.p.2">fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112, min macSize - 64</p>
+<p id="rfc.section.2.6.2.p.3">fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min macSize - 64</p>
 <p id="rfc.section.2.6.2.p.4">"noKdfNoKc" requires "hashAlg"</p>
 <p id="rfc.section.2.6.2.p.5">"kdfNoKc" requires "hashAlg" and at least one valid MAC registration</p>
 <p id="rfc.section.2.6.2.p.6">"kdfKc" requires "hashAlg" and at least one valid MAC registration</p>

--- a/artifacts/acvp_sub_kas_ffc.txt
+++ b/artifacts/acvp_sub_kas_ffc.txt
@@ -427,7 +427,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
    | fb        | The fb parameter | object   | See Section  | Yes      |
    |           | set              |          | 2.6.2        |          |
    |           |                  |          |              |          |
-   | fb        | The fb parameter | object   | See Section  | Yes      |
+   | fc        | The fc parameter | object   | See Section  | Yes      |
    |           | set              |          | 2.6.2        |          |
    |           |                  |          |              |          |
    +-----------+------------------+----------+--------------+----------+
@@ -439,7 +439,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
    fb/fc changes minimum allowed values on options.
 
    fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112,
-   min macSize - 112
+   min macSize - 64
 
 
 
@@ -451,7 +451,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
    fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128,
-   min macSize - 128
+   min macSize - 64
 
    "noKdfNoKc" requires "hashAlg"
 

--- a/src/acvp_sub_kas_ffc.xml
+++ b/src/acvp_sub_kas_ffc.xml
@@ -389,8 +389,8 @@
 			<c>Yes</c>
 		<c/><c/><c/><c/><c/>
 
-			<c>fb</c>
-		<c>The fb parameter set</c>
+			<c>fc</c>
+		<c>The fc parameter set</c>
 		<c>object</c>
 		<c>See <xref target="parameter_set_details"/></c>	
 			<c>Yes</c>
@@ -401,8 +401,8 @@
 
 		<section anchor="parameter_set_details" title="KAS FFC Parameter Set Details">
 			<t>fb/fc changes minimum allowed values on options.</t>
-			<t>fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112, min macSize - 112</t>
-			<t>fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min macSize - 128</t>
+			<t>fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112, min macSize - 64</t>
+			<t>fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min macSize - 64</t>
 			<t>"noKdfNoKc" requires "hashAlg"</t>
 			<t>"kdfNoKc" requires "hashAlg" and at least one valid MAC registration</t>
 			<t>"kdfKc" requires "hashAlg" and at least one valid MAC registration</t>


### PR DESCRIPTION
FFC parameter sets section was referencing some incorrect lengths, and had a typo (had a second `fb` parameter set, rather than `fb` and `fc`)