### PR TITLE
Consistency updates focused on registration of symmetric algorithms

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -373,62 +373,62 @@
   /*]]>*/
   </style>
 
-  <link href="#rfc.toc" rel="Contents">
-<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
-<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
-<link href="#rfc.section.2" rel="Chapter" title="2 Overview">
-<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Audience">
-<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Goals">
-<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Terminology">
-<link href="#rfc.section.3" rel="Chapter" title="3 Architecture">
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Server/Client Architecture">
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Server/Proxy Architecture">
-<link href="#rfc.section.4" rel="Chapter" title="4 ACV Protocol">
-<link href="#rfc.section.4.1" rel="Chapter" title="4.1 HTTP URI Hierarchy">
-<link href="#rfc.section.4.2" rel="Chapter" title="4.2 HTTP URI Operations">
-<link href="#rfc.section.5" rel="Chapter" title="5 Security">
-<link href="#rfc.section.6" rel="Chapter" title="6 Authentication">
-<link href="#rfc.section.7" rel="Chapter" title="7 Traceability">
-<link href="#rfc.section.8" rel="Chapter" title="8 Encoding">
-<link href="#rfc.section.9" rel="Chapter" title="9 Versioning">
-<link href="#rfc.section.10" rel="Chapter" title="10 Messaging">
-<link href="#rfc.section.10.1" rel="Chapter" title="10.1 Product Registration/Capabilities Exchange">
-<link href="#rfc.section.10.2" rel="Chapter" title="10.2 Test Exchange">
-<link href="#rfc.section.11" rel="Chapter" title="11 Message Formats">
-<link href="#rfc.section.11.1" rel="Chapter" title="11.1 Establish Connection HTTPS GET/200 OK">
-<link href="#rfc.section.11.2" rel="Chapter" title="11.2 Product Registration with Capabilities">
-<link href="#rfc.section.11.3" rel="Chapter" title="11.3 Vector Set Download Request">
-<link href="#rfc.section.11.4" rel="Chapter" title="11.4 Submit Test Results">
-<link href="#rfc.section.11.5" rel="Chapter" title="11.5 Validation Results Request">
-<link href="#rfc.section.11.6" rel="Chapter" title="11.6 Optional Flows">
-<link href="#rfc.section.12" rel="Chapter" title="12 Vector Set Expiration">
-<link href="#rfc.section.12.1" rel="Chapter" title="12.1 Resending Test Responses">
-<link href="#rfc.section.13" rel="Chapter" title="13 Error Codes">
-<link href="#rfc.section.14" rel="Chapter" title="14 Custom Specification Objects">
-<link href="#rfc.section.14.1" rel="Chapter" title="14.1 BitString">
-<link href="#rfc.section.14.1.1" rel="Chapter" title="14.1.1 Endianness">
-<link href="#rfc.section.14.1.2" rel="Chapter" title="14.1.2 Hex to Bitstring Parsing">
-<link href="#rfc.section.14.1.2.1" rel="Chapter" title="14.1.2.1 Hex string parsing examples">
-<link href="#rfc.section.14.2" rel="Chapter" title="14.2 Range">
-<link href="#rfc.section.14.2.1" rel="Chapter" title="14.2.1 Range JSON examples">
-<link href="#rfc.section.14.3" rel="Chapter" title="14.3 Domain">
-<link href="#rfc.section.14.3.1" rel="Chapter" title="14.3.1 Domain JSON examples">
-<link href="#rfc.section.14.3.2" rel="Chapter" title="14.3.2 Additional Domain Information">
-<link href="#rfc.section.15" rel="Chapter" title="15 Other Considerations">
-<link href="#rfc.section.16" rel="Chapter" title="16 Acknowledgements">
-<link href="#rfc.section.17" rel="Chapter" title="17 IANA Considerations">
-<link href="#rfc.references" rel="Chapter" title="18 Normative References">
-<link href="#rfc.appendix.A" rel="Chapter" title="A JSON Formatting Guidelines">
-<link href="#rfc.appendix.B" rel="Chapter" title="B JSON Encoded Error Messages">
-<link href="#rfc.authors" rel="Chapter">
+  <link href="#rfc.toc" rel="Contents"/>
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction"/>
+<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language"/>
+<link href="#rfc.section.2" rel="Chapter" title="2 Overview"/>
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Audience"/>
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Goals"/>
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Terminology"/>
+<link href="#rfc.section.3" rel="Chapter" title="3 Architecture"/>
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Server/Client Architecture"/>
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Server/Proxy Architecture"/>
+<link href="#rfc.section.4" rel="Chapter" title="4 ACV Protocol"/>
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 HTTP URI Hierarchy"/>
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 HTTP URI Operations"/>
+<link href="#rfc.section.5" rel="Chapter" title="5 Security"/>
+<link href="#rfc.section.6" rel="Chapter" title="6 Authentication"/>
+<link href="#rfc.section.7" rel="Chapter" title="7 Traceability"/>
+<link href="#rfc.section.8" rel="Chapter" title="8 Encoding"/>
+<link href="#rfc.section.9" rel="Chapter" title="9 Versioning"/>
+<link href="#rfc.section.10" rel="Chapter" title="10 Messaging"/>
+<link href="#rfc.section.10.1" rel="Chapter" title="10.1 Product Registration/Capabilities Exchange"/>
+<link href="#rfc.section.10.2" rel="Chapter" title="10.2 Test Exchange"/>
+<link href="#rfc.section.11" rel="Chapter" title="11 Message Formats"/>
+<link href="#rfc.section.11.1" rel="Chapter" title="11.1 Establish Connection HTTPS GET/200 OK"/>
+<link href="#rfc.section.11.2" rel="Chapter" title="11.2 Product Registration with Capabilities"/>
+<link href="#rfc.section.11.3" rel="Chapter" title="11.3 Vector Set Download Request"/>
+<link href="#rfc.section.11.4" rel="Chapter" title="11.4 Submit Test Results"/>
+<link href="#rfc.section.11.5" rel="Chapter" title="11.5 Validation Results Request"/>
+<link href="#rfc.section.11.6" rel="Chapter" title="11.6 Optional Flows"/>
+<link href="#rfc.section.12" rel="Chapter" title="12 Vector Set Expiration"/>
+<link href="#rfc.section.12.1" rel="Chapter" title="12.1 Resending Test Responses"/>
+<link href="#rfc.section.13" rel="Chapter" title="13 Error Codes"/>
+<link href="#rfc.section.14" rel="Chapter" title="14 Custom Specification Objects"/>
+<link href="#rfc.section.14.1" rel="Chapter" title="14.1 BitString"/>
+<link href="#rfc.section.14.1.1" rel="Chapter" title="14.1.1 Endianness"/>
+<link href="#rfc.section.14.1.2" rel="Chapter" title="14.1.2 Hex to Bitstring Parsing"/>
+<link href="#rfc.section.14.1.2.1" rel="Chapter" title="14.1.2.1 Hex string parsing examples"/>
+<link href="#rfc.section.14.2" rel="Chapter" title="14.2 Range"/>
+<link href="#rfc.section.14.2.1" rel="Chapter" title="14.2.1 Range JSON examples"/>
+<link href="#rfc.section.14.3" rel="Chapter" title="14.3 Domain"/>
+<link href="#rfc.section.14.3.1" rel="Chapter" title="14.3.1 Domain JSON examples"/>
+<link href="#rfc.section.14.3.2" rel="Chapter" title="14.3.2 Additional Domain Information"/>
+<link href="#rfc.section.15" rel="Chapter" title="15 Other Considerations"/>
+<link href="#rfc.section.16" rel="Chapter" title="16 Acknowledgements"/>
+<link href="#rfc.section.17" rel="Chapter" title="17 IANA Considerations"/>
+<link href="#rfc.references" rel="Chapter" title="18 Normative References"/>
+<link href="#rfc.appendix.A" rel="Chapter" title="A JSON Formatting Guidelines"/>
+<link href="#rfc.appendix.B" rel="Chapter" title="B JSON Encoded Error Messages"/>
+<link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.3" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-7-6" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.4" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-3-16" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -440,20 +440,20 @@
     <tbody>
     
     	<tr>
-<td class="left">Internet Engineering Task Force</td>
-<td class="right">B. Fussell, Ed.</td>
+  <td class="left">Internet Engineering Task Force</td>
+  <td class="right">B. Fussell, Ed.</td>
 </tr>
 <tr>
-<td class="left">Internet-Draft</td>
-<td class="right">Cisco Systems</td>
+  <td class="left">Internet-Draft</td>
+  <td class="right">Cisco Systems</td>
 </tr>
 <tr>
-<td class="left">Intended status: Informational</td>
-<td class="right">July 6, 2017</td>
+  <td class="left">Intended status: Informational</td>
+  <td class="right">March 16, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: January 7, 2018</td>
-<td class="right"></td>
+  <td class="left">Expires: September 17, 2018</td>
+  <td class="right"></td>
 </tr>
 
     	
@@ -461,17 +461,23 @@
   </table>
 
   <p class="title">Automated Cryptographic Validation Protocol <br />
-  <span class="filename">draft-ietf-acvp-protocol-0.3</span></p>
+  <span class="filename">draft-ietf-acvp-protocol-0.4</span></p>
   
-  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+  <h1 id="rfc.abstract">
+  <a href="#rfc.abstract">Abstract</a>
+</h1>
 <p>This document defines the Automated Cryptographic Validation Protocol(ACVP).</p>
-<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<h1 id="rfc.status">
+  <a href="#rfc.status">Status of This Memo</a>
+</h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on January 7, 2018.</p>
-<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
-<p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This Internet-Draft will expire on September 17, 2018.</p>
+<h1 id="rfc.copyrightnotice">
+  <a href="#rfc.copyrightnotice">Copyright Notice</a>
+</h1>
+<p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
@@ -479,156 +485,101 @@
   <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
   <ul class="toc">
 
-  	<li>1.   <a href="#rfc.section.1">Introduction</a>
-</li>
-<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a>
-</li>
-</ul><li>2.   <a href="#rfc.section.2">Overview</a>
-</li>
-<ul><li>2.1.   <a href="#rfc.section.2.1">Audience</a>
-</li>
-<li>2.2.   <a href="#rfc.section.2.2">Goals</a>
-</li>
-<li>2.3.   <a href="#rfc.section.2.3">Terminology</a>
-</li>
-</ul><li>3.   <a href="#rfc.section.3">Architecture</a>
-</li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">Server/Client Architecture</a>
-</li>
-<li>3.2.   <a href="#rfc.section.3.2">Server/Proxy Architecture</a>
-</li>
-</ul><li>4.   <a href="#rfc.section.4">ACV Protocol</a>
-</li>
-<ul><li>4.1.   <a href="#rfc.section.4.1">HTTP URI Hierarchy</a>
-</li>
-<li>4.2.   <a href="#rfc.section.4.2">HTTP URI Operations</a>
-</li>
-</ul><li>5.   <a href="#rfc.section.5">Security</a>
-</li>
-<li>6.   <a href="#rfc.section.6">Authentication</a>
-</li>
-<li>7.   <a href="#rfc.section.7">Traceability</a>
-</li>
-<li>8.   <a href="#rfc.section.8">Encoding</a>
-</li>
-<li>9.   <a href="#rfc.section.9">Versioning</a>
-</li>
-<li>10.   <a href="#rfc.section.10">Messaging</a>
-</li>
-<ul><li>10.1.   <a href="#rfc.section.10.1">Product Registration/Capabilities Exchange</a>
-</li>
-<li>10.2.   <a href="#rfc.section.10.2">Test Exchange</a>
-</li>
-</ul><li>11.   <a href="#rfc.section.11">Message Formats</a>
-</li>
-<ul><li>11.1.   <a href="#rfc.section.11.1">Establish Connection HTTPS GET/200 OK</a>
-</li>
-<li>11.2.   <a href="#rfc.section.11.2">Product Registration with Capabilities</a>
-</li>
-<li>11.3.   <a href="#rfc.section.11.3">Vector Set Download Request</a>
-</li>
-<li>11.4.   <a href="#rfc.section.11.4">Submit Test Results</a>
-</li>
-<li>11.5.   <a href="#rfc.section.11.5">Validation Results Request</a>
-</li>
-<li>11.6.   <a href="#rfc.section.11.6">Optional Flows</a>
-</li>
-</ul><li>12.   <a href="#rfc.section.12">Vector Set Expiration</a>
-</li>
-<ul><li>12.1.   <a href="#rfc.section.12.1">Resending Test Responses</a>
-</li>
-</ul><li>13.   <a href="#rfc.section.13">Error Codes</a>
-</li>
-<li>14.   <a href="#rfc.section.14">Custom Specification Objects</a>
-</li>
-<ul><li>14.1.   <a href="#rfc.section.14.1">BitString</a>
-</li>
-<ul><li>14.1.1.   <a href="#rfc.section.14.1.1">Endianness</a>
-</li>
-<li>14.1.2.   <a href="#rfc.section.14.1.2">Hex to Bitstring Parsing</a>
-</li>
-<ul><li>14.1.2.1.   <a href="#rfc.section.14.1.2.1">Hex string parsing examples</a>
-</li>
-</ul></ul><li>14.2.   <a href="#rfc.section.14.2">Range</a>
-</li>
-<ul><li>14.2.1.   <a href="#rfc.section.14.2.1">Range JSON examples</a>
-</li>
-</ul><li>14.3.   <a href="#rfc.section.14.3">Domain</a>
-</li>
-<ul><li>14.3.1.   <a href="#rfc.section.14.3.1">Domain JSON examples</a>
-</li>
-<li>14.3.2.   <a href="#rfc.section.14.3.2">Additional Domain Information</a>
-</li>
-</ul></ul><li>15.   <a href="#rfc.section.15">Other Considerations</a>
-</li>
-<li>16.   <a href="#rfc.section.16">Acknowledgements</a>
-</li>
-<li>17.   <a href="#rfc.section.17">IANA Considerations</a>
-</li>
-<li>18.   <a href="#rfc.references">Normative References</a>
-</li>
-<li>Appendix A.   <a href="#rfc.appendix.A">JSON Formatting Guidelines</a>
-</li>
-<li>Appendix B.   <a href="#rfc.appendix.B">JSON Encoded Error Messages</a>
-</li>
-<li><a href="#rfc.authors">Author's Address</a>
-</li>
+  	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
+<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a></li>
+</ul><li>2.   <a href="#rfc.section.2">Overview</a></li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Audience</a></li>
+<li>2.2.   <a href="#rfc.section.2.2">Goals</a></li>
+<li>2.3.   <a href="#rfc.section.2.3">Terminology</a></li>
+</ul><li>3.   <a href="#rfc.section.3">Architecture</a></li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Server/Client Architecture</a></li>
+<li>3.2.   <a href="#rfc.section.3.2">Server/Proxy Architecture</a></li>
+</ul><li>4.   <a href="#rfc.section.4">ACV Protocol</a></li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">HTTP URI Hierarchy</a></li>
+<li>4.2.   <a href="#rfc.section.4.2">HTTP URI Operations</a></li>
+</ul><li>5.   <a href="#rfc.section.5">Security</a></li>
+<li>6.   <a href="#rfc.section.6">Authentication</a></li>
+<li>7.   <a href="#rfc.section.7">Traceability</a></li>
+<li>8.   <a href="#rfc.section.8">Encoding</a></li>
+<li>9.   <a href="#rfc.section.9">Versioning</a></li>
+<li>10.   <a href="#rfc.section.10">Messaging</a></li>
+<ul><li>10.1.   <a href="#rfc.section.10.1">Product Registration/Capabilities Exchange</a></li>
+<li>10.2.   <a href="#rfc.section.10.2">Test Exchange</a></li>
+</ul><li>11.   <a href="#rfc.section.11">Message Formats</a></li>
+<ul><li>11.1.   <a href="#rfc.section.11.1">Establish Connection HTTPS GET/200 OK</a></li>
+<li>11.2.   <a href="#rfc.section.11.2">Product Registration with Capabilities</a></li>
+<li>11.3.   <a href="#rfc.section.11.3">Vector Set Download Request</a></li>
+<li>11.4.   <a href="#rfc.section.11.4">Submit Test Results</a></li>
+<li>11.5.   <a href="#rfc.section.11.5">Validation Results Request</a></li>
+<li>11.6.   <a href="#rfc.section.11.6">Optional Flows</a></li>
+</ul><li>12.   <a href="#rfc.section.12">Vector Set Expiration</a></li>
+<ul><li>12.1.   <a href="#rfc.section.12.1">Resending Test Responses</a></li>
+</ul><li>13.   <a href="#rfc.section.13">Error Codes</a></li>
+<li>14.   <a href="#rfc.section.14">Custom Specification Objects</a></li>
+<ul><li>14.1.   <a href="#rfc.section.14.1">BitString</a></li>
+<ul><li>14.1.1.   <a href="#rfc.section.14.1.1">Endianness</a></li>
+<li>14.1.2.   <a href="#rfc.section.14.1.2">Hex to Bitstring Parsing</a></li>
+<ul><li>14.1.2.1.   <a href="#rfc.section.14.1.2.1">Hex string parsing examples</a></li>
+</ul></ul><li>14.2.   <a href="#rfc.section.14.2">Range</a></li>
+<ul><li>14.2.1.   <a href="#rfc.section.14.2.1">Range JSON examples</a></li>
+</ul><li>14.3.   <a href="#rfc.section.14.3">Domain</a></li>
+<ul><li>14.3.1.   <a href="#rfc.section.14.3.1">Domain JSON examples</a></li>
+<li>14.3.2.   <a href="#rfc.section.14.3.2">Additional Domain Information</a></li>
+</ul></ul><li>15.   <a href="#rfc.section.15">Other Considerations</a></li>
+<li>16.   <a href="#rfc.section.16">Acknowledgements</a></li>
+<li>17.   <a href="#rfc.section.17">IANA Considerations</a></li>
+<li>18.   <a href="#rfc.references">Normative References</a></li>
+<li>Appendix A.   <a href="#rfc.appendix.A">JSON Formatting Guidelines</a></li>
+<li>Appendix B.   <a href="#rfc.appendix.B">JSON Encoded Error Messages</a></li>
+<li><a href="#rfc.authors">Author's Address</a></li>
 
 
   </ul>
 
-  <h1 id="rfc.section.1">
-<a href="#rfc.section.1">1.</a> Introduction</h1>
+  <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> Introduction</h1>
 <p id="rfc.section.1.p.1">ACVP enables communication between a cryptographic module that is embedded inside of a device or otherwise running on a platform accessible via computer network, and an external testing system, using standard network communication interfaces and protocols.  This communication protocol can also be used to validate the correctness of the implementations of the algorithms in the cryptographic module with a validation authority.  This document describes how ACVP is structured with respect to the client-server model, the messaging protocol, optional features and flows.</p>
-<h1 id="rfc.section.1.1">
-<a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
-<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119" class="xref">RFC 2119</a>.</p>
-<h1 id="rfc.section.2">
-<a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Overview</a>
-</h1>
+<h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
+<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <a href="#RFC2119">RFC 2119</a> <cite title="NONE">[RFC2119]</cite>.</p>
+<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Overview</a></h1>
 <p id="rfc.section.2.p.1">ACVP has the following goals:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>To work in situations where the testing system is remote from the cryptographic module, e.g. running as a process on a separate device.</li>
-<li>To enable automated testing that can take place with a minimum of human interaction.</li>
-<li>To enable the testing system to discover the capabilities of the module being tested; that is, the particular algorithms and parameters that the module supports.</li>
-<li>To provide extensibility that can be used to introduce tests for new algorithms, and new tests for existing algorithms.</li>
-<li>To be compatible with emerging automated validation systems wherever possible, especially the FIPS-140 Cryptographic Algorithm Validation Program.</li>
-<li>To provide a standard communication method so that vendors can utilize the same testing service for FIPS-140, 3rd party crypto verification and product FCS readiness testing.</li>
+  <li>To work in situations where the testing system is remote from the cryptographic module, e.g. running as a process on a separate device.</li>
+  <li>To enable automated testing that can take place with a minimum of human interaction.</li>
+  <li>To enable the testing system to discover the capabilities of the module being tested; that is, the particular algorithms and parameters that the module supports.</li>
+  <li>To provide extensibility that can be used to introduce tests for new algorithms, and new tests for existing algorithms.</li>
+  <li>To be compatible with emerging automated validation systems wherever possible, especially the FIPS-140 Cryptographic Algorithm Validation Program.</li>
+  <li>To provide a standard communication method so that vendors can utilize the same testing service for FIPS-140, 3rd party crypto verification and product FCS readiness testing.</li>
 </ul>
 <p id="rfc.section.2.p.3">ACVP defines how to communicate a request (to execute a cryptographic operation) to a cryptographic module, and how to communicate the corresponding response (containing the output of that operation) back to a testing system.  It defines a transport (based on HTTP or HTTPS), an encoding and message format (which is negotiated), and a set of message exchanges.  Each vector test set corresponds to a single message exchange driven from the client associated with the module under test.  ACVP does not define the cryptographic algorithms, nor does it detail the precise conditions for a response to be acceptable.  Instead, it references existing specifications for those algorithms, and defines a mapping between the data on the wire and the algorithm testing specification.  ACVP does not define detailed conformance criteria, such as those in FIPS-140.  Instead, it aims to be independent of particular conformance criteria, so that it can be used in multiple domains with different (even potentially conflicting) conformance criteria.  ACVP does not define an interface that can be used to manage or control a cryptographic module.</p>
-<h1 id="rfc.section.2.1">
-<a href="#rfc.section.2.1">2.1.</a> Audience</h1>
+<h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> Audience</h1>
 <p id="rfc.section.2.1.p.1">This document is written to address multiple audiences:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>Crypto module developers who require validation testing</li>
