### PR TITLE
Updates CMAC specification to utilize a keyLen property.

### DIFF
--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -12,6 +12,28 @@
 	  a {
 	  text-decoration: none;
 	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
 	  a.smpl {
 	  color: black;
 	  }
@@ -351,30 +373,30 @@
   /*]]>*/
   </style>
 
-  <link href="#rfc.toc" rel="Contents"/>
-<link href="#rfc.section.1" rel="Chapter" title="1 Introduction"/>
-<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language"/>
-<link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration"/>
-<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for MAC Validations"/>
-<link href="#rfc.section.2.2" rel="Chapter" title="2.2 MAC Algorithm Capabilities Registration"/>
-<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Supported MAC Algorithms"/>
-<link href="#rfc.section.3" rel="Chapter" title="3 Test Vectors"/>
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Test Groups JSON Schema"/>
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Test Case JSON Schema"/>
-<link href="#rfc.section.4" rel="Chapter" title="4 Test Vector Responses"/>
-<link href="#rfc.section.5" rel="Chapter" title="5 Acknowledgements"/>
-<link href="#rfc.section.6" rel="Chapter" title="6 IANA Considerations"/>
-<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations"/>
-<link href="#rfc.references" rel="Chapter" title="8 References"/>
-<link href="#rfc.references.1" rel="Chapter" title="8.1 Normative References"/>
-<link href="#rfc.references.2" rel="Chapter" title="8.2 Informative References"/>
-<link href="#rfc.appendix.A" rel="Chapter" title="A Example MAC Capabilities JSON Object"/>
-<link href="#rfc.appendix.B" rel="Chapter" title="B Example Test Vectors JSON Object"/>
-<link href="#rfc.appendix.C" rel="Chapter" title="C Example Test Results JSON Object"/>
-<link href="#rfc.authors" rel="Chapter"/>
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
+<link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration">
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for MAC Validations">
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 MAC Algorithm Capabilities Registration">
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Supported MAC Algorithms">
+<link href="#rfc.section.3" rel="Chapter" title="3 Test Vectors">
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Test Groups JSON Schema">
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Test Case JSON Schema">
+<link href="#rfc.section.4" rel="Chapter" title="4 Test Vector Responses">
+<link href="#rfc.section.5" rel="Chapter" title="5 Acknowledgements">
+<link href="#rfc.section.6" rel="Chapter" title="6 IANA Considerations">
+<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="8 References">
+<link href="#rfc.references.1" rel="Chapter" title="8.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="8.2 Informative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A Example MAC Capabilities JSON Object">
+<link href="#rfc.appendix.B" rel="Chapter" title="B Example Test Vectors JSON Object">
+<link href="#rfc.appendix.C" rel="Chapter" title="C Example Test Results JSON Object">
+<link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.4.3 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
@@ -391,20 +413,20 @@
     <tbody>
     
     	<tr>
-  <td class="left">TBD</td>
-  <td class="right">B. Fussell, Ed.</td>
+<td class="left">TBD</td>
+<td class="right">B. Fussell, Ed.</td>
 </tr>
 <tr>
-  <td class="left">Internet-Draft</td>
-  <td class="right">Cisco Systems, Inc.</td>
+<td class="left">Internet-Draft</td>
+<td class="right">Cisco Systems, Inc.</td>
 </tr>
 <tr>
-  <td class="left">Intended status: Informational</td>
-  <td class="right">June 2016</td>
+<td class="left">Intended status: Informational</td>
+<td class="right">June 2016</td>
 </tr>
 <tr>
-  <td class="left">Expires: December 3, 2016</td>
-  <td class="right"></td>
+<td class="left">Expires: December 3, 2016</td>
+<td class="right"></td>
 </tr>
 
     	
@@ -414,20 +436,14 @@
   <p class="title">ACVP Message Authentication Algorithm JSON Specification<br />
   <span class="filename">draft-ietf-acvp-submac-0.4</span></p>
   
-  <h1 id="rfc.abstract">
-  <a href="#rfc.abstract">Abstract</a>
-</h1>
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification.</p>
-<h1 id="rfc.status">
-  <a href="#rfc.status">Status of This Memo</a>
-</h1>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
 <p>This Internet-Draft will expire on December 3, 2016.</p>
-<h1 id="rfc.copyrightnotice">
-  <a href="#rfc.copyrightnotice">Copyright Notice</a>
-</h1>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2016 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
@@ -436,719 +452,743 @@
   <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
   <ul class="toc">
 
-  	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
-<li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a></li>
-<li>2.   <a href="#rfc.section.2">Capabilities Registration</a></li>
-<li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for MAC Validations</a></li>
-<li>2.2.   <a href="#rfc.section.2.2">MAC Algorithm Capabilities Registration</a></li>
-<li>2.3.   <a href="#rfc.section.2.3">Supported MAC Algorithms</a></li>
-<li>3.   <a href="#rfc.section.3">Test Vectors</a></li>
-<li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a></li>
-<li>3.2.   <a href="#rfc.section.3.2">Test Case JSON Schema</a></li>
-<li>4.   <a href="#rfc.section.4">Test Vector Responses</a></li>
-<li>5.   <a href="#rfc.section.5">Acknowledgements</a></li>
-<li>6.   <a href="#rfc.section.6">IANA Considerations</a></li>
-<li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
-<li>8.   <a href="#rfc.references">References</a></li>
-<li>8.1.   <a href="#rfc.references.1">Normative References</a></li>
-<li>8.2.   <a href="#rfc.references.2">Informative References</a></li>
-<li>Appendix A.   <a href="#rfc.appendix.A">Example MAC Capabilities JSON Object</a></li>
-<li>Appendix B.   <a href="#rfc.appendix.B">Example Test Vectors JSON Object</a></li>
-<li>Appendix C.   <a href="#rfc.appendix.C">Example Test Results JSON Object</a></li>
-<li><a href="#rfc.authors">Author's Address</a></li>
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a>
+</li>
+</ul><li>2.   <a href="#rfc.section.2">Capabilities Registration</a>
+</li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for MAC Validations</a>
+</li>
+<li>2.2.   <a href="#rfc.section.2.2">MAC Algorithm Capabilities Registration</a>
+</li>
+<li>2.3.   <a href="#rfc.section.2.3">Supported MAC Algorithms</a>
+</li>
+</ul><li>3.   <a href="#rfc.section.3">Test Vectors</a>
+</li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a>
+</li>
+<li>3.2.   <a href="#rfc.section.3.2">Test Case JSON Schema</a>
+</li>
+</ul><li>4.   <a href="#rfc.section.4">Test Vector Responses</a>
+</li>
+<li>5.   <a href="#rfc.section.5">Acknowledgements</a>
+</li>
+<li>6.   <a href="#rfc.section.6">IANA Considerations</a>
+</li>
+<li>7.   <a href="#rfc.section.7">Security Considerations</a>
+</li>
+<li>8.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>8.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>8.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Example MAC Capabilities JSON Object</a>
+</li>
+<li>Appendix B.   <a href="#rfc.appendix.B">Example Test Vectors JSON Object</a>
+</li>
+<li>Appendix C.   <a href="#rfc.appendix.C">Example Test Results JSON Object</a>
+</li>
+<li><a href="#rfc.authors">Author's Address</a>
+</li>
 
 
   </ul>
 
-  <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> Introduction</h1>
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> Introduction</h1>
 <p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module.  The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more.  The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms.  Each sub-specification addresses a specific class of crypto algorithms.  This sub-specification defines the JSON constructs for testing HMAC and CMAC crypto algorithms using ACVP.</p>
-<h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
-<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119">RFC 2119</a> <cite title="NONE">[RFC2119]</cite>.</p>
-<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a></h1>
+<h1 id="rfc.section.1.1">
+<a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
+<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>.</p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
+</h1>
 <p id="rfc.section.2.p.1">ACVP requires crypto modules to register their capabilities.  This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  This section describes the constructs for advertising support of HMAC and CMAC algorithms to the ACVP server.</p>
 <p id="rfc.section.2.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message.  The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section.  The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.  Each algorithm capability advertised is a self-contained JSON object. </p>
-<h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for MAC Validations</a></h1>
+<h1 id="rfc.section.2.1">
+<a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for MAC Validations</a>
+</h1>
 <p id="rfc.section.2.1.p.1">Each MAC implementation relies on other cryptographic primitives.  For example, CMAC uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
-<div id="rfc.table.1"/>
-<div id="rereqs_table"/>
+<div id="rfc.table.1"></div>
+<div id="rereqs_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Required MAC Prerequisite Algorithms JSON Values</caption>
-  <thead>
-    <tr>
-      <th class="left">JSON Value</th>
-      <th class="left">Description</th>
-      <th class="left">JSON type</th>
-      <th class="left">Valid Values</th>
-      <th class="left">Optional</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">algorithm</td>
-      <td class="left">a prerequisite algorithm</td>
-      <td class="left">value</td>
-      <td class="left">AES, SHA, TDES</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">valValue</td>
-      <td class="left">algorithm validation number</td>
-      <td class="left">value</td>
-      <td class="left">actual number or "same"</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">prereqAlgVal</td>
-      <td class="left">prerequistie algorithm validation</td>
-      <td class="left">object with algorithm and valValue properties</td>
-      <td class="left">see above</td>
-      <td class="left">No</td>
-    </tr>
-  </tbody>
+<caption>Required MAC Prerequisite Algorithms JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">a prerequisite algorithm</td>
+<td class="left">value</td>
+<td class="left">AES, SHA, TDES</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">valValue</td>
+<td class="left">algorithm validation number</td>
+<td class="left">value</td>
+<td class="left">actual number or "same"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqAlgVal</td>
+<td class="left">prerequistie algorithm validation</td>
+<td class="left">object with algorithm and valValue properties</td>
+<td class="left">see above</td>
+<td class="left">No</td>
+</tr>
+</tbody>
 </table>
-<h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> <a href="#mac_caps_reg" id="mac_caps_reg">MAC Algorithm Capabilities Registration</a></h1>
+<h1 id="rfc.section.2.2">
+<a href="#rfc.section.2.2">2.2.</a> <a href="#mac_caps_reg" id="mac_caps_reg">MAC Algorithm Capabilities Registration</a>
+</h1>
 <p id="rfc.section.2.2.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
-<div id="rfc.table.2"/>
-<div id="caps_table2"/>
+<div id="rfc.table.2"></div>
+<div id="caps_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>MAC Algorithm Capabilities JSON Values</caption>
-  <thead>
-    <tr>
-      <th class="left">JSON Value</th>
-      <th class="left">Description</th>
-      <th class="left">JSON type</th>
-      <th class="left">Valid Values</th>
-      <th class="left">Optional</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">algorithm</td>
-      <td class="left">The MAC algorithm and mode to be validated.</td>
-      <td class="left">value</td>
-      <td class="left">See <a href="#supported_algs">Section 2.3</a></td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">prereqVals</td>
-      <td class="left">prerequistie algorithm validations, See <a href="#app-reg-ex">Appendix A</a> for examples</td>
-      <td class="left">array of prereqAlgVal objects</td>
-      <td class="left">See <a href="#prereq_algs">Section 2.1</a></td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">direction</td>
-      <td class="left">The MAC direction(s) to test. Only applies to CMAC.</td>
-      <td class="left">array</td>
-      <td class="left">gen, ver</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">keyLen</td>
-      <td class="left">The keyLen Domain supported by the IUT in bits. (HMAC only)</td>
-      <td class="left">Domain</td>
-      <td class="left">8-524288</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">keyingOption</td>
-      <td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save KATs) is a single key, now deprecated (K1, K1, K1).</td>
-      <td class="left">array</td>
-      <td class="left">1, 2</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">msgLen</td>
-      <td class="left">The CMAC message lengths supported.  Min/max/increment and values must be mod 8.</td>
-      <td class="left">Domain</td>
-      <td class="left">0-524288</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">macLen</td>
-      <td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#supported_algs">Section 2.3</a>).</td>
-      <td class="left">Domain</td>
-      <td class="left">32-512</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-  </tbody>
+<caption>MAC Algorithm Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The MAC algorithm and mode to be validated.</td>
+<td class="left">value</td>
+<td class="left">See <a href="#supported_algs" class="xref">Section 2.3</a>
+</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqVals</td>
+<td class="left">prerequistie algorithm validations, See <a href="#app-reg-ex" class="xref">Appendix A</a> for examples</td>
+<td class="left">array of prereqAlgVal objects</td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a>
+</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The MAC direction(s) to test. Only applies to CMAC.</td>
+<td class="left">array</td>
+<td class="left">gen, ver</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">The keyLen Domain supported by the IUT in bits. (HMAC only)</td>
+<td class="left">Domain</td>
+<td class="left">8-524288</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">The array of keyLens supported by the IUT in bits. (CMAC only)</td>
+<td class="left">array</td>
+<td class="left">128, 192, 256</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyingOption</td>
+<td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save KATs) is a single key, now deprecated (K1, K1, K1).</td>
+<td class="left">array</td>
+<td class="left">1, 2</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msgLen</td>
+<td class="left">The CMAC message lengths supported.  Min/max/increment and values must be mod 8.</td>
+<td class="left">Domain</td>
+<td class="left">0-524288</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">macLen</td>
+<td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#supported_algs" class="xref">Section 2.3</a>).</td>
+<td class="left">Domain</td>
+<td class="left">32-512</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
 </table>
 <p id="rfc.section.2.2.p.2">Note: Some optional values are required depending on the algorithm. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</p>
 <p id="rfc.section.2.2.p.3">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>2 values below the Hash's block length. See <a href="#supported_algs">Section 2.3</a></li>
