### PR TITLE
Fix ctrDRBG mode name

### DIFF
--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -395,12 +395,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.8.2 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.9.2 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-3" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-03" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -586,7 +586,7 @@
 </tr>
 <tr>
 <td class="left">"ctrDRBG"</td>
-<td class="left">"3KeyTDEA"</td>
+<td class="left">"TDES"</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -602,6 +602,7 @@
 </tr>
 </tbody>
 </table>
+<p id="rfc.section.2.1.p.2">Note 1: The ctrDRBG algorithm in TDES mode shall only be used with the three-key option of the Triple-DES algorithm. </p>
 <h1 id="rfc.section.2.2">
 <a href="#rfc.section.2.2">2.2.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for DRBG Validations</a>
 </h1>
@@ -859,14 +860,14 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.2.3.p.3">Note 1: If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </p>
-<p id="rfc.section.2.3.p.4">Note 2: Implementations that either have prediction resistance always ON or always OFF, the array predResistanceEnabled shall contain two distinct elements, 'true' and 'false'. </p>
-<p id="rfc.section.2.3.p.5">Note 3: Implementations containing multiple equal array elements for predResistanceEnabled will be rejected.</p>
-<p id="rfc.section.2.3.p.6">Note 4: For ctrDRBG implementations, the derFuncEnabled property must be included.</p>
-<p id="rfc.section.2.3.p.7">Note 5: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept.  The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length.</p>
-<p id="rfc.section.2.3.p.8">Note 6: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half the maximum security strength supported by the mechanism/option.</p>
-<p id="rfc.section.2.3.p.9">Note 7: ACVP allows bit length values for persoString ranging from the maximum supported security strength except in the case of derFuncEnabled set to false, where the second personalization string length must be less than or equal to the seed length.  If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0).  If the implementation does not use at all a persoString, set all range parameters (min, max, step) to 0 (zero). If the implementation can work with and without persoString, set the min to zero (0), set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that.</p>
-<p id="rfc.section.2.3.p.10">Note 8: The addtionalInput configuration and restrictions are the same as those for the persoString.</p>
+<p id="rfc.section.2.3.p.3">Note 2: If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </p>
+<p id="rfc.section.2.3.p.4">Note 3: Implementations that either have prediction resistance always ON or always OFF, the array predResistanceEnabled shall contain two distinct elements, 'true' and 'false'. </p>
+<p id="rfc.section.2.3.p.5">Note 4: Implementations containing multiple equal array elements for predResistanceEnabled will be rejected.</p>
+<p id="rfc.section.2.3.p.6">Note 5: For ctrDRBG implementations, the derFuncEnabled property must be included.</p>
+<p id="rfc.section.2.3.p.7">Note 6: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept.  The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length.</p>
+<p id="rfc.section.2.3.p.8">Note 7: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half the maximum security strength supported by the mechanism/option.</p>
+<p id="rfc.section.2.3.p.9">Note 8: ACVP allows bit length values for persoString ranging from the maximum supported security strength except in the case of derFuncEnabled set to false, where the second personalization string length must be less than or equal to the seed length.  If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0).  If the implementation does not use at all a persoString, set all range parameters (min, max, step) to 0 (zero). If the implementation can work with and without persoString, set the min to zero (0), set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that.</p>
+<p id="rfc.section.2.3.p.10">Note 9: The addtionalInput configuration and restrictions are the same as those for the persoString.</p>
 <h1 id="rfc.section.3">
 <a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
 </h1>

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -154,7 +154,7 @@ Internet-Draft                DRBG Alg JSON                   March 2017
                 |                      | "SHA2-512/224"  |
                 |                      | "SHA2-512/256"  |
                 |                      |                 |
-                | "ctrDRBG"            | "3KeyTDEA"      |
+                | "ctrDRBG"            | "TDES"          |
                 |                      | "AES-128"       |
                 |                      | "AES-192"       |
                 |                      | "AES-256"       |
@@ -169,6 +169,9 @@ Vassilev                Expires September 2, 2017               [Page 3]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
+
+   Note 1: The ctrDRBG algorithm in TDES mode shall only be used with
+   the three-key option of the Triple-DES algorithm.
 
 2.2.  Required Prerequisite Algorithms for DRBG Validations
 
@@ -215,9 +218,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    value is part of the 'capability_exchange' element of the ACVP JSON
    registration message.  See the ACVP specification for details on the
    registration message.  Each DRBG mode capability advertised is a
-   self-contained JSON object.  The following JSON values are used for
-   DRBG mode capabilities:
-
 
 
 
@@ -225,6 +225,9 @@ Vassilev                Expires September 2, 2017               [Page 4]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
+
+   self-contained JSON object.  The following JSON values are used for
+   DRBG mode capabilities:
 
    +----------------+-----------+--------+-----------------+-----------+
    | JSON Value     | Descripti | JSON   | Valid Values    | Optional  |
