### PR TITLE
Cmac tdes keying option

### DIFF
--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -625,7 +625,7 @@
 <td class="left">The keyLen Domain supported by the IUT in bits. (HMAC only)</td>
 <td class="left">Domain</td>
 <td class="left">8-524288</td>
-<td class="left">Yes (required HMAC)</td>
+<td class="left">Yes (required for HMAC)</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -639,7 +639,7 @@
 <td class="left">The array of keyLens supported by the IUT in bits. (CMAC-AES only)</td>
 <td class="left">array</td>
 <td class="left">128, 192, 256</td>
-<td class="left">Yes (required CMAC-AES)</td>
+<td class="left">Yes (required for CMAC-AES)</td>
 </tr>
 <tr>
 <td class="left"></td>

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -625,7 +625,7 @@
 <td class="left">The keyLen Domain supported by the IUT in bits. (HMAC only)</td>
 <td class="left">Domain</td>
 <td class="left">8-524288</td>
-<td class="left">Yes</td>
+<td class="left">Yes (required HMAC)</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -636,10 +636,10 @@
 </tr>
 <tr>
 <td class="left">keyLen</td>
-<td class="left">The array of keyLens supported by the IUT in bits. (CMAC only)</td>
+<td class="left">The array of keyLens supported by the IUT in bits. (CMAC-AES only)</td>
 <td class="left">array</td>
 <td class="left">128, 192, 256</td>
-<td class="left">Yes</td>
+<td class="left">Yes (required CMAC-AES)</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -650,10 +650,10 @@
 </tr>
 <tr>
 <td class="left">keyingOption</td>
-<td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save KATs) is a single key, now deprecated (K1, K1, K1).</td>
+<td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1).</td>
 <td class="left">array</td>
 <td class="left">1, 2</td>
-<td class="left">Yes</td>
+<td class="left">Yes (required for CMAC-TDES)</td>
 </tr>
 <tr>
 <td class="left"></td>

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -175,49 +175,49 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +-------------+-----------------+-------------+----------+----------+
-   | JSON Value  | Description     | JSON type   | Valid    | Optional |
-   |             |                 |             | Values   |          |
-   +-------------+-----------------+-------------+----------+----------+
-   | algorithm   | The MAC         | value       | See      | No       |
-   |             | algorithm and   |             | Section  |          |
-   |             | mode to be      |             | 2.3      |          |
-   |             | validated.      |             |          |          |
-   |             |                 |             |          |          |
-   | prereqVals  | prerequistie    | array of pr | See      | No       |
-   |             | algorithm       | ereqAlgVal  | Section  |          |
-   |             | validations,    | objects     | 2.1      |          |
-   |             | See Appendix A  |             |          |          |
-   |             | for examples    |             |          |          |
-   |             |                 |             |          |          |
-   | direction   | The MAC         | array       | gen, ver | No       |
-   |             | direction(s) to |             |          |          |
-   |             | test. Only      |             |          |          |
-   |             | applies to      |             |          |          |
-   |             | CMAC.           |             |          |          |
-   |             |                 |             |          |          |
-   | keyLen      | The keyLen      | Domain      | 8-524288 | Yes      |
-   |             | Domain          |             |          |          |
-   |             | supported by    |             |          |          |
-   |             | the IUT in      |             |          |          |
-   |             | bits. (HMAC     |             |          |          |
-   |             | only)           |             |          |          |
-   |             |                 |             |          |          |
-   | keyLen      | The array of    | array       | 128,     | Yes      |
-   |             | keyLens         |             | 192, 256 |          |
-   |             | supported by    |             |          |          |
-   |             | the IUT in      |             |          |          |
-   |             | bits. (CMAC     |             |          |          |
-   |             | only)           |             |          |          |
-   |             |                 |             |          |          |
-   | keyingOptio | The Keying      | array       | 1, 2     | Yes      |
-   | n           | Option used in  |             |          |          |
-   |             | TDES.  Keying   |             |          |          |
-   |             | option 1 (1) is |             |          |          |
-   |             | 3 distinct keys |             |          |          |
-   |             | (K1, K2, K3).   |             |          |          |
-   |             | Keying Option 2 |             |          |          |
-   |             | (2) is 2        |             |          |          |
+   +------------+-----------------+-------------+----------+-----------+
+   | JSON Value | Description     | JSON type   | Valid    | Optional  |
+   |            |                 |             | Values   |           |
+   +------------+-----------------+-------------+----------+-----------+
+   | algorithm  | The MAC         | value       | See      | No        |
+   |            | algorithm and   |             | Section  |           |
+   |            | mode to be      |             | 2.3      |           |
+   |            | validated.      |             |          |           |
+   |            |                 |             |          |           |
+   | prereqVals | prerequistie    | array of pr | See      | No        |
+   |            | algorithm       | ereqAlgVal  | Section  |           |
+   |            | validations,    | objects     | 2.1      |           |
+   |            | See Appendix A  |             |          |           |
+   |            | for examples    |             |          |           |
+   |            |                 |             |          |           |
+   | direction  | The MAC         | array       | gen, ver | No        |
+   |            | direction(s) to |             |          |           |
+   |            | test. Only      |             |          |           |
+   |            | applies to      |             |          |           |
+   |            | CMAC.           |             |          |           |
+   |            |                 |             |          |           |
+   | keyLen     | The keyLen      | Domain      | 8-524288 | Yes       |
+   |            | Domain          |             |          | (required |
+   |            | supported by    |             |          | HMAC)     |
+   |            | the IUT in      |             |          |           |
+   |            | bits. (HMAC     |             |          |           |
+   |            | only)           |             |          |           |
+   |            |                 |             |          |           |
+   | keyLen     | The array of    | array       | 128,     | Yes       |
+   |            | keyLens         |             | 192, 256 | (required |
+   |            | supported by    |             |          | CMAC-AES) |
+   |            | the IUT in      |             |          |           |
+   |            | bits. (CMAC-AES |             |          |           |
+   |            | only)           |             |          |           |
+   |            |                 |             |          |           |
+   | keyingOpti | The Keying      | array       | 1, 2     | Yes       |
+   | on         | Option used in  |             |          | (required |
+   |            | TDES.  Keying   |             |          | for CMAC- |
+   |            | option 1 (1) is |             |          | TDES)     |
+   |            | 3 distinct keys |             |          |           |
+   |            | (K1, K2, K3).   |             |          |           |
+   |            | Keying Option 2 |             |          |           |
+   |            | (2) is 2        |             |          |           |
 
 
 