-  <li>The Hash's block length.</li>
-  <li>2 values above the Hash's block length.</li>
+<li>2 values below the Hash's block length. See <a href="#supported_algs" class="xref">Section 2.3</a>
+</li>
+<li>The Hash's block length.</li>
+<li>2 values above the Hash's block length.</li>
 </ul>
 <p id="rfc.section.2.2.p.5">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>The smallest CMAC length supported</li>
-  <li>A second CMAC length supported</li>
-  <li>The largest CMAC length supported</li>
+<li>The smallest CMAC length supported</li>
+<li>A second CMAC length supported</li>
+<li>The largest CMAC length supported</li>
 </ul>
 <p id="rfc.section.2.2.p.7">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
-<p/>
+<p></p>
 
 <ul>
-  <li>The smallest message length supported</li>
-  <li>Two message lengths divisible by block size</li>
-  <li>Two message lengths NOT divisible by block size</li>
-  <li>The largest message length supported</li>
+<li>The smallest message length supported</li>
+<li>Two message lengths divisible by block size</li>
+<li>Two message lengths NOT divisible by block size</li>
+<li>The largest message length supported</li>
 </ul>
-<h1 id="rfc.section.2.3"><a href="#rfc.section.2.3">2.3.</a> <a href="#supported_algs" id="supported_algs">Supported MAC Algorithms</a></h1>
+<h1 id="rfc.section.2.3">
+<a href="#rfc.section.2.3">2.3.</a> <a href="#supported_algs" id="supported_algs">Supported MAC Algorithms</a>
+</h1>
 <p id="rfc.section.2.3.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
-<div id="rfc.table.3"/>
-<div id="table_algInfo"/>
+<div id="rfc.table.3"></div>
+<div id="table_algInfo"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Algorithms w/ block size and max MAC length.</caption>
-  <thead>
-    <tr>
-      <th class="left">Algorithm Value</th>
-      <th class="left">Block Length</th>
-      <th class="left">Max MAC Length</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">HMAC-SHA-1</td>
-      <td class="left">512</td>
-      <td class="left">160</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA2-224</td>
-      <td class="left">512</td>
-      <td class="left">224</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA2-256</td>
-      <td class="left">512</td>
-      <td class="left">256</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA2-384</td>
-      <td class="left">1024</td>
-      <td class="left">384</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA2-512</td>
-      <td class="left">1024</td>
-      <td class="left">512</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA2-512/224</td>
-      <td class="left">1024</td>
-      <td class="left">224</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA2-512/256</td>
-      <td class="left">1024</td>
-      <td class="left">256</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA3-224</td>
-      <td class="left">1152</td>
-      <td class="left">224</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA3-256</td>
-      <td class="left">1088</td>
-      <td class="left">256</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA3-384</td>
-      <td class="left">832</td>
-      <td class="left">384</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">HMAC-SHA3-512</td>
-      <td class="left">576</td>
-      <td class="left">512</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">CMAC-AES-128</td>
-      <td class="left">128</td>
-      <td class="left">128</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">CMAC-AES-192</td>
-      <td class="left">128</td>
-      <td class="left">128</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">CMAC-AES-256</td>
-      <td class="left">128</td>
-      <td class="left">128</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">CMAC-TDES</td>
-      <td class="left">64</td>
-      <td class="left">64</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-  </tbody>
+<caption>Algorithms w/ block size and max MAC length.</caption>
+<thead><tr>
+<th class="left">Algorithm Value</th>
+<th class="left">Block Length</th>
+<th class="left">Max MAC Length</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">HMAC-SHA-1</td>
+<td class="left">512</td>
+<td class="left">160</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA2-224</td>
+<td class="left">512</td>
+<td class="left">224</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA2-256</td>
+<td class="left">512</td>
+<td class="left">256</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA2-384</td>
+<td class="left">1024</td>
+<td class="left">384</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA2-512</td>
+<td class="left">1024</td>
+<td class="left">512</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA2-512/224</td>
+<td class="left">1024</td>
+<td class="left">224</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA2-512/256</td>
+<td class="left">1024</td>
+<td class="left">256</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA3-224</td>
+<td class="left">1152</td>
+<td class="left">224</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA3-256</td>
+<td class="left">1088</td>
+<td class="left">256</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA3-384</td>
+<td class="left">832</td>
+<td class="left">384</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">HMAC-SHA3-512</td>
+<td class="left">576</td>
+<td class="left">512</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">CMAC-AES</td>
+<td class="left">128</td>
+<td class="left">128</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">CMAC-TDES</td>
+<td class="left">64</td>
+<td class="left">64</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
 </table>