@@ -271,9 +274,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                |           |        | longer nonces   |           |
    |                |           |        | are permitted,  |           |
    |                |           |        | step -          |           |
-   |                |           |        | increment       |           |
-   |                |           |        |                 |           |
-   | persoStringLen | See Table | range  | min - the       | No        |
 
 
 
@@ -282,6 +282,9 @@ Vassilev                Expires September 2, 2017               [Page 5]
 Internet-Draft                DRBG Alg JSON                   March 2017
 
 
+   |                |           |        | increment       |           |
+   |                |           |        |                 |           |
+   | persoStringLen | See Table | range  | min - the       | No        |
    |                | 4 notes   |        | maximum         |           |
    |                | below.    |        | security        |           |
    |                |           |        | strength        |           |
@@ -328,9 +331,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    object.  The following JSON values are used for DRBG algorithm
    capabilities:
 
-   +------------------+-------------+------------+-----------+---------+
-   | JSON Value       | Description | JSON type  | Valid     | Optiona |
-
 
 
 Vassilev                Expires September 2, 2017               [Page 6]
@@ -338,6 +338,8 @@ Vassilev                Expires September 2, 2017               [Page 6]
 Internet-Draft                DRBG Alg JSON                   March 2017
 
 
+   +------------------+-------------+------------+-----------+---------+
+   | JSON Value       | Description | JSON type  | Valid     | Optiona |
    |                  |             |            | Values    | l       |
    +------------------+-------------+------------+-----------+---------+
    | algorithm        | The DRBG    | value      | See Table | No      |
@@ -384,8 +386,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    |                  | ities of a  |            |           |         |
    |                  | mode of the |            |           |         |
    |                  | algorithm.  |            |           |         |
-   |                  | See Table 3 |            |           |         |
-   |                  | for more in |            |           |         |
 
 
 
@@ -394,26 +394,28 @@ Vassilev                Expires September 2, 2017               [Page 7]
 Internet-Draft                DRBG Alg JSON                   March 2017
 
 
+   |                  | See Table 3 |            |           |         |
+   |                  | for more in |            |           |         |
    |                  | formation.  |            |           |         |
    +------------------+-------------+------------+-----------+---------+
 
              Table 4: DRBG Algorithm Capabilities JSON Values
 
-   Note 1: If an implementation can only be used without prediction
+   Note 2: If an implementation can only be used without prediction
    resistance, the array predResistanceEnabled shall only contain a
    single 'false' element.
 
-   Note 2: Implementations that either have prediction resistance always
+   Note 3: Implementations that either have prediction resistance always
    ON or always OFF, the array predResistanceEnabled shall contain two
    distinct elements, 'true' and 'false'.
 
-   Note 3: Implementations containing multiple equal array elements for
+   Note 4: Implementations containing multiple equal array elements for
    predResistanceEnabled will be rejected.
 
-   Note 4: For ctrDRBG implementations, the derFuncEnabled property must
+   Note 5: For ctrDRBG implementations, the derFuncEnabled property must
    be included.
 
-   Note 5: All DRBGs are tested at their maximum supported security
+   Note 6: All DRBGs are tested at their maximum supported security
    strength so this is the minimum bit length of the entropy input that
    ACVP will accept.  The maximum supported security strength is also
    the default value for this input.  Longer entropy inputs are
@@ -421,12 +423,12 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    derFuncEnabled set to false, the bit length must equal the seed
    length.
 
-   Note 6: ctrDRBG with derFuncEnabled set to false does not use a
+   Note 7: ctrDRBG with derFuncEnabled set to false does not use a
    nonce; the nonce values, if supplied, will be ignored for this case.
    The default nonce bit length is one-half the maximum security
    strength supported by the mechanism/option.
 
-   Note 7: ACVP allows bit length values for persoString ranging from
+   Note 8: ACVP allows bit length values for persoString ranging from
    the maximum supported security strength except in the case of
    derFuncEnabled set to false, where the second personalization string
    length must be less than or equal to the seed length.  If the
@@ -439,8 +441,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    set the step equal to at least the maximum supported strength to
    avoid testing lengths less than that.
 
-   Note 8: The addtionalInput configuration and restrictions are the
-   same as those for the persoString.
 
 
 
@@ -449,6 +449,9 @@ Vassilev                Expires September 2, 2017               [Page 8]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
+
+   Note 9: The addtionalInput configuration and restrictions are the
+   same as those for the persoString.
 
 3.  Test Vectors
 
@@ -495,9 +498,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    similar test cases to reduce the amount of data transmitted in the
    vector set.  For instance, all test vectors that use the same key
    size would be grouped together.  The Test Group JSON object contains
