### PR TITLE
Added references to SP800-90A for help on param values

### DIFF
--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,7 +400,7 @@
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-03-05" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-03-09" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">March 5, 2018</td>
+<td class="right">March 9, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: September 6, 2018</td>
+<td class="left">Expires: September 10, 2018</td>
 <td class="right"></td>
 </tr>
 
@@ -441,7 +441,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 6, 2018.</p>
+<p>This Internet-Draft will expire on September 10, 2018.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -860,14 +860,14 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.2.3.p.3">Note 2: If an implementation utilizes a nonce in the construction of a seed during instantiation, the length of the nonce shall be at least half the maximum security strength supported. </p>
-<p id="rfc.section.2.3.p.4">Note 3If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </p>
+<p id="rfc.section.2.3.p.3">Note 2: If an implementation utilizes a nonce in the construction of a seed during instantiation, the length of the nonce shall be at least half the maximum security strength supported. See Tables 2 and 3 in <a href="#SP800-90A" class="xref">[SP800-90A]</a> for help on choosing appropriate parameter values for the tested DRBG implementation.</p>
+<p id="rfc.section.2.3.p.4">Note 3: If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </p>
 <p id="rfc.section.2.3.p.5">Note 4: Implementations that either have prediction resistance always ON or always OFF, the array predResistanceEnabled shall contain two distinct elements, 'true' and 'false'. </p>
 <p id="rfc.section.2.3.p.6">Note 5: Implementations containing multiple equal array elements for predResistanceEnabled will be rejected.</p>
 <p id="rfc.section.2.3.p.7">Note 6: For ctrDRBG implementations, the derFuncEnabled property must be included.</p>
-<p id="rfc.section.2.3.p.8">Note 7: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept.  The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length.</p>
-<p id="rfc.section.2.3.p.9">Note 8: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half the maximum security strength supported by the mechanism/option.</p>
-<p id="rfc.section.2.3.p.10">Note 9: ACVP allows bit length values for persoString ranging from the maximum supported security strength except in the case of derFuncEnabled set to false, where the second personalization string length must be less than or equal to the seed length.  If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0).  If the implementation does not use at all a persoString, set all range parameters (min, max, step) to 0 (zero). If the implementation can work with and without persoString, set the min to zero (0), set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that.</p>
+<p id="rfc.section.2.3.p.8">Note 7: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept.  The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length. See Tables 2 and 3 in <a href="#SP800-90A" class="xref">[SP800-90A]</a> for help on choosing appropriate parameter values for the DRBG being tested.</p>
+<p id="rfc.section.2.3.p.9">Note 8: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half the maximum security strength supported by the mechanism/option. See Tables 2 and 3 in <a href="#SP800-90A" class="xref">[SP800-90A]</a> for help on choosing appropriate parameter values for the tested DRBG implementation.</p>
+<p id="rfc.section.2.3.p.10">Note 9: ACVP allows bit length values for persoString ranging from the maximum supported security strength except in the case of derFuncEnabled set to false, where the second personalization string length must be less than or equal to the seed length.  If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0).  If the implementation does not use at all a persoString, set all range parameters (min, max, step) to 0 (zero). If the implementation can work with and without persoString, set the min to zero (0), set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that.  See Tables 2 and 3 in <a href="#SP800-90A" class="xref">[SP800-90A]</a> for help on choosing appropriate parameter values for the tested DRBG implementation.</p>
 <p id="rfc.section.2.3.p.11">Note 10: The addtionalInput configuration and restrictions are the same as those for the persoString.</p>
 <h1 id="rfc.section.3">
 <a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                             March 5, 2018
-Expires: September 6, 2018
+Intended status: Informational                             March 9, 2018
+Expires: September 10, 2018
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 6, 2018.
+   This Internet-Draft will expire on September 10, 2018.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev                Expires September 6, 2018               [Page 1]
+Vassilev               Expires September 10, 2018               [Page 1]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Vassilev                Expires September 6, 2018               [Page 2]
+Vassilev               Expires September 10, 2018               [Page 2]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018               [Page 3]
+Vassilev               Expires September 10, 2018               [Page 3]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -221,7 +221,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018               [Page 4]
+Vassilev               Expires September 10, 2018               [Page 4]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -277,7 +277,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018               [Page 5]
+Vassilev               Expires September 10, 2018               [Page 5]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -333,7 +333,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018               [Page 6]
+Vassilev               Expires September 10, 2018               [Page 6]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -389,7 +389,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018               [Page 7]
+Vassilev               Expires September 10, 2018               [Page 7]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -407,9 +407,11 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
    Note 2: If an implementation utilizes a nonce in the construction of
    a seed during instantiation, the length of the nonce shall be at