-<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
-<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES-128, etc.  This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+</h1>
+<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc.  This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
 <p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
-<div id="rfc.table.4"/>
-<div id="vs_top_table"/>
+<div id="rfc.table.4"></div>
+<div id="vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Vector Set JSON Object</caption>
-  <thead>
-    <tr>
-      <th class="left">JSON Value</th>
-      <th class="left">Description</th>
-      <th class="left">JSON type</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">acvVersion</td>
-      <td class="left">Protocol version identifier</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">vsId</td>
-      <td class="left">Unique numeric identifier for the vector set</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">algorithm</td>
-      <td class="left">The algorithm and mode used for the test vectors.  See <a href="#supported_algs">Section 2.3</a> for possible values.</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">testGroups</td>
-      <td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs">Section 3.1</a></td>
-      <td class="left">array</td>
-    </tr>
-  </tbody>
+<caption>Vector Set JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The algorithm and mode used for the test vectors.  See <a href="#supported_algs" class="xref">Section 2.3</a> for possible values.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 3.1</a>
+</td>
+<td class="left">array</td>
+</tr>
+</tbody>
 </table>
-<h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a></h1>
+<h1 id="rfc.section.3.1">
+<a href="#rfc.section.3.1">3.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
+</h1>
 <p id="rfc.section.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set.  For instance, all test vectors that use the same key size would be grouped together.  The Test Group JSON object contains meta data that applies to all test vectors within the group.  The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
-<div id="rfc.table.5"/>
-<div id="vs_tg_table"/>
+<div id="rfc.table.5"></div>
+<div id="vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Test Group JSON Object</caption>
-  <thead>
-    <tr>
-      <th class="left">JSON Value</th>
-      <th class="left">Description</th>
-      <th class="left">JSON type</th>
-      <th class="left">Optional</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">testType</td>
-      <td class="left">Test category type (AFT)</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">direction</td>
-      <td class="left">The direction of the tests - gen or ver - only applies to CMAC</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">keyLen</td>
-      <td class="left">Length of key in bits to use</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">msgLen</td>
-      <td class="left">Length of message/hash in bits</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">macLen</td>
-      <td class="left">Length of MAC in bits to generate/verify</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">tests</td>
-      <td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs">Section 3.2</a></td>
-      <td class="left">array</td>
-      <td class="left">No</td>
-    </tr>
-  </tbody>
+<caption>Test Group JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">testType</td>
+<td class="left">Test category type (AFT)</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The direction of the tests - gen or ver - only applies to CMAC</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">Length of key in bits to use</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msgLen</td>
+<td class="left">Length of message/hash in bits</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">macLen</td>
+<td class="left">Length of MAC in bits to generate/verify</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 3.2</a>
+</td>
+<td class="left">array</td>
+<td class="left">No</td>
+</tr>
+</tbody>
 </table>
-<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a></h1>
+<h1 id="rfc.section.3.2">
+<a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
+</h1>
 <p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each secure MAC test vector.</p>
-<div id="rfc.table.6"/>
-<div id="vs_tc_table2"/>
+<div id="rfc.table.6"></div>
+<div id="vs_tc_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Test Case JSON Object</caption>
-  <thead>
-    <tr>
-      <th class="left">JSON Value</th>
-      <th class="left">Description</th>
-      <th class="left">JSON type</th>
-      <th class="left">Optional</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">tcId</td>
-      <td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">key</td>
-      <td class="left">Encryption key to use AES</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">key1, key2, key3</td>
-      <td class="left">Encryption keys to use for TDES</td>
-      <td class="left">value</td>
-      <td class="left">Yes</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">msg</td>
-      <td class="left">Value of the message</td>
-      <td class="left">value</td>
-      <td class="left">No</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">mac</td>
-      <td class="left">MAC value, for CMAC verify</td>
-      <td class="left">value</td>
-      <td class="left">Yes</td>
-    </tr>
-  </tbody>
+<caption>Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">key</td>
+<td class="left">Encryption key to use AES</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">key1, key2, key3</td>
+<td class="left">Encryption keys to use for TDES</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msg</td>
+<td class="left">Value of the message</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mac</td>
+<td class="left">MAC value, for CMAC verify</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+</tbody>
 </table>
-<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a></h1>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
+</h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.7"/>
-<div id="vr_top_table"/>
+<div id="rfc.table.7"></div>
+<div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-  <caption>Vector Set Response JSON Object</caption>
-  <thead>
-    <tr>
-      <th class="left">JSON Value</th>
-      <th class="left">Description</th>
-      <th class="left">JSON type</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="left">acvVersion</td>
-      <td class="left">Protocol version identifier</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">vsId</td>
-      <td class="left">Unique numeric identifier for the vector set</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">testResults</td>
-      <td class="left">Array of JSON objects that represent each test vector result and is made up of one of the following values </td>
-      <td class="left">array</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">mac</td>
-      <td class="left">MAC value generated</td>
-      <td class="left">value</td>
-    </tr>
-    <tr>
-      <td class="left"/>
-      <td class="left"/>
-      <td class="left"/>
-    </tr>
-    <tr>
-      <td class="left">result</td>
-      <td class="left">The result of CMAC verify</td>
-      <td class="left">pass or fail</td>
-    </tr>
-  </tbody>
+<caption>Vector Set Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testResults</td>
+<td class="left">Array of JSON objects that represent each test vector result and is made up of one of the following values </td>
+<td class="left">array</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mac</td>
+<td class="left">MAC value generated</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">result</td>
+<td class="left">The result of CMAC verify</td>
+<td class="left">pass or fail</td>
+</tr>
+</tbody>
 </table>
-<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a></h1>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
+</h1>
 <p id="rfc.section.5.p.1">TBD...</p>
-<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#IANA" id="IANA">IANA Considerations</a></h1>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+</h1>
 <p id="rfc.section.6.p.1">This memo includes no request to IANA.</p>
-<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#Security" id="Security">Security Considerations</a></h1>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
 <p id="rfc.section.7.p.1">Security considerations are addressed by the ACVP specification.</p>
-<h1 id="rfc.references"><a href="#rfc.references">8.</a> References</h1>
-<h1 id="rfc.references.1"><a href="#rfc.references.1">8.1.</a> Normative References</h1>
-<table>
-  <tbody>
-    <tr>
-      <td class="reference">
-        <b id="ACVP">[ACVP]</b>
-      </td>
-      <td class="top"><a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="RFC2119">[RFC2119]</b>
-      </td>
-      <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
-    </tr>
-  </tbody>
-</table>
-<h1 id="rfc.references.2"><a href="#rfc.references.2">8.2.</a> Informative References</h1>
-<table>
-  <tbody>
-    <tr>
-      <td class="reference">
-        <b id="CMACVS">[CMACVS]</b>
-      </td>
-      <td class="top"><a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The CMAC Validation System (CMACVS)</a>", 2011.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="HMACVS">[HMACVS]</b>
-      </td>
-      <td class="top"><a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Keyed-Hash Message Authentication Code Validation System (HMACVS)</a>", 2016.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="SHA3VS">[SHA3VS]</b>
-      </td>
-      <td class="top"><a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm 3 Validation System (SHA3VS)</a>", 2016.</td>
-    </tr>
-    <tr>
-      <td class="reference">
-        <b id="SHAVS">[SHAVS]</b>
-      </td>
-      <td class="top"><a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm Validation System (SHAVS)</a>", 2014.</td>
-    </tr>
-  </tbody>
-</table>
-<h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example MAC Capabilities JSON Object</a></h1>
+<h1 id="rfc.references">
+<a href="#rfc.references">8.</a> References</h1>
+<h1 id="rfc.references.1">
+<a href="#rfc.references.1">8.1.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="ACVP">[ACVP]</b></td>
+<td class="top">
+<a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.references.2">
+<a href="#rfc.references.2">8.2.</a> Informative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="CMACVS">[CMACVS]</b></td>
+<td class="top">
+<a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The CMAC Validation System (CMACVS)</a>", 2011.</td>
+</tr>
+<tr>
+<td class="reference"><b id="HMACVS">[HMACVS]</b></td>
+<td class="top">
+<a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Keyed-Hash Message Authentication Code Validation System (HMACVS)</a>", 2016.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SHA3VS">[SHA3VS]</b></td>
+<td class="top">
+<a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm 3 Validation System (SHA3VS)</a>", 2016.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SHAVS">[SHAVS]</b></td>
+<td class="top">
+<a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm Validation System (SHAVS)</a>", 2014.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example MAC Capabilities JSON Object</a>
+</h1>
 <p id="rfc.section.A.p.1">The following is an example JSON object advertising support for HMAC-SHA-1.</p>
 <pre>
 