@@ -226,34 +226,34 @@ Fussell                 Expires December 3, 2016                [Page 4]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |             | distinct only   |             |          |          |
-   |             | suitable for    |             |          |          |
-   |             | decrypt (K1,    |             |          |          |
-   |             | K2, K1).        |             |          |          |
-   |             | Keying option 3 |             |          |          |
-   |             | (No longer      |             |          |          |
-   |             | valid for       |             |          |          |
-   |             | testing, save   |             |          |          |
-   |             | KATs) is a      |             |          |          |
-   |             | single key, now |             |          |          |
-   |             | deprecated (K1, |             |          |          |
-   |             | K1, K1).        |             |          |          |
-   |             |                 |             |          |          |
-   | msgLen      | The CMAC        | Domain      | 0-524288 | Yes      |
-   |             | message lengths |             |          |          |
-   |             | supported.  Min |             |          |          |
-   |             | /max/increment  |             |          |          |
-   |             | and values must |             |          |          |
-   |             | be mod 8.       |             |          |          |
-   |             |                 |             |          |          |
-   | macLen      | The supported   | Domain      | 32-512   | No       |
-   |             | mac sizes.      |             |          |          |
-   |             | (range          |             |          |          |
-   |             | dependent on    |             |          |          |
-   |             | algorithm, see  |             |          |          |
-   |             | Section 2.3).   |             |          |          |
-   |             |                 |             |          |          |
-   +-------------+-----------------+-------------+----------+----------+
+   |            | distinct only   |             |          |           |
+   |            | suitable for    |             |          |           |
+   |            | decrypt (K1,    |             |          |           |
+   |            | K2, K1).        |             |          |           |
+   |            | Keying option 3 |             |          |           |
+   |            | (No longer      |             |          |           |
+   |            | valid for       |             |          |           |
+   |            | testing, save   |             |          |           |
+   |            | TDES KATs) is a |             |          |           |
+   |            | single key, now |             |          |           |
+   |            | deprecated (K1, |             |          |           |
+   |            | K1, K1).        |             |          |           |
+   |            |                 |             |          |           |
+   | msgLen     | The CMAC        | Domain      | 0-524288 | Yes       |
+   |            | message lengths |             |          |           |
+   |            | supported.  Min |             |          |           |
+   |            | /max/increment  |             |          |           |
+   |            | and values must |             |          |           |
+   |            | be mod 8.       |             |          |           |
+   |            |                 |             |          |           |
+   | macLen     | The supported   | Domain      | 32-512   | No        |
+   |            | mac sizes.      |             |          |           |
+   |            | (range          |             |          |           |
+   |            | dependent on    |             |          |           |
+   |            | algorithm, see  |             |          |           |
+   |            | Section 2.3).   |             |          |           |
+   |            |                 |             |          |           |
+   +------------+-----------------+-------------+----------+-----------+
 
               Table 2: MAC Algorithm Capabilities JSON Values
 

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -198,15 +198,15 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |            |                 |             |          |           |
    | keyLen     | The keyLen      | Domain      | 8-524288 | Yes       |
    |            | Domain          |             |          | (required |
-   |            | supported by    |             |          | HMAC)     |
+   |            | supported by    |             |          | for HMAC) |
    |            | the IUT in      |             |          |           |
    |            | bits. (HMAC     |             |          |           |
    |            | only)           |             |          |           |
    |            |                 |             |          |           |
    | keyLen     | The array of    | array       | 128,     | Yes       |
    |            | keyLens         |             | 192, 256 | (required |
-   |            | supported by    |             |          | CMAC-AES) |
-   |            | the IUT in      |             |          |           |
+   |            | supported by    |             |          | for CMAC- |
+   |            | the IUT in      |             |          | AES)      |
    |            | bits. (CMAC-AES |             |          |           |
    |            | only)           |             |          |           |
    |            |                 |             |          |           |

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -205,14 +205,14 @@
 	  <c>The keyLen Domain supported by the IUT in bits. (HMAC only)</c>
           <c>Domain</c>
           <c>8-524288</c>