-<li>Crypto validation organizations who will perform validation testing</li>
-<li>Crypto module customers that desire validation testing results or verifiable artifacts of testing</li>
+  <li>Crypto module developers who require validation testing</li>
+  <li>Crypto validation organizations who will perform validation testing</li>
+  <li>Crypto module customers that desire validation testing results or verifiable artifacts of testing</li>
 </ul>
-<h1 id="rfc.section.2.2">
-<a href="#rfc.section.2.2">2.2.</a> Goals</h1>
+<h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> Goals</h1>
 <p id="rfc.section.2.2.p.1">The goals for this document are to provide a messaging protocol that can be used with existing authentication and communication protocols to provide a way to test crypto modules.  The following functions are outside the scope of this document:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>The API to the cryptographic module</li>
-<li>How the tests are generated</li>
-<li>How the results/artifacts are stored or managed</li>
-<li>Authentication used</li>
-<li>Scalability</li>
-<li>Management interface</li>
+  <li>The API to the cryptographic module</li>
+  <li>How the tests are generated</li>
+  <li>How the results/artifacts are stored or managed</li>
+  <li>Authentication used</li>
+  <li>Scalability</li>
+  <li>Management interface</li>
 </ul>
 <p id="rfc.section.2.2.p.3">With that in mind there are several expectations when building a server used as a validation authority.  A validation authority shall use HTTPS, TLS 1.2 or greater and mutual authentication. Therefore a client that expects to be used with a validation authority shall have the same requirements.  A server, proxy or client developed for the purposes of internal organizational testing only may chose not to include some of those features.</p>
-<h1 id="rfc.section.2.3">
-<a href="#rfc.section.2.3">2.3.</a> Terminology</h1>
+<h1 id="rfc.section.2.3"><a href="#rfc.section.2.3">2.3.</a> Terminology</h1>
 <p id="rfc.section.2.3.p.1">TBD </p>
-<h1 id="rfc.section.3">
-<a href="#rfc.section.3">3.</a> Architecture</h1>
-<div id="rfc.figure.1"></div>
-<div id="xml_figure1"></div>
+<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> Architecture</h1>
+<div id="rfc.figure.1"/>
+<div id="xml_figure1"/>
 <p>Server/Client Architecture</p>
 <pre>
 
@@ -650,22 +601,20 @@
 
            </pre>
 <p class="figure">Figure 1</p>
-<h1 id="rfc.section.3.1">
-<a href="#rfc.section.3.1">3.1.</a> Server/Client Architecture</h1>
+<h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> Server/Client Architecture</h1>
 <p id="rfc.section.3.1.p.1">A server client model is used where the roles are defined as:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>ACV Client - resides in, or accessible from, the device under test and communicates with the ACV server using Java Script Object Notation (JSON) as well as the crypto module using product specific methods.</li>
-<li>ACV Server - Sends JSON formatted messaging and test data to the ACV client and processes test responses.</li>
-<li>ACV Proxy - Resides between the ACV server and ACV client to proxy the connection for the client.  This is particularly useful when the client does not support TLS, key management or have signature capabilities and they are required by the server.  An example architecture is provided in Figure 2.</li>
-<li>Device Under Test - contains the ACV client and the crypto module under test which can include various algorithms and functions that encrypt/decrypt, generate keys, signatures, perform varifications and DRBG functions.</li>
-<li>Crpyographic Module API - This is the interface to the crypto module from the ACV Client.  This interface is environment specific and will vary depending on the API available on the crypto module.</li>
+  <li>ACV Client - resides in, or accessible from, the device under test and communicates with the ACV server using Java Script Object Notation (JSON) as well as the crypto module using product specific methods.</li>
+  <li>ACV Server - Sends JSON formatted messaging and test data to the ACV client and processes test responses.</li>
+  <li>ACV Proxy - Resides between the ACV server and ACV client to proxy the connection for the client.  This is particularly useful when the client does not support TLS, key management or have signature capabilities and they are required by the server.  An example architecture is provided in Figure 2.</li>
+  <li>Device Under Test - contains the ACV client and the crypto module under test which can include various algorithms and functions that encrypt/decrypt, generate keys, signatures, perform varifications and DRBG functions.</li>
+  <li>Crpyographic Module API - This is the interface to the crypto module from the ACV Client.  This interface is environment specific and will vary depending on the API available on the crypto module.</li>
 </ul>
-<h1 id="rfc.section.3.2">
-<a href="#rfc.section.3.2">3.2.</a> Server/Proxy Architecture</h1>
-<div id="rfc.figure.2"></div>
-<div id="xml_figure2"></div>
+<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> Server/Proxy Architecture</h1>
+<div id="rfc.figure.2"/>
+<div id="xml_figure2"/>
 <p>Server/Proxy Architecture</p>
 <pre>
 
@@ -686,11 +635,10 @@
 
            </pre>
 <p class="figure">Figure 2</p>
-<h1 id="rfc.section.4">
-<a href="#rfc.section.4">4.</a> ACV Protocol</h1>
+<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> ACV Protocol</h1>
 <p id="rfc.section.4.p.1">The ACV protocol will utilize existing mechanisms for transport coordinated with JSON formatted messaging.</p>
-<div id="rfc.figure.3"></div>
-<div id="xml_figure3"></div>
+<div id="rfc.figure.3"/>
+<div id="xml_figure3"/>
 <p>Protocol Layering</p>
 <pre>
 +-----------------------------------------------+
@@ -705,10 +653,9 @@
 
            </pre>
 <p class="figure">Figure 3</p>
-<h1 id="rfc.section.4.1">
-<a href="#rfc.section.4.1">4.1.</a> HTTP URI Hierarchy</h1>
-<div id="rfc.figure.4"></div>
-<div id="xml_figure4"></div>
+<h1 id="rfc.section.4.1"><a href="#rfc.section.4.1">4.1.</a> HTTP URI Hierarchy</h1>
+<div id="rfc.figure.4"/>
+<div id="xml_figure4"/>
 <pre>
 
           +-------------------------------------------------+
@@ -721,115 +668,117 @@
            </pre>
 <p class="figure">Figure 4</p>
 <p id="rfc.section.4.1.p.1">Note that deployments utilizing ACV Proxy server may use a different protocol, e.g., HTTP, and custom URI path prefix, context and port number to interact with the DUT.</p>
-<h1 id="rfc.section.4.2">
-<a href="#rfc.section.4.2">4.2.</a> HTTP URI Operations</h1>
+<h1 id="rfc.section.4.2"><a href="#rfc.section.4.2">4.2.</a> HTTP URI Operations</h1>
 <p id="rfc.section.4.2.p.1">Operations and their corresponding operation names</p>
-<div id="rfc.table.1"></div>
-<div id="uri_table"></div>
+<div id="rfc.table.1"/>
+<div id="uri_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<thead><tr>
-<th class="left">Operation</th>
-<th class="left">Operation Path</th>
-<th class="left">HTTP Method</th>
-<th class="left">Details</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">Registration and DUT Capabilities</td>
-<td class="left">/register</td>
-<td class="left">POST</td>
-<td class="left"><a href="#reg_capex" class="xref">Section 11.2</a></td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">Vector Set download request</td>
-<td class="left">/vectors</td>
-<td class="left">GET</td>
-<td class="left"><a href="#vector_dl" class="xref">Section 11.3</a></td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">Submit Vector Test Results</td>
-<td class="left">/vectors</td>
-<td class="left">POST</td>
-<td class="left"><a href="#vector_dl2" class="xref">Section 11.4</a></td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">Request Validation Results</td>
-<td class="left">/results</td>
-<td class="left">GET</td>
-<td class="left"><a href="#results_req" class="xref">Section 11.5</a></td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">Request server to cancel session</td>
-<td class="left">/cancel</td>
-<td class="left">POST</td>
-<td class="left"><a href="#optional_flows" class="xref">Section 11.6</a></td>
-</tr>
-</tbody>
+  <thead>
+    <tr>
+      <th class="left">Operation</th>
+      <th class="left">Operation Path</th>
+      <th class="left">HTTP Method</th>
+      <th class="left">Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">Registration and DUT Capabilities</td>
+      <td class="left">/register</td>
+      <td class="left">POST</td>
+      <td class="left">
+        <a href="#reg_capex">Section 11.2</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">Vector Set download request</td>
+      <td class="left">/vectors</td>
+      <td class="left">GET</td>
+      <td class="left">
+        <a href="#vector_dl">Section 11.3</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">Submit Vector Test Results</td>
+      <td class="left">/vectors</td>
+      <td class="left">POST</td>
+      <td class="left">
+        <a href="#vector_dl2">Section 11.4</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">Request Validation Results</td>
+      <td class="left">/results</td>
+      <td class="left">GET</td>
+      <td class="left">
+        <a href="#results_req">Section 11.5</a>
+      </td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">Request server to cancel session</td>
+      <td class="left">/cancel</td>
+      <td class="left">POST</td>
+      <td class="left">
+        <a href="#optional_flows">Section 11.6</a>
+      </td>
+    </tr>
+  </tbody>
 </table>
 <p id="rfc.section.4.2.p.2">The operation path is appended to the path prefix to form the URI used with HTTP GET or POST to perform the desired ACVP operation.  An example valid URI absolute path for the "/register" operation is "/validation/acvp/register".  To register a DUT the ACVP client would use the following HTTP request-line:</p>
-<p id="rfc.section.4.2.p.3">POST /validation/acvp/register HTTP/1.2</p>
+<p id="rfc.section.4.2.p.3">POST /validation/acvp/register HTTP/1.0</p>
 <p id="rfc.section.4.2.p.4">Likewise, to request a specific vector set from the server the ACVP client would use the following request-line:</p>
-<p id="rfc.section.4.2.p.5">GET /validation/acvp/vectors?vsId=1 HTTP/1.2</p>
-<h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> Security</h1>
+<p id="rfc.section.4.2.p.5">GET /validation/acvp/vectors?vsId=1 HTTP/1.0</p>
+<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> Security</h1>
 <p id="rfc.section.5.p.1">It is recommended that HTTPS and TLS 1.2 or greater be used in order to enforce a secure communication method.  Not all environments will have TLS so HTTP with some level of authentication may be the only option.</p>
-<h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> Authentication</h1>
+<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> Authentication</h1>
 <p id="rfc.section.6.p.1">It is recommended that an authentication scheme be used.  Depending on the target environment and usage objectives, that can be as weak as basic HTTP authentication or as strong as TLS mutual certificate authentication. Definition of an authentication scheme will not be discussed here, but should be agreed upon between the client and server owning entities including the servers owned by the validation authorities.  For the purposes of the message flow examples, no authentication will be used.</p>
-<h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> Traceability</h1>
+<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> Traceability</h1>
 <p id="rfc.section.7.p.1">TBD </p>
-<h1 id="rfc.section.8">
-<a href="#rfc.section.8">8.</a> Encoding</h1>
+<h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> Encoding</h1>
 <p id="rfc.section.8.p.1">The encoding used for the request/response messaging will be JSON. The data will be identified by: Content-type: application/json In order to allow environment specific extensions to a particular version of the ACV protocol, a top-level JSON keyword, extensions will be used to extend the OE description and/or the capabilities.  Extensions may be ignored by the ACV server.  Vector and vector response data will be JSON encoded.</p>
-<h1 id="rfc.section.9">
-<a href="#rfc.section.9">9.</a> Versioning</h1>
+<h1 id="rfc.section.9"><a href="#rfc.section.9">9.</a> Versioning</h1>
 <p id="rfc.section.9.p.1">The version of the ACVP protocol will be carried with each message and will contain a simple major.minor format.  Major version changes will not be backward compatible, however additions and enhancements that do not disrupt compatibility will be indicated with a minor version change.  A server may accept a down-level version from the client if it can process at a lower level.  If not, it will reject the session.  All subsequent messages will carry the negotiated version value.</p>
-<h1 id="rfc.section.10">
-<a href="#rfc.section.10">10.</a> Messaging</h1>
-<h1 id="rfc.section.10.1">
-<a href="#rfc.section.10.1">10.1.</a> Product Registration/Capabilities Exchange</h1>
+<h1 id="rfc.section.10"><a href="#rfc.section.10">10.</a> Messaging</h1>
+<h1 id="rfc.section.10.1"><a href="#rfc.section.10.1">10.1.</a> Product Registration/Capabilities Exchange</h1>
 <p id="rfc.section.10.1.p.1">The product registration message will include many of the normal cryptographic algorithm identification line items that are found when filling out a testing form. This pre-test message will carry the Company name, primary contact (OE information) as well as a detailed list of the supported cryptographic algorithms to be tested during a session.  The server will return the vector test list to the client.  It will consist of a list of vector set IDs (vsId) each of which represent a set of test vectors which can be used to request the test vectors at a later time.</p>
-<h1 id="rfc.section.10.2">
-<a href="#rfc.section.10.2">10.2.</a> Test Exchange</h1>
+<h1 id="rfc.section.10.2"><a href="#rfc.section.10.2">10.2.</a> Test Exchange</h1>
 <p id="rfc.section.10.2.p.1">The test exchange consists of the ACV client requesting a particular set of vectors selected from the vector test list.  The server responds with the test vectors.  Once the client has run the vectors the response data will be returned to the server for processing.  The client will repeat this process until all of the tests in the session test list have been processed.  The client may request results from the server at any time, however if test sets have not been completed the overall status will be incomplete.</p>
-<h1 id="rfc.section.11">
-<a href="#rfc.section.11">11.</a> Message Formats</h1>
+<h1 id="rfc.section.11"><a href="#rfc.section.11">11.</a> Message Formats</h1>
 <p id="rfc.section.11.p.1">Servers may require a contextual path in the URI prior to the service section and clients/proxies must be able to support it.</p>
 <p id="rfc.section.11.p.2">Unique variable definitions to identify the vector set, device and session include:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>Session - represented by a JSON Web Token(JWT).  Within the JWT, the JWT ID(JTI) will be a unique identifier that will be generated by the server and can be used as a session ID.</li>
-<li>Vector Set - represented by the VS-ID which represents a specific CAVS vector request file, e.g. gcmEncryptIntIV128.req. Passed to the client as part of the capabilities exchange.</li>
+  <li>Session - represented by a JSON Web Token(JWT).  Within the JWT, the JWT ID(JTI) will be a unique identifier that will be generated by the server and can be used as a session ID.</li>
+  <li>Vector Set - represented by the VS-ID which represents a specific CAVS vector request file, e.g. gcmEncryptIntIV128.req. Passed to the client as part of the capabilities exchange.</li>
 </ul>
 <p id="rfc.section.11.p.4">JWT example:</p>