@@ -1160,15 +1200,16 @@
                 "macLen": [ 192 ]
             }
             </pre>
-<p id="rfc.section.A.p.2">The following is an example JSON object advertising support for CMAC-AES-128.</p>
+<p id="rfc.section.A.p.2">The following is an example JSON object advertising support for CMAC-AES.</p>
 <pre>
 
 
             {
-                "algorithm": "CMAC-AES-128",
+                "algorithm": "CMAC-AES",
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
+				"keyLen" [ 128 ],
                 "macLen" : [ 64 ],
                 "msgLen" : [ 0 ]
             }
@@ -1186,7 +1227,9 @@
                 "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
             </pre>
-<h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example Test Vectors JSON Object</a></h1>
+<h1 id="rfc.appendix.B">
+<a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example Test Vectors JSON Object</a>
+</h1>
 <p id="rfc.section.B.p.1">The following is an example JSON object for HMAC test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
 [
@@ -1216,7 +1259,7 @@
 	}
 ]
             </pre>
-<p id="rfc.section.B.p.2">The following is an example JSON object for CMAC-AES-128 test vectors sent from the ACVP server to the crypto module.</p>
+<p id="rfc.section.B.p.2">The following is an example JSON object for CMAC-AES test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
 [
 	{
@@ -1224,7 +1267,7 @@
 	},
 	{
 		"vsId": 3500,
-		"algorithm": "CMAC-AES-128",
+		"algorithm": "CMAC-AES",
 		"testGroups": [{
 			"testType": "AFT",
 			"direction": "gen",
@@ -1247,7 +1290,7 @@
 	{
 		"testType": "AFT",
 		"direction": "ver",
-		"keyLen": 127,
+		"keyLen": 128,
 		"msgLen": 0,
 		"macLen": 64,
 		"tests": [{
@@ -1325,7 +1368,9 @@
 	}
 ]
             </pre>
-<h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Object</a></h1>
+<h1 id="rfc.appendix.C">
+<a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Object</a>
+</h1>
 <p id="rfc.section.C.p.1">The following is an example JSON object for HMAC test results sent from the crypto module to the ACVP server.</p>
 <pre>
 [
@@ -1346,7 +1391,7 @@
 	}
 ]
             </pre>
-<p id="rfc.section.C.p.2">The following is an example JSON object for CMAC-AES-128 test results sent from the crypto module to the ACVP server.</p>
+<p id="rfc.section.C.p.2">The following is an example JSON object for CMAC-AES test results sent from the crypto module to the ACVP server.</p>
 <pre>
 [
 	{
@@ -1402,9 +1447,7 @@
 	}
 ]
             </pre>
-<h1 id="rfc.authors">
-  <a href="#rfc.authors">Author's Address</a>
-</h1>
+<h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
 <div class="avoidbreak">
   <address class="vcard">
 	<span class="vcardline">
@@ -1415,7 +1458,7 @@
 	</span>
 	<span class="org vcardline">Cisco Systems, Inc.</span>
 	<span class="adr">
-	  <span>170 West Tasman Dr.</span>
+	  <span class="vcardline">170 West Tasman Dr.</span>
 
 	  <span class="vcardline">
 		<span class="locality">San Jose</span>,  

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -1209,7 +1209,7 @@
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-				"keyLen" [ 128 ],
+                "keyLen" : [ 128, 192 ],
                 "macLen" : [ 64 ],
                 "msgLen" : [ 0 ]
             }

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -656,7 +656,7 @@ Appendix A.  Example MAC Capabilities JSON Object
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
                                 {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-                                "keyLen" [ 128 ],
+                "keyLen" : [ 128, 192 ],
                 "macLen" : [ 64 ],
                 "msgLen" : [ 0 ]
             }

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -62,24 +62,24 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
-   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   2
+   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
      2.1.  Required Prerequisite Algorithms for MAC Validations  . .   3
      2.2.  MAC Algorithm Capabilities Registration . . . . . . . . .   4
      2.3.  Supported MAC Algorithms  . . . . . . . . . . . . . . . .   6
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   7
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   8
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   9
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   9
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  10
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  10
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  10
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  11
-   Appendix A.  Example MAC Capabilities JSON Object . . . . . . . .  11
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  12
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  15
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  16
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  10
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  11
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  11
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  11
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  11
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  11
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  12
+   Appendix A.  Example MAC Capabilities JSON Object . . . . . . . .  12
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  13
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  16
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  18
 
 1.  Introduction
 
@@ -102,10 +102,10 @@ Table of Contents
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted in RFC 2119 [RFC2119].
 
-2.  Capabilities Registration
 
-   ACVP requires crypto modules to register their capabilities.  This
-   allows the crypto module to advertise support for specific
+
+
+
 
 
 
@@ -114,6 +114,10 @@ Fussell                 Expires December 3, 2016                [Page 2]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+2.  Capabilities Registration
+
+   ACVP requires crypto modules to register their capabilities.  This
+   allows the crypto module to advertise support for specific
    algorithms, notifying the ACVP server which algorithms need test
    vectors generated for the validation process.  This section describes
    the constructs for advertising support of HMAC and CMAC algorithms to
@@ -136,30 +140,26 @@ Internet-Draft                Sym Alg JSON                     June 2016
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
 
-   +--------------+----------------+--------------+---------+----------+
-   | JSON Value   | Description    | JSON type    | Valid   | Optional |
-   |              |                |              | Values  |          |
-   +--------------+----------------+--------------+---------+----------+
-   | algorithm    | a prerequisite | value        | AES,    | No       |
-   |              | algorithm      |              | SHA,    |          |
-   |              |                |              | TDES    |          |
-   |              |                |              |         |          |
-   | valValue     | algorithm      | value        | actual  | No       |
-   |              | validation     |              | number  |          |
-   |              | number         |              | or      |          |
-   |              |                |              | "same"  |          |
-   |              |                |              |         |          |
-   | prereqAlgVal | prerequistie   | object with  | see     | No       |
-   |              | algorithm      | algorithm    | above   |          |
-   |              | validation     | and valValue |         |          |
-   |              |                | properties   |         |          |
-   +--------------+----------------+--------------+---------+----------+
+   +--------------+--------------+---------------+----------+----------+
+   | JSON Value   | Description  | JSON type     | Valid    | Optional |
+   |              |              |               | Values   |          |
+   +--------------+--------------+---------------+----------+----------+
+   | algorithm    | a            | value         | AES,     | No       |
+   |              | prerequisite |               | SHA,     |          |
+   |              | algorithm    |               | TDES     |          |
+   |              |              |               |          |          |
+   | valValue     | algorithm    | value         | actual   | No       |
+   |              | validation   |               | number   |          |
+   |              | number       |               | or       |          |
+   |              |              |               | "same"   |          |
+   |              |              |               |          |          |
+   | prereqAlgVal | prerequistie | object with   | see      | No       |
+   |              | algorithm    | algorithm and | above    |          |
+   |              | validation   | valValue      |          |          |
+   |              |              | properties    |          |          |
+   +--------------+--------------+---------------+----------+----------+
 
          Table 1: Required MAC Prerequisite Algorithms JSON Values
-
-
-
-
 
 
 
@@ -175,49 +175,49 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +--------------+-----------------+--------------+---------+---------+
-   | JSON Value   | Description     | JSON type    | Valid   | Optiona |
-   |              |                 |              | Values  | l       |
-   +--------------+-----------------+--------------+---------+---------+
-   | algorithm    | The MAC         | value        | See     | No      |
-   |              | algorithm and   |              | Section |         |
-   |              | mode to be      |              | 2.3     |         |
-   |              | validated.      |              |         |         |
-   |              |                 |              |         |         |
-   | prereqVals   | prerequistie    | array of     | See     | No      |
-   |              | algorithm       | prereqAlgVal | Section |         |
-   |              | validations,    | objects      | 2.1     |         |
-   |              | See Appendix A  |              |         |         |
-   |              | for examples    |              |         |         |
-   |              |                 |              |         |         |
-   | direction    | The MAC         | array        | gen,    | No      |
-   |              | direction(s) to |              | ver     |         |
-   |              | test. Only      |              |         |         |
-   |              | applies to      |              |         |         |
-   |              | CMAC.           |              |         |         |
-   |              |                 |              |         |         |
-   | keyLen       | The keyLen      | Domain       | 8-52428 | Yes     |
-   |              | Domain          |              | 8       |         |
-   |              | supported by    |              |         |         |
-   |              | the IUT in      |              |         |         |
-   |              | bits. (HMAC     |              |         |         |
-   |              | only)           |              |         |         |
-   |              |                 |              |         |         |
-   | keyingOption | The Keying      | array        | 1, 2    | Yes     |
-   |              | Option used in  |              |         |         |
-   |              | TDES.  Keying   |              |         |         |
-   |              | option 1 (1) is |              |         |         |
-   |              | 3 distinct keys |              |         |         |
-   |              | (K1, K2, K3).   |              |         |         |
-   |              | Keying Option 2 |              |         |         |
-   |              | (2) is 2        |              |         |         |
-   |              | distinct only   |              |         |         |
-   |              | suitable for    |              |         |         |
-   |              | decrypt (K1,    |              |         |         |
-   |              | K2, K1).        |              |         |         |
-   |              | Keying option 3 |              |         |         |
-   |              | (No longer      |              |         |         |
-   |              | valid for       |              |         |         |
+   +-------------+-----------------+-------------+----------+----------+
+   | JSON Value  | Description     | JSON type   | Valid    | Optional |
+   |             |                 |             | Values   |          |
+   +-------------+-----------------+-------------+----------+----------+
+   | algorithm   | The MAC         | value       | See      | No       |
+   |             | algorithm and   |             | Section  |          |
+   |             | mode to be      |             | 2.3      |          |
+   |             | validated.      |             |          |          |
+   |             |                 |             |          |          |
+   | prereqVals  | prerequistie    | array of pr | See      | No       |
+   |             | algorithm       | ereqAlgVal  | Section  |          |
+   |             | validations,    | objects     | 2.1      |          |
+   |             | See Appendix A  |             |          |          |
+   |             | for examples    |             |          |          |
+   |             |                 |             |          |          |
+   | direction   | The MAC         | array       | gen, ver | No       |
+   |             | direction(s) to |             |          |          |
+   |             | test. Only      |             |          |          |
+   |             | applies to      |             |          |          |
+   |             | CMAC.           |             |          |          |
+   |             |                 |             |          |          |
+   | keyLen      | The keyLen      | Domain      | 8-524288 | Yes      |
+   |             | Domain          |             |          |          |
+   |             | supported by    |             |          |          |
+   |             | the IUT in      |             |          |          |
+   |             | bits. (HMAC     |             |          |          |
+   |             | only)           |             |          |          |
+   |             |                 |             |          |          |
+   | keyLen      | The array of    | array       | 128,     | Yes      |
+   |             | keyLens         |             | 192, 256 |          |
+   |             | supported by    |             |          |          |
+   |             | the IUT in      |             |          |          |
+   |             | bits. (CMAC     |             |          |          |
+   |             | only)           |             |          |          |
+   |             |                 |             |          |          |
+   | keyingOptio | The Keying      | array       | 1, 2     | Yes      |
+   | n           | Option used in  |             |          |          |
+   |             | TDES.  Keying   |             |          |          |
+   |             | option 1 (1) is |             |          |          |
+   |             | 3 distinct keys |             |          |          |
+   |             | (K1, K2, K3).   |             |          |          |
+   |             | Keying Option 2 |             |          |          |
+   |             | (2) is 2        |             |          |          |
 
 
 
@@ -226,27 +226,34 @@ Fussell                 Expires December 3, 2016                [Page 4]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |              | testing, save   |              |         |         |
-   |              | KATs) is a      |              |         |         |
-   |              | single key, now |              |         |         |
-   |              | deprecated (K1, |              |         |         |
-   |              | K1, K1).        |              |         |         |
-   |              |                 |              |         |         |
-   | msgLen       | The CMAC        | Domain       | 0-52428 | Yes     |
-   |              | message lengths |              | 8       |         |
-   |              | supported.  Min |              |         |         |
-   |              | /max/increment  |              |         |         |
-   |              | and values must |              |         |         |
-   |              | be mod 8.       |              |         |         |
-   |              |                 |              |         |         |
-   | macLen       | The supported   | Domain       | 32-512  | No      |
-   |              | mac sizes.      |              |         |         |
-   |              | (range          |              |         |         |
-   |              | dependent on    |              |         |         |
-   |              | algorithm, see  |              |         |         |
-   |              | Section 2.3).   |              |         |         |
-   |              |                 |              |         |         |
-   +--------------+-----------------+--------------+---------+---------+
+   |             | distinct only   |             |          |          |
+   |             | suitable for    |             |          |          |
+   |             | decrypt (K1,    |             |          |          |
+   |             | K2, K1).        |             |          |          |
+   |             | Keying option 3 |             |          |          |
+   |             | (No longer      |             |          |          |
+   |             | valid for       |             |          |          |
+   |             | testing, save   |             |          |          |
+   |             | KATs) is a      |             |          |          |
+   |             | single key, now |             |          |          |
+   |             | deprecated (K1, |             |          |          |
+   |             | K1, K1).        |             |          |          |
+   |             |                 |             |          |          |
+   | msgLen      | The CMAC        | Domain      | 0-524288 | Yes      |
+   |             | message lengths |             |          |          |
+   |             | supported.  Min |             |          |          |
+   |             | /max/increment  |             |          |          |
+   |             | and values must |             |          |          |
+   |             | be mod 8.       |             |          |          |
+   |             |                 |             |          |          |
+   | macLen      | The supported   | Domain      | 32-512   | No       |
+   |             | mac sizes.      |             |          |          |
+   |             | (range          |             |          |          |
+   |             | dependent on    |             |          |          |
+   |             | algorithm, see  |             |          |          |
+   |             | Section 2.3).   |             |          |          |
+   |             |                 |             |          |          |
+   +-------------+-----------------+-------------+----------+----------+
 
               Table 2: MAC Algorithm Capabilities JSON Values
 
@@ -268,19 +275,19 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    o  The smallest CMAC length supported
 
-   o  A second CMAC length supported
-
-   o  The largest CMAC length supported
-
-   msgLen for CMAC contains a Domain of values, the server may choose
-   values defined by these rules:
-
 
 
 Fussell                 Expires December 3, 2016                [Page 5]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
+
+   o  A second CMAC length supported
+
+   o  The largest CMAC length supported
+
+   msgLen for CMAC contains a Domain of values, the server may choose
+   values defined by these rules:
 
    o  The smallest message length supported
 
@@ -294,13 +301,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The following algorithms may be advertised by the ACVP compliant
    crypto module:
-
-
-
-
-
-
-
 
 
 
@@ -363,11 +363,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            |                   |              |                |
            | HMAC-SHA3-512     | 576          | 512            |
            |                   |              |                |
-           | CMAC-AES-128      | 128          | 128            |
-           |                   |              |                |
-           | CMAC-AES-192      | 128          | 128            |
-           |                   |              |                |
-           | CMAC-AES-256      | 128          | 128            |
+           | CMAC-AES          | 128          | 128            |
            |                   |              |                |
            | CMAC-TDES         | 64           | 64             |
            |                   |              |                |
@@ -382,10 +378,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
    typical ACVP validation session would require multiple test vector
    sets to be downloaded and processed by the ACVP client.  Each test
    vector set represents an individual crypto algorithm, such as HMAC-
-   SHA-1, HMAC-SHA2-224, CMAC-AES-128, etc.  This section describes the
-   JSON schema for a test vector set used with HMAC and CMAC crypto
+   SHA-1, HMAC-SHA2-224, CMAC-AES, etc.  This section describes the JSON
+   schema for a test vector set used with HMAC and CMAC crypto
    algorithms.
 
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
+   test vectors to be processed by the ACVP client.  The following table
+   describes the JSON elements at the top level of the hierarchy.
 
 
 
@@ -394,27 +394,21 @@ Fussell                 Expires December 3, 2016                [Page 7]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   The test vector set JSON schema is a multi-level hierarchy that
-   contains meta data for the entire vector set as well as individual
-   test vectors to be processed by the ACVP client.  The following table
-   describes the JSON elements at the top level of the hierarchy.
-
-   +----------------+----------------------------------------+---------+
-   | JSON Value     | Description                            | JSON    |
-   |                |                                        | type    |
-   +----------------+----------------------------------------+---------+
-   | acvVersion     | Protocol version identifier            | value   |
-   |                |                                        |         |
-   | vsId           | Unique numeric identifier for the      | value   |
-   |                | vector set                             |         |
-   |                |                                        |         |
-   | algorithm      | The algorithm and mode used for the    | value   |
-   |                | test vectors.  See Section 2.3 for     |         |
-   |                | possible values.                       |         |
-   |                |                                        |         |
-   | testGroups     | Array of test group JSON objects,      | array   |
-   |                | which are defined in Section 3.1       |         |
-   +----------------+----------------------------------------+---------+
+   +------------+----------------------------------------------+-------+
+   | JSON Value | Description                                  | JSON  |
+   |            |                                              | type  |
+   +------------+----------------------------------------------+-------+
+   | acvVersion | Protocol version identifier                  | value |
+   |            |                                              |       |
+   | vsId       | Unique numeric identifier for the vector set | value |
+   |            |                                              |       |
+   | algorithm  | The algorithm and mode used for the test     | value |
+   |            | vectors.  See Section 2.3 for possible       |       |
+   |            | values.                                      |       |
+   |            |                                              |       |
+   | testGroups | Array of test group JSON objects, which are  | array |
+   |            | defined in Section 3.1                       |       |
+   +------------+----------------------------------------------+-------+
 
                       Table 4: Vector Set JSON Object
 
@@ -429,19 +423,25 @@ Internet-Draft                Sym Alg JSON                     June 2016
    following table describes the secure HMAC and CMAC JSON elements of
    the Test Group JSON object.
 
-   +-------------+-------------------------------+---------+-----------+
-   | JSON Value  | Description                   | JSON    | Optional  |
-   |             |                               | type    |           |
-   +-------------+-------------------------------+---------+-----------+
-   | testType    | Test category type (AFT)      | value   | No        |
-   |             |                               |         |           |
-   | direction   | The direction of the tests -  | value   | No        |
-   |             | gen or ver - only applies to  |         |           |
-   |             | CMAC                          |         |           |
-   |             |                               |         |           |
-   | keyLen      | Length of key in bits to use  | value   | No        |
-   |             |                               |         |           |
-   | msgLen      | Length of message/hash in     | value   | No        |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -450,15 +450,26 @@ Fussell                 Expires December 3, 2016                [Page 8]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |             | bits                          |         |           |
-   |             |                               |         |           |
-   | macLen      | Length of MAC in bits to      | value   | No        |
-   |             | generate/verify               |         |           |
-   |             |                               |         |           |
-   | tests       | Array of individual test      | array   | No        |
-   |             | vector JSON objects, which    |         |           |
-   |             | are defined in Section 3.2    |         |           |
-   +-------------+-------------------------------+---------+-----------+
+   +-----------+------------------------------------+-------+----------+
+   | JSON      | Description                        | JSON  | Optional |
+   | Value     |                                    | type  |          |
+   +-----------+------------------------------------+-------+----------+
+   | testType  | Test category type (AFT)           | value | No       |
+   |           |                                    |       |          |
+   | direction | The direction of the tests - gen   | value | No       |
+   |           | or ver - only applies to CMAC      |       |          |
+   |           |                                    |       |          |
+   | keyLen    | Length of key in bits to use       | value | No       |
+   |           |                                    |       |          |
+   | msgLen    | Length of message/hash in bits     | value | No       |
+   |           |                                    |       |          |
+   | macLen    | Length of MAC in bits to           | value | No       |
+   |           | generate/verify                    |       |          |
+   |           |                                    |       |          |
+   | tests     | Array of individual test vector    | array | No       |
+   |           | JSON objects, which are defined in |       |          |
+   |           | Section 3.2                        |       |          |
+   +-----------+------------------------------------+-------+----------+
 
                       Table 5: Test Group JSON Object
 
@@ -469,24 +480,50 @@ Internet-Draft                Sym Alg JSON                     June 2016
    processed by the ACVP client.  The following table describes the JSON
    elements for each secure MAC test vector.
 
-   +-----------+-------------------------------+----------+------------+
-   | JSON      | Description                   | JSON     | Optional   |
-   | Value     |                               | type     |            |
-   +-----------+-------------------------------+----------+------------+
-   | tcId      | Numeric identifier for the    | value    | No         |
-   |           | test case, unique across the  |          |            |
-   |           | entire vector set.            |          |            |
-   |           |                               |          |            |
-   | key       | Encryption key to use AES     | value    | No         |
-   |           |                               |          |            |
-   | key1,     | Encryption keys to use for    | value    | Yes        |
-   | key2,     | TDES                          |          |            |
-   | key3      |                               |          |            |
-   |           |                               |          |            |
-   | msg       | Value of the message          | value    | No         |
-   |           |                               |          |            |
-   | mac       | MAC value, for CMAC verify    | value    | Yes        |
-   +-----------+-------------------------------+----------+------------+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 9]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   +----------+-------------------------------------+-------+----------+
+   | JSON     | Description                         | JSON  | Optional |
+   | Value    |                                     | type  |          |
+   +----------+-------------------------------------+-------+----------+
+   | tcId     | Numeric identifier for the test     | value | No       |
+   |          | case, unique across the entire      |       |          |
+   |          | vector set.                         |       |          |
+   |          |                                     |       |          |
+   | key      | Encryption key to use AES           | value | No       |
+   |          |                                     |       |          |
+   | key1,    | Encryption keys to use for TDES     | value | Yes      |
+   | key2,    |                                     |       |          |
+   | key3     |                                     |       |          |
+   |          |                                     |       |          |
+   | msg      | Value of the message                | value | No       |
+   |          |                                     |       |          |
+   | mac      | MAC value, for CMAC verify          | value | Yes      |
+   +----------+-------------------------------------+-------+----------+
 
                       Table 6: Test Case JSON Object
 
@@ -501,28 +538,49 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016                [Page 9]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 10]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +---------------+---------------------------------------+-----------+
-   | JSON Value    | Description                           | JSON type |
-   +---------------+---------------------------------------+-----------+
-   | acvVersion    | Protocol version identifier           | value     |
-   |               |                                       |           |
-   | vsId          | Unique numeric identifier for the     | value     |
-   |               | vector set                            |           |
-   |               |                                       |           |
-   | testResults   | Array of JSON objects that represent  | array     |
-   |               | each test vector result and is made   |           |
-   |               | up of one of the following values     |           |
-   |               |                                       |           |
-   | mac           | MAC value generated                   | value     |
-   |               |                                       |           |
-   | result        | The result of CMAC verify             | pass or   |
-   |               |                                       | fail      |
-   +---------------+---------------------------------------+-----------+
+   +-------------+---------------------------------------------+-------+
+   | JSON Value  | Description                                 | JSON  |
+   |             |                                             | type  |
+   +-------------+---------------------------------------------+-------+
+   | acvVersion  | Protocol version identifier                 | value |
+   |             |                                             |       |
+   | vsId        | Unique numeric identifier for the vector    | value |
+   |             | set                                         |       |
+   |             |                                             |       |
+   | testResults | Array of JSON objects that represent each   | array |
+   |             | test vector result and is made up of one of |       |
+   |             | the following values                        |       |
+   |             |                                             |       |
+   | mac         | MAC value generated                         | value |
+   |             |                                             |       |
+   | result      | The result of CMAC verify                   | pass  |
+   |             |                                             | or    |
+   |             |                                             | fail  |
+   +-------------+---------------------------------------------+-------+
 
                  Table 7: Vector Set Response JSON Object
 
@@ -545,9 +603,9 @@ Internet-Draft                Sym Alg JSON                     June 2016
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
-              RFC2119, March 1997, <https://www.rfc-editor.org/info/
-              rfc2119>.
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
+              editor.org/info/rfc2119>.
 
 
 
@@ -555,9 +613,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-
-Fussell                 Expires December 3, 2016               [Page 10]
+Fussell                 Expires December 3, 2016               [Page 11]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -583,89 +639,33 @@ Appendix A.  Example MAC Capabilities JSON Object
 
 
 
-               {
-                   "algorithm": "HMAC-SHA2-256",
-                   "prereqVals" : [{"algorithm" : "SHA", "valValue" : "123456"}],
-                   "keyLen": [ { "min": 256, "max": 2048, "increment": 8 } ],
-                   "macLen": [ 192 ]
-               }
+            {
+                "algorithm": "HMAC-SHA2-256",
+                "prereqVals" : [{"algorithm" : "SHA", "valValue" : "123456"}],
+                "keyLen": [ { "min": 256, "max": 2048, "increment": 8 } ],
+                "macLen": [ 192 ]
+            }
 
    The following is an example JSON object advertising support for CMAC-
-   AES-128.
+   AES.
 
 
 
-               {
-                   "algorithm": "CMAC-AES-128",
-                   "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                           {"algorithm" : "TDES", "valValue" : "123456"}],
-                   "direction" : [ "gen", "ver" ],
-                   "macLen" : [ 64 ],
-                   "msgLen" : [ 0 ]
-               }
+            {
+                "algorithm": "CMAC-AES",
+                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                                {"algorithm" : "TDES", "valValue" : "123456"}],
+                "direction" : [ "gen", "ver" ],
+                                "keyLen" [ 128 ],
+                "macLen" : [ 64 ],
+                "msgLen" : [ 0 ]
+            }
 
    The following is an example JSON object advertising support for CMAC-
    TDES.
 
 
 