-   least half the maximum security strength supported.
+   least half the maximum security strength supported.  See Tables 2 and
+   3 in [SP800-90A] for help on choosing appropriate parameter values
+   for the tested DRBG implementation.
 
-   Note 3If an implementation can only be used without prediction
+   Note 3: If an implementation can only be used without prediction
    resistance, the array predResistanceEnabled shall only contain a
    single 'false' element.
 
@@ -429,12 +431,24 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    the default value for this input.  Longer entropy inputs are
    permitted, with the following exception: for ctrDRBG with
    derFuncEnabled set to false, the bit length must equal the seed
-   length.
+   length.  See Tables 2 and 3 in [SP800-90A] for help on choosing
+   appropriate parameter values for the DRBG being tested.
 
    Note 8: ctrDRBG with derFuncEnabled set to false does not use a
    nonce; the nonce values, if supplied, will be ignored for this case.
    The default nonce bit length is one-half the maximum security
-   strength supported by the mechanism/option.
+   strength supported by the mechanism/option.  See Tables 2 and 3 in
+   [SP800-90A] for help on choosing appropriate parameter values for the
+   tested DRBG implementation.
+
+
+
+
+
+Vassilev               Expires September 10, 2018               [Page 8]
+
+Internet-Draft                DRBG Alg JSON                   March 2018
+
 
    Note 9: ACVP allows bit length values for persoString ranging from
    the maximum supported security strength except in the case of
@@ -442,20 +456,14 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    length must be less than or equal to the seed length.  If the
    implementation only supports one personalization string length, then
    set only that value as the range min and max and set the step to zero
-
-
-
-Vassilev                Expires September 6, 2018               [Page 8]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
    (0).  If the implementation does not use at all a persoString, set
    all range parameters (min, max, step) to 0 (zero).  If the
    implementation can work with and without persoString, set the min to
    zero (0), set the max to at least the maximum supported strength and
    set the step equal to at least the maximum supported strength to
-   avoid testing lengths less than that.
+   avoid testing lengths less than that.  See Tables 2 and 3 in
+   [SP800-90A] for help on choosing appropriate parameter values for the
+   tested DRBG implementation.
 
    Note 10: The addtionalInput configuration and restrictions are the
    same as those for the persoString.
@@ -474,6 +482,29 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    contains meta data for the entire vector set as well as individual
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev               Expires September 10, 2018               [Page 9]
+
+Internet-Draft                DRBG Alg JSON                   March 2018
+
 
    +-------------+---------------------------------------------+-------+
    | JSON Value  | Description                                 | JSON  |
@@ -497,14 +528,6 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    +-------------+---------------------------------------------+-------+
 
                       Table 5: Vector Set JSON Object
-
-
-
-
-Vassilev                Expires September 6, 2018               [Page 9]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
 
 3.1.  Test Groups JSON Schema
 
@@ -534,30 +557,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires September 6, 2018              [Page 10]
+Vassilev               Expires September 10, 2018              [Page 10]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -613,7 +613,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 11]
+Vassilev               Expires September 10, 2018              [Page 11]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -669,7 +669,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 12]
+Vassilev               Expires September 10, 2018              [Page 12]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -725,7 +725,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 13]
+Vassilev               Expires September 10, 2018              [Page 13]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -781,7 +781,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 14]
+Vassilev               Expires September 10, 2018              [Page 14]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -837,7 +837,7 @@ Appendix A.  Example DRBG Capabilities JSON Object
 
 
 