-<div id="rfc.figure.5"></div>
-<div id="xml_json1"></div>
+<div id="rfc.figure.5"/>
+<div id="xml_json1"/>
 <pre>
 {
 "alg" : "none"
@@ -847,20 +796,19 @@
            </pre>
 <p class="figure">Figure 5</p>
 <p id="rfc.section.11.p.5">The JWT can be secured if desired using the header encryption "alg" value defined to HS256(HMAC-SHA256) or one of the other secure values.  Key agreement would follow RFC7518.  </p>
-<p id="rfc.section.11.p.6">The first four claims are required, however "pkey" is an optional private claim used to pass the key used for encrypting the database at the server.  Enabling this option is discussed further in <a href="#reg_capex" class="xref">Section 11.2</a></p>
-<h1 id="rfc.section.11.1">
-<a href="#rfc.section.11.1">11.1.</a> Establish Connection HTTPS GET/200 OK</h1>
+<p id="rfc.section.11.p.6">The first four claims are required, however "pkey" is an optional private claim used to pass the key used for encrypting the database at the server.  Enabling this option is discussed further in <a href="#reg_capex">Section 11.2</a></p>
+<h1 id="rfc.section.11.1"><a href="#rfc.section.11.1">11.1.</a> Establish Connection HTTPS GET/200 OK</h1>
 <p id="rfc.section.11.1.p.1">Establish the connection, send POST and receive 200 OK response with JWT from server.</p>
-<div id="rfc.figure.6"></div>
-<div id="xml_json2"></div>
+<div id="rfc.figure.6"/>
+<div id="xml_json2"/>
 <pre>
-POST /validation/acvp/register HTTP1.2
+POST /validation/acvp/register HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Capabilities information(see next section)
 
 ..authentication happens here..
 
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: (length of JWT)
@@ -875,28 +823,26 @@ each message.
            </pre>
 <p class="figure">Figure 6</p>
 <p id="rfc.section.11.1.p.2">The authentication mechanism will be defined by the server.</p>
-<h1 id="rfc.section.11.2">
-<a href="#rfc.section.11.2">11.2.</a> <a href="#reg_capex" id="reg_capex">Product Registration with Capabilities</a>
-</h1>
+<h1 id="rfc.section.11.2"><a href="#rfc.section.11.2">11.2.</a> <a href="#reg_capex" id="reg_capex">Product Registration with Capabilities</a></h1>
 <p id="rfc.section.11.2.p.1">POST the registration to the server consisting of the ACVP version, Operating Environment (OE), vector encoding, capabilities and any extensions. In addition there are a few parameters that specify session specific information:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>certificateRequest - If an algorithm certificate is not desired for this registration populate the field "certificateRequest"  with "no", otherwise "yes".</li>
-<li>debugRequest - If this vector session is for the purposes of testing the client or DUT prior to a certificate request and desires the answers to the vectors as well, indicate with "yes", otherwise omit the keyword or indicate with "no"</li>
-<li>production - If this is a production environment indicate so with "yes", otherwise omit this keyword or indicate with "no".  A production environment may not be able to support intermediate value tests and therefore those tests will be excluded.</li>
-<li>encryptAtRest - The client may request the server to encrypt all data at rest by registering "encryptAtRest" with "yes". Omitting the "encryptAtRest" field or registering with "no" will indicate to the server that no encryption is require for the data at rest.</li>
+  <li>certificateRequest - If an algorithm certificate is not desired for this registration populate the field "certificateRequest"  with "no", otherwise "yes".</li>
+  <li>debugRequest - If this vector session is for the purposes of testing the client or DUT prior to a certificate request and desires the answers to the vectors as well, indicate with "yes", otherwise omit the keyword or indicate with "no"</li>
+  <li>production - If this is a production environment indicate so with "yes", otherwise omit this keyword or indicate with "no".  A production environment may not be able to support intermediate value tests and therefore those tests will be excluded.</li>
+  <li>encryptAtRest - The client may request the server to encrypt all data at rest by registering "encryptAtRest" with "yes". Omitting the "encryptAtRest" field or registering with "no" will indicate to the server that no encryption is require for the data at rest.</li>
 </ul>
 <p id="rfc.section.11.2.p.3">Note that when a certificate request is made, production and debugRequest shall be omitted or set to "no". Conversely if no certificate is requested, the operationalEnvironment section may be omitted.</p>
-<div id="rfc.figure.7"></div>
-<div id="xml_json3"></div>
+<div id="rfc.figure.7"/>
+<div id="xml_json3"/>
 <pre>
-POST /validation/acvp/register HTTP1.2
+POST /validation/acvp/register HTTP1.0
 User Agent:
 Host: www.acvts.nist.gov/acvp
 Accept: 
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "operation" : "register",
    "certificateRequest" : "yes",
    "debugRequest" : "no",
@@ -954,7 +900,7 @@ Accept:
   "ivLen" : [
              96
                ],
-  "ptLen" : [
+  "dataLength" : [
              0,
              128,
              136
@@ -971,12 +917,12 @@ Accept:
            </pre>
 <p class="figure">Figure 7</p>
 <p id="rfc.section.11.2.p.4">Successful response from server is 200 OK and a set of vector set identifiers.  The extensions section is optional and can be implementation specific for value add. Follow on versions could include protocol information.</p>
-<div id="rfc.figure.8"></div>
-<div id="xml_json4"></div>
+<div id="rfc.figure.8"/>
+<div id="xml_json4"/>
 <pre>
 200 OK Response:
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "capabilityResponse" : { "vectorSets" : [
                        {"vsId":1437},
                        {"vsId":1438}] } , 
@@ -986,21 +932,19 @@ Accept:
 ]
            </pre>
 <p class="figure">Figure 8</p>
-<h1 id="rfc.section.11.3">
-<a href="#rfc.section.11.3">11.3.</a> <a href="#vector_dl" id="vector_dl">Vector Set Download Request</a>
-</h1>
+<h1 id="rfc.section.11.3"><a href="#rfc.section.11.3">11.3.</a> <a href="#vector_dl" id="vector_dl">Vector Set Download Request</a></h1>
 <p id="rfc.section.11.3.p.1">After registration, the server provides a list of vector sets to the client, each identified by a VS-ID.  The client shall download, process, and upload test results for each vector set, one at a time. Note that the client shall upload complete test results for each processed vector set, i.e. containing a result for every test case in the vector set.  </p>
-<div id="rfc.figure.9"></div>
-<div id="xml_json5"></div>
+<div id="rfc.figure.9"/>
+<div id="xml_json5"/>
 <pre>
-GET /validation/acvp/vectors?vsId=1437  HTTP1.2
+GET /validation/acvp/vectors?vsId=1437  HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Authorization: Bearer JWT
             </pre>
 <p class="figure">Figure 9</p>
 <p id="rfc.section.11.3.p.2">The server will respond with the vector set associated with the vsId for the client to process.  The actual test group content contained in the response will vary depending on the specific sub-specification of the algorithm and testType being tested.</p>
-<div id="rfc.figure.10"></div>
-<div id="xml_json6"></div>
+<div id="rfc.figure.10"/>
+<div id="xml_json6"/>
 <pre>
 
 200 OK Response:
@@ -1008,7 +952,7 @@ Status: 200 OK
 Content-Type: application/json
 Content-Length: &lt;length of results&gt;
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "vsId": 1437,
    "algorithm": "AES-GCM",
    "testGroups": [
@@ -1040,15 +984,15 @@ Content-Length: &lt;length of results&gt;
             </pre>
 <p class="figure">Figure 10</p>
 <p id="rfc.section.11.3.p.3">If the server did not have enough time to generate the vector set for a given test session, the server may reply: </p>
-<div id="rfc.figure.11"></div>
-<div id="xml_json7"></div>
+<div id="rfc.figure.11"/>
+<div id="xml_json7"/>
 <pre>
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: &lt;length of results&gt;
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "vsId": 1437,
     "retry" : 10
   }
@@ -1056,19 +1000,17 @@ Content-Length: &lt;length of results&gt;
            </pre>
 <p class="figure">Figure 11</p>
 <p id="rfc.section.11.3.p.4">Where the retry value represents the number of seconds for the client to wait before retrying the request.  The server may set the retry value based on the current server load and expected processing time to generate the vector set.  </p>
-<h1 id="rfc.section.11.4">
-<a href="#rfc.section.11.4">11.4.</a> <a href="#vector_dl2" id="vector_dl2">Submit Test Results</a>
-</h1>
+<h1 id="rfc.section.11.4"><a href="#rfc.section.11.4">11.4.</a> <a href="#vector_dl2" id="vector_dl2">Submit Test Results</a></h1>
 <p id="rfc.section.11.4.p.1">The client will send this request to submit the test results for an individual vector set. Similar to the vector set download the format will vary depending on the specific sub-specification of the algorithm and testType being tested.</p>
-<div id="rfc.figure.12"></div>
-<div id="xml_json8"></div>
+<div id="rfc.figure.12"/>
+<div id="xml_json8"/>
 <pre>
-POST /validation/acvp/vectors?vsId=1437 HTTP1.2
+POST /validation/acvp/vectors?vsId=1437 HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Authorization: Bearer JWT
 Accept:   
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "vsId": 1437,
    "testResults": [
    {
@@ -1086,14 +1028,12 @@ Accept:
 ]
            </pre>
 <p class="figure">Figure 12</p>
-<h1 id="rfc.section.11.5">
-<a href="#rfc.section.11.5">11.5.</a> <a href="#results_req" id="results_req">Validation Results Request</a>
-</h1>
+<h1 id="rfc.section.11.5"><a href="#rfc.section.11.5">11.5.</a> <a href="#results_req" id="results_req">Validation Results Request</a></h1>
 <p id="rfc.section.11.5.p.1">The client will send this request to learn the validation results for an individual vector set.</p>
-<div id="rfc.figure.13"></div>
-<div id="xml_json9"></div>
+<div id="rfc.figure.13"/>
+<div id="xml_json9"/>
 <pre>
-GET /validation/acvp/results?vsId=1437 HTTP1.2
+GET /validation/acvp/results?vsId=1437 HTTP1.0
 User Agent:
 Host: www.acvts.nist.gov/acvp
 Accept: /
@@ -1101,12 +1041,12 @@ Accept: /
 
 Response to GET is:
 
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: &lt;length of results&gt;
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "results" : {
       "vsId" : 1437,
       "disposition" : "incomplete",
@@ -1121,51 +1061,48 @@ Content-Length: &lt;length of results&gt;
 <p class="figure">Figure 13</p>
 <p id="rfc.section.11.5.p.2">The results request is an optional flow since some clients may not require success/fail information. Another possibility is to provide an out of band management session on the server may provide access to algorithm test results.</p>
 <p id="rfc.section.11.5.p.3">"disposition" is defined overall for the entire vector set as:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>"fail" indicates at least one test case has failed.</li>
-<li>"unreceived" indicates the server has not received responses from the client for all the test cases.</li>
-<li>"incomplete" indicates not all tests have been processed by the server, however none have failed thus far.</li>
-<li>"expired" indicates not all the test case responses were received from the client prior to expiry.</li>
-<li>"passed" indicates all test cases have been processed by the server and have passed.</li>
+  <li>"fail" indicates at least one test case has failed.</li>
+  <li>"unreceived" indicates the server has not received responses from the client for all the test cases.</li>
+  <li>"incomplete" indicates not all tests have been processed by the server, however none have failed thus far.</li>
+  <li>"expired" indicates not all the test case responses were received from the client prior to expiry.</li>
+  <li>"passed" indicates all test cases have been processed by the server and have passed.</li>
 </ul>
 <p id="rfc.section.11.5.p.5">"result" is defined for individual test cases:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>"fail" indicates the test case has failed.</li>
-<li>"unreceived" indicates the server has not received a response from the client for the test case.</li>
-<li>"incomplete" indicates the server has not processed the test case.</li>
-<li>"expired" indicates the client did not send the test case response to the server prior to expiry.</li>
-<li>"passed" indicates the test case passed.</li>
-<li>"reason" provides additional detail for the test result.</li>
+  <li>"fail" indicates the test case has failed.</li>
+  <li>"unreceived" indicates the server has not received a response from the client for the test case.</li>
+  <li>"incomplete" indicates the server has not processed the test case.</li>
+  <li>"expired" indicates the client did not send the test case response to the server prior to expiry.</li>
+  <li>"passed" indicates the test case passed.</li>
+  <li>"reason" provides additional detail for the test result.</li>
 </ul>
-<h1 id="rfc.section.11.6">
-<a href="#rfc.section.11.6">11.6.</a> <a href="#optional_flows" id="optional_flows">Optional Flows</a>
-</h1>
+<h1 id="rfc.section.11.6"><a href="#rfc.section.11.6">11.6.</a> <a href="#optional_flows" id="optional_flows">Optional Flows</a></h1>
 <p id="rfc.section.11.6.p.1">The cancel URI can be used by the client to free a session.  The server is responsible for maintaining any database information for traceability or debugging purposes it desires.  This may be important for those cases where there are test failures.</p>
-<div id="rfc.figure.14"></div>
-<div id="xml_json10"></div>
+<div id="rfc.figure.14"/>
+<div id="xml_json10"/>
 <pre>
-POST /validation/acvp/cancel HTTP1.2
+POST /validation/acvp/cancel HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Authorization: Bearer JWT
            </pre>
 <p class="figure">Figure 14</p>
 <p id="rfc.section.11.6.p.2">The server response will always be 200 OK.</p>
-<h1 id="rfc.section.12">
-<a href="#rfc.section.12">12.</a> Vector Set Expiration</h1>
+<h1 id="rfc.section.12"><a href="#rfc.section.12">12.</a> Vector Set Expiration</h1>
 <p id="rfc.section.12.p.1">Vector sets can expire.  For example, in terms of a validation authority use, the vector sets are one-time use only.  Old vector sets can never be reused to obtain a new validation certificate for an algorithm implementation or to update an existing certificate. Expiration is a server specific definition which depends on database costs, need for artifacts, etc. If the vector set has expired, the server will reply with an expired response when the client attempts to download the vector set: </p>
-<div id="rfc.figure.15"></div>
-<div id="xml_json11"></div>
+<div id="rfc.figure.15"/>
+<div id="xml_json11"/>
 <pre>
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: &lt;length of results&gt;
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "vsId" : &lt;vs-id&gt;,
     "status" : "expired"
   }
@@ -1174,11 +1111,11 @@ Content-Length: &lt;length of results&gt;
 <p class="figure">Figure 15</p>
 <p id="rfc.section.12.p.2">The ACVP protocol requires server implementations to generate test values and retain the data while the ACVP client processes and returns the results.  Some crypto modules implementing the client-side ACVP protocol may not return results immediately.  The ACVP protocol design implies the server must retain the test values to verify the client test responses at some time in the future.  However, some test vector sets are fairly large, which could place significant storage requirements on ACVP server implementations.  To alleviate long term storage requirements, ACVP allows for an expiration timestamp to be set when a test vector set is generated by the server.  </p>
 <p id="rfc.section.12.p.3">The vector set expiration timestamp must be included by the server in the vector set when the client downloads the vector set.  The server may change the expiration timestamp of a previously issued vector set to extend its lifetime subject to server policy.  The expiration timestamp must be in the 'expiry' JSON value, which is included in the JSON encoded vector set.  The expiry JSON value will be a string value of the UTC timestamp using form "YYYY-MM-DD HH:MM:SS".  The following figure shows a partial JSON encoded vector set that contains the expiry value.  </p>
-<div id="rfc.figure.16"></div>
-<div id="xml_json12"></div>
+<div id="rfc.figure.16"/>
+<div id="xml_json12"/>
 <pre>
               [
-                { "acvVersion": "0.3" },
+                { "acvVersion": "0.4" },
                 { "vsId": 1437,
 		  "expiry": "2018-12-31 23:59:59",
                   "algorithm": "AES-GCM",
@@ -1208,44 +1145,35 @@ Content-Length: &lt;length of results&gt;
 
 	    </pre>
 <p class="figure">Figure 16</p>
-<h1 id="rfc.section.12.1">
-<a href="#rfc.section.12.1">12.1.</a> Resending Test Responses</h1>
+<h1 id="rfc.section.12.1"><a href="#rfc.section.12.1">12.1.</a> Resending Test Responses</h1>
 <p id="rfc.section.12.1.p.1">When one or more test cases fails, the client will need to correct the issue in the crypto module and send the responses again.  The resending of responses for failed test cases will occur for an entire vector set.  Therefore, even if only a single test case in the vector set failed, the client will need to download, process, and upload responses to the server for the entire vector set (presumably after the problem has been corrected in the DUT).  The resending of vector set responses must occur prior to expiry.  </p>
-<h1 id="rfc.section.13">
-<a href="#rfc.section.13">13.</a> Error Codes</h1>
+<h1 id="rfc.section.13"><a href="#rfc.section.13">13.</a> Error Codes</h1>
 <p id="rfc.section.13.p.1">Errors will follow HTTP[S] numbering scheme.  In addition errors as well as 200 messages may carry JSON encoded information that describes in detail the error and any associated troubleshooting information.  A non-exhaustive list of JSON encoded error messages are in Appendix B.</p>
-<h1 id="rfc.section.14">
-<a href="#rfc.section.14">14.</a> Custom Specification Objects</h1>
-<h1 id="rfc.section.14.1">
-<a href="#rfc.section.14.1">14.1.</a> BitString</h1>
+<h1 id="rfc.section.14"><a href="#rfc.section.14">14.</a> Custom Specification Objects</h1>
+<h1 id="rfc.section.14.1"><a href="#rfc.section.14.1">14.1.</a> BitString</h1>
 <p id="rfc.section.14.1.p.1">Bitstrings are used to communicate a string of bits between the ACVP server and IUT.  </p>
-<h1 id="rfc.section.14.1.1">
-<a href="#rfc.section.14.1.1">14.1.1.</a> Endianness</h1>
+<h1 id="rfc.section.14.1.1"><a href="#rfc.section.14.1.1">14.1.1.</a> Endianness</h1>
 <p id="rfc.section.14.1.1.p.1">BitStrings should be considered in big endian order, unless otherwise specified by the algorithm.  </p>
 <p id="rfc.section.14.1.1.p.2">The hex string "FA" (assuming all bits are considered) should represent the bits 11111010 (in MSb) or the value 250.  </p>
-<h1 id="rfc.section.14.1.2">
-<a href="#rfc.section.14.1.2">14.1.2.</a> Hex to Bitstring Parsing</h1>
+<h1 id="rfc.section.14.1.2"><a href="#rfc.section.14.1.2">14.1.2.</a> Hex to Bitstring Parsing</h1>
 <p id="rfc.section.14.1.2.p.1">"valueLen" will be used as the example, but it can apply to any bit length registration/vector set/etc parameters.  </p>
 <p id="rfc.section.14.1.2.p.2">When a "value" is provided along with a "valueLen", the "valueLen" MUST be considered when parsing the hex string represented in "value", EXCEPT in empty bitstring cases, which MUST be represented as an empty string "".  Parsing Hex strings into Bit strings is especially important for algorithms such as the SHA variations that may only include a portion of bits from the provided hex string.  When only a portion of bits from a Hex string are considered, bits for use in the bitstring should be taken from the most significant bits, meaning the lesser significant bits are the bits that are dropped.  </p>
-<h1 id="rfc.section.14.1.2.1">
-<a href="#rfc.section.14.1.2.1">14.1.2.1.</a> Hex string parsing examples</h1>
-<p></p>
+<h1 id="rfc.section.14.1.2.1"><a href="#rfc.section.14.1.2.1">14.1.2.1.</a> Hex string parsing examples</h1>
+<p/>
 
 <ul>
-<li>valueLen: 8, value: "FA", should be parsed as the bits 11111010, or the value 250.  </li>
-<li>valueLen: 7, value: "FA", should be parsed as the bits 1111101, or the value 125.  </li>
-<li>valueLen: 5, value: "FA", should be parsed as the bits 11111, or the value 31.  </li>
-<li>valueLen: 3, value: "FA", should be parsed as the bits 111, or the value 7.  </li>
-<li>valueLen: 0, value: "", MUST be interpreted as an empty bit string.  </li>
+  <li>valueLen: 8, value: "FA", should be parsed as the bits 11111010, or the value 250.  </li>
+  <li>valueLen: 7, value: "FA", should be parsed as the bits 1111101, or the value 125.  </li>
+  <li>valueLen: 5, value: "FA", should be parsed as the bits 11111, or the value 31.  </li>
+  <li>valueLen: 3, value: "FA", should be parsed as the bits 111, or the value 7.  </li>
+  <li>valueLen: 0, value: "", MUST be interpreted as an empty bit string.  </li>
 </ul>
-<h1 id="rfc.section.14.2">
-<a href="#rfc.section.14.2">14.2.</a> Range</h1>
+<h1 id="rfc.section.14.2"><a href="#rfc.section.14.2">14.2.</a> Range</h1>
 <p id="rfc.section.14.2.p.1">The Range object can be used to convey a range of values.  It contains its own set of properties made up of "min", "max", and "increment".  </p>
-<h1 id="rfc.section.14.2.1">
-<a href="#rfc.section.14.2.1">14.2.1.</a> Range JSON examples</h1>
+<h1 id="rfc.section.14.2.1"><a href="#rfc.section.14.2.1">14.2.1.</a> Range JSON examples</h1>
 <p id="rfc.section.14.2.1.p.1">A range object specifying a minimum of 0, a maximum of 8, with an increment of 1.  This range object includes the values 1, 2, 3, 4, 5, 6, 7, and 8.  </p>
-<div id="rfc.figure.17"></div>
-<div id="xml_json13"></div>
+<div id="rfc.figure.17"/>
+<div id="xml_json13"/>
 <pre>
           
           {
@@ -1260,8 +1188,8 @@ Content-Length: &lt;length of results&gt;
         </pre>
 <p class="figure">Figure 17</p>
 <p id="rfc.section.14.2.1.p.2">A range object specifying a minimum of 0, a maximum of 8, with an increment of 2.  This range object includes the values 0, 2, 4, 6, and 8.  </p>
-<div id="rfc.figure.18"></div>
-<div id="xml_json14"></div>
+<div id="rfc.figure.18"/>
+<div id="xml_json14"/>
 <pre>
           
           {
@@ -1275,14 +1203,12 @@ Content-Length: &lt;length of results&gt;
           
         </pre>
 <p class="figure">Figure 18</p>
-<h1 id="rfc.section.14.3">
-<a href="#rfc.section.14.3">14.3.</a> Domain</h1>
+<h1 id="rfc.section.14.3"><a href="#rfc.section.14.3">14.3.</a> Domain</h1>
 <p id="rfc.section.14.3.p.1">The Domain object can be used to specify a set of values similar to Range, albeit with more control.  A domain can be made up of an array of objects, where those objects can be literal values, and/or Range objects.  </p>
-<h1 id="rfc.section.14.3.1">
-<a href="#rfc.section.14.3.1">14.3.1.</a> Domain JSON examples</h1>
+<h1 id="rfc.section.14.3.1"><a href="#rfc.section.14.3.1">14.3.1.</a> Domain JSON examples</h1>
 <p id="rfc.section.14.3.1.p.1">Several sample domain objects that state 0, 8, 16, 32, 96, 128, 192, and 256 are valid values.  </p>
-<div id="rfc.figure.19"></div>
-<div id="xml_json15"></div>
+<div id="rfc.figure.19"/>
+<div id="xml_json15"/>
 <pre>
           
           {
@@ -1305,8 +1231,8 @@ Content-Length: &lt;length of results&gt;
           
         </pre>
 <p class="figure">Figure 19</p>
-<div id="rfc.figure.20"></div>
-<div id="xml_json16"></div>
+<div id="rfc.figure.20"/>
+<div id="xml_json16"/>
 <pre>
           
           {
@@ -1318,41 +1244,37 @@ Content-Length: &lt;length of results&gt;
           
         </pre>
 <p class="figure">Figure 20</p>
-<h1 id="rfc.section.14.3.2">
-<a href="#rfc.section.14.3.2">14.3.2.</a> Additional Domain Information</h1>
+<h1 id="rfc.section.14.3.2"><a href="#rfc.section.14.3.2">14.3.2.</a> Additional Domain Information</h1>
 <p id="rfc.section.14.3.2.p.1">Because the Domain is an array of objects consisting of (potentially) both literals and ranges, algorithms that use an array of integers can be used interchangably with the Domain object.  </p>
-<h1 id="rfc.section.15">
-<a href="#rfc.section.15">15.</a> Other Considerations</h1>
+<h1 id="rfc.section.15"><a href="#rfc.section.15">15.</a> Other Considerations</h1>
 <p id="rfc.section.15.p.1">When an ACVP client is attached to a cryptographic module that is in use, access to ACVP MUST be controlled so that only an administrator or other authorized user can send and receive ACVP messages.  This is because an attacker that has access to ACVP can potentially use it to probe for weaknesses in the cryptographic module.</p>
-<h1 id="rfc.section.16">
-<a href="#rfc.section.16">16.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
-</h1>
+<h1 id="rfc.section.16"><a href="#rfc.section.16">16.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a></h1>
 <p id="rfc.section.16.p.1">Original ACVP created by David McGrew, Bill Hudson and Anthony Grieco of Cisco Systems.</p>
-<h1 id="rfc.section.17">
-<a href="#rfc.section.17">17.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
-</h1>
+<h1 id="rfc.section.17"><a href="#rfc.section.17">17.</a> <a href="#IANA" id="IANA">IANA Considerations</a></h1>
 <p id="rfc.section.17.p.1">This memo includes no request to IANA.</p>
-<h1 id="rfc.references">
-<a href="#rfc.references">18.</a> Normative References</h1>
-<table><tbody><tr>
-<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
-<td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
-</tr></tbody></table>
-<h1 id="rfc.appendix.A">
-<a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">JSON Formatting Guidelines</a>
-</h1>
+<h1 id="rfc.references"><a href="#rfc.references">18.</a> Normative References</h1>
+<table>
+  <tbody>
+    <tr>
+      <td class="reference">
+        <b id="RFC2119">[RFC2119]</b>
+      </td>
+      <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">JSON Formatting Guidelines</a></h1>
 <p id="rfc.section.A.p.1">All JSON keywords shall use lower camelCase format with no underscores or hyphens and use the following characters only a-z, A-Z, 0-9. Keywords shall abbreviate common words and phrases wherever possible for brevity.</p>
 <p id="rfc.section.A.p.2">For example: password length - pwLen plain text length - ptLen </p>
 <p id="rfc.section.A.p.3">Keywords should be chosen such that they are informative and brief, for example: </p>
-<p id="rfc.section.A.p.4">[ { "acvVersion": "0.3" }, { "results" : { "disposition" : "incomplete", } } ] </p>
+<p id="rfc.section.A.p.4">[ { "acvVersion": "0.4" }, { "results" : { "disposition" : "incomplete", } } ] </p>
 <p id="rfc.section.A.p.5">Metadata assigned to the keyword may use any format which best reflects the information being represented including hyphens, underscores alternating case, numbers, etc. However, brevity should be a major consideration, for example:</p>
 <p id="rfc.section.A.p.6">"algorithms" : [ { "algorithm" : "AES-GCM", "mode" : "modes", "ivGen" : "internal", "ivGenMode" : "8.2.1", } All metadata representing strings or big numbers shall use double quotes at both ends.  Big numbers require conversion from strings to whatever format is used by the DUT.  Numerical values of integer size or with decimal points may use quotations if those values are generally used as a string, for example the acvVersion would generally be used in displaying information not in any mathematical operations.  Something like keyLen or ptLen values would be better used without quotes to avoid having to convert the string to an integer for use in the code.  </p>
-<h1 id="rfc.appendix.B">
-<a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-reg-ex2" id="app-reg-ex2">JSON Encoded Error Messages</a>
-</h1>
+<h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-reg-ex2" id="app-reg-ex2">JSON Encoded Error Messages</a></h1>
 <p id="rfc.section.B.p.1">TBD </p>
-<h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
+<h1 id="rfc.authors">
+  <a href="#rfc.authors">Author's Address</a>
+</h1>
 <div class="avoidbreak">
   <address class="vcard">
 	<span class="vcardline">

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,12 +4,12 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                              July 6, 2017
-Expires: January 7, 2018
+Intended status: Informational                            March 16, 2018
+Expires: September 17, 2018
 
 
               Automated Cryptographic Validation Protocol
-                      draft-ietf-acvp-protocol-0.3
+                      draft-ietf-acvp-protocol-0.4
 
 Abstract
 
@@ -31,11 +31,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 7, 2018.
+   This Internet-Draft will expire on September 17, 2018.
 
 Copyright Notice
 
-   Copyright (c) 2017 IETF Trust and the persons identified as the
+   Copyright (c) 2018 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Fussell                  Expires January 7, 2018                [Page 1]
+Fussell                Expires September 17, 2018               [Page 1]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
 Table of Contents
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Fussell                  Expires January 7, 2018                [Page 2]
+Fussell                Expires September 17, 2018               [Page 2]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  25
@@ -165,9 +165,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 3]
+Fussell                Expires September 17, 2018               [Page 3]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    corresponding response (containing the output of that operation) back
@@ -221,9 +221,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 4]
+Fussell                Expires September 17, 2018               [Page 4]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    With that in mind there are several expectations when building a
@@ -277,9 +277,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 5]
+Fussell                Expires September 17, 2018               [Page 5]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    o  ACV Proxy - Resides between the ACV server and ACV client to proxy
@@ -333,9 +333,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 6]
+Fussell                Expires September 17, 2018               [Page 6]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
                              Protocol Layering
@@ -389,30 +389,30 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 7]
+Fussell                Expires September 17, 2018               [Page 7]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
-   +---------------------------+--------------+-----------+------------+
-   | Operation                 | Operation    | HTTP      | Details    |
-   |                           | Path         | Method    |            |
-   +---------------------------+--------------+-----------+------------+
-   | Registration and DUT      | /register    | POST      | Section    |
-   | Capabilities              |              |           | 11.2       |
-   |                           |              |           |            |
-   | Vector Set download       | /vectors     | GET       | Section    |
-   | request                   |              |           | 11.3       |
-   |                           |              |           |            |
-   | Submit Vector Test        | /vectors     | POST      | Section    |
-   | Results                   |              |           | 11.4       |
-   |                           |              |           |            |
-   | Request Validation        | /results     | GET       | Section    |
-   | Results                   |              |           | 11.5       |
-   |                           |              |           |            |
-   | Request server to cancel  | /cancel      | POST      | Section    |
-   | session                   |              |           | 11.6       |
-   +---------------------------+--------------+-----------+------------+
+   +--------------------------+-------------+-----------+--------------+
+   | Operation                | Operation   | HTTP      | Details      |
+   |                          | Path        | Method    |              |
+   +--------------------------+-------------+-----------+--------------+
+   | Registration and DUT     | /register   | POST      | Section 11.2 |
+   | Capabilities             |             |           |              |
+   |                          |             |           |              |
+   | Vector Set download      | /vectors    | GET       | Section 11.3 |
+   | request                  |             |           |              |
+   |                          |             |           |              |
+   | Submit Vector Test       | /vectors    | POST      | Section 11.4 |
+   | Results                  |             |           |              |
+   |                          |             |           |              |
+   | Request Validation       | /results    | GET       | Section 11.5 |
+   | Results                  |             |           |              |
+   |                          |             |           |              |
+   | Request server to cancel | /cancel     | POST      | Section 11.6 |
+   | session                  |             |           |              |
+   +--------------------------+-------------+-----------+--------------+
 
                                   Table 1
 
@@ -422,12 +422,12 @@ Internet-Draft              Abbreviated Title                  July 2017
    "/validation/acvp/register".  To register a DUT the ACVP client would
    use the following HTTP request-line:
 
-   POST /validation/acvp/register HTTP/1.2
+   POST /validation/acvp/register HTTP/1.0
 
    Likewise, to request a specific vector set from the server the ACVP
    client would use the following request-line:
 
-   GET /validation/acvp/vectors?vsId=1 HTTP/1.2
+   GET /validation/acvp/vectors?vsId=1 HTTP/1.0
 
 5.  Security
 
@@ -445,9 +445,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 8]
+Fussell                Expires September 17, 2018               [Page 8]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    discussed here, but should be agreed upon between the client and
@@ -501,9 +501,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018                [Page 9]
+Fussell                Expires September 17, 2018               [Page 9]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
 10.2.  Test Exchange
@@ -557,9 +557,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 10]
+Fussell                Expires September 17, 2018              [Page 10]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    The first four claims are required, however "pkey" is an optional
@@ -572,13 +572,13 @@ Internet-Draft              Abbreviated Title                  July 2017
    Establish the connection, send POST and receive 200 OK response with
    JWT from server.
 
-POST /validation/acvp/register HTTP1.2
+POST /validation/acvp/register HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Capabilities information(see next section)
 
 ..authentication happens here..
 
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: (length of JWT)
@@ -613,9 +613,9 @@ each message.
 
 
 
-Fussell                  Expires January 7, 2018               [Page 11]
+Fussell                Expires September 17, 2018              [Page 11]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    o  production - If this is a production environment indicate so with
@@ -633,12 +633,12 @@ Internet-Draft              Abbreviated Title                  July 2017
    certificate is requested, the operationalEnvironment section may be
    omitted.
 
-POST /validation/acvp/register HTTP1.2
+POST /validation/acvp/register HTTP1.0
 User Agent:
 Host: www.acvts.nist.gov/acvp
 Accept:
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "operation" : "register",
    "certificateRequest" : "yes",
    "debugRequest" : "no",
@@ -669,9 +669,9 @@ Accept:
 
 
 
-Fussell                  Expires January 7, 2018               [Page 12]
+Fussell                Expires September 17, 2018              [Page 12]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
             "family" : "ARK",
@@ -704,7 +704,7 @@ Internet-Draft              Abbreviated Title                  July 2017
   "ivLen" : [
              96
                ],
-  "ptLen" : [
+  "dataLength" : [
              0,
              128,
              136
@@ -725,9 +725,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 13]
+Fussell                Expires September 17, 2018              [Page 13]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    Successful response from server is 200 OK and a set of vector set
@@ -737,7 +737,7 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 200 OK Response:
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "capabilityResponse" : { "vectorSets" : [
                        {"vsId":1437},
                        {"vsId":1438}] } ,
@@ -757,7 +757,7 @@ Internet-Draft              Abbreviated Title                  July 2017
    processed vector set, i.e. containing a result for every test case in
    the vector set.
 
-   GET /validation/acvp/vectors?vsId=1437  HTTP1.2
+   GET /validation/acvp/vectors?vsId=1437  HTTP1.0
    Host: www.acvts.nist.gov/acvp
    Authorization: Bearer JWT
 
@@ -781,9 +781,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 14]
+Fussell                Expires September 17, 2018              [Page 14]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    200 OK Response:
@@ -791,7 +791,7 @@ Internet-Draft              Abbreviated Title                  July 2017
    Content-Type: application/json
    Content-Length: <length of results>
    [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1437,
       "algorithm": "AES-GCM",
       "testGroups": [
@@ -837,17 +837,17 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 15]
+Fussell                Expires September 17, 2018              [Page 15]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
-   HTTP 1.2 200 OK
+   HTTP 1.0 200 OK
    Status: 200 OK
    Content-Type: application/json
    Content-Length: <length of results>
    [
-     { "acvVersion": "0.3" },
+     { "acvVersion": "0.4" },
      { "vsId": 1437,
        "retry" : 10
      }
@@ -867,12 +867,12 @@ Internet-Draft              Abbreviated Title                  July 2017
    will vary depending on the specific sub-specification of the
    algorithm and testType being tested.
 
-   POST /validation/acvp/vectors?vsId=1437 HTTP1.2
+   POST /validation/acvp/vectors?vsId=1437 HTTP1.0
    Host: www.acvts.nist.gov/acvp
    Authorization: Bearer JWT
    Accept:
    [
-    { "acvVersion": "0.3" },
+    { "acvVersion": "0.4" },
     { "vsId": 1437,
       "testResults": [
       {
@@ -893,9 +893,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 16]
+Fussell                Expires September 17, 2018              [Page 16]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
 11.5.  Validation Results Request
@@ -903,7 +903,7 @@ Internet-Draft              Abbreviated Title                  July 2017
    The client will send this request to learn the validation results for
    an individual vector set.
 
-GET /validation/acvp/results?vsId=1437 HTTP1.2
+GET /validation/acvp/results?vsId=1437 HTTP1.0
 User Agent:
 Host: www.acvts.nist.gov/acvp
 Accept: /
@@ -911,12 +911,12 @@ Accept: /
 
 Response to GET is:
 
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: <length of results>
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "results" : {
       "vsId" : 1437,
       "disposition" : "incomplete",
@@ -949,9 +949,9 @@ Content-Length: <length of results>
 
 
 
-Fussell                  Expires January 7, 2018               [Page 17]
+Fussell                Expires September 17, 2018              [Page 17]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    o  "expired" indicates not all the test case responses were received
@@ -983,7 +983,7 @@ Internet-Draft              Abbreviated Title                  July 2017
    traceability or debugging purposes it desires.  This may be important
    for those cases where there are test failures.
 
-   POST /validation/acvp/cancel HTTP1.2
+   POST /validation/acvp/cancel HTTP1.0
    Host: www.acvts.nist.gov/acvp
    Authorization: Bearer JWT
 
@@ -1005,17 +1005,17 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 18]
+Fussell                Expires September 17, 2018              [Page 18]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
-   HTTP 1.2 200 OK
+   HTTP 1.0 200 OK
    Status: 200 OK
    Content-Type: application/json
    Content-Length: <length of results>
    [
-     { "acvVersion": "0.3" },
+     { "acvVersion": "0.4" },
      { "vsId" : <vs-id>,
        "status" : "expired"
      }
@@ -1061,13 +1061,13 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 19]
+Fussell                Expires September 17, 2018              [Page 19]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
                  [
-                   { "acvVersion": "0.3" },
+                   { "acvVersion": "0.4" },
                    { "vsId": 1437,
                      "expiry": "2018-12-31 23:59:59",
                      "algorithm": "AES-GCM",
@@ -1117,9 +1117,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 20]
+Fussell                Expires September 17, 2018              [Page 20]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    information.  A non-exhaustive list of JSON encoded error messages
@@ -1173,9 +1173,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 21]
+Fussell                Expires September 17, 2018              [Page 21]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    o  valueLen: 0, value: "", MUST be interpreted as an empty bit
@@ -1229,9 +1229,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 22]
+Fussell                Expires September 17, 2018              [Page 22]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
 14.3.  Domain
@@ -1285,9 +1285,9 @@ Internet-Draft              Abbreviated Title                  July 2017
 
 
 
-Fussell                  Expires January 7, 2018               [Page 23]
+Fussell                Expires September 17, 2018              [Page 23]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
 14.3.2.  Additional Domain Information
@@ -1317,8 +1317,8 @@ Internet-Draft              Abbreviated Title                  July 2017
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997,
-              <http://www.rfc-editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
+              editor.org/info/rfc2119>.
 
 Appendix A.  JSON Formatting Guidelines
 
@@ -1332,7 +1332,7 @@ Appendix A.  JSON Formatting Guidelines
    Keywords should be chosen such that they are informative and brief,
    for example:
 
-   [ { "acvVersion": "0.3" }, { "results" : { "disposition" :
+   [ { "acvVersion": "0.4" }, { "results" : { "disposition" :
    "incomplete", } } ]
 
    Metadata assigned to the keyword may use any format which best
@@ -1341,9 +1341,9 @@ Appendix A.  JSON Formatting Guidelines
 
 
 
-Fussell                  Expires January 7, 2018               [Page 24]
+Fussell                Expires September 17, 2018              [Page 24]
 
-Internet-Draft              Abbreviated Title                  July 2017
+Internet-Draft              Abbreviated Title                 March 2018
 
 
    underscores alternating case, numbers, etc.  However, brevity should
@@ -1397,4 +1397,4 @@ Author's Address
 
 
 
-Fussell                  Expires January 7, 2018               [Page 25]
+Fussell                Expires September 17, 2018              [Page 25]

--- a/artifacts/acvp_sub_symmetric.html
+++ b/artifacts/acvp_sub_symmetric.html
@@ -373,41 +373,41 @@
   /*]]>*/
   </style>
 
-  <link href="#rfc.toc" rel="Contents">
-<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
-<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
-<link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration">
-<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for Symmetric Validations">
-<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Symmetric Algorithm Capabilities JSON Values">
-<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Data, IV and AAD Lengths">
-<link href="#rfc.section.2.4" rel="Chapter" title="2.4 Supported Symmetric Algorithms">
-<link href="#rfc.section.3" rel="Chapter" title="3 Test Vectors">
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Test Groups JSON Schema">
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Test Case JSON Schema">
-<link href="#rfc.section.4" rel="Chapter" title="4 Test Vector Responses">
-<link href="#rfc.section.5" rel="Chapter" title="5 Acknowledgements">
-<link href="#rfc.section.6" rel="Chapter" title="6 IANA Considerations">
-<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="8 References">
-<link href="#rfc.references.1" rel="Chapter" title="8.1 Normative References">
-<link href="#rfc.references.2" rel="Chapter" title="8.2 Informative References">
-<link href="#rfc.appendix.A" rel="Chapter" title="A Example Capabilities JSON Object">
-<link href="#rfc.appendix.B" rel="Chapter" title="B Example AES Test and Results Vectors JSON Object">
-<link href="#rfc.appendix.C" rel="Chapter" title="C Example AES MCT Test and Results JSON Object">
-<link href="#rfc.appendix.D" rel="Chapter" title="D Example TDES Test and Results JSON Object">
-<link href="#rfc.appendix.E" rel="Chapter" title="E Example TDES MCT Test and Results JSON Object">
-<link href="#rfc.appendix.F" rel="Chapter" title="F Example Test Results JSON Object">
-<link href="#rfc.appendix.G" rel="Chapter" title="G Example Test Prompt CTR JSON Object">
-<link href="#rfc.appendix.H" rel="Chapter" title="H Example Test Results CTR JSON Object">
-<link href="#rfc.authors" rel="Chapter">
+  <link href="#rfc.toc" rel="Contents"/>
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction"/>
+<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language"/>
+<link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration"/>
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for Symmetric Validations"/>
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 Symmetric Algorithm Capabilities JSON Values"/>
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Data, IV and AAD Lengths"/>
+<link href="#rfc.section.2.4" rel="Chapter" title="2.4 Supported Symmetric Algorithms"/>
+<link href="#rfc.section.3" rel="Chapter" title="3 Test Vectors"/>
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Test Groups JSON Schema"/>
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Test Case JSON Schema"/>
+<link href="#rfc.section.4" rel="Chapter" title="4 Test Vector Responses"/>
+<link href="#rfc.section.5" rel="Chapter" title="5 Acknowledgements"/>
+<link href="#rfc.section.6" rel="Chapter" title="6 IANA Considerations"/>
+<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations"/>
+<link href="#rfc.references" rel="Chapter" title="8 References"/>
+<link href="#rfc.references.1" rel="Chapter" title="8.1 Normative References"/>
+<link href="#rfc.references.2" rel="Chapter" title="8.2 Informative References"/>
+<link href="#rfc.appendix.A" rel="Chapter" title="A Example Capabilities JSON Object"/>
+<link href="#rfc.appendix.B" rel="Chapter" title="B Example AES Test and Results Vectors JSON Object"/>
+<link href="#rfc.appendix.C" rel="Chapter" title="C Example AES MCT Test and Results JSON Object"/>
+<link href="#rfc.appendix.D" rel="Chapter" title="D Example TDES Test and Results JSON Object"/>
+<link href="#rfc.appendix.E" rel="Chapter" title="E Example TDES MCT Test and Results JSON Object"/>
+<link href="#rfc.appendix.F" rel="Chapter" title="F Example Test Results JSON Object"/>
+<link href="#rfc.appendix.G" rel="Chapter" title="G Example Test Prompt CTR JSON Object"/>
+<link href="#rfc.appendix.H" rel="Chapter" title="H Example Test Results CTR JSON Object"/>
+<link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Foley, J., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsym-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-2-28" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-2" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using symmetric algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using symmetric algorithms with the ACVP specification." />
 
@@ -419,20 +419,20 @@
     <tbody>
     
     	<tr>
-<td class="left">TBD</td>
-<td class="right">J. Foley, Ed.</td>
+  <td class="left">TBD</td>
+  <td class="right">J. Foley, Ed.</td>
 </tr>
 <tr>
-<td class="left">Internet-Draft</td>
-<td class="right">Cisco Systems, Inc.</td>
+  <td class="left">Internet-Draft</td>
+  <td class="right">Cisco Systems, Inc.</td>
 </tr>
 <tr>
-<td class="left">Intended status: Informational</td>
-<td class="right">February 28, 2018</td>
+  <td class="left">Intended status: Informational</td>
+  <td class="right">February 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: September 1, 2018</td>
-<td class="right"></td>
+  <td class="left">Expires: August 5, 2018</td>
+  <td class="right"></td>
 </tr>
 
     	
@@ -442,14 +442,20 @@
   <p class="title">ACVP Symmetric Algorithm JSON Specification<br />
   <span class="filename">draft-ietf-acvp-subsym-0.4</span></p>
   
-  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+  <h1 id="rfc.abstract">
+  <a href="#rfc.abstract">Abstract</a>
+</h1>
 <p>This document defines the JSON schema for using symmetric algorithms with the ACVP specification.</p>
-<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<h1 id="rfc.status">
+  <a href="#rfc.status">Status of This Memo</a>
+</h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 1, 2018.</p>
-<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>This Internet-Draft will expire on August 5, 2018.</p>
+<h1 id="rfc.copyrightnotice">
+  <a href="#rfc.copyrightnotice">Copyright Notice</a>
+</h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
@@ -458,971 +464,1385 @@
   <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
   <ul class="toc">
 
-  	<li>1.   <a href="#rfc.section.1">Introduction</a>
-</li>
-<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a>
-</li>
-</ul><li>2.   <a href="#rfc.section.2">Capabilities Registration</a>
-</li>
-<ul><li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for Symmetric Validations</a>
-</li>
-<li>2.2.   <a href="#rfc.section.2.2">Symmetric Algorithm Capabilities JSON Values</a>
-</li>
-<li>2.3.   <a href="#rfc.section.2.3">Data, IV and AAD Lengths</a>
-</li>
-<li>2.4.   <a href="#rfc.section.2.4">Supported Symmetric Algorithms</a>
-</li>
-</ul><li>3.   <a href="#rfc.section.3">Test Vectors</a>
-</li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a>
-</li>
-<li>3.2.   <a href="#rfc.section.3.2">Test Case JSON Schema</a>
-</li>
-</ul><li>4.   <a href="#rfc.section.4">Test Vector Responses</a>
-</li>
-<li>5.   <a href="#rfc.section.5">Acknowledgements</a>
-</li>
-<li>6.   <a href="#rfc.section.6">IANA Considerations</a>
-</li>
-<li>7.   <a href="#rfc.section.7">Security Considerations</a>
-</li>
-<li>8.   <a href="#rfc.references">References</a>
-</li>
-<ul><li>8.1.   <a href="#rfc.references.1">Normative References</a>
-</li>
-<li>8.2.   <a href="#rfc.references.2">Informative References</a>
-</li>
-</ul><li>Appendix A.   <a href="#rfc.appendix.A">Example Capabilities JSON Object</a>
-</li>
-<li>Appendix B.   <a href="#rfc.appendix.B">Example AES Test and Results Vectors JSON Object</a>
-</li>
-<li>Appendix C.   <a href="#rfc.appendix.C">Example AES MCT Test and Results JSON Object</a>
-</li>
-<li>Appendix D.   <a href="#rfc.appendix.D">Example TDES Test and Results JSON Object</a>
-</li>
-<li>Appendix E.   <a href="#rfc.appendix.E">Example TDES MCT Test and Results JSON Object</a>
-</li>
-<li>Appendix F.   <a href="#rfc.appendix.F">Example Test Results JSON Object</a>
-</li>
-<li>Appendix G.   <a href="#rfc.appendix.G">Example Test Prompt CTR JSON Object</a>
-</li>
-<li>Appendix H.   <a href="#rfc.appendix.H">Example Test Results CTR JSON Object</a>
-</li>
-<li><a href="#rfc.authors">Author's Address</a>
-</li>
+  	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
+<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a></li>
+</ul><li>2.   <a href="#rfc.section.2">Capabilities Registration</a></li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for Symmetric Validations</a></li>
+<li>2.2.   <a href="#rfc.section.2.2">Symmetric Algorithm Capabilities JSON Values</a></li>
+<li>2.3.   <a href="#rfc.section.2.3">Data, IV and AAD Lengths</a></li>
+<li>2.4.   <a href="#rfc.section.2.4">Supported Symmetric Algorithms</a></li>
+</ul><li>3.   <a href="#rfc.section.3">Test Vectors</a></li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a></li>
+<li>3.2.   <a href="#rfc.section.3.2">Test Case JSON Schema</a></li>
+</ul><li>4.   <a href="#rfc.section.4">Test Vector Responses</a></li>
+<li>5.   <a href="#rfc.section.5">Acknowledgements</a></li>
+<li>6.   <a href="#rfc.section.6">IANA Considerations</a></li>
+<li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
+<li>8.   <a href="#rfc.references">References</a></li>
+<ul><li>8.1.   <a href="#rfc.references.1">Normative References</a></li>
+<li>8.2.   <a href="#rfc.references.2">Informative References</a></li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Example Capabilities JSON Object</a></li>
+<li>Appendix B.   <a href="#rfc.appendix.B">Example AES Test and Results Vectors JSON Object</a></li>
+<li>Appendix C.   <a href="#rfc.appendix.C">Example AES MCT Test and Results JSON Object</a></li>
+<li>Appendix D.   <a href="#rfc.appendix.D">Example TDES Test and Results JSON Object</a></li>
+<li>Appendix E.   <a href="#rfc.appendix.E">Example TDES MCT Test and Results JSON Object</a></li>
+<li>Appendix F.   <a href="#rfc.appendix.F">Example Test Results JSON Object</a></li>
+<li>Appendix G.   <a href="#rfc.appendix.G">Example Test Prompt CTR JSON Object</a></li>
+<li>Appendix H.   <a href="#rfc.appendix.H">Example Test Results CTR JSON Object</a></li>
+<li><a href="#rfc.authors">Author's Address</a></li>
 
 
   </ul>
 
-  <h1 id="rfc.section.1">
-<a href="#rfc.section.1">1.</a> Introduction</h1>
+  <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> Introduction</h1>
 <p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module.  The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more.  The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms.  Each sub-specification addresses a specific class of crypto algorithms.  This sub-specification defines the JSON constructs for testing symmetric crypto algorithms using ACVP.</p>
-<h1 id="rfc.section.1.1">
-<a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
-<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>.</p>
-<h1 id="rfc.section.2">
-<a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
-</h1>
+<h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
+<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119">RFC 2119</a> <cite title="NONE">[RFC2119]</cite>.</p>
+<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a></h1>
 <p id="rfc.section.2.p.1">ACVP requires crypto modules to register their capabilities.  This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  This section describes the constructs for advertising support of symmetric algorithms to the ACVP server.</p>
 <p id="rfc.section.2.p.2">The symmetric algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message.  The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section.  The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.  Each symmetric algorithm capability advertised is a self-contained JSON object.</p>
-<h1 id="rfc.section.2.1">
-<a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for Symmetric Validations</a>
-</h1>
+<h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for Symmetric Validations</a></h1>
 <p id="rfc.section.2.1.p.1">Some symmetric algorithm implementations rely on other cryptographic primitives.  For example, CCM uses an underlying AES algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
-<div id="rfc.table.1"></div>
-<div id="rereqs_table"></div>
+<div id="rfc.table.1"/>
+<div id="rereqs_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Required Prerequisite Algorithms JSON Values</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-<th class="left">Valid Values</th>
-<th class="left">Optional</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">algorithm</td>
-<td class="left">a prerequisite algorithm</td>
-<td class="left">value</td>
-<td class="left">AES, DRBG, TDES</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">valValue</td>
-<td class="left">algorithm validation number</td>
-<td class="left">value</td>
-<td class="left">actual number or "same"</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">prereqAlgVal</td>
-<td class="left">prerequisite algorithm validation</td>
-<td class="left">object with algorithm and valValue properties</td>
-<td class="left">see above</td>
-<td class="left">Yes</td>
-</tr>
-</tbody>
+  <caption>Required Prerequisite Algorithms JSON Values</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Valid Values</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">algorithm</td>
+      <td class="left">a prerequisite algorithm</td>
+      <td class="left">value</td>
+      <td class="left">AES, DRBG, TDES</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">valValue</td>
+      <td class="left">algorithm validation number</td>
+      <td class="left">value</td>
+      <td class="left">actual number or "same"</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">prereqAlgVal</td>
+      <td class="left">prerequisite algorithm validation</td>
+      <td class="left">object with algorithm and valValue properties</td>
+      <td class="left">see above</td>
+      <td class="left">Yes</td>
+    </tr>
+  </tbody>
 </table>
-<h1 id="rfc.section.2.2">
-<a href="#rfc.section.2.2">2.2.</a> <a href="#cap_ex" id="cap_ex">Symmetric Algorithm Capabilities JSON Values</a>
-</h1>
+<h1 id="rfc.section.2.2"><a href="#rfc.section.2.2">2.2.</a> <a href="#cap_ex" id="cap_ex">Symmetric Algorithm Capabilities JSON Values</a></h1>
 <p id="rfc.section.2.2.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
-<div id="rfc.table.2"></div>
-<div id="caps_table"></div>
+<div id="rfc.table.2"/>
+<div id="caps_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Symmetric Algorithm Capabilities JSON Values</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-<th class="left">Valid Values</th>
-<th class="left">Optional</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">algorithm</td>
-<td class="left">The symmetric algorithm and mode to be validated.</td>
-<td class="left">value</td>
-<td class="left">See <a href="#supported_algs" class="xref">Section 2.4</a>
-</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">prereqVals</td>
-<td class="left">Prerequisite algorithm validations</td>
-<td class="left">array of prereqAlgVal objects</td>
-<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a>
-</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">direction</td>
-<td class="left">The IUT processing direction</td>
-<td class="left">array</td>
-<td class="left">encrypt, decrypt</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">keyLen</td>
-<td class="left">The supported key lengths in bits</td>
-<td class="left">array</td>
-<td class="left">128, 168, 192, 256</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ptLen</td>
-<td class="left">The supported plaintext lengths in bits.   This varies depending on the algorithm type, for additional details see <a href="#data_lengths" class="xref">Section 2.3</a>
-</td>
-<td class="left">domain</td>
-<td class="left">0-65536</td>
-<td class="left">Yes (See <a href="#data_lengths" class="xref">Section 2.3</a>)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivLen</td>
-<td class="left">The supported IV/Nonce lengths in bits, see <a href="#data_lengths" class="xref">Section 2.3</a>
-</td>
-<td class="left">domain</td>
-<td class="left">8-1024</td>
-<td class="left">Yes (See <a href="#data_lengths" class="xref">Section 2.3</a>)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivGen</td>
-<td class="left">IV generation method for AES-GCM/AES-XPN algorithms</td>
-<td class="left">value</td>
-<td class="left">internal, external</td>
-<td class="left">Yes (Required for AES-GCM/AES-XPN)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivGenMode</td>
-<td class="left">IV generation mode for AES-GCM/AES-XPN algorithms</td>
-<td class="left">value</td>
-<td class="left">8.2.1, 8.2.2</td>
-<td class="left">Yes (Required for AES-GCM/AES-XPN)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">saltGen</td>
-<td class="left">Salt generation method for AES-XPN mode only.</td>
-<td class="left">value</td>
-<td class="left">internal, external</td>
-<td class="left">Yes (Required for AES-XPN)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">aadLen</td>
-<td class="left">The supported AAD lengths in bits for AEAD algorithms, </td>
-<td class="left">domain</td>
-<td class="left">0-65536</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">tagLen</td>
-<td class="left">The supported Tag lengths in bits for AEAD algorithms, <a href="#data_lengths" class="xref">Section 2.3</a>
-</td>
-<td class="left">domain</td>
-<td class="left">4-128</td>
-<td class="left">Yes (See <a href="#data_lengths" class="xref">Section 2.3</a>)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">kwCipher</td>
-<td class="left">The cipher as defined in SP800-38F for key wrap mode</td>
-<td class="left">array</td>
-<td class="left">cipher, inverse</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">tweakFormat</td>
-<td class="left">The format of tweak value input for AES-XTS</td>
-<td class="left">array</td>
-<td class="left">128hex, duSequence</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">keyingOption</td>
-<td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save KATs) is a single key, now deprecated (K1, K1, K1).</td>
-<td class="left">array</td>
-<td class="left">1, 2</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">overflowCounter</td>
-<td class="left">Indicates if the implementation can handle a counter exceeding the maximum value</td>
-<td class="left">boolean</td>
-<td class="left">true, false</td>
-<td class="left">No for Counter (CTR) modes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">incrementalCounter</td>
-<td class="left">Indicates if the implementation increments the counter (versus decrementing the counter)</td>
-<td class="left">boolean</td>
-<td class="left">true, false</td>
-<td class="left">No for Counter (CTR) modes</td>
-</tr>
-</tbody>
+  <caption>Symmetric Algorithm Capabilities JSON Values</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Valid Values</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">algorithm</td>
+      <td class="left">The symmetric algorithm and mode to be validated.</td>
+      <td class="left">value</td>
+      <td class="left">See <a href="#supported_algs">Section 2.4</a></td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">prereqVals</td>
+      <td class="left">Prerequisite algorithm validations</td>
+      <td class="left">array of prereqAlgVal objects</td>
+      <td class="left">See <a href="#prereq_algs">Section 2.1</a></td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">direction</td>
+      <td class="left">The IUT processing direction</td>
+      <td class="left">array</td>
+      <td class="left">encrypt, decrypt</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">keyLen</td>
+      <td class="left">The supported key lengths in bits</td>
+      <td class="left">array</td>
+      <td class="left">128, 168, 192, 256</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">dataLen</td>
+      <td class="left">The supported plain and cipher text lengths in bits.   This varies depending on the algorithm type, for additional details see <a href="#data_lengths">Section 2.3</a></td>
+      <td class="left">domain</td>
+      <td class="left">0-65536</td>
+      <td class="left">Yes (See <a href="#data_lengths">Section 2.3</a>)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivLen</td>
+      <td class="left">The supported IV/Nonce lengths in bits, see <a href="#data_lengths">Section 2.3</a></td>
+      <td class="left">domain</td>
+      <td class="left">8-1024</td>
+      <td class="left">Yes (See <a href="#data_lengths">Section 2.3</a>)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivGen</td>
+      <td class="left">IV generation method for AES-GCM/AES-XPN algorithms</td>
+      <td class="left">value</td>
+      <td class="left">internal, external</td>
+      <td class="left">Yes (Required for AES-GCM/AES-XPN)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivGenMode</td>
+      <td class="left">IV generation mode for AES-GCM/AES-XPN algorithms</td>
+      <td class="left">value</td>
+      <td class="left">8.2.1, 8.2.2</td>
+      <td class="left">Yes (Required for AES-GCM/AES-XPN)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">saltGen</td>
+      <td class="left">Salt generation method for AES-XPN mode only.</td>
+      <td class="left">value</td>
+      <td class="left">internal, external</td>
+      <td class="left">Yes (Required for AES-XPN)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">aadLen</td>
+      <td class="left">The supported AAD lengths in bits for AEAD algorithms, </td>
+      <td class="left">domain</td>
+      <td class="left">0-65536</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">tagLen</td>
+      <td class="left">The supported Tag lengths in bits for AEAD algorithms, <a href="#data_lengths">Section 2.3</a></td>
+      <td class="left">domain</td>
+      <td class="left">4-128</td>
+      <td class="left">Yes (See <a href="#data_lengths">Section 2.3</a>)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">kwCipher</td>
+      <td class="left">The cipher as defined in SP800-38F for key wrap mode</td>
+      <td class="left">array</td>
+      <td class="left">cipher, inverse</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">tweakFormat</td>
+      <td class="left">The format of tweak value input for AES-XTS</td>
+      <td class="left">array</td>
+      <td class="left">128hex, duSequence</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">keyingOption</td>
+      <td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save KATs) is a single key, now deprecated (K1, K1, K1).</td>
+      <td class="left">array</td>
+      <td class="left">1, 2</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">overflowCounter</td>
+      <td class="left">Indicates if the implementation can handle a counter exceeding the maximum value</td>
+      <td class="left">boolean</td>
+      <td class="left">true, false</td>
+      <td class="left">No for Counter (CTR) modes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">incrementalCounter</td>
+      <td class="left">Indicates if the implementation increments the counter (versus decrementing the counter)</td>
+      <td class="left">boolean</td>
+      <td class="left">true, false</td>
+      <td class="left">No for Counter (CTR) modes</td>
+    </tr>
+  </tbody>
 </table>
 <p id="rfc.section.2.2.p.2">Note: Some optional values are required depending on the algorithm.  For example, AES-GCM requires ivLen, ivGen, ivGenMode, aadLen and tagLen.  Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</p>
-<h1 id="rfc.section.2.3">
-<a href="#rfc.section.2.3">2.3.</a> <a href="#data_lengths" id="data_lengths">Data, IV and AAD Lengths</a>
-</h1>
+<h1 id="rfc.section.2.3"><a href="#rfc.section.2.3">2.3.</a> <a href="#data_lengths" id="data_lengths">Data, IV and AAD Lengths</a></h1>
 <p id="rfc.section.2.3.p.1">Some algorithms allow ranges of data, IV and AAD lengths.  This table outlines the allowed values.</p>
-<div id="rfc.table.3"></div>
-<div id="data_table"></div>
+<div id="rfc.table.3"/>
+<div id="data_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Symmetric Algorithm Capabilities JSON Values</caption>
-<thead><tr>
-<th class="left">Algorithm</th>
-<th class="left">ptLen(payload)</th>
-<th class="left">IV/Nonce</th>
-<th class="left">Tag</th>
-<th class="left">AAD</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">AES-CCM</td>
-<td class="left">Range of values {Min: 0, Max: 256, Increment: 8} minimum greater than or equal to zero and maximum less than or equal to 256.</td>
-<td class="left">Range of values {Min: 56, Max: 104, Increment: 8}  (represents 7 to 13 bytes)</td>
-<td class="left">Range of values {Min: 32, Max: 128, Increment: 16} (represents from 4 to 16 bytes, even values only)</td>
-<td class="left">Range of values minimum greater than or equal to zero and maximum less than or equal to 524,288 (2^16)*8)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">AES-GCM</td>
-<td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</td>
-<td class="left">Array one to three values between 8 and 1024</td>
-<td class="left">Array of supported values of: 32, 64, 96, 104, 112, 120, 128</td>
-<td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">AES-XTS</td>
-<td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128. Followed by the maximum data length not to exceed 2^20</td>
-<td class="left">N/A</td>
-<td class="left">N/A</td>
-<td class="left">N/A</td>
-</tr>
-</tbody>
+  <caption>Symmetric Algorithm Capabilities JSON Values</caption>
+  <thead>
+    <tr>
+      <th class="left">Algorithm</th>
+      <th class="left">dataLen(payload)</th>
+      <th class="left">IV/Nonce</th>
+      <th class="left">Tag</th>
+      <th class="left">AAD</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">AES-CCM</td>
+      <td class="left">Range of values {Min: 0, Max: 256, Increment: 8} minimum greater than or equal to zero and maximum less than or equal to 256.</td>
+      <td class="left">Range of values {Min: 56, Max: 104, Increment: 8}  (represents 7 to 13 bytes)</td>
+      <td class="left">Range of values {Min: 32, Max: 128, Increment: 16} (represents from 4 to 16 bytes, even values only)</td>
+      <td class="left">Range of values minimum greater than or equal to zero and maximum less than or equal to 524,288 (2^16)*8)</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">AES-GCM</td>
+      <td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</td>
+      <td class="left">Array one to three values between 8 and 1024</td>
+      <td class="left">Array of supported values of: 32, 64, 96, 104, 112, 120, 128</td>
+      <td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">AES-XTS</td>
+      <td class="left">Array to include, if supported,  zero, two values divisible by 128 and two values not divisible by 128. Followed by the maximum data length not to exceed 2^20</td>
+      <td class="left">N/A</td>
+      <td class="left">N/A</td>
+      <td class="left">N/A</td>
+    </tr>
+  </tbody>
 </table>
-<h1 id="rfc.section.2.4">
-<a href="#rfc.section.2.4">2.4.</a> <a href="#supported_algs" id="supported_algs">Supported Symmetric Algorithms</a>
-</h1>
+<h1 id="rfc.section.2.4"><a href="#rfc.section.2.4">2.4.</a> <a href="#supported_algs" id="supported_algs">Supported Symmetric Algorithms</a></h1>
 <p id="rfc.section.2.4.p.1">The following symmetric algorithms may be advertised by the ACVP compliant crypto module:</p>
-<p></p>
+<p/>
 
 <ul>
-<li>AES-ECB</li>
-<li>AES-CBC</li>
-<li>AES-OFB</li>
-<li>AES-CFB1</li>
-<li>AES-CFB8</li>
-<li>AES-CFB128</li>
-<li>AES-CTR</li>
-<li>AES-GCM</li>
-<li>AES-XPN</li>
-<li>AES-CCM</li>
-<li>AES-XTS</li>
-<li>AES-KW</li>
-<li>AES-KWP</li>
-<li>TDES-ECB</li>
-<li>TDES-CBC</li>
-<li>TDES-CBC-I</li>
-<li>TDES-CFB1</li>
-<li>TDES-CFB8</li>
-<li>TDES-CFB64</li>
-<li>TDES-CFB-P1</li>
-<li>TDES-CFB-P8</li>
-<li>TDES-CFB-P64</li>
-<li>TDES-OFB</li>
-<li>TDES-OFB-I</li>
-<li>TDES-CTR</li>
-<li>TDES-KW</li>
+  <li>AES-ECB</li>
+  <li>AES-CBC</li>
+  <li>AES-OFB</li>
+  <li>AES-CFB1</li>
+  <li>AES-CFB8</li>
+  <li>AES-CFB128</li>
+  <li>AES-CTR</li>
+  <li>AES-GCM</li>
+  <li>AES-XPN</li>
+  <li>AES-CCM</li>
+  <li>AES-XTS</li>
+  <li>AES-KW</li>
+  <li>AES-KWP</li>
+  <li>TDES-ECB</li>
+  <li>TDES-CBC</li>
+  <li>TDES-CBCI</li>
+  <li>TDES-CFB1</li>
+  <li>TDES-CFB8</li>
+  <li>TDES-CFB64</li>
+  <li>TDES-CFBP1</li>
+  <li>TDES-CFBP8</li>
+  <li>TDES-CFBP64</li>
+  <li>TDES-OFB</li>
+  <li>TDES-OFBI</li>
+  <li>TDES-CTR</li>
+  <li>TDES-KW</li>
 </ul>
-<h1 id="rfc.section.3">
-<a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
-</h1>
+<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a></h1>
 <p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual crypto algorithm, such as AES-ECB, AES-CBC, AES-CTR, AES-GCM, DES-CBC, DES-CTR, etc.  This section describes the JSON schema for a test vector set used with symmetric crypto algorithms.</p>
 <p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
-<div id="rfc.table.4"></div>
-<div id="vs_top_table"></div>
+<div id="rfc.table.4"/>
+<div id="vs_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Vector Set JSON Object</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">acvVersion</td>
-<td class="left">Protocol version identifier</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">vsId</td>
-<td class="left">Unique numeric identifier for the vector set</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">algorithm</td>
-<td class="left">The symmetric algorithm and mode used for the test vectors.  See <a href="#supported_algs" class="xref">Section 2.4</a> for possible values.</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 3.1</a>
-</td>
-<td class="left">array</td>
-</tr>
-</tbody>
+  <caption>Vector Set JSON Object</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">acvVersion</td>
+      <td class="left">Protocol version identifier</td>
+      <td class="left">value</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">vsId</td>
+      <td class="left">Unique numeric identifier for the vector set</td>
+      <td class="left">value</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">algorithm</td>
+      <td class="left">The symmetric algorithm and mode used for the test vectors.  See <a href="#supported_algs">Section 2.4</a> for possible values.</td>
+      <td class="left">value</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">testGroups</td>
+      <td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs">Section 3.1</a></td>
+      <td class="left">array</td>
+    </tr>
+  </tbody>
 </table>
-<h1 id="rfc.section.3.1">
-<a href="#rfc.section.3.1">3.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
-</h1>
+<h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a></h1>
 <p id="rfc.section.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set.  For instance, all test vectors that use the same key size would be grouped together.  The Test Group JSON object contains meta data that applies to all test vectors within the group.  The following table describes the JSON elements of the Test Group JSON object.</p>
-<div id="rfc.table.5"></div>
-<div id="vs_tg_table"></div>
+<div id="rfc.table.5"/>
+<div id="vs_tg_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Test Group JSON Object</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-<th class="left">Optional</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">direction</td>
-<td class="left">The IUT processing direction: encrypt or decrypt</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivGen</td>
-<td class="left">IV generation method (Required for AES-GCM and AES-XPN)</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivGenMode</td>
-<td class="left">IV generation method (Required for AES-GCM and AES-XPN w/ internal ivGen)</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">saltGen</td>
-<td class="left">Salt generation method (Required AES-XPN)</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">keyLen</td>
-<td class="left">Length of key in bits to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivLen</td>
-<td class="left">Length of IV in bits to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ptLen</td>
-<td class="left">Length of plaintext in bits to</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">aadLen</td>
-<td class="left">Length of AAD in bits to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">tagLen</td>
-<td class="left">Length of AEAD tag in bits to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">testType</td>
-<td class="left">The test category type (AFT or MCT)</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 3.2</a>
-</td>
-<td class="left">array</td>
-<td class="left">No</td>
-</tr>
-</tbody>
+  <caption>Test Group JSON Object</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">direction</td>
+      <td class="left">The IUT processing direction: encrypt or decrypt</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivGen</td>
+      <td class="left">IV generation method (Required for AES-GCM and AES-XPN)</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivGenMode</td>
+      <td class="left">IV generation method (Required for AES-GCM and AES-XPN w/ internal ivGen)</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">saltGen</td>
+      <td class="left">Salt generation method (Required AES-XPN)</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">keyLen</td>
+      <td class="left">Length of key in bits to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivLen</td>
+      <td class="left">Length of IV in bits to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ptLen</td>
+      <td class="left">Length of plaintext in bits to</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">aadLen</td>
+      <td class="left">Length of AAD in bits to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">tagLen</td>
+      <td class="left">Length of AEAD tag in bits to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">testType</td>
+      <td class="left">The test category type (AFT, MCT or counter)</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">tests</td>
+      <td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs">Section 3.2</a></td>
+      <td class="left">array</td>
+      <td class="left">No</td>
+    </tr>
+  </tbody>
 </table>
-<h1 id="rfc.section.3.2">
-<a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
-</h1>
+<p id="rfc.section.3.1.p.2">The testType field definitions are:</p>
+<p/>
+
+<ul class="empty">
+  <li>AFT - Algorithm Functional Test</li>
+  <li>MCT - Monte Carlo Test</li>
+  <li>counter - Counter mode test</li>
+</ul>
+<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a></h1>
 <p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single vector to be processed by the ACVP client.  The following table describes the JSON elements for each test case.</p>
-<div id="rfc.table.6"></div>
-<div id="vs_tc_table"></div>
+<div id="rfc.table.6"/>
+<div id="vs_tc_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Test Case JSON Object</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-<th class="left">Optional</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">tcId</td>
-<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">key</td>
-<td class="left">Encryption key to use AES</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">key1, key2, key3</td>
-<td class="left">Encryption keys to use for TDES</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">iv</td>
-<td class="left">IV to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">salt</td>
-<td class="left">The salt to use in AES-XPN (required for AES-XPN only)</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">pt</td>
-<td class="left">Plaintext to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ptLen</td>
-<td class="left">Plaintext Length to use in bits. When unspecified, it will be infered from the plaintext.  When specified, only the most significant 'ptLen' bits will be used.</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ct</td>
-<td class="left">Ciphertext to use</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ctLen</td>
-<td class="left">Ciphertext Length to use in bits. When unspecified, it will be infered from the ciphertext.  When specified, only the most significant 'ctLen' bits will be used.</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">aad</td>
-<td class="left">AAD to use for AEAD algorithms</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">tag</td>
-<td class="left">Tag to use for AEAD algorithms</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">ivs</td>
-<td class="left">Array of IVs used in a Counter implementation</td>
-<td class="left">array</td>
-<td class="left">No for Counter (CTR) modes</td>
-</tr>
-</tbody>
+  <caption>Test Case JSON Object</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+      <th class="left">Optional</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">tcId</td>
+      <td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">key</td>
+      <td class="left">Encryption key to use AES</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">key1, key2, key3</td>
+      <td class="left">Encryption keys to use for TDES</td>
+      <td class="left">value</td>
+      <td class="left">No</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">iv</td>
+      <td class="left">IV to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">salt</td>
+      <td class="left">The salt to use in AES-XPN (required for AES-XPN only)</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">pt</td>
+      <td class="left">Plaintext to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ptLen</td>
+      <td class="left">Plaintext Length to use in bits. When unspecified, it will be infered from the plaintext.  When specified, only the most significant 'ptLen' bits will be used.</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ct</td>
+      <td class="left">Ciphertext to use</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ctLen</td>
+      <td class="left">Ciphertext Length to use in bits. When unspecified, it will be infered from the ciphertext.  When specified, only the most significant 'ctLen' bits will be used.</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">aad</td>
+      <td class="left">AAD to use for AEAD algorithms</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">tag</td>
+      <td class="left">Tag to use for AEAD algorithms</td>
+      <td class="left">value</td>
+      <td class="left">Yes</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">ivs</td>
+      <td class="left">Array of IVs used in a Counter implementation</td>
+      <td class="left">array</td>
+      <td class="left">No for Counter (CTR) modes</td>
+    </tr>
+  </tbody>
 </table>
-<h1 id="rfc.section.4">
-<a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
-</h1>
+<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a></h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.7"></div>
-<div id="vr_top_table"></div>
+<div id="rfc.table.7"/>
+<div id="vr_top_table"/>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Vector Set Response JSON Object</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">acvVersion</td>
-<td class="left">Protocol version identifier</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">vsId</td>
-<td class="left">Unique numeric identifier for the vector set</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">testResults</td>
-<td class="left">Array of JSON objects that represent each test vector result, which uses the same JSON schema as defined in <a href="#tvjs" class="xref">Section 3.2</a> </td>
-<td class="left">array</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">decryptFail</td>
-<td class="left">Some test cases included with decrypt operations in AES-GCM, AES-CCM, AES-XPN, AES-KW, AES-KWP, and TDES-KW will have expected failures. For these cases the JSON reponse should include the decryptFail keyword, see <a href="#app-test-results-ex" class="xref">Appendix F</a> </td>
-<td class="left">boolean true</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">resultsArray</td>
-<td class="left">Array of JSON objects that represent each iteration of a Monte Carlo Test.  Each iteration will contain the key(s), pt, ct and iv(except for ECB mode)</td>
-<td class="left">array</td>
-</tr>
-</tbody>
+  <caption>Vector Set Response JSON Object</caption>
+  <thead>
+    <tr>
+      <th class="left">JSON Value</th>
+      <th class="left">Description</th>
+      <th class="left">JSON type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="left">acvVersion</td>
+      <td class="left">Protocol version identifier</td>
+      <td class="left">value</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">vsId</td>
+      <td class="left">Unique numeric identifier for the vector set</td>
+      <td class="left">value</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">testResults</td>
+      <td class="left">Array of JSON objects that represent each test vector result, which uses the same JSON schema as defined in <a href="#tvjs">Section 3.2</a> </td>
+      <td class="left">array</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">decryptFail</td>
+      <td class="left">Some test cases included with decrypt operations in AES-GCM, AES-CCM, AES-XPN, AES-KW, AES-KWP, and TDES-KW will have expected failures. For these cases the JSON reponse should include the decryptFail keyword, see <a href="#app-vs-ex">Appendix B</a> </td>
+      <td class="left">boolean true</td>
+    </tr>
+    <tr>
+      <td class="left"/>
+      <td class="left"/>
+      <td class="left"/>
+    </tr>
+    <tr>
+      <td class="left">resultsArray</td>
+      <td class="left">Array of JSON objects that represent each iteration of a Monte Carlo Test.  Each iteration will contain the key(s), pt, ct and iv(except for ECB mode)</td>
+      <td class="left">array</td>
+    </tr>
+  </tbody>
 </table>
-<h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
-</h1>
+<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a></h1>
 <p id="rfc.section.5.p.1">TBD...</p>
-<h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
-</h1>
+<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#IANA" id="IANA">IANA Considerations</a></h1>
 <p id="rfc.section.6.p.1">This memo includes no request to IANA.</p>
-<h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#Security" id="Security">Security Considerations</a>
-</h1>
+<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#Security" id="Security">Security Considerations</a></h1>
 <p id="rfc.section.7.p.1">Security considerations are addressed by the ACVP specification.</p>
-<h1 id="rfc.references">
-<a href="#rfc.references">8.</a> References</h1>
-<h1 id="rfc.references.1">
-<a href="#rfc.references.1">8.1.</a> Normative References</h1>
-<table><tbody>
-<tr>
-<td class="reference"><b id="ACVP">[ACVP]</b></td>
-<td class="top">
-<a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
-<td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
-</tr>
-</tbody></table>
-<h1 id="rfc.references.2">
-<a href="#rfc.references.2">8.2.</a> Informative References</h1>
-<table><tbody>
-<tr>
-<td class="reference"><b id="AESAVS">[AESAVS]</b></td>
-<td class="top">
-<a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Advanced Encryption Standard Algorithm Validation Suite (AESAVS)</a>", 2002.</td>
-</tr>
-<tr>
-<td class="reference"><b id="CCMVS">[CCMVS]</b></td>
-<td class="top">
-<a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The CCM Validation System (CCMVS)</a>", 2012.</td>
-</tr>
-<tr>
-<td class="reference"><b id="GCMVS">[GCMVS]</b></td>
-<td class="top">
-<a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The GCM, GMAC and XPN Validation System (GCMVS)</a>", 2016.</td>
-</tr>
-<tr>
-<td class="reference"><b id="KWVS">[KWVS]</b></td>
-<td class="top">
-<a title="NIST">Timothy A. Hall, TAH.</a>, "<a>The Key Wrap Validation System (KWVS)</a>", 2014.</td>
-</tr>
-<tr>
-<td class="reference"><b id="TMOVS">[TMOVS]</b></td>
-<td class="top">
-<a title="NIST">Sharon S. Keller, SSK.</a>, "<a>Modes of Operation Validation System for the Triple Data Encryption Algorithm (TMOVS)</a>", 2012.</td>
-</tr>
-<tr>
-<td class="reference"><b id="XTSVS">[XTSVS]</b></td>
-<td class="top">
-<a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The XTS-AES Validation System (XTSVS)</a>", 2013.</td>
-</tr>
-</tbody></table>
-<h1 id="rfc.appendix.A">
-<a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example Capabilities JSON Object</a>
-</h1>
-<p id="rfc.section.A.p.1">The following is a example JSON object advertising support for AES-GCM.</p>
+<h1 id="rfc.references"><a href="#rfc.references">8.</a> References</h1>
+<h1 id="rfc.references.1"><a href="#rfc.references.1">8.1.</a> Normative References</h1>
+<table>
+  <tbody>
+    <tr>
+      <td class="reference">
+        <b id="ACVP">[ACVP]</b>
+      </td>
+      <td class="top"><a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC2119">[RFC2119]</b>
+      </td>
+      <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="rfc.references.2"><a href="#rfc.references.2">8.2.</a> Informative References</h1>
+<table>
+  <tbody>
+    <tr>
+      <td class="reference">
+        <b id="AESAVS">[AESAVS]</b>
+      </td>
+      <td class="top"><a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Advanced Encryption Standard Algorithm Validation Suite (AESAVS)</a>", 2002.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="CCMVS">[CCMVS]</b>
+      </td>
+      <td class="top"><a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The CCM Validation System (CCMVS)</a>", 2012.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="GCMVS">[GCMVS]</b>
+      </td>
+      <td class="top"><a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The GCM, GMAC and XPN Validation System (GCMVS)</a>", 2016.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="KWVS">[KWVS]</b>
+      </td>
+      <td class="top"><a title="NIST">Timothy A. Hall, TAH.</a>, "<a>The Key Wrap Validation System (KWVS)</a>", 2014.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="TMOVS">[TMOVS]</b>
+      </td>
+      <td class="top"><a title="NIST">Sharon S. Keller, SSK.</a>, "<a>Modes of Operation Validation System for the Triple Data Encryption Algorithm (TMOVS)</a>", 2012.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="XTSVS">[XTSVS]</b>
+      </td>
+      <td class="top"><a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The XTS-AES Validation System (XTSVS)</a>", 2013.</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example Capabilities JSON Object</a></h1>
+<p id="rfc.section.A.p.1">The following is a example JSON object advertising support for all the symmetric ciphers.</p>
 <pre>
 
-
-            {
-                "algorithm": "AES-GCM",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-		                {"algorithm" : "DRBG", "valValue" : "123456"}],
-                "direction": [
-                    "encrypt",
-                    "decrypt"
-                ],
-                "ivGen": "internal",
-                "ivGenMode": "8.2.2",
-                "keyLen": [
-                    128,
-                    192,
-                    256
-                ],
-                "tagLen": [
-                    96,
-                    128
-                ],
-                "ivLen": [
-                    96
-                ],
-                "ptLen": [
-                    0,
-                    256
-                ],
-                "aadLen": [
-                    128,
-                    256
-                ]
-            }
+POST [
+           {
+                    "algorithm": "AES-GCM",
+                    "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                            {"algorithm" : "DRBG", "valValue" : "123456"}],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "ivGen": "internal",
+                    "ivGenMode": "8.2.2",
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        96,
+                        128
+                    ],
+                    "ivLen": [
+                        96
+                    ],
+                    "dataLen": [
+                        0,
+                        256
+                    ],
+                    "aadLen": [
+                        128,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "AES-ECB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-CBC",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB128",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-OFB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-XPN",
+                    "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                            {"algorithm" : "DRBG", "valValue" : "123456"}],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "ivGen": "internal",
+                    "ivGenMode": "8.2.2",
+                    "saltGen": "internal",      
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        96,
+                       128
+                    ],
+                   "dataLen": [
+                        0,
+                        128
+                    ]
+                   "aadLen": [
+                        120,
+                        128
+                   ]
+                },
+                {
+                    "algorithm": "AES-CTR",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                 },
+                 {
+                    "algorithm": "AES-CCM",
+                    "prereqVals": [
+                        {
+                            "algorithm": "AES",
+                            "valValue": "same"
+                        }
+                    ],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        128
+                    ],
+                    "ivLen": [
+                        56
+                    ],
+                    "dataLen": [
+                        0,
+                        256
+                    ],
+                    "aadLen": [
+                        0,
+                        65536
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-KW",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        512,
+                        192,
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-KWP",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        8,
+                        32,
+                        96,
+                        808
+                    ]
+                },
+                {
+                    "algorithm": "AES-XTS",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        256
+                    ],
+                    "dataLen": [
+                        65536
+                    ],
+                    "tweakMode": [
+                        "hex"
+                    ]
+                },
+                {
+                    "algorithm": "TDES-ECB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        512
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CBC",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        128,
+                        192,
+                        768
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CBCI",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        128,
+                        192,
+                        768
+                    ]
+                },
+                {
+                    "algorithm": "TDES-OFB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-OFBI",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB64",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        320
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP64",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        320
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CTR",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-KW",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        512,
+                        192,
+                        128
+                    ]
+                }
+            ]
+        }
+    }
+] 
             </pre>