-               {
-
-
-
-Fussell                 Expires December 3, 2016               [Page 11]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
-                   "algorithm": "CMAC-TDES",
-                   "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                           {"algorithm" : "TDES", "valValue" : "123456"}],
-                   "direction" : [ "gen", "ver" ],
-                   "macLen" : [ 8, 64 ],
-                   "msgLen" : [ 0, 256, 120, 248, 320 ]
-               }
-
-Appendix B.  Example Test Vectors JSON Object
-
-   The following is an example JSON object for HMAC test vectors sent
-   from the ACVP server to the crypto module.
-
-   [
-       {
-           "acvVersion": "0.4"
-       },
-       {
-           "vsId": 1565,
-           "algorithm": "HMAC-SHA-1",
-           "testGroups": [{
-               "testType": "AFT",
-               "keyLen": 256,
-               "msgLen": 160,
-               "macLen": 80,
-               "tests": [{
-                       "tcId": 2172,
-                       "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-                       "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-                   },
-                   {
-                       "tcId": 2173,
-                       "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-                       "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-                   }
-               ]
-           }]
-       }
-   ]
-
-   The following is an example JSON object for CMAC-AES-128 test vectors
-   sent from the ACVP server to the crypto module.
-
-   [
-       {
-           "acvVersion": "0.4"
-       },
-       {
 
 
 
@@ -674,54 +674,54 @@ Fussell                 Expires December 3, 2016               [Page 12]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-           "vsId": 3500,
-           "algorithm": "CMAC-AES-128",
-           "testGroups": [{
-               "testType": "AFT",
-               "direction": "gen",
-               "keyLen": 128,
-               "msgLen": 0,
-               "macLen": 64,
-               "tests": [{
-                       "tcId": 2750,
-                       "key": "f28effca41cb11819a81eb3ebf3b7e83",
-                       "msg": ""
-                   },
-                   {
-                       "tcId": 2751,
-                       "key": "ab566f4af532efc8bc56555fe07696fd",
-                       "msg": ""
-                   }
-               ]
-           }]
-       },
-       {
-           "testType": "AFT",
-           "direction": "ver",
-           "keyLen": 127,
-           "msgLen": 0,
-           "macLen": 64,
-           "tests": [{
-                   "tcId": 2752,
-                   "key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-                   "msg": "",
-                   "mac": "2eef1e38fcc7c568"
-               },
-               {
-                   "tcId": 2753,
-                   "key": "eb87fb7a5fb60caecb9b23564befe513",
-                   "msg": "",
-                   "mac": "cafecafecafecafe"
-               }
-           ]
-       }
-   ]
+            {
+                "algorithm": "CMAC-TDES",
+                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                                {"algorithm" : "TDES", "valValue" : "123456"}],
+                "direction" : [ "gen", "ver" ],
+                "macLen" : [ 8, 64 ],
+                "msgLen" : [ 0, 256, 120, 248, 320 ]
+            }
 