-Vassilev                Expires September 6, 2018              [Page 15]
+Vassilev               Expires September 10, 2018              [Page 15]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -893,7 +893,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 16]
+Vassilev               Expires September 10, 2018              [Page 16]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -949,7 +949,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 17]
+Vassilev               Expires September 10, 2018              [Page 17]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1005,7 +1005,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 18]
+Vassilev               Expires September 10, 2018              [Page 18]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1061,7 +1061,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 19]
+Vassilev               Expires September 10, 2018              [Page 19]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1117,7 +1117,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 20]
+Vassilev               Expires September 10, 2018              [Page 20]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1173,7 +1173,7 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-Vassilev                Expires September 6, 2018              [Page 21]
+Vassilev               Expires September 10, 2018              [Page 21]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1229,7 +1229,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 22]
+Vassilev               Expires September 10, 2018              [Page 22]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1285,7 +1285,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 23]
+Vassilev               Expires September 10, 2018              [Page 23]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1341,7 +1341,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 24]
+Vassilev               Expires September 10, 2018              [Page 24]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1397,7 +1397,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 25]
+Vassilev               Expires September 10, 2018              [Page 25]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1453,7 +1453,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 26]
+Vassilev               Expires September 10, 2018              [Page 26]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1509,7 +1509,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 27]
+Vassilev               Expires September 10, 2018              [Page 27]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1565,7 +1565,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 28]
+Vassilev               Expires September 10, 2018              [Page 28]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1621,7 +1621,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev                Expires September 6, 2018              [Page 29]
+Vassilev               Expires September 10, 2018              [Page 29]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1677,7 +1677,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 6, 2018              [Page 30]
+Vassilev               Expires September 10, 2018              [Page 30]
 
 Internet-Draft                DRBG Alg JSON                   March 2018
 
@@ -1733,4 +1733,4 @@ Author's Address
 
 
 
-Vassilev                Expires September 6, 2018              [Page 31]
+Vassilev               Expires September 10, 2018              [Page 31]

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -376,21 +376,22 @@
     
 	
 	         <t>Note 2: If an implementation utilizes a nonce in the construction of a seed during instantiation, the length of the nonce shall be
-	         at least half the maximum security strength supported. </t>
-	         <t>Note 3If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </t>
+	         at least half the maximum security strength supported. See Tables 2 and 3 in <xref target="SP800-90A"/> for help on choosing appropriate parameter values for the tested DRBG implementation.</t>
+	         <t>Note 3: If an implementation can only be used without prediction resistance, the array predResistanceEnabled shall only contain a single 'false' element. </t>
 	         <t>Note 4: Implementations that either have prediction resistance always ON or always OFF, the array predResistanceEnabled shall contain two distinct elements, 'true' and 'false'. </t>
 	         <t>Note 5: Implementations containing multiple equal array elements for predResistanceEnabled will be rejected.</t>
 	         <t>Note 6: For ctrDRBG implementations, the derFuncEnabled property must be included.</t>	
            <t>Note 7: All DRBGs are tested at their maximum supported security strength so this is the minimum bit length of the entropy input that ACVP will accept. 
            The maximum supported security strength is also the default value for this input. Longer entropy inputs are permitted, 
-          with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length.</t>
+          with the following exception: for ctrDRBG with derFuncEnabled set to false, the bit length must equal the seed length. See Tables 2 and 3 in <xref target="SP800-90A"/> for help on choosing appropriate parameter values for the DRBG being tested.</t>
           <t>Note 8: ctrDRBG with derFuncEnabled set to false does not use a nonce; the nonce values, if supplied, will be ignored for this case. The default nonce bit length is one-half
-           the maximum security strength supported by the mechanism/option.</t>
+           the maximum security strength supported by the mechanism/option. See Tables 2 and 3 in <xref target="SP800-90A"/> for help on choosing appropriate parameter values for the tested DRBG implementation.</t>
           <t>Note 9: ACVP allows bit length values for persoString ranging from the maximum 
            supported security strength except in the case of derFuncEnabled set to false, where the second personalization string length must be less than or equal to the seed length. 
           If the implementation only supports one personalization string length, then set only that value as the range min and max and set the step to zero (0). 
           If the implementation does not use at all a persoString, set all range parameters (min, max, step) to 0 (zero). If the implementation can work with and without persoString, set the min to zero (0), 
-          set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that.</t>
+          set the max to at least the maximum supported strength and set the step equal to at least the maximum supported strength to avoid testing lengths less than that. 
+          See Tables 2 and 3 in <xref target="SP800-90A"/> for help on choosing appropriate parameter values for the tested DRBG implementation.</t>
           <t>Note 10: The addtionalInput configuration and restrictions are the same as those for the persoString.</t>
           
    </section>


### PR DESCRIPTION
This firther improves the hints to the reader for how to choose appropriate parameter values for the corresponding DRBG implementation without burdening this spec with information already available in SP800-90A. 