-<h1 id="rfc.appendix.B">
-<a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example AES Test and Results Vectors JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example AES Test and Results Vectors JSON Object</a></h1>
 <p id="rfc.section.B.p.1">The following is a example JSON object for AES-GCM test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
               [
@@ -1631,9 +2051,7 @@
 	      ]
 
             </pre>
-<h1 id="rfc.appendix.C">
-<a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-mct-results-ex" id="app-mct-results-ex">Example AES MCT Test and Results JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-mct-results-ex" id="app-mct-results-ex">Example AES MCT Test and Results JSON Object</a></h1>
 <p id="rfc.section.C.p.1">The following is a example JSON object for test vectors sent from the ACVP server to the crypto module for an AES-CBC Monte Carlo test.</p>
 <pre>
               [
@@ -1685,9 +2103,7 @@
 		  }
                 ]
             </pre>
-<h1 id="rfc.appendix.D">
-<a href="#rfc.appendix.D">Appendix D.</a> <a href="#app-tdes1-results-ex" id="app-tdes1-results-ex">Example TDES Test and Results JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.D"><a href="#rfc.appendix.D">Appendix D.</a> <a href="#app-tdes1-results-ex" id="app-tdes1-results-ex">Example TDES Test and Results JSON Object</a></h1>
 <p id="rfc.section.D.p.1">The following is a example JSON object for test vectors sent from the ACVP server to the crypto module for an TDES-ECB algorithm functional test.</p>
 <pre>
               [
@@ -1821,9 +2237,7 @@
 		  }
                 ]
             </pre>