-   The following is an example JSON object for CMAC-TDES test vectors
+Appendix B.  Example Test Vectors JSON Object
+
+   The following is an example JSON object for HMAC test vectors sent
+   from the ACVP server to the crypto module.
+
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 1565,
+                "algorithm": "HMAC-SHA-1",
+                "testGroups": [{
+                        "testType": "AFT",
+                        "keyLen": 256,
+                        "msgLen": 160,
+                        "macLen": 80,
+                        "tests": [{
+                                        "tcId": 2172,
+                                        "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
+                                        "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
+                                },
+                                {
+                                        "tcId": 2173,
+                                        "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
+                                        "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
+                                }
+                        ]
+                }]
+        }
+]
+
+   The following is an example JSON object for CMAC-AES test vectors
    sent from the ACVP server to the crypto module.
 
-   [
-       {
+
+
+
+
 
 
 
@@ -730,54 +730,54 @@ Fussell                 Expires December 3, 2016               [Page 13]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-           "acvVersion": "0.4"
-       },
-       {
-           "vsId": 1566,
-           "algorithm": "CMAC-TDES",
-           "testGroups": [{
-                   "testType": "AFT",
-                   "direction": "gen",
-                   "keyingOption": 1,
-                   "msgLen": 0,
-                   "macLen": 40,
-                   "tests": [{
-                           "tcId": 2175,
-                           "key1": "c479f813ad1a45d5",
-                           "key2": "dc43459da4c85e85",
-                           "key3": "1cda518af886bf1f",
-                           "msg": ""
-                       },
-                       {
-                           "tcId": 2176,
-                           "key1": "731331866754588f",
-                           "key2": "d332ef51e0ce1925",
-                           "key3": "d586cba70440f44f",
-                           "msg": ""
-                       }
-                   ]
-               },
-               {
-                   "testType": "AFT",
-                   "direction": "ver",
-                   "keyingOption": 1,
-                   "msgLen": 0,
-                   "macLen": 40,
-                   "tests": [{
-                           "tcId": 2177,
-                           "key1": "d586cba70440f44f",
-                           "key2": "d332ef51e0ce1925",
-                           "key3": "dc43459da4c85e85",
-                           "msg": "",
-                           "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                       },
-                       {
-                           "tcId": 2177,
-                           "key1": "dc43459da4c85e85",
-                           "key2": "c479f813ad1a45d5",
-                           "key3": "1cda518af886bf1f",
-                           "msg": "",
-                           "mac": "cafecafecafecafecafecafecafecafecafecafe"
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 3500,
+                "algorithm": "CMAC-AES",
+                "testGroups": [{
+                        "testType": "AFT",
+                        "direction": "gen",
+                        "keyLen": 128,
+                        "msgLen": 0,
+                        "macLen": 64,
+                        "tests": [{
+                                        "tcId": 2750,
+                                        "key": "f28effca41cb11819a81eb3ebf3b7e83",
+                                        "msg": ""
+                                },
+                                {
+                                        "tcId": 2751,
+                                        "key": "ab566f4af532efc8bc56555fe07696fd",
+                                        "msg": ""
+                                }
+                        ]
+                }]
+        },
+        {
+                "testType": "AFT",
+                "direction": "ver",
+                "keyLen": 128,
+                "msgLen": 0,
+                "macLen": 64,
+                "tests": [{
+                                "tcId": 2752,
+                                "key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
+                                "msg": "",
+                                "mac": "2eef1e38fcc7c568"
+                        },
+                        {
+                                "tcId": 2753,
+                                "key": "eb87fb7a5fb60caecb9b23564befe513",
+                                "msg": "",
+                                "mac": "cafecafecafecafe"
+                        }
+                ]
+        }
+]
+
 
 
 
@@ -786,54 +786,54 @@ Fussell                 Expires December 3, 2016               [Page 14]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                       }
-                   ]
-               }
-           ]
-       }
-   ]
+   The following is an example JSON object for CMAC-TDES test vectors
+   sent from the ACVP server to the crypto module.
 