-          <c>Yes</c>
+          <c>Yes (required HMAC)</c>
 	  <c/><c/><c/><c/><c/>
 	  
           <c>keyLen</c>
-	  <c>The array of keyLens supported by the IUT in bits. (CMAC only)</c>
+	  <c>The array of keyLens supported by the IUT in bits. (CMAC-AES only)</c>
           <c>array</c>
           <c>128, 192, 256</c>
-          <c>Yes</c>
+          <c>Yes (required CMAC-AES)</c>
 	  <c/><c/><c/><c/><c/>
 
 
@@ -221,10 +221,10 @@
          
           Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  
           Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).   
-          Keying option 3 (No longer valid for testing, save KATs) is a single key, now deprecated (K1, K1, K1).</c>
+          Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1).</c>
           <c>array</c>
           <c>1, 2</c>
-          <c>Yes</c>
+          <c>Yes (required for CMAC-TDES)</c>
 	  <c/><c/><c/><c/><c/>	  
 	  
           <c>msgLen</c>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -205,14 +205,14 @@
 	  <c>The keyLen Domain supported by the IUT in bits. (HMAC only)</c>
           <c>Domain</c>
           <c>8-524288</c>
-          <c>Yes (required HMAC)</c>
+          <c>Yes (required for HMAC)</c>
 	  <c/><c/><c/><c/><c/>
 	  
           <c>keyLen</c>
 	  <c>The array of keyLens supported by the IUT in bits. (CMAC-AES only)</c>
           <c>array</c>
           <c>128, 192, 256</c>
-          <c>Yes (required CMAC-AES)</c>
+          <c>Yes (required for CMAC-AES)</c>
 	  <c/><c/><c/><c/><c/>
 
 


### PR DESCRIPTION
Related to #208

I'm not sure for properties that are used for only certain algorithms, if it makes sense to say "Optional: No (Required for CMAC-TDES)", or "Optional: Yes (Required for CMAC-TDES)".  The idea that I'm attempting to convey is, the property is required for CMAC-TDES, but not relevant for other CMAC modes.

Perhaps some of the confusion could be alleviated by further breaking out specifications, but am curious what makes the most sense to others.  Also related: #209