-<h1 id="rfc.appendix.E">
-<a href="#rfc.appendix.E">Appendix E.</a> <a href="#app-tdes2-results-ex" id="app-tdes2-results-ex">Example TDES MCT Test and Results JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#app-tdes2-results-ex" id="app-tdes2-results-ex">Example TDES MCT Test and Results JSON Object</a></h1>
 <p id="rfc.section.E.p.1">The following is a example JSON object for test vectors sent from the ACVP server to the crypto module for an TDES-ECB Monte Carlo test.</p>
 <pre>
               [
@@ -1877,9 +2291,7 @@
 		  }
                 ]
             </pre>
-<h1 id="rfc.appendix.F">
-<a href="#rfc.appendix.F">Appendix F.</a> <a href="#app-test-results-ex" id="app-test-results-ex">Example Test Results JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.F"><a href="#rfc.appendix.F">Appendix F.</a> <a href="#app-test-results-ex" id="app-test-results-ex">Example Test Results JSON Object</a></h1>
 <p id="rfc.section.F.p.1">An example of the test results format from an AES-GCM decrypt operation including failure case.</p>
 <pre>
               [
@@ -1898,9 +2310,7 @@
 		    }
                 ]
             </pre>
-<h1 id="rfc.appendix.G">
-<a href="#rfc.appendix.G">Appendix G.</a> <a href="#app-test-prompt-ex-ctr" id="app-test-prompt-ex-ctr">Example Test Prompt CTR JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.G"><a href="#rfc.appendix.G">Appendix G.</a> <a href="#app-test-prompt-ex-ctr" id="app-test-prompt-ex-ctr">Example Test Prompt CTR JSON Object</a></h1>
 <p id="rfc.section.G.p.1">An example of the test format sent from the server to the client for an AES-CTR encrypt operation.</p>
 <pre>
               [
@@ -1924,9 +2334,7 @@
                       },
                 ]
             </pre>