-Appendix C.  Example Test Results JSON Object
-
-   The following is an example JSON object for HMAC test results sent
-   from the crypto module to the ACVP server.
-
-   [
-       {
-           "acvVersion": "0.4"
-       },
-       {
-           "vsId": 1565,
-           "testResults": [{
-                   "tcId": 2172,
-                   "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
-               },
-               {
-                   "tcId": 2173,
-                   "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-               }
-           ]
-       }
-   ]
-
-   The following is an example JSON object for CMAC-AES-128 test results
-   sent from the crypto module to the ACVP server.
-
-   [
-       {
-           "acvVersion": "0.4"
-       },
-       {
-           "vsId": 3500,
-           "testResults": [{
-                   "tcId": 2750,
-                   "mac": "e77145f0d6c77ad5"
-               },
-               {
-                   "tcId": 2751,
-                   "mac": "6b078f7e53b6d183"
-               },
-               {
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 1566,
+                "algorithm": "CMAC-TDES",
+                "testGroups": [{
+                                "testType": "AFT",
+                                "direction": "gen",
+                                "keyingOption": 1,
+                                "msgLen": 0,
+                                "macLen": 40,
+                                "tests": [{
+                                                "tcId": 2175,
+                                                "key1": "c479f813ad1a45d5",
+                                                "key2": "dc43459da4c85e85",
+                                                "key3": "1cda518af886bf1f",
+                                                "msg": ""
+                                        },
+                                        {
+                                                "tcId": 2176,
+                                                "key1": "731331866754588f",
+                                                "key2": "d332ef51e0ce1925",
+                                                "key3": "d586cba70440f44f",
+                                                "msg": ""
+                                        }
+                                ]
+                        },
+                        {
+                                "testType": "AFT",
+                                "direction": "ver",
+                                "keyingOption": 1,
+                                "msgLen": 0,
+                                "macLen": 40,
+                                "tests": [{
+                                                "tcId": 2177,
+                                                "key1": "d586cba70440f44f",
+                                                "key2": "d332ef51e0ce1925",
+                                                "key3": "dc43459da4c85e85",
+                                                "msg": "",
+                                                "mac": "cafecafecafecafecafecafecafecafecafecafe"
+                                        },
+                                        {
+                                                "tcId": 2177,
 
 
 
@@ -842,47 +842,47 @@ Fussell                 Expires December 3, 2016               [Page 15]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-                   "tcId": 2752,
-                   "result": "pass"
-               },
-               {
-                   "tcId": 2753,
-                   "result": "fail"
-               }
-           ]
-       }
-   ]
+                                                "key1": "dc43459da4c85e85",
+                                                "key2": "c479f813ad1a45d5",
+                                                "key3": "1cda518af886bf1f",
+                                                "msg": "",
+                                                "mac": "cafecafecafecafecafecafecafecafecafecafe"
+                                        }
+                                ]
+                        }
+                ]
+        }
+]
 