-   meta data that applies to all test vectors within the group.  The
-   following table describes the DRBG JSON elements of the Test Group
-   JSON object.
 
 
 
@@ -505,6 +505,10 @@ Vassilev                Expires September 2, 2017               [Page 9]
 
 Internet-Draft                DRBG Alg JSON                   March 2017
 
+
+   meta data that applies to all test vectors within the group.  The
+   following table describes the DRBG JSON elements of the Test Group
+   JSON object.
 
    ACVP allows default bit lengths for the inputs to specific
    algorithms, typically communicated as numerical value zero (0).  If
@@ -551,10 +555,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
 
                       Table 6: Test Group JSON Object
 
-   Note 9: According to SP 800-90A [SP800-90A], a DRBG implementation
-   has two separate controls for determining the correct test procedure
-   for handling addtional entropy and other data in providing prediction
-
 
 
 Vassilev                Expires September 2, 2017              [Page 10]
@@ -562,6 +562,9 @@ Vassilev                Expires September 2, 2017              [Page 10]
 Internet-Draft                DRBG Alg JSON                   March 2017
 
 
+   Note 9: According to SP 800-90A [SP800-90A], a DRBG implementation
+   has two separate controls for determining the correct test procedure
+   for handling addtional entropy and other data in providing prediction
    resistance assurances.  Depending on the capabilities advertised by
    the predResistanceEnabled and reseedImplemented flags ACVP generates
    test data according to the following test scenarios:
@@ -601,9 +604,6 @@ Internet-Draft                DRBG Alg JSON                   March 2017
    test case is a JSON object that represents a single vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each test case.
-
-
-
 
 
 

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -175,7 +175,7 @@
           <c/>
           <c/>
         <c>"ctrDRBG"</c>
-          <c>"3KeyTDEA"</c>
+          <c>"TDES"</c>
           <c/>
           <c>"AES-128"</c>
           <c/>
@@ -183,6 +183,7 @@
           <c/>
           <c>"AES-256"</c>
 </texttable>
+ <t>Note 1: The ctrDRBG algorithm in TDES mode shall only be used with the three-key option of the Triple-DES algorithm. </t>
 	</section>
 	<section anchor="prereq_algs" title="Required Prerequisite Algorithms for DRBG Validations">
 	    <t>Each DRBG implementation relies on other cryptographic primitives (algorithms) - see <xref target="SP800-90A"/>. 
@@ -369,26 +370,26 @@
           <c>capabilities</c>
           <c>An array of objects describing the capabilities of a mode of the algorithm. See <xref target="capabilities_table"/> for more information.</c>
           <c>array</c>
-          <c></c>
+          <c/>
           <c>No</c>
           </texttable>
     
 	
-	         <t>Note 1: If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </t>
-	         <t>Note 2: Implementations that either have prediction resistance always ON or always OFF, the array predResistanceEnabled shall contain two distinct elements, 'true' and 'false'. </t>
-	         <t>Note 3: Implementations containing multiple equal array elements for predResistanceEnabled will be rejected.</t>
-	         <t>Note 4: For ctrDRBG implementations, the derFuncEnabled property must be included.</t>	
-           <t>Note 5: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept. 
+	         <t>Note 2: If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </t>
+	         <t>Note 3: Implementations that either have prediction resistance always ON or always OFF, the array predResistanceEnabled shall contain two distinct elements, 'true' and 'false'. </t>
+	         <t>Note 4: Implementations containing multiple equal array elements for predResistanceEnabled will be rejected.</t>
+	         <t>Note 5: For ctrDRBG implementations, the derFuncEnabled property must be included.</t>	
+           <t>Note 6: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept. 
            The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, 
           with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length.</t>
-          <t>Note 6: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half
+          <t>Note 7: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half
            the maximum security strength supported by the mechanism/option.</t>
-          <t>Note 7: ACVP allows bit length values for persoString ranging from the maximum 
+          <t>Note 8: ACVP allows bit length values for persoString ranging from the maximum 
            supported security strength except in the case of derFuncEnabled set to false, where the second personalization string length must be less than or equal to the seed length. 
           If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0). 
           If the implementation does not use at all a persoString, set all range parameters (min, max, step) to 0 (zero). If the implementation can work with and without persoString, set the min to zero (0), 
           set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that.</t>
-          <t>Note 8: The addtionalInput configuration and restrictions are the same as those for the persoString.</t>
+          <t>Note 9: The addtionalInput configuration and restrictions are the same as those for the persoString.</t>
           
    </section>
     </section>


### PR DESCRIPTION
Replaced 3KeyTDEA with TDES in Table 1 to match the rest of the spec.
Added Note 1 to restirct the use of TDES to the three-key version only.