-<h1 id="rfc.appendix.H">
-<a href="#rfc.appendix.H">Appendix H.</a> <a href="#app-test-results-ex-ctr" id="app-test-results-ex-ctr">Example Test Results CTR JSON Object</a>
-</h1>
+<h1 id="rfc.appendix.H"><a href="#rfc.appendix.H">Appendix H.</a> <a href="#app-test-results-ex-ctr" id="app-test-results-ex-ctr">Example Test Results CTR JSON Object</a></h1>
 <p id="rfc.section.H.p.1">An example of the test results format from an AES-CTR encrypt operation.</p>
 <pre>
               [
@@ -1953,7 +2361,9 @@
                         }
                 ]
             </pre>
-<h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
+<h1 id="rfc.authors">
+  <a href="#rfc.authors">Author's Address</a>
+</h1>
 <div class="avoidbreak">
   <address class="vcard">
 	<span class="vcardline">

--- a/artifacts/acvp_sub_symmetric.txt
+++ b/artifacts/acvp_sub_symmetric.txt
@@ -4,8 +4,8 @@
 
 TBD                                                        J. Foley, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                         February 28, 2018
-Expires: September 1, 2018
+Intended status: Informational                             February 2018
+Expires: August 5, 2018
 
 
               ACVP Symmetric Algorithm JSON Specification
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 1, 2018.
+   This Internet-Draft will expire on August 5, 2018.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Foley                   Expires September 1, 2018               [Page 1]
+Foley                    Expires August 5, 2018                 [Page 1]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -70,23 +70,23 @@ Table of Contents
      2.4.  Supported Symmetric Algorithms  . . . . . . . . . . . . .   9
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  10
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  10
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  11
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  13
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  14
-   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  14
-   Appendix B.  Example AES Test and Results Vectors JSON Object . .  15
-   Appendix C.  Example AES MCT Test and Results JSON Object . . . .  20
-   Appendix D.  Example TDES Test and Results JSON Object  . . . . .  21
-   Appendix E.  Example TDES MCT Test and Results JSON Object  . . .  25
-   Appendix F.  Example Test Results JSON Object . . . . . . . . . .  27
-   Appendix G.  Example Test Prompt CTR JSON Object  . . . . . . . .  28
-   Appendix H.  Example Test Results CTR JSON Object . . . . . . . .  28
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  29
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  12
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  14
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  15
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  15
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  15
+   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  15
+   Appendix B.  Example AES Test and Results Vectors JSON Object . .  25
+   Appendix C.  Example AES MCT Test and Results JSON Object . . . .  30
+   Appendix D.  Example TDES Test and Results JSON Object  . . . . .  31
+   Appendix E.  Example TDES MCT Test and Results JSON Object  . . .  35
+   Appendix F.  Example Test Results JSON Object . . . . . . . . . .  37
+   Appendix G.  Example Test Prompt CTR JSON Object  . . . . . . . .  38
+   Appendix H.  Example Test Results CTR JSON Object . . . . . . . .  38
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  39
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Foley                   Expires September 1, 2018               [Page 2]
+Foley                    Expires August 5, 2018                 [Page 2]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018               [Page 3]
+Foley                    Expires August 5, 2018                 [Page 3]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -196,172 +196,173 @@ Internet-Draft                Sym Alg JSON                 February 2018
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +---------------+-------------+-----------+----------+--------------+
-   | JSON Value    | Description | JSON type | Valid    | Optional     |
-   |               |             |           | Values   |              |
-   +---------------+-------------+-----------+----------+--------------+
-   | algorithm     | The         | value     | See      | No           |
-   |               | symmetric   |           | Section  |              |
-   |               | algorithm   |           | 2.4      |              |
-   |               | and mode to |           |          |              |
-   |               | be          |           |          |              |
-   |               | validated.  |           |          |              |
-   |               |             |           |          |              |
-   | prereqVals    | Prerequisit | array of  | See      | Yes          |
-   |               | e algorithm | prereqAlg | Section  |              |
-   |               | validations | Val       | 2.1      |              |
-   |               |             | objects   |          |              |
-   |               |             |           |          |              |
-   | direction     | The IUT     | array     | encrypt, | No           |
-   |               | processing  |           | decrypt  |              |
-   |               | direction   |           |          |              |
-   |               |             |           |          |              |
-   | keyLen        | The         | array     | 128,     | No           |
-   |               | supported   |           | 168,     |              |
+   +---------------+-------------+----------+-----------+--------------+
+   | JSON Value    | Description | JSON     | Valid     | Optional     |
+   |               |             | type     | Values    |              |
+   +---------------+-------------+----------+-----------+--------------+
+   | algorithm     | The         | value    | See       | No           |
+   |               | symmetric   |          | Section   |              |
+   |               | algorithm   |          | 2.4       |              |
+   |               | and mode to |          |           |              |
+   |               | be          |          |           |              |
+   |               | validated.  |          |           |              |
+   |               |             |          |           |              |
+   | prereqVals    | Prerequisit | array of | See       | Yes          |
+   |               | e algorithm | prereqAl | Section   |              |
+   |               | validations | gVal     | 2.1       |              |
+   |               |             | objects  |           |              |
+   |               |             |          |           |              |
+   | direction     | The IUT     | array    | encrypt,  | No           |
+   |               | processing  |          | decrypt   |              |
+   |               | direction   |          |           |              |
+   |               |             |          |           |              |
+   | keyLen        | The         | array    | 128, 168, | No           |
+   |               | supported   |          | 192, 256  |              |
 
 
 
-Foley                   Expires September 1, 2018               [Page 4]
+Foley                    Expires August 5, 2018                 [Page 4]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
 