-   The following is an example JSON object for CMAC-TDES test results
+Appendix C.  Example Test Results JSON Object
+
+   The following is an example JSON object for HMAC test results sent
+   from the crypto module to the ACVP server.
+
+[
+        {
+                "acvVersion": "0.4"
+        },
+        {
+                "vsId": 1565,
+                "testResults": [{
+                                "tcId": 2172,
+                                "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
+                        },
+                        {
+                                "tcId": 2173,
+                                "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
+                        }
+                ]
+        }
+]
+
+   The following is an example JSON object for CMAC-AES test results
    sent from the crypto module to the ACVP server.
 
-   [
-       {
-           "acvVersion": "0.4"
-       },
-       {
-           "vsId": 1566,
-           "testResults": [{
-                   "tcId": 2175,
-                   "mac": "fea01c84a7"
-               },
-               {
-                   "tcId": 2176,
-                   "mac": "164bdb8582"
-               },
-               {
-                   "tcId": 2177,
-                   "result": "fail"
-               },
-               {
-                   "tcId": 2178,
-                   "result": "fail"
-               }
-           ]
-       }
-   ]
 
-Author's Address
+
+
 
 
 
@@ -898,34 +898,34 @@ Fussell                 Expires December 3, 2016               [Page 16]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   Barry Fussell (editor)
-   Cisco Systems, Inc.
-   170 West Tasman Dr.
-   San Jose, CA  95134
-   USA
+   [
+           {
+                   "acvVersion": "0.4"
+           },
+           {
+                   "vsId": 3500,
+                   "testResults": [{
+                                   "tcId": 2750,
+                                   "mac": "e77145f0d6c77ad5"
+                           },
+                           {
+                                   "tcId": 2751,
+                                   "mac": "6b078f7e53b6d183"
+                           },
+                           {
+                                   "tcId": 2752,
+                                   "result": "pass"
+                           },
+                           {
+                                   "tcId": 2753,
+                                   "result": "fail"
+                           }
+                   ]
+           }
+   ]
 
-   Email: bfussell@cisco.com
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+   The following is an example JSON object for CMAC-TDES test results
+   sent from the crypto module to the ACVP server.
 
 
 
@@ -950,3 +950,59 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 Fussell                 Expires December 3, 2016               [Page 17]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   [
+           {
+                   "acvVersion": "0.4"
+           },
+           {
+                   "vsId": 1566,
+                   "testResults": [{
+                                   "tcId": 2175,
+                                   "mac": "fea01c84a7"
+                           },
+                           {
+                                   "tcId": 2176,
+                                   "mac": "164bdb8582"
+                           },
+                           {
+                                   "tcId": 2177,
+                                   "result": "fail"
+                           },
+                           {
+                                   "tcId": 2178,
+                                   "result": "fail"
+                           }
+                   ]
+           }
+   ]
+
+Author's Address
+
+   Barry Fussell (editor)
+   Cisco Systems, Inc.
+   170 West Tasman Dr.
+   San Jose, CA  95134
+   USA
+
+   Email: bfussell@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 18]

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -208,6 +208,14 @@
           <c>Yes</c>
 	  <c/><c/><c/><c/><c/>
 	  
+          <c>keyLen</c>
+	  <c>The array of keyLens supported by the IUT in bits. (CMAC only)</c>
+          <c>array</c>
+          <c>128, 192, 256</c>
+          <c>Yes</c>
+	  <c/><c/><c/><c/><c/>
+
+
           <c>keyingOption</c>
 	  <c>The Keying Option used in TDES.   
          
@@ -324,17 +332,7 @@
 				<c>512</c>
 				<c/><c/><c/>
 
-				<c>CMAC-AES-128</c>
-				<c>128</c>
-				<c>128</c>
-				<c/><c/><c/>
-
-				<c>CMAC-AES-192</c>
-				<c>128</c>
-				<c>128</c>
-				<c/><c/><c/>
-
-				<c>CMAC-AES-256</c>
+				<c>CMAC-AES</c>
 				<c>128</c>
 				<c>128</c>
 				<c/><c/><c/>
@@ -352,7 +350,7 @@
 	<t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to
 	    the ACVP server for validation.  A typical ACVP validation session would require multiple test vector
 	    sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual
-	    crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES-128, etc.  This section
+	    crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc.  This section
 	describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</t>
 
 	<t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire
@@ -625,16 +623,17 @@
             }
             ]]></artwork>
     </figure>
-      <t>The following is an example JSON object advertising support for CMAC-AES-128.</t>
+      <t>The following is an example JSON object advertising support for CMAC-AES.</t>
       <figure>
         <artwork><![CDATA[
 
 
             {
-                "algorithm": "CMAC-AES-128",
+                "algorithm": "CMAC-AES",
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
+				"keyLen" [ 128 ],
                 "macLen" : [ 64 ],
                 "msgLen" : [ 0 ]
             }
@@ -688,7 +687,7 @@
 ]
             ]]></artwork>
        </figure>
-<t>The following is an example JSON object for CMAC-AES-128 test vectors sent from the ACVP server to the crypto module.</t>
+<t>The following is an example JSON object for CMAC-AES test vectors sent from the ACVP server to the crypto module.</t>
       <figure>
         <artwork><![CDATA[
 [
@@ -697,7 +696,7 @@
 	},
 	{
 		"vsId": 3500,
-		"algorithm": "CMAC-AES-128",
+		"algorithm": "CMAC-AES",
 		"testGroups": [{
 			"testType": "AFT",
 			"direction": "gen",
@@ -720,7 +719,7 @@
 	{
 		"testType": "AFT",
 		"direction": "ver",
-		"keyLen": 127,
+		"keyLen": 128,
 		"msgLen": 0,
 		"macLen": 64,
 		"tests": [{
@@ -825,7 +824,7 @@
 ]
             ]]></artwork>
        </figure>
-<t>The following is an example JSON object for CMAC-AES-128 test results sent from the crypto module to the ACVP server.</t>
+<t>The following is an example JSON object for CMAC-AES test results sent from the crypto module to the ACVP server.</t>
       <figure>
         <artwork><![CDATA[
 [

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -633,7 +633,7 @@
                 "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
 		                {"algorithm" : "TDES", "valValue" : "123456"}],
                 "direction" : [ "gen", "ver" ],
-				"keyLen" [ 128 ],
+                "keyLen" : [ 128, 192 ],
                 "macLen" : [ 64 ],
                 "msgLen" : [ 0 ]
             }


### PR DESCRIPTION
Removes valid algorithm registrations of `CMAC-AES-128`, `CMAC-AES-192`, and `CMAC-AES-256`.  New value is `CMAC-AES`, with a keyLen[] parameter.