-   |               | key lengths |           | 192, 256 |              |
-   |               | in bits     |           |          |              |
-   |               |             |           |          |              |
-   | ptLen         | The         | domain    | 0-65536  | Yes (See     |
-   |               | supported   |           |          | Section 2.3) |
-   |               | plaintext   |           |          |              |
-   |               | lengths in  |           |          |              |
-   |               | bits.       |           |          |              |
-   |               | This varies |           |          |              |
-   |               | depending   |           |          |              |
-   |               | on the      |           |          |              |
-   |               | algorithm   |           |          |              |
-   |               | type, for   |           |          |              |
-   |               | additional  |           |          |              |
-   |               | details see |           |          |              |
-   |               | Section 2.3 |           |          |              |
-   |               |             |           |          |              |
-   | ivLen         | The         | domain    | 8-1024   | Yes (See     |
-   |               | supported   |           |          | Section 2.3) |
-   |               | IV/Nonce    |           |          |              |
-   |               | lengths in  |           |          |              |
-   |               | bits, see   |           |          |              |
-   |               | Section 2.3 |           |          |              |
-   |               |             |           |          |              |
-   | ivGen         | IV          | value     | internal | Yes          |
-   |               | generation  |           | ,        | (Required    |
-   |               | method for  |           | external | for AES-     |
-   |               | AES-        |           |          | GCM/AES-XPN) |
-   |               | GCM/AES-XPN |           |          |              |
-   |               | algorithms  |           |          |              |
-   |               |             |           |          |              |
-   | ivGenMode     | IV          | value     | 8.2.1,   | Yes          |
-   |               | generation  |           | 8.2.2    | (Required    |
-   |               | mode for    |           |          | for AES-     |
-   |               | AES-        |           |          | GCM/AES-XPN) |
-   |               | GCM/AES-XPN |           |          |              |
-   |               | algorithms  |           |          |              |
-   |               |             |           |          |              |
-   | saltGen       | Salt        | value     | internal | Yes          |
-   |               | generation  |           | ,        | (Required    |
-   |               | method for  |           | external | for AES-XPN) |
-   |               | AES-XPN     |           |          |              |
-   |               | mode only.  |           |          |              |
-   |               |             |           |          |              |
-   | aadLen        | The         | domain    | 0-65536  | Yes          |
-   |               | supported   |           |          |              |
-   |               | AAD lengths |           |          |              |
-   |               | in bits for |           |          |              |
+   |               | key lengths |          |           |              |
+   |               | in bits     |          |           |              |
+   |               |             |          |           |              |
+   | dataLen       | The         | domain   | 0-65536   | Yes (See     |
+   |               | supported   |          |           | Section 2.3) |
+   |               | plain and   |          |           |              |
+   |               | cipher text |          |           |              |
+   |               | lengths in  |          |           |              |
+   |               | bits.       |          |           |              |
+   |               | This varies |          |           |              |
+   |               | depending   |          |           |              |
+   |               | on the      |          |           |              |
+   |               | algorithm   |          |           |              |
+   |               | type, for   |          |           |              |
+   |               | additional  |          |           |              |
+   |               | details see |          |           |              |
+   |               | Section 2.3 |          |           |              |
+   |               |             |          |           |              |
+   | ivLen         | The         | domain   | 8-1024    | Yes (See     |
+   |               | supported   |          |           | Section 2.3) |
+   |               | IV/Nonce    |          |           |              |
+   |               | lengths in  |          |           |              |
+   |               | bits, see   |          |           |              |
+   |               | Section 2.3 |          |           |              |
+   |               |             |          |           |              |
+   | ivGen         | IV          | value    | internal, | Yes          |
+   |               | generation  |          | external  | (Required    |
+   |               | method for  |          |           | for AES-GCM  |
+   |               | AES-GCM     |          |           | /AES-XPN)    |
+   |               | /AES-XPN    |          |           |              |
+   |               | algorithms  |          |           |              |
+   |               |             |          |           |              |
+   | ivGenMode     | IV          | value    | 8.2.1,    | Yes          |
+   |               | generation  |          | 8.2.2     | (Required    |
+   |               | mode for    |          |           | for AES-GCM  |
+   |               | AES-GCM     |          |           | /AES-XPN)    |
+   |               | /AES-XPN    |          |           |              |
+   |               | algorithms  |          |           |              |
+   |               |             |          |           |              |
+   | saltGen       | Salt        | value    | internal, | Yes          |
+   |               | generation  |          | external  | (Required    |
+   |               | method for  |          |           | for AES-XPN) |
+   |               | AES-XPN     |          |           |              |
+   |               | mode only.  |          |           |              |
+   |               |             |          |           |              |
+   | aadLen        | The         | domain   | 0-65536   | Yes          |
+   |               | supported   |          |           |              |
+   |               | AAD lengths |          |           |              |
 
 
 
-Foley                   Expires September 1, 2018               [Page 5]
+Foley                    Expires August 5, 2018                 [Page 5]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
 
-   |               | AEAD        |           |          |              |
-   |               | algorithms, |           |          |              |
-   |               |             |           |          |              |
-   | tagLen        | The         | domain    | 4-128    | Yes (See     |
-   |               | supported   |           |          | Section 2.3) |
-   |               | Tag lengths |           |          |              |
-   |               | in bits for |           |          |              |
-   |               | AEAD        |           |          |              |
-   |               | algorithms, |           |          |              |
-   |               | Section 2.3 |           |          |              |
-   |               |             |           |          |              |
-   | kwCipher      | The cipher  | array     | cipher,  | Yes          |
-   |               | as defined  |           | inverse  |              |
-   |               | in          |           |          |              |
-   |               | SP800-38F   |           |          |              |
-   |               | for key     |           |          |              |
-   |               | wrap mode   |           |          |              |
-   |               |             |           |          |              |
-   | tweakFormat   | The format  | array     | 128hex,  | Yes          |
-   |               | of tweak    |           | duSequen |              |
-   |               | value input |           | ce       |              |
-   |               | for AES-XTS |           |          |              |
-   |               |             |           |          |              |
-   | keyingOption  | The Keying  | array     | 1, 2     | Yes          |
-   |               | Option used |           |          |              |
-   |               | in TDES.    |           |          |              |
-   |               | Keying      |           |          |              |
-   |               | option 1    |           |          |              |
-   |               | (1) is 3    |           |          |              |
-   |               | distinct    |           |          |              |
-   |               | keys (K1,   |           |          |              |
-   |               | K2, K3).    |           |          |              |
-   |               | Keying      |           |          |              |
-   |               | Option 2    |           |          |              |
-   |               | (2) is 2    |           |          |              |
-   |               | distinct    |           |          |              |
-   |               | only        |           |          |              |
-   |               | suitable    |           |          |              |
-   |               | for decrypt |           |          |              |
-   |               | (K1, K2,    |           |          |              |
-   |               | K1).        |           |          |              |
-   |               | Keying      |           |          |              |
-   |               | option 3    |           |          |              |
-   |               | (No longer  |           |          |              |
-   |               | valid for   |           |          |              |
-   |               | testing,    |           |          |              |
-   |               | save KATs)  |           |          |              |
-   |               | is a single |           |          |              |
+   |               | in bits for |          |           |              |
+   |               | AEAD        |          |           |              |
+   |               | algorithms, |          |           |              |
+   |               |             |          |           |              |
+   | tagLen        | The         | domain   | 4-128     | Yes (See     |
+   |               | supported   |          |           | Section 2.3) |
+   |               | Tag lengths |          |           |              |
+   |               | in bits for |          |           |              |
+   |               | AEAD        |          |           |              |
+   |               | algorithms, |          |           |              |
+   |               | Section 2.3 |          |           |              |
+   |               |             |          |           |              |
+   | kwCipher      | The cipher  | array    | cipher,   | Yes          |
+   |               | as defined  |          | inverse   |              |
+   |               | in          |          |           |              |
+   |               | SP800-38F   |          |           |              |
+   |               | for key     |          |           |              |
+   |               | wrap mode   |          |           |              |
+   |               |             |          |           |              |
+   | tweakFormat   | The format  | array    | 128hex, d | Yes          |
+   |               | of tweak    |          | uSequence |              |
+   |               | value input |          |           |              |
+   |               | for AES-XTS |          |           |              |
+   |               |             |          |           |              |
+   | keyingOption  | The Keying  | array    | 1, 2      | Yes          |
+   |               | Option used |          |           |              |
+   |               | in TDES.    |          |           |              |
+   |               | Keying      |          |           |              |
+   |               | option 1    |          |           |              |
+   |               | (1) is 3    |          |           |              |
+   |               | distinct    |          |           |              |
+   |               | keys (K1,   |          |           |              |
+   |               | K2, K3).    |          |           |              |
+   |               | Keying      |          |           |              |
+   |               | Option 2    |          |           |              |
+   |               | (2) is 2    |          |           |              |
+   |               | distinct    |          |           |              |
+   |               | only        |          |           |              |
+   |               | suitable    |          |           |              |
+   |               | for decrypt |          |           |              |
+   |               | (K1, K2,    |          |           |              |
+   |               | K1).        |          |           |              |
+   |               | Keying      |          |           |              |
+   |               | option 3    |          |           |              |
+   |               | (No longer  |          |           |              |
+   |               | valid for   |          |           |              |
+   |               | testing,    |          |           |              |
+   |               | save KATs)  |          |           |              |
 
 
 
-Foley                   Expires September 1, 2018               [Page 6]
+Foley                    Expires August 5, 2018                 [Page 6]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
 
-   |               | key, now    |           |          |              |
-   |               | deprecated  |           |          |              |
-   |               | (K1, K1,    |           |          |              |
-   |               | K1).        |           |          |              |
-   |               |             |           |          |              |
-   | overflowCount | Indicates   | boolean   | true,    | No for       |
-   | er            | if the impl |           | false    | Counter      |
-   |               | ementation  |           |          | (CTR) modes  |
-   |               | can handle  |           |          |              |
-   |               | a counter   |           |          |              |
-   |               | exceeding   |           |          |              |
-   |               | the maximum |           |          |              |
-   |               | value       |           |          |              |
-   |               |             |           |          |              |
-   | incrementalCo | Indicates   | boolean   | true,    | No for       |
-   | unter         | if the impl |           | false    | Counter      |
-   |               | ementation  |           |          | (CTR) modes  |
-   |               | increments  |           |          |              |
-   |               | the counter |           |          |              |
-   |               | (versus dec |           |          |              |
-   |               | rementing   |           |          |              |
-   |               | the         |           |          |              |
-   |               | counter)    |           |          |              |
-   +---------------+-------------+-----------+----------+--------------+
+   |               | is a single |          |           |              |
+   |               | key, now    |          |           |              |
+   |               | deprecated  |          |           |              |
+   |               | (K1, K1,    |          |           |              |
+   |               | K1).        |          |           |              |
+   |               |             |          |           |              |
+   | overflowCount | Indicates   | boolean  | true,     | No for       |
+   | er            | if the impl |          | false     | Counter      |
+   |               | ementation  |          |           | (CTR) modes  |
+   |               | can handle  |          |           |              |
+   |               | a counter   |          |           |              |
+   |               | exceeding   |          |           |              |
+   |               | the maximum |          |           |              |
+   |               | value       |          |           |              |
+   |               |             |          |           |              |
+   | incrementalCo | Indicates   | boolean  | true,     | No for       |
+   | unter         | if the impl |          | false     | Counter      |
+   |               | ementation  |          |           | (CTR) modes  |
+   |               | increments  |          |           |              |
+   |               | the counter |          |           |              |
+   |               | (versus dec |          |           |              |
+   |               | rementing   |          |           |              |
+   |               | the         |          |           |              |
+   |               | counter)    |          |           |              |
+   +---------------+-------------+----------+-----------+--------------+
 
            Table 2: Symmetric Algorithm Capabilities JSON Values
 
@@ -388,64 +389,63 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-
-Foley                   Expires September 1, 2018               [Page 7]
+Foley                    Expires August 5, 2018                 [Page 7]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
 
-   +----------+---------------+-------------+-------------+------------+
-   | Algorith | ptLen(payload | IV/Nonce    | Tag         | AAD        |
-   | m        | )             |             |             |            |
-   +----------+---------------+-------------+-------------+------------+
-   | AES-CCM  | Range of      | Range of    | Range of    | Range of   |
-   |          | values {Min:  | values      | values      | values     |
-   |          | 0, Max: 256,  | {Min: 56,   | {Min: 32,   | minimum    |
-   |          | Increment: 8} | Max: 104,   | Max: 128,   | greater    |
-   |          | minimum       | Increment:  | Increment:  | than or    |
-   |          | greater than  | 8}          | 16}         | equal to   |
-   |          | or equal to   | (represents | (represents | zero and   |
-   |          | zero and      | 7 to 13     | from 4 to   | maximum    |
-   |          | maximum less  | bytes)      | 16 bytes,   | less than  |
-   |          | than or equal |             | even values | or equal   |
-   |          | to 256.       |             | only)       | to 524,288 |
-   |          |               |             |             | (2^16)*8)  |
-   |          |               |             |             |            |
-   | AES-GCM  | Array to      | Array one   | Array of    | Array to   |
-   |          | include, if   | to three    | supported   | include,   |
-   |          | supported,    | values      | values of:  | if         |
-   |          | zero, two     | between 8   | 32, 64, 96, | supported, |
-   |          | values        | and 1024    | 104, 112,   | zero, two  |
-   |          | divisible by  |             | 120, 128    | values     |
-   |          | 128 and two   |             |             | divisible  |
-   |          | values not    |             |             | by 128 and |
-   |          | divisible by  |             |             | two values |
-   |          | 128           |             |             | not        |
-   |          |               |             |             | divisible  |
-   |          |               |             |             | by 128     |
-   |          |               |             |             |            |
-   | AES-XTS  | Array to      | N/A         | N/A         | N/A        |
-   |          | include, if   |             |             |            |
-   |          | supported,    |             |             |            |
-   |          | zero, two     |             |             |            |
-   |          | values        |             |             |            |
-   |          | divisible by  |             |             |            |
-   |          | 128 and two   |             |             |            |
-   |          | values not    |             |             |            |
-   |          | divisible by  |             |             |            |
-   |          | 128. Followed |             |             |            |
-   |          | by the        |             |             |            |
-   |          | maximum data  |             |             |            |
-   |          | length not to |             |             |            |
-   |          | exceed 2^20   |             |             |            |
-   +----------+---------------+-------------+-------------+------------+
+   +----------+----------------+------------+-------------+------------+
+   | Algorith | dataLen(payloa | IV/Nonce   | Tag         | AAD        |
+   | m        | d)             |            |             |            |
+   +----------+----------------+------------+-------------+------------+
+   | AES-CCM  | Range of       | Range of   | Range of    | Range of   |
+   |          | values {Min:   | values     | values      | values     |
+   |          | 0, Max: 256,   | {Min: 56,  | {Min: 32,   | minimum    |
+   |          | Increment: 8}  | Max: 104,  | Max: 128,   | greater    |
+   |          | minimum        | Increment: | Increment:  | than or    |
+   |          | greater than   | 8}  (repre | 16}         | equal to   |
+   |          | or equal to    | sents 7 to | (represents | zero and   |
+   |          | zero and       | 13 bytes)  | from 4 to   | maximum    |
+   |          | maximum less   |            | 16 bytes,   | less than  |
+   |          | than or equal  |            | even values | or equal   |
+   |          | to 256.        |            | only)       | to 524,288 |
+   |          |                |            |             | (2^16)*8)  |
+   |          |                |            |             |            |
+   | AES-GCM  | Array to       | Array one  | Array of    | Array to   |
+   |          | include, if    | to three   | supported   | include,   |
+   |          | supported,     | values     | values of:  | if         |
+   |          | zero, two      | between 8  | 32, 64, 96, | supported, |
+   |          | values         | and 1024   | 104, 112,   | zero, two  |
+   |          | divisible by   |            | 120, 128    | values     |
+   |          | 128 and two    |            |             | divisible  |
+   |          | values not     |            |             | by 128 and |
+   |          | divisible by   |            |             | two values |
+   |          | 128            |            |             | not        |
+   |          |                |            |             | divisible  |
+   |          |                |            |             | by 128     |
+   |          |                |            |             |            |
+   | AES-XTS  | Array to       | N/A        | N/A         | N/A        |
+   |          | include, if    |            |             |            |
+   |          | supported,     |            |             |            |
+   |          | zero, two      |            |             |            |
+   |          | values         |            |             |            |
+   |          | divisible by   |            |             |            |
+   |          | 128 and two    |            |             |            |
+   |          | values not     |            |             |            |
+   |          | divisible by   |            |             |            |
+   |          | 128. Followed  |            |             |            |
+   |          | by the maximum |            |             |            |
+   |          | data length    |            |             |            |
+   |          | not to exceed  |            |             |            |
+   |          | 2^20           |            |             |            |
+   +----------+----------------+------------+-------------+------------+
 
            Table 3: Symmetric Algorithm Capabilities JSON Values
 
 
 
 
-Foley                   Expires September 1, 2018               [Page 8]
+Foley                    Expires August 5, 2018                 [Page 8]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -485,7 +485,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
    o  TDES-CBC
 
-   o  TDES-CBC-I
+   o  TDES-CBCI
 
    o  TDES-CFB1
 
@@ -493,22 +493,22 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
    o  TDES-CFB64
 
-   o  TDES-CFB-P1
+   o  TDES-CFBP1
 
-   o  TDES-CFB-P8
+   o  TDES-CFBP8
 
-   o  TDES-CFB-P64
+   o  TDES-CFBP64
 
 
 
-Foley                   Expires September 1, 2018               [Page 9]
+Foley                    Expires August 5, 2018                 [Page 9]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
 
    o  TDES-OFB
 
-   o  TDES-OFB-I
+   o  TDES-OFBI
 
    o  TDES-CTR
 
@@ -557,7 +557,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 10]
+Foley                    Expires August 5, 2018                [Page 10]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -594,8 +594,8 @@ Internet-Draft                Sym Alg JSON                 February 2018
    |           |                                    |       |          |
    | tagLen    | Length of AEAD tag in bits to use  | value | Yes      |
    |           |                                    |       |          |
-   | testType  | The test category type (AFT or     | value | No       |
-   |           | MCT)                               |       |          |
+   | testType  | The test category type (AFT, MCT   | value | No       |
+   |           | or counter)                        |       |          |
    |           |                                    |       |          |
    | tests     | Array of individual test vector    | array | No       |
    |           | JSON objects, which are defined in |       |          |
@@ -603,6 +603,22 @@ Internet-Draft                Sym Alg JSON                 February 2018
    +-----------+------------------------------------+-------+----------+
 
                       Table 5: Test Group JSON Object
+
+   The testType field definitions are:
+
+      AFT - Algorithm Functional Test
+
+      MCT - Monte Carlo Test
+
+
+
+
+Foley                    Expires August 5, 2018                [Page 11]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+      counter - Counter mode test
 
 3.2.  Test Case JSON Schema
 
@@ -613,7 +629,47 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 11]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Foley                    Expires August 5, 2018                [Page 12]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -669,7 +725,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 12]
+Foley                    Expires August 5, 2018                [Page 13]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -700,7 +756,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
    |              | AES-KW, AES-KWP, and TDES-KW will have   |         |
    |              | expected failures. For these cases the   |         |
    |              | JSON reponse should include the          |         |
-   |              | decryptFail keyword, see Appendix F      |         |
+   |              | decryptFail keyword, see Appendix B      |         |
    |              |                                          |         |
    | resultsArray | Array of JSON objects that represent     | array   |
    |              | each iteration of a Monte Carlo Test.    |         |
@@ -725,7 +781,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 13]
+Foley                    Expires August 5, 2018                [Page 14]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -768,55 +824,568 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 Appendix A.  Example Capabilities JSON Object
 
-   The following is a example JSON object advertising support for AES-
-   GCM.
+   The following is a example JSON object advertising support for all
+   the symmetric ciphers.
+
+
+POST [
+           {
+                    "algorithm": "AES-GCM",
+                    "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                            {"algorithm" : "DRBG", "valValue" : "123456"}],
+                    "direction": [
 
 
 
-
-
-
-
-
-
-
-
-Foley                   Expires September 1, 2018              [Page 14]
+Foley                    Expires August 5, 2018                [Page 15]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
 
-            {
-                "algorithm": "AES-GCM",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                                {"algorithm" : "DRBG", "valValue" : "123456"}],
-                "direction": [
-                    "encrypt",
-                    "decrypt"
-                ],
-                "ivGen": "internal",
-                "ivGenMode": "8.2.2",
-                "keyLen": [
-                    128,
-                    192,
-                    256
-                ],
-                "tagLen": [
-                    96,
-                    128
-                ],
-                "ivLen": [
-                    96
-                ],
-                "ptLen": [
-                    0,
-                    256
-                ],
-                "aadLen": [
-                    128,
-                    256
-                ]
-            }
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "ivGen": "internal",
+                    "ivGenMode": "8.2.2",
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        96,
+                        128
+                    ],
+                    "ivLen": [
+                        96
+                    ],
+                    "dataLen": [
+                        0,
+                        256
+                    ],
+                    "aadLen": [
+                        128,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "AES-ECB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-CBC",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+
+
+
+Foley                    Expires August 5, 2018                [Page 16]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB128",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-OFB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+
+
+
+Foley                    Expires August 5, 2018                [Page 17]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-XPN",
+                    "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                            {"algorithm" : "DRBG", "valValue" : "123456"}],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "ivGen": "internal",
+                    "ivGenMode": "8.2.2",
+                    "saltGen": "internal",
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        96,
+                       128
+                    ],
+                   "dataLen": [
+                        0,
+                        128
+                    ]
+                   "aadLen": [
+                        120,
+                        128
+                   ]
+                },
+                {
+                    "algorithm": "AES-CTR",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+
+
+
+Foley                    Expires August 5, 2018                [Page 18]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                 },
+                 {
+                    "algorithm": "AES-CCM",
+                    "prereqVals": [
+                        {
+                            "algorithm": "AES",
+                            "valValue": "same"
+                        }
+                    ],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        128
+                    ],
+                    "ivLen": [
+                        56
+                    ],
+                    "dataLen": [
+                        0,
+                        256
+                    ],
+                    "aadLen": [
+                        0,
+                        65536
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+
+
+
+Foley                    Expires August 5, 2018                [Page 19]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                {
+                    "algorithm": "AES-KW",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        512,
+                        192,
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-KWP",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        8,
+                        32,
+                        96,
+                        808
+                    ]
+                },
+                {
+                    "algorithm": "AES-XTS",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+
+
+
+Foley                    Expires August 5, 2018                [Page 20]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                        128,
+                        256
+                    ],
+                    "dataLen": [
+                        65536
+                    ],
+                    "tweakMode": [
+                        "hex"
+                    ]
+                },
+                {
+                    "algorithm": "TDES-ECB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        512
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CBC",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        128,
+                        192,
+                        768
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CBCI",
+                    "direction": [
+
+
+
+Foley                    Expires August 5, 2018                [Page 21]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        128,
+                        192,
+                        768
+                    ]
+                },
+                {
+                    "algorithm": "TDES-OFB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-OFBI",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+
+
+
+Foley                    Expires August 5, 2018                [Page 22]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                {
+                    "algorithm": "TDES-CFB64",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        320
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+
+
+
+Foley                    Expires August 5, 2018                [Page 23]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                },
+                {
+                    "algorithm": "TDES-CFBP64",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        320
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+
+
+
+Foley                    Expires August 5, 2018                [Page 24]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CTR",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-KW",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        512,
+                        192,
+                        128
+                    ]
+                }
+            ]
+        }
+    }
+]
 
 Appendix B.  Example AES Test and Results Vectors JSON Object
 
@@ -825,6 +1394,14 @@ Appendix B.  Example AES Test and Results Vectors JSON Object
 
                  [
                    { "acvVersion": "0.4" },
+
+
+
+Foley                    Expires August 5, 2018                [Page 25]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
                    { "vsId": 1564,
                      "algorithm": "AES-GCM",
                      "testGroups": [
@@ -834,14 +1411,6 @@ Appendix B.  Example AES Test and Results Vectors JSON Object
                          "ivGen": "internal",
                          "ivGenMode": "8.2.2",
                          "keyLen": 128,
-
-
-
-Foley                   Expires September 1, 2018              [Page 15]
-
-Internet-Draft                Sym Alg JSON                 February 2018
-
-
                          "ivLen": 96,
                          "ptLen": 0,
                          "aadLen": 128,
@@ -881,6 +1450,14 @@ Internet-Draft                Sym Alg JSON                 February 2018
                          "ivGenMode": "8.2.2",
                          "keyLen": 128,
                          "ivLen": 96,
+
+
+
+Foley                    Expires August 5, 2018                [Page 26]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
                          "ptLen": 0,
                          "aadLen": 136,
                          "tagLen": 128,
@@ -890,14 +1467,6 @@ Internet-Draft                Sym Alg JSON                 February 2018
                              "tcId": 2186,
                              "key": "5E296F244BB0A92BF0FF5F2C50FA7443",
                              "pt": "",
-
-
-
-Foley                   Expires September 1, 2018              [Page 16]
-
-Internet-Draft                Sym Alg JSON                 February 2018
-
-
                              "aad": "B414F4DA8203C31815FF117B0553DBF618"
                            },
                            {
@@ -937,6 +1506,14 @@ Internet-Draft                Sym Alg JSON                 February 2018
                              "key": "27B3C4CAFD6222FEE08403BC222DCBFD",
                              "pt": "2F75708AD2F1ADE3786885DEDDFC9B78",
                              "aad": "2AB6426DCFEB6909DF99D19063CCF88D"
+
+
+
+Foley                    Expires August 5, 2018                [Page 27]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
                            },
                            {
                              "tcId": 2204,
@@ -946,14 +1523,6 @@ Internet-Draft                Sym Alg JSON                 February 2018
                            },
                            {
                              "tcId": 2205,
-
-
-
-Foley                   Expires September 1, 2018              [Page 17]
-
-Internet-Draft                Sym Alg JSON                 February 2018
-
-
                              "key": "CE1D8C9E3AB2F46B01E3F110B3BC6E05",
                              "pt": "3DD9EEFA5C6E89C43D460907E8946B9C",
                              "aad": "DBE62172F439956FF21A67A379324100"
@@ -993,6 +1562,14 @@ Internet-Draft                Sym Alg JSON                 February 2018
                                "tcId": 2173,
                                "iv": "01020304D3B09894BB14B6CF",
                                "ct": "",
+
+
+
+Foley                    Expires August 5, 2018                [Page 28]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
                                "tag": "DFF22B329AC87B82726EBBF20E66EEE2"
                            },
                            {
@@ -1002,14 +1579,6 @@ Internet-Draft                Sym Alg JSON                 February 2018
                                "tag": "BAFBFA38AD5D6C6E7C97D08DDEC26580"
                            },
                            {
-
-
-
-Foley                   Expires September 1, 2018              [Page 18]
-
-Internet-Draft                Sym Alg JSON                 February 2018
-
-
                                "tcId": 2186,
                                "iv": "01020304C6A745B0C4C9F2D5",
                                "ct": "",
@@ -1049,6 +1618,14 @@ Internet-Draft                Sym Alg JSON                 February 2018
                                "tcId": 2205,
                                "iv": "010203041E9FD60F49957FF5",
                                "ct": "A1F124EE6E98CAB776CCD601B7F65D6A",
+
+
+
+Foley                    Expires August 5, 2018                [Page 29]
+
+Internet-Draft                Sym Alg JSON                 February 2018
+
+
                                "tag": "F4D7D0D75FC9961A12B3C6A3E6379972"
                            },
                            {
@@ -1058,14 +1635,6 @@ Internet-Draft                Sym Alg JSON                 February 2018
                                "tag": "48F3D4D7EB4B9FCB924ACC05B3834F98"
                            }
                        ]
-
-
-
-Foley                   Expires September 1, 2018              [Page 19]
-
-Internet-Draft                Sym Alg JSON                 February 2018
-
-
                     }
                  ]
 
@@ -1108,16 +1677,7 @@ Appendix C.  Example AES MCT Test and Results JSON Object
 
 
 
-
-
-
-
-
-
-
-
-
-Foley                   Expires September 1, 2018              [Page 20]
+Foley                    Expires August 5, 2018                [Page 30]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1173,7 +1733,7 @@ Appendix D.  Example TDES Test and Results JSON Object
 
 
 
-Foley                   Expires September 1, 2018              [Page 21]
+Foley                    Expires August 5, 2018                [Page 31]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1229,7 +1789,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 22]
+Foley                    Expires August 5, 2018                [Page 32]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1285,7 +1845,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 23]
+Foley                    Expires August 5, 2018                [Page 33]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1341,7 +1901,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 24]
+Foley                    Expires August 5, 2018                [Page 34]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1397,7 +1957,7 @@ Appendix E.  Example TDES MCT Test and Results JSON Object
 
 
 
-Foley                   Expires September 1, 2018              [Page 25]
+Foley                    Expires August 5, 2018                [Page 35]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1453,7 +2013,7 @@ Internet-Draft                Sym Alg JSON                 February 2018
 
 
 
-Foley                   Expires September 1, 2018              [Page 26]
+Foley                    Expires August 5, 2018                [Page 36]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1509,7 +2069,7 @@ Appendix F.  Example Test Results JSON Object
 
 
 
-Foley                   Expires September 1, 2018              [Page 27]
+Foley                    Expires August 5, 2018                [Page 37]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1565,7 +2125,7 @@ Appendix H.  Example Test Results CTR JSON Object
 
 
 
-Foley                   Expires September 1, 2018              [Page 28]
+Foley                    Expires August 5, 2018                [Page 38]
 
 Internet-Draft                Sym Alg JSON                 February 2018
 
@@ -1621,4 +2181,4 @@ Author's Address
 
 
 
-Foley                   Expires September 1, 2018              [Page 29]
+Foley                    Expires August 5, 2018                [Page 39]

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-protocol-0.3" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-protocol-0.4" ipr="trust200902">
  <!-- category values: std, bcp, info, exp, and historic
     ipr values: trust200902, noModificationTrust200902, noDerivativesTrust200902,
        or pre5378Trust200902
@@ -71,7 +71,7 @@
      </address>
    </author>
 
-   <date year="2017"/>
+   <date year="2018"/>
 
    <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
         in the current day for you. If only the current year is specified, xml2rfc will fill 
@@ -306,12 +306,12 @@ The following functions are outside the scope of this document:</t>
 	   operation is "/validation/acvp/register".  To register a DUT
            the ACVP client would use the following HTTP request-line:</t>
 
-	   <t>POST /validation/acvp/register HTTP/1.2</t>
+	   <t>POST /validation/acvp/register HTTP/1.0</t>
 
 	   <t>Likewise, to request a specific vector set from the server the ACVP client  
 	   would use the following request-line:</t>
 
-	   <t>GET /validation/acvp/vectors?vsId=1 HTTP/1.2</t>
+	   <t>GET /validation/acvp/vectors?vsId=1 HTTP/1.0</t>
 
 
        </section>
@@ -394,13 +394,13 @@ A server may accept a down-level version from the client if it can process at a 
 
      <figure align="center" anchor="xml_json2">
        <artwork align="left"><![CDATA[
-POST /validation/acvp/register HTTP1.2
+POST /validation/acvp/register HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Capabilities information(see next section)
 
 ..authentication happens here..
 
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: (length of JWT)
@@ -439,12 +439,12 @@ each message.
 
      <figure align="center" anchor="xml_json3">
        <artwork align="left"><![CDATA[
-POST /validation/acvp/register HTTP1.2
+POST /validation/acvp/register HTTP1.0
 User Agent:
 Host: www.acvts.nist.gov/acvp
 Accept: 
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "operation" : "register",
    "certificateRequest" : "yes",
    "debugRequest" : "no",
@@ -502,7 +502,7 @@ Accept:
   "ivLen" : [
              96
                ],
-  "ptLen" : [
+  "dataLength" : [
              0,
              128,
              136
@@ -525,7 +525,7 @@ Accept:
        <artwork align="left"><![CDATA[
 200 OK Response:
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "capabilityResponse" : { "vectorSets" : [
                        {"vsId":1437},
                        {"vsId":1438}] } , 
@@ -547,7 +547,7 @@ Accept:
 	 </t>
 	 <figure align="center" anchor="xml_json5">
 	    <artwork align="left"><![CDATA[
-GET /validation/acvp/vectors?vsId=1437  HTTP1.2
+GET /validation/acvp/vectors?vsId=1437  HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Authorization: Bearer JWT
             ]]></artwork>
@@ -566,7 +566,7 @@ Status: 200 OK
 Content-Type: application/json
 Content-Length: <length of results>
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "vsId": 1437,
    "algorithm": "AES-GCM",
    "testGroups": [
@@ -605,12 +605,12 @@ Content-Length: <length of results>
 	 </t>
 	<figure align="center" anchor="xml_json7">
 	    <artwork align="left"><![CDATA[
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: <length of results>
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "vsId": 1437,
     "retry" : 10
   }
@@ -629,12 +629,12 @@ Content-Length: <length of results>
 
      <figure align="center" anchor="xml_json8">
        <artwork align="left"><![CDATA[
-POST /validation/acvp/vectors?vsId=1437 HTTP1.2
+POST /validation/acvp/vectors?vsId=1437 HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Authorization: Bearer JWT
 Accept:   
 [
- { "acvVersion": "0.3" },
+ { "acvVersion": "0.4" },
  { "vsId": 1437,
    "testResults": [
    {
@@ -659,7 +659,7 @@ Accept:
 
      <figure align="center" anchor="xml_json9">
        <artwork align="left"><![CDATA[
-GET /validation/acvp/results?vsId=1437 HTTP1.2
+GET /validation/acvp/results?vsId=1437 HTTP1.0
 User Agent:
 Host: www.acvts.nist.gov/acvp
 Accept: /
@@ -667,12 +667,12 @@ Accept: /
 
 Response to GET is:
 
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: <length of results>
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "results" : {
       "vsId" : 1437,
       "disposition" : "incomplete",
@@ -712,7 +712,7 @@ Content-Length: <length of results>
 <t>The cancel URI can be used by the client to free a session.  The server is responsible for maintaining any database information for traceability or debugging purposes it desires.  This may be important for those cases where there are test failures.</t>
      <figure align="center" anchor="xml_json10">
        <artwork align="left"><![CDATA[
-POST /validation/acvp/cancel HTTP1.2
+POST /validation/acvp/cancel HTTP1.0
 Host: www.acvts.nist.gov/acvp
 Authorization: Bearer JWT
            ]]></artwork>
@@ -737,12 +737,12 @@ Authorization: Bearer JWT
        </t>
 	<figure align="center" anchor="xml_json11">
 	<artwork align="left"><![CDATA[
-HTTP 1.2 200 OK
+HTTP 1.0 200 OK
 Status: 200 OK
 Content-Type: application/json
 Content-Length: <length of results>
 [
-  { "acvVersion": "0.3" },
+  { "acvVersion": "0.4" },
   { "vsId" : <vs-id>,
     "status" : "expired"
   }
@@ -769,7 +769,7 @@ Content-Length: <length of results>
        <figure align="center" anchor="xml_json12">
             <artwork><![CDATA[
               [
-                { "acvVersion": "0.3" },
+                { "acvVersion": "0.4" },
                 { "vsId": 1437,
 		  "expiry": "2018-12-31 23:59:59",
                   "algorithm": "AES-GCM",
@@ -1007,7 +1007,7 @@ plain text length - ptLen
 
 <t>
 [
-   { "acvVersion": "0.3" },
+   { "acvVersion": "0.4" },
    { "results" : {
         "disposition" : "incomplete",
       }

--- a/src/acvp_sub_symmetric.xml
+++ b/src/acvp_sub_symmetric.xml
@@ -206,8 +206,8 @@
           <c>No</c>
 	  <c/><c/><c/><c/><c/>
 
-          <c>ptLen</c>
-	  <c>The supported plaintext lengths in bits.   This varies depending on the algorithm type, for additional details see <xref target="data_lengths"/></c>
+          <c>dataLen</c>
+	  <c>The supported plain and cipher text lengths in bits.   This varies depending on the algorithm type, for additional details see <xref target="data_lengths"/></c>
           <c>domain</c>
           <c>0-65536</c>
           <c>Yes (See <xref target="data_lengths"/>)</c>
@@ -303,7 +303,7 @@
 	<t>Some algorithms allow ranges of data, IV and AAD lengths.  This table outlines the allowed values.</t>
         <texttable anchor="data_table" title="Symmetric Algorithm Capabilities JSON Values">
           <ttcol align="left">Algorithm</ttcol>
-          <ttcol align="left">ptLen(payload)</ttcol>
+          <ttcol align="left">dataLen(payload)</ttcol>
           <ttcol align="left">IV/Nonce</ttcol>
           <ttcol align="left">Tag</ttcol>
           <ttcol align="left">AAD</ttcol>
@@ -349,15 +349,15 @@
 		<t>AES-KWP</t>
     <t>TDES-ECB</t>
 		<t>TDES-CBC</t>
-		<t>TDES-CBC-I</t>
+		<t>TDES-CBCI</t>
 		<t>TDES-CFB1</t>
 		<t>TDES-CFB8</t>
 		<t>TDES-CFB64</t>
-		<t>TDES-CFB-P1</t>
-		<t>TDES-CFB-P8</t>
-		<t>TDES-CFB-P64</t>
+		<t>TDES-CFBP1</t>
+		<t>TDES-CFBP8</t>
+		<t>TDES-CFBP64</t>
 		<t>TDES-OFB</t>
-		<t>TDES-OFB-I</t>
+		<t>TDES-OFBI</t>
 		<t>TDES-CTR</t>
 		<t>TDES-KW</t>
 	    </list></t>
@@ -467,7 +467,7 @@
 		<c/><c/><c/><c/>
 
 		<c>testType</c>
-		<c>The test category type (AFT or MCT)</c>
+		<c>The test category type (AFT, MCT or counter)</c>
 		<c>value</c>
 		<c>No</c>
 		<c/><c/><c/><c/>
@@ -477,6 +477,14 @@
 		<c>array</c>
 		<c>No</c>
 	    </texttable>
+
+<t>The testType field definitions are:</t>
+
+        <t><list style="testtype">
+		<t>AFT - Algorithm Functional Test</t>
+		<t>MCT - Monte Carlo Test</t>
+		<t>counter - Counter mode test</t>
+        </list></t>
 	</section>
 
 	<section title="Test Case JSON Schema" anchor="tvjs">
@@ -593,7 +601,7 @@
 
 	  <c>decryptFail</c>
 	  <c>Some test cases included with decrypt operations in AES-GCM, AES-CCM, AES-XPN, AES-KW, AES-KWP, and TDES-KW will have expected failures. For these cases the
-	      JSON reponse should include the decryptFail keyword, see <xref target="app-test-results-ex"/> </c>
+	      JSON reponse should include the decryptFail keyword, see <xref target="app-vs-ex"/> </c>
           <c>boolean true</c>
 	  <c/><c/><c/>
 
@@ -729,42 +737,488 @@
     </references>
 
     <section anchor="app-reg-ex" title="Example Capabilities JSON Object">
-      <t>The following is a example JSON object advertising support for AES-GCM.</t>
+      <t>The following is a example JSON object advertising support for all the symmetric ciphers.</t>
       <figure>
         <artwork><![CDATA[
 
-
-            {
-                "algorithm": "AES-GCM",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-		                {"algorithm" : "DRBG", "valValue" : "123456"}],
-                "direction": [
-                    "encrypt",
-                    "decrypt"
-                ],
-                "ivGen": "internal",
-                "ivGenMode": "8.2.2",
-                "keyLen": [
-                    128,
-                    192,
-                    256
-                ],
-                "tagLen": [
-                    96,
-                    128
-                ],
-                "ivLen": [
-                    96
-                ],
-                "ptLen": [
-                    0,
-                    256
-                ],
-                "aadLen": [
-                    128,
-                    256
-                ]
-            }
+POST [
+           {
+                    "algorithm": "AES-GCM",
+                    "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                            {"algorithm" : "DRBG", "valValue" : "123456"}],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "ivGen": "internal",
+                    "ivGenMode": "8.2.2",
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        96,
+                        128
+                    ],
+                    "ivLen": [
+                        96
+                    ],
+                    "dataLen": [
+                        0,
+                        256
+                    ],
+                    "aadLen": [
+                        128,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "AES-ECB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-CBC",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB128",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-OFB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-XPN",
+                    "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
+                            {"algorithm" : "DRBG", "valValue" : "123456"}],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "ivGen": "internal",
+                    "ivGenMode": "8.2.2",
+                    "saltGen": "internal",      
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        96,
+                       128
+                    ],
+                   "dataLen": [
+                        0,
+                        128
+                    ]
+                   "aadLen": [
+                        120,
+                        128
+                   ]
+                },
+                {
+                    "algorithm": "AES-CTR",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        128
+                    ]
+                 },
+                 {
+                    "algorithm": "AES-CCM",
+                    "prereqVals": [
+                        {
+                            "algorithm": "AES",
+                            "valValue": "same"
+                        }
+                    ],
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "tagLen": [
+                        128
+                    ],
+                    "ivLen": [
+                        56
+                    ],
+                    "dataLen": [
+                        0,
+                        256
+                    ],
+                    "aadLen": [
+                        0,
+                        65536
+                    ]
+                },
+                {
+                    "algorithm": "AES-CFB1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        1536
+                    ]
+                },
+                {
+                    "algorithm": "AES-KW",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        512,
+                        192,
+                        128
+                    ]
+                },
+                {
+                    "algorithm": "AES-KWP",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        128,
+                        192,
+                        256
+                    ],
+                    "dataLen": [
+                        8,
+                        32,
+                        96,
+                        808
+                    ]
+                },
+                {
+                    "algorithm": "AES-XTS",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyLen": [
+                        128,
+                        256
+                    ],
+                    "dataLen": [
+                        65536
+                    ],
+                    "tweakMode": [
+                        "hex"
+                    ]
+                },
+                {
+                    "algorithm": "TDES-ECB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        512
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CBC",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        128,
+                        192,
+                        768
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CBCI",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        128,
+                        192,
+                        768
+                    ]
+                },
+                {
+                    "algorithm": "TDES-OFB",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-OFBI",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB64",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        320
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFB1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP64",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        320
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP8",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64,
+                        256
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CFBP1",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-CTR",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "keyingOption": [
+                        1
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        64
+                    ]
+                },
+                {
+                    "algorithm": "TDES-KW",
+                    "direction": [
+                        "encrypt",
+                        "decrypt"
+                    ],
+                    "kwCipher": [
+                        "cipher"
+                    ],
+                    "keyLen": [
+                        192
+                    ],
+                    "dataLen": [
+                        512,
+                        192,
+                        128
+                    ]
+                }
+            ]
+        }
+    }
+] 
             ]]></artwork>
     </figure>
     </section>


### PR DESCRIPTION
Add registration examples for all supported flavors. All require dataLen, not dataLength or ptLen.
Fixed HTTP and testType issues #122 and #218.

Note we don't support XPN so please look closely at that registration because it was generated based on the requirements and not from a "real" registration.