### PR TITLE
Indicate intended use explicitly

### DIFF
--- a/artifacts/acvp_protocol.html
+++ b/artifacts/acvp_protocol.html
@@ -461,12 +461,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.9.6 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.9.9 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-protocol-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-06" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-05" />
   <meta name="dct.abstract" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
   <meta name="description" content="This document defines the Automated Cryptographic Validation Protocol(ACVP)." />
 
@@ -487,10 +487,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">June 6, 2018</td>
+<td class="right">July 5, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: December 8, 2018</td>
+<td class="left">Expires: January 6, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -507,7 +507,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on December 8, 2018.</p>
+<p>This Internet-Draft will expire on January 6, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -1007,7 +1007,7 @@
 <p id="rfc.section.5.p.1">It is recommended that HTTPS and TLS 1.2 or greater be used in order to enforce a secure communication method. Not all environments will have TLS so HTTP with some level of authentication may be the only option.</p>
 <h1 id="rfc.section.6">
 <a href="#rfc.section.6">6.</a> Authentication</h1>
-<p id="rfc.section.6.p.1">It is recommended that an authentication scheme be used. Depending on the target environment and usage objectives, that can be as weak as basic HTTP authentication or as strong as TLS mutual certificate authentication. Definition of an authentication scheme will not be discussed here, but should be agreed upon between the client and server owning entities including the servers owned by the validation authorities. For the purposes of the message flow examples, no authentication will be used.</p>
+<p id="rfc.section.6.p.1">It is recommended that an authentication scheme be used. Typically, a JSON Web Token (JWT) is created by the server upon successful client authentication and returned to the client to use as an authorization mechanism for accessing the server resources - see <a href="#jwtToken" class="xref">JWT specification</a>  below for more information.  Depending on the target environment and usage objectives, the authentication can be as weak as basic HTTP authentication or as strong as TLS mutual certificate authentication. Definition of an authentication scheme will not be discussed here, but should be agreed upon between the client and server owning entities including the servers owned by the validation authorities. For the purposes of the message flow examples, no authentication will be used.</p>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> Traceability</h1>
 <p id="rfc.section.7.p.1">TBD </p>
@@ -1054,6 +1054,176 @@
 <pre>
             Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibmlzdC5vcmciLCJleHAiOiAxNDYyOTg0OTUzLCJjb21wYW55IjogIkNpc2NvIiwianRpIjo0NTh9.zDhd3WrLcb1Xf5-VKOX6k-G70mACbi1tdir8qHAMPyQ
            </pre>
+<div id="rfc.table.2"></div>
+<div id="authorizationFlow_table"></div>
+<p><em>All exchanges below are over HTTP."</em> </p>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Workflow authorization flows</caption>
+<thead><tr>
+<th class="left">Client</th>
+<th class="left"></th>
+<th class="left">Server</th>
+<th class="left">Notes</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left"></td>
+<td class="left">POST to /login or similar with appropriate credentials</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">--------------------------------&gt;</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">receive the access token</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">&lt;-  -  -  -  -  -  -  -  -  -  - </td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">POST to /register with access token in header</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">-------------------------------&gt;</td>
+<td class="left"></td>
+<td class="left">the token from login is used</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">receive the session info and a session access token</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">&lt;-  -  -  -  -  -  -  -  -  -  - </td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">GET /vectors?vsID=&lt;ID&gt; with session access token in header</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">-------------------------------&gt;</td>
+<td class="left"></td>
+<td class="left">the token from registration is used to retrieve vector sets, submit answers etc.</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">receive vectors</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">&lt;-  -  -  -  -  -  -  -  -  -  - </td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">POST to /vectors?vsID=&lt;ID&gt; with session access token in header and answers in body</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">-------------------------------&gt;</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">GET /results?vsID=&lt;ID&gt; with session access token in body</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">-------------------------------&gt;</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">receive results</td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left">&lt;-  -  -  -  -  -  -  -  -  -  - </td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
 <h1 id="rfc.section.11.2">
 <a href="#rfc.section.11.2">11.2.</a> <a href="#vendors" id="vendors">Vendor Resources</a>
 </h1>

--- a/artifacts/acvp_protocol.txt
+++ b/artifacts/acvp_protocol.txt
@@ -4,8 +4,8 @@
 
 Internet Engineering Task Force                          B. Fussell, Ed.
 Internet-Draft                                             Cisco Systems
-Intended status: Informational                              May 30, 2018
-Expires: December 1, 2018
+Intended status: Informational                              July 5, 2018
+Expires: January 6, 2019
 
 
               Automated Cryptographic Validation Protocol
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 1, 2018.
+   This Internet-Draft will expire on January 6, 2019.
 
 Copyright Notice
 
@@ -53,68 +53,106 @@ Copyright Notice
 
 
 
-Fussell                 Expires December 1, 2018                [Page 1]
+Fussell                  Expires January 6, 2019                [Page 1]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
-     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
-   2.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .   3
-     2.1.  Audience  . . . . . . . . . . . . . . . . . . . . . . . .   4
-     2.2.  Goals . . . . . . . . . . . . . . . . . . . . . . . . . .   4
-     2.3.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   5
-   3.  Architecture  . . . . . . . . . . . . . . . . . . . . . . . .   5
-     3.1.  Server/Client Architecture  . . . . . . . . . . . . . . .   5
-     3.2.  Server/Proxy Architecture . . . . . . . . . . . . . . . .   6
-   4.  ACV Protocol  . . . . . . . . . . . . . . . . . . . . . . . .   6
-     4.1.  HTTP URI Hierarchy  . . . . . . . . . . . . . . . . . . .   7
-     4.2.  HTTP URI Objects  . . . . . . . . . . . . . . . . . . . .   7
-   5.  Security  . . . . . . . . . . . . . . . . . . . . . . . . . .   9
-   6.  Authentication  . . . . . . . . . . . . . . . . . . . . . . .  10
-   7.  Traceability  . . . . . . . . . . . . . . . . . . . . . . . .  10
-   8.  Encoding  . . . . . . . . . . . . . . . . . . . . . . . . . .  10
-   9.  Versioning  . . . . . . . . . . . . . . . . . . . . . . . . .  10
-   10. Messaging . . . . . . . . . . . . . . . . . . . . . . . . . .  10
-     10.1.  Product Registration/Capabilities Exchange . . . . . . .  10
-     10.2.  Test Exchange  . . . . . . . . . . . . . . . . . . . . .  11
-   11. Message Formats . . . . . . . . . . . . . . . . . . . . . . .  11
-     11.1.  Establish Connection HTTPS GET/200 OK  . . . . . . . . .  12
-     11.2.  Product Registration with Capabilities . . . . . . . . .  13
-     11.3.  Vector Set Download Request  . . . . . . . . . . . . . .  16
-     11.4.  Submit Test Results  . . . . . . . . . . . . . . . . . .  18
-     11.5.  Validation Results Request . . . . . . . . . . . . . . .  19
-     11.6.  Optional Flows . . . . . . . . . . . . . . . . . . . . .  20
-   12. Vector Set Expiration . . . . . . . . . . . . . . . . . . . .  20
-     12.1.  Resending Test Responses . . . . . . . . . . . . . . . .  22
-   13. Error Codes . . . . . . . . . . . . . . . . . . . . . . . . .  22
-   14. Custom Specification Objects  . . . . . . . . . . . . . . . .  23
-     14.1.  BitString  . . . . . . . . . . . . . . . . . . . . . . .  23
-       14.1.1.  Endianness . . . . . . . . . . . . . . . . . . . . .  23
-       14.1.2.  Hex to Bitstring Parsing . . . . . . . . . . . . . .  23
-         14.1.2.1.  Hex string parsing examples  . . . . . . . . . .  23
-     14.2.  Range  . . . . . . . . . . . . . . . . . . . . . . . . .  24
-       14.2.1.  Range JSON examples  . . . . . . . . . . . . . . . .  24
-     14.3.  Domain . . . . . . . . . . . . . . . . . . . . . . . . .  25
-       14.3.1.  Domain JSON examples . . . . . . . . . . . . . . . .  25
-       14.3.2.  Additional Domain Information  . . . . . . . . . . .  26
-   15. Other Considerations  . . . . . . . . . . . . . . . . . . . .  26
-   16. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
-   17. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
-   18. Normative References  . . . . . . . . . . . . . . . . . . . .  26
-   Appendix A.  JSON Formatting Guidelines . . . . . . . . . . . . .  26
-   Appendix B.  JSON Encoded Error Messages  . . . . . . . . . . . .  27
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   4
+   2.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+     2.1.  Audience  . . . . . . . . . . . . . . . . . . . . . . . .   5
+     2.2.  Goals . . . . . . . . . . . . . . . . . . . . . . . . . .   5
+     2.3.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   6
+   3.  Architecture  . . . . . . . . . . . . . . . . . . . . . . . .   6
+     3.1.  Server/Client Architecture  . . . . . . . . . . . . . . .   6
+     3.2.  Server/Proxy Architecture . . . . . . . . . . . . . . . .   7
+   4.  ACV Protocol  . . . . . . . . . . . . . . . . . . . . . . . .   7
+     4.1.  HTTP URI Hierarchy  . . . . . . . . . . . . . . . . . . .   8
+     4.2.  HTTP URI Resources  . . . . . . . . . . . . . . . . . . .   8
+   5.  Security  . . . . . . . . . . . . . . . . . . . . . . . . . .  11
+   6.  Authentication  . . . . . . . . . . . . . . . . . . . . . . .  12
+   7.  Traceability  . . . . . . . . . . . . . . . . . . . . . . . .  12
+   8.  Encoding  . . . . . . . . . . . . . . . . . . . . . . . . . .  12
+   9.  Versioning  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+   10. Messaging . . . . . . . . . . . . . . . . . . . . . . . . . .  12
+     10.1.  Product Registration/Capabilities Exchange . . . . . . .  13
+     10.2.  Test Exchange  . . . . . . . . . . . . . . . . . . . . .  13
+   11. Message Formats . . . . . . . . . . . . . . . . . . . . . . .  13
+     11.1.  JSON Web Token (JWT) . . . . . . . . . . . . . . . . . .  13
+     11.2.  Vendor Resources . . . . . . . . . . . . . . . . . . . .  16
+       11.2.1.  Vendor Listing . . . . . . . . . . . . . . . . . . .  16
+       11.2.2.  Create a New Vendor  . . . . . . . . . . . . . . . .  18
+       11.2.3.  Vendor Information . . . . . . . . . . . . . . . . .  19
+       11.2.4.  Update an existing Vendor  . . . . . . . . . . . . .  19
+       11.2.5.  Remove a Vendor  . . . . . . . . . . . . . . . . . .  20
+     11.3.  Modules  . . . . . . . . . . . . . . . . . . . . . . . .  21
+       11.3.1.  List Modules . . . . . . . . . . . . . . . . . . . .  21
+       11.3.2.  Register a new Module  . . . . . . . . . . . . . . .  22
+       11.3.3.  Retrieve information for a Module  . . . . . . . . .  23
+       11.3.4.  Update a Module  . . . . . . . . . . . . . . . . . .  23
+       11.3.5.  Delete a Module  . . . . . . . . . . . . . . . . . .  23
+     11.4.  Operational Environments (OEs) . . . . . . . . . . . . .  24
+       11.4.1.  List Operational Environments  . . . . . . . . . . .  24
+       11.4.2.  Create a new Operational Environment . . . . . . . .  24
+       11.4.3.  Retrieve information for an Operational Environment   25
+       11.4.4.  Update an Operational Environment  . . . . . . . . .  25
+       11.4.5.  Delete an Operational Environment  . . . . . . . . .  26
+     11.5.  Dependencies . . . . . . . . . . . . . . . . . . . . . .  26
+       11.5.1.  List Dependencies  . . . . . . . . . . . . . . . . .  26
+       11.5.2.  Register a new Dependency  . . . . . . . . . . . . .  27
+       11.5.3.  List Dependency Properties . . . . . . . . . . . . .  27
+       11.5.4.  Retrieve information for a Dependency  . . . . . . .  30
+       11.5.5.  Update a Dependency  . . . . . . . . . . . . . . . .  30
 
 
 
-Fussell                 Expires December 1, 2018                [Page 2]
+Fussell                  Expires January 6, 2019                [Page 2]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  27
+       11.5.6.  Delete a Dependency  . . . . . . . . . . . . . . . .  30
+     11.6.  Algorithms . . . . . . . . . . . . . . . . . . . . . . .  30
+       11.6.1.  Algorithms Listing . . . . . . . . . . . . . . . . .  31
+       11.6.2.  Algorithm Information  . . . . . . . . . . . . . . .  31
+     11.7.  Test Sessions  . . . . . . . . . . . . . . . . . . . . .  31
+       11.7.1.  Test Session Listing (Current User)  . . . . . . . .  32
+       11.7.2.  Create a New Test Session  . . . . . . . . . . . . .  33
+       11.7.3.  Test Session Information . . . . . . . . . . . . . .  35
+       11.7.4.  Submit For Validation  . . . . . . . . . . . . . . .  35
+       11.7.5.  Cancel Test Session  . . . . . . . . . . . . . . . .  37
+       11.7.6.  Request Validation Results . . . . . . . . . . . . .  37
+     11.8.  Vector Sets  . . . . . . . . . . . . . . . . . . . . . .  38
+       11.8.1.  Vectors Set Listing  . . . . . . . . . . . . . . . .  38
+       11.8.2.  Vector Set Download  . . . . . . . . . . . . . . . .  39
+       11.8.3.  Cancel Testing of a Vector Set . . . . . . . . . . .  41
+       11.8.4.  Request Validation Results . . . . . . . . . . . . .  41
+       11.8.5.  Submit Results . . . . . . . . . . . . . . . . . . .  43
+       11.8.6.  Update Results Submission  . . . . . . . . . . . . .  44
+       11.8.7.  Retrieve Expected Results  . . . . . . . . . . . . .  45
+   12. Vector Set Expiration . . . . . . . . . . . . . . . . . . . .  45
+   13. Paging Parameters . . . . . . . . . . . . . . . . . . . . . .  46
+   14. Error Codes . . . . . . . . . . . . . . . . . . . . . . . . .  47
+   15. Custom Specification Objects  . . . . . . . . . . . . . . . .  47
+     15.1.  Date . . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     15.2.  BitString  . . . . . . . . . . . . . . . . . . . . . . .  47
+       15.2.1.  Endianness . . . . . . . . . . . . . . . . . . . . .  47
+       15.2.2.  Hex to Bitstring Parsing . . . . . . . . . . . . . .  47
+     15.3.  Range  . . . . . . . . . . . . . . . . . . . . . . . . .  48
+       15.3.1.  Range JSON examples  . . . . . . . . . . . . . . . .  48
+     15.4.  Domain . . . . . . . . . . . . . . . . . . . . . . . . .  49
+       15.4.1.  Domain JSON examples . . . . . . . . . . . . . . . .  49
+       15.4.2.  Additional Domain Information  . . . . . . . . . . .  49
+   16. Other Considerations  . . . . . . . . . . . . . . . . . . . .  49
+   17. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  50
+   18. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  50
+   19. Normative References  . . . . . . . . . . . . . . . . . . . .  50
+   Appendix A.  JSON Formatting Guidelines . . . . . . . . . . . . .  50
+   Appendix B.  JSON Encoded Error Messages  . . . . . . . . . . . .  51
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  51
 
 1.  Introduction
 
@@ -124,6 +162,14 @@ Internet-Draft              Abbreviated Title                   May 2018
    using standard network communication interfaces and protocols.  This
    communication protocol can also be used to validate the correctness
    of the implementations of the algorithms in the cryptographic module
+
+
+
+Fussell                  Expires January 6, 2019                [Page 3]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
    with a validation authority.  This document describes how ACVP is
    structured with respect to the client-server model, the messaging
    protocol, optional features and flows.
@@ -162,14 +208,6 @@ Internet-Draft              Abbreviated Title                   May 2018
 
    ACVP defines how to communicate a request (to execute a cryptographic
    operation) to a cryptographic module, and how to communicate the
-
-
-
-Fussell                 Expires December 1, 2018                [Page 3]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    corresponding response (containing the output of that operation) back
    to a testing system.  It defines a transport (based on HTTP or
    HTTPS), an encoding and message format (which is negotiated), and a
@@ -180,6 +218,14 @@ Internet-Draft              Abbreviated Title                   May 2018
    to be acceptable.  Instead, it references existing specifications for
    those algorithms, and defines a mapping between the data on the wire
    and the algorithm testing specification.  ACVP does not define
+
+
+
+Fussell                  Expires January 6, 2019                [Page 4]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
    detailed conformance criteria, such as those in FIPS-140.  Instead,
    it aims to be independent of particular conformance criteria, so that
    it can be used in multiple domains with different (even potentially
@@ -217,15 +263,6 @@ Internet-Draft              Abbreviated Title                   May 2018
 
    o  Management interface
 
-
-
-
-
-Fussell                 Expires December 1, 2018                [Page 4]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    With that in mind there are several expectations when building a
    server used as a validation authority.  A validation authority shall
    use HTTPS, TLS 1.2 or greater and mutual authentication.  Therefore a
@@ -233,6 +270,17 @@ Internet-Draft              Abbreviated Title                   May 2018
    the same requirements.  A server, proxy or client developed for the
    purposes of internal organizational testing only may chose not to
    include some of those features.
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019                [Page 5]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
 
 2.3.  Terminology
 
@@ -274,14 +322,6 @@ Internet-Draft              Abbreviated Title                   May 2018
    o  ACV Server - Sends JSON formatted messaging and test data to the
       ACV client and processes test responses.
 
-
-
-
-Fussell                 Expires December 1, 2018                [Page 5]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    o  ACV Proxy - Resides between the ACV server and ACV client to proxy
       the connection for the client.  This is particularly useful when
       the client does not support TLS, key management or have signature
@@ -290,6 +330,14 @@ Internet-Draft              Abbreviated Title                   May 2018
 
    o  Device Under Test - contains the ACV client and the crypto module
       under test which can include various algorithms and functions that
+
+
+
+Fussell                  Expires January 6, 2019                [Page 6]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
       encrypt/decrypt, generate keys, signatures, perform varifications
       and DRBG functions.
 
@@ -333,9 +381,17 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 
 
-Fussell                 Expires December 1, 2018                [Page 6]
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019                [Page 7]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
                              Protocol Layering
@@ -351,147 +407,203 @@ Internet-Draft              Abbreviated Title                   May 2018
    |_______________________________________________|
 
 
+
                                  Figure 3
 
 4.1.  HTTP URI Hierarchy
 
 
-            +----------------------------------------------------------+
-            server path prefix           version
-            +-------------+----------+----+--+-------------------------+
+            +-------------+------------------+-------------------------+
+               server          path prefix          resource
+            +-------------+------------------+-------------------------+
     https://acvts.nist.gov/validation/acvp/v1/testSession/1/vectorSet/1
             +-------------+----------+----+--+-------------------------+
-                             context  API           object
+                             context  API   |
+                                         version
+
 
 
                                  Figure 4
 
    Note that deployments utilizing ACV Proxy server may use a different
-   protocol, e.g., HTTP, custom server path prefix, context and port
-   number to interact with the DUT.
+   protocol, e.g., HTTP, custom server, context and port number to
+   interact with the DUT.
 
-4.2.  HTTP URI Objects
+4.2.  HTTP URI Resources
 
-   Objects and their available operations.
+   In the table below, any part of a resource path enclosed in curly
+   braces, { or }, are replaced by an instance of what is described in
+   the brackets.  For example {testSessionId} could be replaced with 1.
 
-   In the table below, any part of a path enclosed in brackets are
-   replaced by an instance of what is described in the brackets.  For
-   example <testSessionId> could be replaced with 1.
+     _An empty cell for a resource and HTTP Method combination denotes
+    that the server returns an HTTP Status 405 code "Method not allowed
+                                 (405)"._
 
-   +--------+----------------------------------------+------+----------+
-   | Object | Object Path                            | HTTP | Details  |
-   |        |                                        | Meth |          |
-   |        |                                        | od   |          |
-   +--------+----------------------------------------+------+----------+
-   | Create | /testSessions                          | POST | Section  |
-   | Test S |                                        |      | 11.2     |
-   | ession |                                        |      |          |
+   +--------------+------------+------------+------------+-------------+
+   | Resource     | GET (read) | POST       | PUT        | DELETE      |
+   |              |            | (create)   | (update)   |             |
 
 
 
-Fussell                 Expires December 1, 2018                [Page 7]
+Fussell                  Expires January 6, 2019                [Page 8]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-   |        |                                        |      |          |
-   | Vector | /testSessions/<testSessionId>/vectorSe | GET  | Section  |
-   | Set do | ts/<vectorSetId>/tests                 |      | 11.3     |
-   | wnload |                                        |      |          |
-   | reques |                                        |      |          |
-   | t      |                                        |      |          |
-   |        |                                        |      |          |
-   | Submit | /testSessions/<testSessionId>/vectorSe | POST | Section  |
-   | Vector | ts/<vectorSetId>/submissions           |      | 11.4     |
-   | Set    |                                        |      |          |
-   | Test R |                                        |      |          |
-   | esults |                                        |      |          |
-   |        |                                        |      |          |
-   | Reques | /testSessions/<testSessionId>/vectorSe | GET  | Section  |
-   | t Vali | ts/<vectorSetId>/results               |      | 11.5     |
-   | dation |                                        |      |          |
-   | Result |                                        |      |          |
-   | s for  |                                        |      |          |
-   | a      |                                        |      |          |
-   | Vector |                                        |      |          |
-   | Set    |                                        |      |          |
-   |        |                                        |      |          |
-   | Expect | /testSessions/<testSessionId>/vectorSe | POST | Section  |
-   | ed     | ts/<vectorSetId>/answers               |      | 11.4     |
-   | Test R |                                        |      |          |
-   | esults |                                        |      |          |
-   | (Optio |                                        |      |          |
-   | nal)   |                                        |      |          |
-   |        |                                        |      |          |
-   | Reques | /testSessions/<testSessionId>/results  | GET  | Section  |
-   | t Vali |                                        |      | 11.5     |
-   | dation |                                        |      |          |
-   | Result |                                        |      |          |
-   | s for  |                                        |      |          |
-   | a Test |                                        |      |          |
-   | Sessio |                                        |      |          |
-   | n      |                                        |      |          |
-   |        |                                        |      |          |
-   | Reques | /testSessions/<testSessionId>/vectorSe | DELE | Section  |
-   | t      | ts/<vectorSetId>                       | TE   | 11.6     |
-   | server |                                        |      |          |
-   | to     |                                        |      |          |
-   | remove |                                        |      |          |
-   | a      |                                        |      |          |
-   | Vector |                                        |      |          |
-   | Set (c |                                        |      |          |
-   | ancel  |                                        |      |          |
-   | testin |                                        |      |          |
+   +--------------+------------+------------+------------+-------------+
+   | /vendors     | Returns a  | Register a |            |             |
+   |              | list of    | new vendor |            |             |
+   |              | vendors    | (Section   |            |             |
+   |              | (Section   | 11.2.2)    |            |             |
+   |              | 11.2.1)    |            |            |             |
+   | /vendors/{ve | Retrieve I |            | Update a   | Delete a    |
+   | ndorId}      | nformation |            | vendor     | vendor      |
+   |              | for a      |            | (Section   | (Section    |
+   |              | specific   |            | 11.2.4)    | 11.2.5)     |
+   |              | vendor     |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.2.3)    |            |            |             |
+   | /oes         | Return a   | Create a   |            |             |
+   |              | List of    | new OE     |            |             |
+   |              | OEs        | (Section   |            |             |
+   |              | (Section   | 11.4.2)    |            |             |
+   |              | 11.4.1)    |            |            |             |
+   | /oes/{oeId}  | Retrieve I |            | Update an  | Delete an   |
+   |              | nformation |            | OE         | OE (Section |
+   |              | for a OE   |            | (Section   | 11.4.5)     |
+   |              | (Section   |            | 11.4.4)    |             |
+   |              | 11.4.3)    |            |            |             |
+   | /modules     | Return a   | Register a |            |             |
+   |              | List of    | new Module |            |             |
+   |              | Modules    | (Section   |            |             |
+   |              | (Section   | 11.3.2)    |            |             |
+   |              | 11.3.1)    |            |            |             |
+   | /modules/{mo | Retrieve I |            | Update a   | Delete a    |
+   | duleId}      | nformation |            | module     | module      |
+   |              | for a      |            | (Section   | (Section    |
+   |              | specific   |            | 11.3.4)    | 11.3.5)     |
+   |              | module     |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.3.3)    |            |            |             |
+   | /dependencie | Returns a  | Create a   |            |             |
+   | s            | list of de | new        |            |             |
+   |              | pendencies | dependency |            |             |
+   |              | (Section   | (Section   |            |             |
+   |              | 11.5.1)    | 11.5.2)    |            |             |
+   | /dependencie | Returns a  |            |            |             |
+   | s/properties | list of    |            |            |             |
+   |              | properties |            |            |             |
+   |              | for depend |            |            |             |
+   |              | encies     |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.5.3)    |            |            |             |
+   | /dependencie | Retrieve I |            | Update a   | Delete a    |
 
 
 
-Fussell                 Expires December 1, 2018                [Page 8]
+Fussell                  Expires January 6, 2019                [Page 9]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-   | g for  |                                        |      |          |
-   | that   |                                        |      |          |
-   | vector |                                        |      |          |
-   | set)   |                                        |      |          |
-   | Reques | /testSessions/<testSessionId>          | DELE | Section  |
-   | t      |                                        | TE   | 11.6     |
-   | server |                                        |      |          |
-   | to     |                                        |      |          |
-   | remove |                                        |      |          |
-   | a Test |                                        |      |          |
-   | Sessio |                                        |      |          |
-   | n (can |                                        |      |          |
-   | cel te |                                        |      |          |
-   | sting  |                                        |      |          |
-   | for    |                                        |      |          |
-   | that   |                                        |      |          |
-   | test s |                                        |      |          |
-   | ession |                                        |      |          |
-   | )      |                                        |      |          |
-   | Submit | /testSessions/<testSessionId>/submissi | POST | Section  |
-   | the    | ons                                    |      | 11.6     |
-   | test s |                                        |      |          |
-   | ession |                                        |      |          |
-   | for va |                                        |      |          |
-   | lidati |                                        |      |          |
-   | on.    |                                        |      |          |
-   +--------+----------------------------------------+------+----------+
+   | s/{dependenc | nformation |            | dependency | dependency  |
+   | yId}         | for a      |            | (Section   | (Section    |
+   |              | specific   |            | 11.5.5)    | 11.5.6)     |
+   |              | dependency |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.5.4)    |            |            |             |
+   | /algorithms  | Return a   |            |            |             |
+   |              | List of    |            |            |             |
+   |              | Available  |            |            |             |
+   |              | Algorithms |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.6.1)    |            |            |             |
+   | /algorithms/ | Retrieve I |            |            |             |
+   | {algorithmId | nformation |            |            |             |
+   | }            | about an   |            |            |             |
+   |              | Algorithm  |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.6.2)    |            |            |             |
+   | /testSession | Returns a  | Create a   |            |             |
+   | s            | list of    | new Test   |            |             |
+   |              | Test       | Session    |            |             |
+   |              | Sessions   | (Section   |            |             |
+   |              | for the    | 11.7.2)    |            |             |
+   |              | current    |            |            |             |
+   |              | user       |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.7.1)    |            |            |             |
+   |              | (Optional) |            |            |             |
+   | /testSession | Returns in |            | Certify    | Cancel      |
+   | s/{testSessi | formation  |            | the Test   | testing for |
+   | onId}        | about the  |            | Session    | a specific  |
+   |              | specific   |            | for valida | Test        |
+   |              | Test       |            | tion.      | Session     |
+   |              | Session    |            | (Section   | (Section    |
+   |              | (Section   |            | 11.7.4)    | 11.7.5)     |
+   |              | 11.7.3)    |            |            |             |
+   |              | (Optional) |            |            |             |
+   | /testSession | Request    |            |            |             |
+   | s/{testSessi | Validation |            |            |             |
+   | onId}/result | Results    |            |            |             |
+   | s            | for a Test |            |            |             |
+   |              | Session    |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.7.6)    |            |            |             |
+   | /testSession | Returns a  |            |            |             |
+   | s/{testSessi | list of    |            |            |             |
+   | onId}/vector | Vector     |            |            |             |
+   | Sets         | Sets for   |            |            |             |
 
-                                  Table 1
 
-   The operation path is appended to the path prefix to form the URI
-   used with HTTP GET or POST to perform the desired ACVP operation.  An
-   example valid URI absolute path for the "/register" operation is
-   "/validation/acvp/register".  To register a DUT the ACVP client would
-   use the following HTTP request-line:
 
-   POST /validation/acvp/register HTTP/1.0
+Fussell                  Expires January 6, 2019               [Page 10]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   |              | the        |            |            |             |
+   |              | specific   |            |            |             |
+   |              | Test       |            |            |             |
+   |              | Session    |            |            |             |
+   |              | (Section   |            |            |             |
+   |              | 11.8.1)    |            |            |             |
+   | /testSession | Vector Set |            |            | Cancel      |
+   | s/{testSessi | download   |            |            | testing for |
+   | onId}/vector | request    |            |            | a specific  |
+   | Sets/{vector | (Section   |            |            | Vector Set  |
+   | SetId}       | 11.8.2)    |            |            | (Section    |
+   |              |            |            |            | 11.8.3)     |
+   | /testSession | Request    | Initial    | Update     |             |
+   | s/{testSessi | Validation | Submission | Vector Set |             |
+   | onId}/vector | Results    | of Vector  | Test       |             |
+   | Sets/{vector | for a      | Set Test   | Results    |             |
+   | SetId}/resul | Vector Set | Results    | Submission |             |
+   | ts           | (Section   | (Section   | (Section   |             |
+   |              | 11.8.4)    | 11.8.5)    | 11.8.6)    |             |
+   | /testSession | Expected   |            |            |             |
+   | s/{testSessi | Test       |            |            |             |
+   | onId}/vector | Results    |            |            |             |
+   | Sets/{vector | (Section   |            |            |             |
+   | SetId}/expec | 11.8.7)    |            |            |             |
+   | ted          | (Optional) |            |            |             |
+   +--------------+------------+------------+------------+-------------+
+
+             Table 1: Resources and their available operations
+
+   The resource path is appended to the path prefix to form the URI used
+   with an HTTP Method to perform the desired ACVP operation.  For
+   example to create a new test session using the "/testSessions"
+   resource is "/acvp/v1/testSessions" (assuming an empty context).  To
+   create a new Test Session, the ACVP client would use the following
+   HTTP request-line:
+
+   POST /acvp/v1/testSessions HTTP/1.1
 
    Likewise, to request a specific vector set from the server the ACVP
    client would use the following request-line:
 
-   GET /validation/acvp/vectors?vsId=1 HTTP/1.0
+   GET /acvp/v1/testSessions/1/vectorSets/1 HTTP/1.1
 
 5.  Security
 
@@ -501,9 +613,9 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 
 
-Fussell                 Expires December 1, 2018                [Page 9]
+Fussell                  Expires January 6, 2019               [Page 11]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
    have TLS so HTTP with some level of authentication may be the only
@@ -511,14 +623,18 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 6.  Authentication
 
-   It is recommended that an authentication scheme be used.  Depending
-   on the target environment and usage objectives, that can be as weak
-   as basic HTTP authentication or as strong as TLS mutual certificate
-   authentication.  Definition of an authentication scheme will not be
-   discussed here, but should be agreed upon between the client and
-   server owning entities including the servers owned by the validation
-   authorities.  For the purposes of the message flow examples, no
-   authentication will be used.
+   It is recommended that an authentication scheme be used.  Typically,
+   a JSON Web Token (JWT) is created by the server upon successful
+   client authentication and returned to the client to use as an
+   authorization mechanism for accessing the server resources - see JWT
+   specification (Section 11.1) below for more information.  Depending
+   on the target environment and usage objectives, the authentication
+   can be as weak as basic HTTP authentication or as strong as TLS
+   mutual certificate authentication.  Definition of an authentication
+   scheme will not be discussed here, but should be agreed upon between
+   the client and server owning entities including the servers owned by
+   the validation authorities.  For the purposes of the message flow
+   examples, no authentication will be used.
 
 7.  Traceability
 
@@ -547,6 +663,17 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 10.  Messaging
 
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 12]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
 10.1.  Product Registration/Capabilities Exchange
 
    The product registration message will include many of the normal
@@ -554,14 +681,6 @@ Internet-Draft              Abbreviated Title                   May 2018
    filling out a testing form.  This pre-test message will carry the
    Company name, primary contact (OE information) as well as a detailed
    list of the supported cryptographic algorithms to be tested during a
-
-
-
-Fussell                 Expires December 1, 2018               [Page 10]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    session.  The server will return the vector test list to the client.
    It will consist of a list of vector set IDs (vsId) each of which
    represent a set of test vectors which can be used to request the test
@@ -580,21 +699,17 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 11.  Message Formats
 
-   Servers may require a contextual path in the URI prior to the service
-   section and clients/proxies must be able to support it.
+   As described in Section 4.1 servers may require a contextual path in
+   the URI prior to the API and version path parts used to reference a
+   resource and clients/proxies must be able to support contextual
+   paths.
 
-   Unique variable definitions to identify the vector set, device and
-   session include:
+11.1.  JSON Web Token (JWT)
 
-   o  Session - represented by a JSON Web Token(JWT).  Within the JWT,
-      the JWT ID(JTI) will be a unique identifier that will be generated
-      by the server and can be used as a session ID.
+   JSON Web Token is described in RFC 7519 [RFC7519] and is used as an
+   authorization mechanism for gaining access to different resources.
 
-   o  Vector Set - represented by the VS-ID which represents a specific
-      CAVS vector request file, e.g. gcmEncryptIntIV128.req.  Passed to
-      the client as part of the capabilities exchange.
-
-   JWT example:
+   An example JWT:
 
 
 
@@ -610,12 +725,9 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 
 
-
-
-
-Fussell                 Expires December 1, 2018               [Page 11]
+Fussell                  Expires January 6, 2019               [Page 13]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
 {
@@ -632,8 +744,6 @@ Internet-Draft              Abbreviated Title                   May 2018
    Empty octet string (since alg is none).
    }
 
-                                 Figure 5
-
    The JWT can be secured if desired using the header encryption "alg"
    value defined to HS256(HMAC-SHA256) or one of the other secure
    values.  Key agreement would follow RFC7518.
@@ -641,17 +751,15 @@ Internet-Draft              Abbreviated Title                   May 2018
    The first four claims are required, however "pkey" is an optional
    private claim used to pass the key used for encrypting the database
    at the server.  Enabling this option is discussed further in
-   Section 11.2
+   Section 11.7.2
 
-11.1.  Establish Connection HTTPS GET/200 OK
+   In order to access any resource which requires authorization a client
+   must supply the JWT as an "Authorization" header value as a "Bearer"
+   token.  An example header value is:
 
-   Establish the connection, send POST and receive 200 OK response with
-   JWT from server.
+            Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibmlzdC5vcmciLCJleHAiOiAxNDYyOTg0OTUzLCJjb21wYW55IjogIkNpc2NvIiwianRpIjo0NTh9.zDhd3WrLcb1Xf5-VKOX6k-G70mACbi1tdir8qHAMPyQ
 
-
-
-
-
+                   _All exchanges below are over HTTP."_
 
 
 
@@ -669,271 +777,1457 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 
 
-Fussell                 Expires December 1, 2018               [Page 12]
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 14]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-POST /validation/acvp/register HTTP1.0
-Host: www.acvts.nist.gov/acvp
-Capabilities information(see next section)
-
-..authentication happens here..
-
-HTTP 1.0 200 OK
-Status: 200 OK
-Content-Type: application/json
-Content-Length: (length of JWT)
-{
-"accessToken" :
-"eyJhbGciOiJIUzI1NiIsI.eyJpc3MiOiJodHRwczotcGxlL.mFrs3Zo8eaSNcxiNfvRh9dqKP4F1cB",
-}
-
-Once the session is established the client must include the JWT with
-each message.
-
-
-                                 Figure 6
-
-   The authentication mechanism will be defined by the server.
-
-11.2.  Product Registration with Capabilities
-
-   POST the registration to the server consisting of the ACVP version,
-   Operating Environment (OE), vector encoding, capabilities and any
-   extensions.  In addition there are a few parameters that specify
-   session specific information:
-
-   o  certificateRequest - If an algorithm certificate is not desired
-      for this registration populate the field "certificateRequest" with
-      "no", otherwise "yes".
-
-   o  debugRequest - If this vector session is for the purposes of
-      testing the client or DUT prior to a certificate request and
-      desires the answers to the vectors as well, indicate with "yes",
-      otherwise omit the keyword or indicate with "no"
-
-   o  production - If this is a production environment indicate so with
-      "yes", otherwise omit this keyword or indicate with "no".  A
-      production environment may not be able to support intermediate
-      value tests and therefore those tests will be excluded.
-
-   o  encryptAtRest - The client may request the server to encrypt all
-      data at rest by registering "encryptAtRest" with "yes".  Omitting
-      the "encryptAtRest" field or registering with "no" will indicate
-      to the server that no encryption is require for the data at rest.
-
+   +--------+----------------------------------+--------+--------------+
+   | Client |                                  | Server | Notes        |
+   +--------+----------------------------------+--------+--------------+
+   |        | POST to /login or similar with   |        |              |
+   |        | appropriate credentials          |        |              |
+   |        | -------------------------------- |        |              |
+   |        | >                                |        |              |
+   |        |                                  |        |              |
+   |        | receive the access token         |        |              |
+   |        | <-  -  -  -  -  -  -  -  -  -  - |        |              |
+   |        |                                  |        |              |
+   |        | POST to /register with access    |        |              |
+   |        | token in header                  |        |              |
+   |        | -------------------------------> |        | the token    |
+   |        |                                  |        | from login   |
+   |        |                                  |        | is used      |
+   |        |                                  |        |              |
+   |        | receive the session info and a   |        |              |
+   |        | session access token             |        |              |
+   |        | <-  -  -  -  -  -  -  -  -  -  - |        |              |
+   |        |                                  |        |              |
+   |        | GET /vectors?vsID=<ID> with      |        |              |
+   |        | session access token in header   |        |              |
+   |        | -------------------------------> |        | the token    |
+   |        |                                  |        | from         |
+   |        |                                  |        | registration |
+   |        |                                  |        | is used to   |
+   |        |                                  |        | retrieve     |
+   |        |                                  |        | vector sets, |
+   |        |                                  |        | submit       |
+   |        |                                  |        | answers etc. |
+   |        |                                  |        |              |
+   |        | receive vectors                  |        |              |
+   |        | <-  -  -  -  -  -  -  -  -  -  - |        |              |
+   |        |                                  |        |              |
+   |        | POST to /vectors?vsID=<ID> with  |        |              |
+   |        | session access token in header   |        |              |
+   |        | and answers in body              |        |              |
+   |        | -------------------------------> |        |              |
+   |        |                                  |        |              |
+   |        | GET /results?vsID=<ID> with      |        |              |
+   |        | session access token in body     |        |              |
+   |        | -------------------------------> |        |              |
+   |        |                                  |        |              |
+   |        | receive results                  |        |              |
+   |        | <-  -  -  -  -  -  -  -  -  -  - |        |              |
+   +--------+----------------------------------+--------+--------------+
 
 
-Fussell                 Expires December 1, 2018               [Page 13]
+
+
+Fussell                  Expires January 6, 2019               [Page 15]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-   Note that when a certificate request is made, production and
-   debugRequest shall be omitted or set to "no".  Conversely if no
-   certificate is requested, the operationalEnvironment section may be
-   omitted.
+                   Table 2: Workflow authorization flows
 
-POST /validation/acvp/register HTTP1.0
-User Agent:
-Host: www.acvts.nist.gov/acvp
-Accept:
-[
- { "acvVersion": "0.4" },
- { "operation" : "register",
-   "certificateRequest" : "yes",
-   "debugRequest" : "no",
-   "production" : "no",
-   "encryptAtRest" : "yes",
-   "oeInformation" : {
-     "vendor": {
-        "name" : "Cisco",
-        "website": "www.cisco.com",
-        "contact": [{
-            "name" : "John Doe",
-            "email" : "johndoe@cisco.com"
-        }]
-    },
-    "module": {
-      "name": "Cisco ACV Test Module",
-      "version": "1.0",
-      "type": "Software"
-    },
-    "operationalEnvironment" : {
-        "dependencies" : [{
-            "type" : "software",
-            "name" : "Linux 3.1",
-            "cpe"  : "cpe-2.3:o:ubuntu:linux:3.1"
-        },{
-            "type" : "processor",
-            "manufacturer" : "Intel",
-            "family" : "ARK",
-            "name" : "Xeon",
-            "series" : "5100",
-            "features" : [ "rdrand" ]
-        }]
-    },
-    "implementationDescription" : "Sample crypto module for demonstrating ACV protocol."
-  },
-  "capabilityExchange" : {
-  "algorithms" : [
+11.2.  Vendor Resources
+
+   The available properties for vendor resources are:
+
+      *url* - "string", identifier for this resource
+
+      *name* - "string"
+
+      *parentUrl* - a parent vendor identifier, allows for multiple
+      divisions or business units to share a parent company identifier
+
+      *website* - "string"
+
+      *emails* - array of "string"s
+
+      *contacts* - an array of contact objects,
+
+         *name* - "string"
+
+         *emails* - array of "string"s
+
+         *phoneNumbers* - array of phone objects,
+
+            *number* - "string"
+
+            *type* - "string", one of (fax, voice)
+
+      *address* - an address object,
+
+         *street* - "string"
+
+         *locality* - "string"
+
+         *region* - "string"
+
+         *country* - "string"
+
+         *postalCode* - "string"
+
+11.2.1.  Vendor Listing
+
+   *GET /vendors*
+
+   Returns a listing of vendors.
 
 
 
-Fussell                 Expires December 1, 2018               [Page 14]
+
+
+Fussell                  Expires January 6, 2019               [Page 16]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-         {
-  "algorithm" : "AES-GCM",
-  "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                {"algorithm" : "DRBG", "valValue" : "123456"}],
-  "direction": [
-    "encrypt",
-    "decrypt"
-  ],
-  "ivGen" : "internal",
-  "ivGenMode" : "8.2.1",
-  "keyLen" : [
-            128,
-            256
-             ],
-  "tagLen" : [
-            96
-               ],
-  "ivLen" : [
-             96
-               ],
-  "dataLength" : [
-             0,
-             128,
-             136
-               ],
-  "aadLen" : [
-             128,
-             136
-               ]
-         }
-      ]
-    }
-  }
-]
+11.2.1.1.  Parameters
 
-                                 Figure 7
+      Paging Parameters (Section 13)
 
-   Successful response from server is 200 OK and a set of vector set
-   identifiers.  The extensions section is optional and can be
-   implementation specific for value add.  Follow on versions could
-   include protocol information.
+11.2.1.2.  Response
 
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 1, 2018               [Page 15]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
-200 OK Response:
-[
-  { "acvVersion": "0.4" },
-  { "capabilityResponse" : { "vectorSets" : [
-                       {"vsId":1437},
-                       {"vsId":1438}] } ,
-    "testSession" :       {"testId":458} ,
-    "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibmlzdC5vcmciLCJleHAiOiAxNDYyOTg0OTUzLCJjb21wYW55IjogIkNpc2NvIiwianRpIjo0NTh9.zDhd3WrLcb1Xf5-VKOX6k-G70mACbi1tdir8qHAMPyQ"
-  }
-]
-
-                                 Figure 8
-
-11.3.  Vector Set Download Request
-
-   After registration, the server provides a list of vector sets to the
-   client, each identified by a VS-ID.  The client shall download,
-   process, and upload test results for each vector set, one at a time.
-   Note that the client shall upload complete test results for each
-   processed vector set, i.e. containing a result for every test case in
-   the vector set.
-
-   GET /validation/acvp/vectors?vsId=1437  HTTP1.0
-   Host: www.acvts.nist.gov/acvp
-   Authorization: Bearer JWT
-
-                                 Figure 9
-
-   The server will respond with the vector set associated with the vsId
-   for the client to process.  The actual test group content contained
-   in the response will vary depending on the specific sub-specification
-   of the algorithm and testType being tested.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 1, 2018               [Page 16]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
-   200 OK Response:
-   Status: 200 OK
-   Content-Type: application/json
-   Content-Length: <length of results>
    [
-    { "acvVersion": "0.4" },
-    { "vsId": 1437,
-      "algorithm": "AES-GCM",
-      "testGroups": [
-       {
-         "direction": "encrypt",
-         "keyLen": 128,
-         "ivLen": 96,
-         "ptLen": 0,
-         "aadLen": 128,
-         "tagLen": 128,
-         "testType" : "AFT"
-         "tests": [
+       {"acvVersion": "0.5"},
+       {"vendors": [
            {
-             "tcId": 12340,
-             "key": "30BA1DBCB530347A148FB286D9A59757",
-             "pt": "",
-             "aad": "6CA553A59DFBD8F7E0DA619470F8986C"
+               "url": "/acvp/v1/vendors/1",
+               "name": "Cisco",
+               "website": "www.cisco.com",
+               "contacts": [{
+                   "name": "John Doe",
+                   "email": "johndoe@cisco.com"
+               }]
            },
            {
-             "tcId": 12341,
-             "key": "AB7BB9349285B3E7403E99FED8B5060E",
-             "pt": "",
-             "aad": "79504FF995F70FFD328D7070CCBD62F1"
-           }.....
+               "url": "/acvp/v1/vendors/2",
+               "name": "Acme, LLC",
+               "website": "www.acme.acme",
+               "emails" : [ "inquiry@acme.acme" ],
+               "contacts": [{
+                   "name": "Jane Smith",
+                   "emails": ["jane.smith@acme.acme"],
+                   "phoneNumbers" : [
+                       {
+                           "name": "555-555-0001",
+                           "type" : "fax"
+                       }, {
+                           "name": "555-555-0002",
+                           "type" : "voice"
+                       }
+                   ],
+                   "address" : {
+                       "street" : "123 Main Street",
+                       "locality" : "Any Town",
+                       "region" : "AnyState",
+                       "country" : "USA",
+                       "postalCode" : "123456"
+                   }
+               }]
+           }
+       ]}
    ]
 
-           <With debugRequest set iv, ct and tag would be included>
 
 
-                                 Figure 10
+
+
+Fussell                  Expires January 6, 2019               [Page 17]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.2.2.  Create a New Vendor
+
+   *POST /vendors*
+
+   Request the creation of a new Vendor.
+
+11.2.2.1.  Request
+
+   "name" is required and all other properties are optional.  "url" is
+   not allowed.
+
+   [
+       {"acvVersion": "0.5"},
+       {
+         "name": "Acme, LLC",
+         "website": "www.acme.acme",
+         "emails" : [ "inquiry@acme.acme" ],
+         "contacts": [{
+             "name": "Jane Smith",
+             "emails": ["jane.smith@acme.acme"],
+             "phoneNumbers" : [
+                 {
+                     "name": "555-555-0001",
+                     "type" : "fax"
+                 }, {
+                     "name": "555-555-0002",
+                     "type" : "voice"
+                 }
+             ],
+             "address" : {
+                 "street" : "123 Main Street",
+                 "locality" : "Any Town",
+                 "region" : "AnyState",
+                 "country" : "USA",
+                 "postalCode" : "123456"
+             }
+         }]
+       }
+   ]
+
+11.2.2.2.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {"url": "/acvp/v1/vendors/2"}
+   ]
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 18]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.2.3.  Vendor Information
+
+   *GET /vendors/{vendorId}*
+
+   Retrieve Information for a specific vendor
+
+11.2.3.1.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "url": "/acvp/v1/vendors/2",
+           "name": "Acme, LLC",
+           "website": "www.acme.acme",
+           "emails" : [ "inquiry@acme.acme" ],
+           "contacts": [{
+               "name": "Jane Smith",
+               "emails": ["jane.smith@acme.acme"],
+               "phoneNumbers" : [
+                   {
+                       "name": "555-555-0001",
+                       "type" : "fax"
+                   }, {
+                       "name": "555-555-0002",
+                       "type" : "voice"
+                   }
+               ],
+               "address" : {
+                   "street" : "123 Main Street",
+                   "locality" : "Any Town",
+                   "region" : "AnyState",
+                   "country" : "USA",
+                   "postalCode" : "123456"
+               }
+           }]
+       }
+   ]
+
+11.2.4.  Update an existing Vendor
+
+   *PUT /vendors/{vendorId}*
+
+   Update a vendor
+
+   The "url" property is not updateable.
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 19]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.2.4.1.  Request
+
+   Can be any subset of the updateable properties.  If a property is not
+   included its value is not changed.  A "null" value for a property
+   indicates the value should be removed.
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "name": "Acme, LLC",
+           "website": "www.acme.acme",
+           "emails" : [ "inquiry@acme.acme" ],
+           "contacts": [{
+               "name": "Jane Smith",
+               "emails": ["jane.smith@acme.acme"],
+               "phoneNumbers" : [
+                   {
+                       "name": "555-555-0001",
+                       "type" : "fax"
+                   }, {
+                       "name": "555-555-0002",
+                       "type" : "voice"
+                   }
+               ],
+               "address" : {
+                   "street" : "123 Main Street",
+                   "locality" : "Any Town",
+                   "region" : "AnyState",
+                   "country" : "USA",
+                   "postalCode" : "123456"
+               }
+           }]
+       }
+   ]
+
+11.2.5.  Remove a Vendor
+
+   *DELETE /vendors/{vendorId}*
+
+   Delete a specific vendor.
+
+   The server is not required to remove the resource but MUST return an
+   error if the resource will not be removed.
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 20]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.3.  Modules
+
+   The available properties for module resources are:
+
+      *url* - "string", identifier for this resource
+
+      *name* - "string"
+
+      *version* - "string"
+
+      *type* - "string", valid values are:
+
+         "software" - software-based modules
+
+         "hardware" - hardware-based modules
+
+      *vendorUrl* - "string", identifier for a vendor resource
+      (Section 11.2)
+
+      *implementationDescription* - "string", a description of the
+      implementation
+
+11.3.1.  List Modules
+
+   *GET /modules*
+
+   Returns a List of available modules.
+
+11.3.1.1.  Response
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 21]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+[
+    {"acvVersion": "0.5"},
+    {"modules": [
+        {
+            "url": "/acvp/v1/modules/1",
+            "name": "ACME ACV Test Module",
+            "version": "1.0",
+            "type": "Software",
+            "vendorUrl": "/acvp/v1/vendors/2",
+            "implementationDescription" : "ACME test module."
+        },
+        {
+            "url": "/acvp/v1/modules/2",
+            "name": "ACME ACV Test Module",
+            "version": "2.0",
+            "type": "Software",
+            "vendorUrl": "/acvp/v1/vendors/2",
+            "implementationDescription" : "ACME test module with more features."
+        }
+    ]}
+]
+
+11.3.2.  Register a new Module
+
+   *POST /modules*
+
+   Register a new module.
+
+11.3.2.1.  Request
+
+[
+    {"acvVersion": "0.5"},
+    {
+        "name": "ACME ACV Test Module",
+        "version": "3.0",
+        "type": "Software",
+        "vendorUrl": "/acvp/v1/vendors/2",
+        "implementationDescription" : "ACME test module with more bells and whistles."
+    }
+]
+
+11.3.2.2.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {"url": "/acvp/v1/modules/5"}
+   ]
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 22]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.3.3.  Retrieve information for a Module
+
+   *GET /modules/{moduleId}*
+
+   Returns information about a specific module.
+
+11.3.3.1.  Response
+
+[
+    {"acvVersion": "0.5"},
+    {
+        "url": "/acvp/v1/modules/2",
+        "name": "ACME ACV Test Module",
+        "version": "2.0",
+        "type": "Software",
+        "vendorUrl": "/acvp/v1/vendors/2",
+        "implementationDescription": "ACME test module with more features."
+    }
+]
+
+11.3.4.  Update a Module
+
+   *PUT /modules/{moduleId}*
+
+   Update an existing module.
+
+   It may not be possible to update all properties of a module once the
+   module has been associated with a test session.
+
+11.3.4.1.  Request
+
+[
+    {"acvVersion": "0.5"},
+    {
+        "implementationDescription" : "ACME test module with more bells and whistles."
+    }
+]
+
+11.3.5.  Delete a Module
+
+   *DELETE /modules/{moduleId}*
+
+   Delete a module or mark as no longer in use.  (Optional)
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 23]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.4.  Operational Environments (OEs)
+
+   The available properties for operational environment resources are:
+
+      *url* - "string", identifier for this resource
+
+      *name* - "string"
+
+      *dependencyUrls* - an array of "string"s which identify the
+      dependencies (Section 11.5) which comprise this OE.
+
+11.4.1.  List Operational Environments
+
+   *GET /oes*
+
+   Returns a List of available operational environments.
+
+11.4.1.1.  Response
+
+[
+    {"acvVersion": "0.5"},
+    {"oes": [
+        {
+            "url": "/acvp/v1/oes/1",
+            "name": "Windows 10 on Intel Xeon 5100 Series Processor",
+            "dependencyUrls": [ "/acvp/v1/dependencies/1", "/acvp/v1/dependencies/2"]
+        },
+        {
+            "url": "/acvp/v1/oes/2",
+            "name": "Windows 10 on AMD 6272 Opteron Processor",
+            "dependencyUrls": [ "/acvp/v1/dependencies/1", "/acvp/v1/dependencies/3"]
+        }
+    ]}
+]
+
+11.4.2.  Create a new Operational Environment
+
+   *POST /oes*
+
+   Create a new operational environment.
+
+11.4.2.1.  Request
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 24]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+[
+    {"acvVersion": "0.5"},
+    {
+        "name": "Ubuntu Linux 3.1 on AMD 6272 Opteron Processor with Acme package installed",
+        "dependencyUrls": [
+            "/acvp/v1/dependencies/4",
+            "/acvp/v1/dependencies/5",
+            "/acvp/v1/dependencies/7"
+        ]
+    }
+]
+
+11.4.2.2.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {"url": "/acvp/v1/oes/20"}
+   ]
+
+11.4.3.  Retrieve information for an Operational Environment
+
+   *GET /oes/{oeId}*
+
+   Returns information about a specific operational environment.
+
+11.4.3.1.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "url": "/acvp/v1/oes/1",
+           "name": "Windows 10 on Intel Xeon 5100 Series Processor",
+           "dependencyUrls": [
+               "/acvp/v1/dependencies/1",
+               "/acvp/v1/dependencies/2"
+           ]
+       }
+   ]
+
+11.4.4.  Update an Operational Environment
+
+   *PUT /oes/{oeId}*
+
+   Update an existing operational environment.
+
+   It may not be possible to update all (or any) properties of an
+   operational environment resource once the resource has been
+   associated with a test session.
+
+
+
+Fussell                  Expires January 6, 2019               [Page 25]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.4.4.1.  Request
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "name": "Windows 10 on Intel Xeon 5100 Series Processor",
+       }
+   ]
+
+11.4.5.  Delete an Operational Environment
+
+   *DELETE /oes/{oeId}*
+
+   Delete an operational environment or mark as no longer in use.
+   (Optional)
+
+11.5.  Dependencies
+
+   The available properties for dependency resources are:
+
+      *url* - "string", identifier for this resource
+
+      *type* - "string"
+
+      "{varies}" depending on the value of "type" as defined by the
+      response of Section 11.5.3
+
+11.5.1.  List Dependencies
+
+   *GET /dependencies*
+
+   Returns a List of available dependencies.
+
+11.5.1.1.  Response
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 26]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   [
+       {"acvVersion": "0.5"},
+       {"dependencies": [
+           {
+               "type": "software",
+               "name": "Linux 3.1",
+               "cpe": "cpe-2.3:o:ubuntu:linux:3.1"
+           },
+           {
+               "type": "processor",
+               "manufacturer": "Intel",
+               "family": "ARK",
+               "name": "Xeon",
+               "series": "5100",
+               "features": ["rdrand"]
+           }
+       ]}
+   ]
+
+11.5.2.  Register a new Dependency
+
+   *POST /dependencies*
+
+   Register a new dependency.
+
+11.5.2.1.  Request
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "type": "software",
+           "name": "Linux 3.1",
+           "cpe": "cpe-2.3:o:ubuntu:linux:3.1"
+       }
+   ]
+
+11.5.2.2.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {"url": "/acvp/v1/dependencies/7"}
+   ]
+
+11.5.3.  List Dependency Properties
+
+   *GET /dependencies/properties*
+
+   Returns the list of available dependency properties.
+
+
+
+Fussell                  Expires January 6, 2019               [Page 27]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   An array of property objects is returned with the following
+   properties:
+
+      *name* - "string"
+
+      *dataType* - "string"
+
+      *validTypes* - an array of "string"s where each element
+      corresponds to a dependency type value that this property may be
+      used with.
+
+      *description* - "string"
+
+11.5.3.1.  Response
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 28]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+[
+    {"acvVersion": "0.5"},
+    {"properties": [
+        {
+            "name": "name",
+            "dataType": "string",
+            "validTypes": [
+                "software",
+                "processor"
+            ],
+            "description": "The name of the dependency."
+        },
+        {
+            "name": "swid",
+            "dataType": "string",
+            "validTypes": ["software"],
+            "description": "A Software identification (SWID) tag as described in ISO/IEC 19770-2:2015. NIST IR 8060, https://csrc.nist.gov/publications/detail/nistir/8060/final, provides guidance on creating and maintaining SWID tags."
+        },
+        {
+            "name": "cpe",
+            "dataType": "string",
+            "validTypes": [
+                "software",
+                "processor"
+            ],
+            "description": "A Common Platform Enumeration (CPE) formatted name according to Version 2.3 of the CPE Naming Specification found in NISTIR 7695, https://csrc.nist.gov/publications/detail/nistir/7695/final."
+        },
+        {
+            "name": "manufacturer",
+            "dataType": "string",
+            "validTypes": ["processor"],
+            "description": "The name of the manufacturer of the processor dependency."
+        },
+        {
+            "name": "family",
+            "dataType": "string",
+            "validTypes": ["processor"],
+            "description": "The name of the family of the processor."
+        },
+        {
+            "name": "series",
+            "dataType": "string",
+            "validTypes": ["processor"],
+            "description": "The name of the series of the processor."
+        }
+    ]}
+]
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 29]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.5.4.  Retrieve information for a Dependency
+
+   *GET /dependencies/{dependencyId}*
+
+   Returns information about a specific dependency.
+
+11.5.4.1.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "type": "software",
+           "name": "Linux 3.1",
+           "cpe": "cpe-2.3:o:ubuntu:linux:3.1"
+       }
+   ]
+
+11.5.5.  Update a Dependency
+
+   *PUT /dependencies/{dependencyId}*
+
+   Update an existing dependency.
+
+   It may not be possible to update all (or any) properties of a
+   dependency resource once the resource has been associated with an
+   operational environment.
+
+11.5.5.1.  Request
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "name": "Linux 3.1.0",
+       }
+   ]
+
+11.5.6.  Delete a Dependency
+
+   *DELETE /dependencies/{dependencyId}*
+
+   Delete a dependency or mark as no longer in use.  (Optional)
+
+11.6.  Algorithms
+
+   The Algorithm resources are informational only.
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 30]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+11.6.1.  Algorithms Listing
+
+   *GET /algorithms*
+
+   Returns a list of available Algorithms on the server.
+
+   This is an optional operation.
+
+11.6.1.1.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {"algorithms": [
+           {
+               "url": "/acvp/v1/algorithms/2",
+               "name": "AES",
+               "mode": "GCM",
+               "versions": [
+                   "0.4",
+                   "0.5"
+               ]
+           },
+           {
+               "url": "/acvp/v1/algorithms/3",
+               "name": "AES",
+               "mode": "ECB",
+               "versions": [
+                   "0.5"
+               ]
+           }
+       ]}
+   ]
+
+11.6.2.  Algorithm Information
+
+   *GET /algorithms/{algorithmId}*
+
+   Retrieve Information for about a specific algorithm.
+
+11.6.2.1.  Response
+
+   Response may vary from server depending on internal representation.
+
+11.7.  Test Sessions
+
+   The available properties for test session resources are:
+
+      *url* - "string", identifier for this resource
+
+
+
+Fussell                  Expires January 6, 2019               [Page 31]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+      *acvpVersion* - "string", version of ACV protocol used to created
+      the test session.
+
+      *createdOn* - date (Section 15.1)
+
+      *expiresOn* - date (Section 15.1)
+
+      *encryptAtRest* - "boolean"
+
+      *vectorSetsUrl* - "string"
+
+      *publishable* - "boolean", indicates whether this test session may
+      be submitted for validation
+
+      *passed* - "boolean", indicates whether all of the vector set
+      tests have passed
+
+      *isSample* - "boolean", if true
+      /testSessions/{testSessionId}/vectorSets/{vectorSetId}/expected
+      (Section 11.8.7) will return expected result values.
+
+      *production* - "boolean", indicates that the test session excludes
+      tests that require intermediate values; this may cause the test
+      session to have a "publishable" value of "false".
+
+11.7.1.  Test Session Listing (Current User)
+
+   *GET /testSessions*
+
+   Returns a list of Test Sessions for the current user.
+
+   This is an optional operation.
+
+11.7.1.1.  Response
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 32]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   [
+       {"acvVersion": "0.5"},
+       {"testSessions": [{
+           "url": "/acvp/v1/testSessions/2",
+           "acvpVersion": "0.5",
+           "createdOn": "2018-05-31T12:03:43Z",
+           "expiresOn": "2018-06-30T12:03:43Z",
+           "encryptAtRest": false,
+           "vectorSetsUrl": "/acvp/v1/testSessions/2/vectorSets",
+           "publishable": false,
+           "passed": true,
+           "production" : false,
+           "isSample": true
+       }]}
+   ]
+
+11.7.2.  Create a New Test Session
+
+   *POST /testSessions*
+
+   Create a new Test Session.
+
+11.7.2.1.  Request
+
+   "algorithms" is an array of algorithm objects.  Each algorithm object
+   has the following available properties:
+
+      *algorithm* - "string", required
+
+   Additional properties for each algorithm are based on the algorithm
+   definition available in each sub-specification.
+
+   If not provided "isSample", "production" and "encryptAtRest" default
+   to "false".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 33]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   [
+       {"acvVersion": "0.5"},
+       {
+       "isSample" : "true",
+       "algorithms": [{
+           "algorithm": "AES-GCM",
+           "direction": [
+               "encrypt",
+               "decrypt"
+           ],
+           "ivGen": "internal",
+           "ivGenMode": "8.2.1",
+           "keyLen": [
+               128,
+               256
+           ],
+           "tagLen": [96],
+           "ivLen": [96],
+           "dataLength": [
+               0,
+               128,
+               136
+           ],
+           "aadLen": [
+               128,
+               136
+           ]
+       }]}
+   ]
+
+11.7.2.2.  Response
+
+   "accessToken" is a JWT Token [RFC7519] which MUST be supplied as
+   described in Section 11.1 in order to access the Test Session.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 34]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+[
+    {"acvVersion": "0.5"},
+    {
+        "url": "/acvp/v1/testSessions/2",
+        "acvpVersion": "0.5",
+        "createdOn": "2018-05-31T12:03:43Z",
+        "expiresOn": "2018-06-30T12:03:43Z",
+        "encryptAtRest": false,
+        "vectorSetsUrl": "/acvp/v1/testSessions/2/vectorSets",
+        "publishable": false,
+        "passed": true,
+        "production": false,
+        "isSample": true,
+        "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibmlzdC5vcmciLCJleHAiOiAxNDYyOTg0OTUzLCJjb21wYW55IjogIkNpc2NvIiwianRpIjo0NTh9.zDhd3WrLcb1Xf5-VKOX6k-G70mACbi1tdir8qHAMPyQ"
+    }
+]
+
+11.7.3.  Test Session Information
+
+   *GET /testSessions/{testSessionId}*
+
+   Returns information about the specific Test Session
+
+11.7.3.1.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "url": "/acvp/v1/testSessions/2",
+           "acvpVersion": "0.5",
+           "createdOn": "2018-05-31T12:03:43Z",
+           "expiresOn": "2018-06-30T12:03:43Z",
+           "encryptAtRest": false,
+           "vectorSetsUrl": "/acvp/v1/testSessions/2/vectorSets",
+           "publishable": false,
+           "passed": true,
+           "production": false,
+           "isSample": true
+       }
+   ]
+
+11.7.4.  Submit For Validation
+
+   *PUT /testSessions/{testSessionId}*
+
+   Certify the Test Session for validation.
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 35]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   Associates all of the testing information with the test session.  The
+   test session MUST be have both "publishable" and "passed" set to
+   "true".
+
+11.7.4.1.  Request
+
+   Available properties:
+
+      *moduleUrl* - "string"
+
+      *oeUrl* - "string"
+
+      *signature* - a signature object,
+
+         *algorithm* - "string"
+
+         *certificate* - "string"
+
+         *digitalSignature* - "string"
+
+      *algorithmPrerequisites* - array of algorithm prerequiste objects,
+      optional, for any algorithm that has a prerequisite that was not
+      included in testing, the prerequisite MUST be provided by adding
+      an element to this array
+
+         *algorithm* - "string", name of the algorithm
+
+         *mode* - "string", mode of the algorithm, optional, not all
+         algorithms have a mode
+
+         *prerequisites* - "string", array of prerequiste objects
+
+            *algorithm* - "string", required
+
+            *validationId* - "string", required
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 36]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "moduleUrl": "/acvp/v1/modules/20",
+           "oeUrl": "/acvp/v1/oes/60",
+           "algorithmPrerequisites": [{
+               "algorithm": "AES-GCM",
+               "prerequisites": [
+                   {
+                       "algorithm": "AES",
+                       "validationId": "123456"
+                   },
+                   {
+                       "algorithm": "DRBG",
+                       "validationId": "123456"
+                   }
+               ]
+           }],
+           "signature": {
+               "algorithm": "SHA256RSA",
+               "certificate": "{base64encodedcertificate}",
+               "digitalSignature": "{base64encodedsignature}"
+           }
+       }
+   ]
+
+11.7.5.  Cancel Test Session
+
+   *DELETE /testSessions/{testSessionId}*
+
+   Delete a test session.
+
+   Marks a test session as being cancelled and may be deleted by the
+   server.  Further operations with the test session resource may return
+   404 HTTP Status.
+
+11.7.6.  Request Validation Results
+
+   *GET /testSessions/{testSessionId}/results*
+
+   Request Validation Results for a Test Session
+
+11.7.6.1.  Response
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 37]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+ [
+     {"acvVersion": "0.5"},
+     {
+         "passed": false,
+         "results": [
+             {
+                 "vectorSetUrl": "/acvp/v1/testSessions/2/vectorSets/1",
+                 "status": "incomplete"
+             },
+             {
+                 "vectorSetUrl": "/acvp/v1/testSessions/2/vectorSets/2",
+                 "status": "passed"
+             }
+         ]
+     }
+ ]
+
+11.8.  Vector Sets
+
+   The available properties for vector set resources are:
+
+      *url* - "string", identifier for this resource
+
+      *vsId* - "number"
+
+      *algorithm* - "string"
+
+      *mode* - "string"
+
+      *testGroups* - array of test group objects,
+
+         "{varies}" - based on the values of "algorithm" and "mode"
+         there are zero or more test group properties.
+
+         *tests* - array of test objects,
+
+            *tcId* - "number"
+
+            "{varies}" - based on the values of "algorithm" and "mode"
+            there are zero or more test properties.
+
+11.8.1.  Vectors Set Listing
+
+   *GET /testSessions/{testSessionId}/vectorSets*
+
+   Returns a list of Vector Sets for the specific Test Session.
+
+   The property returned is:
+
+
+
+Fussell                  Expires January 6, 2019               [Page 38]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+      *vectorSetUrls* - array of "string"s
+
+11.8.1.1.  Response
+
+   [
+       {"acvVersion": "0.5"},
+       {"vectorSetUrls": [
+           "/acvp/v1/testSessions/2/vectorSets/1",
+           "/acvp/v1/testSessions/2/vectorSets/2"
+       ]}
+   ]
+
+11.8.2.  Vector Set Download
+
+   *GET /testSessions/{testSessionId}/vectorSets/{vectorSetId}*
+
+   Vector Set download request.
+
+   The server will respond with the vector set associated with the vsId
+   for the client to process.  The test group content contained in the
+   response will vary depending on the specific sub-specification of the
+   algorithm and testType being tested.
+
+11.8.2.1.  Response
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 39]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   [
+       {"acvVersion": "0.5"},
+       {
+           "vsId": 11,
+           "algorithm": "AES-CBC",
+           "testGroups": [
+               {
+                   "direction": "encrypt",
+                   "testType": "AFT",
+                   "keyLen": 128,
+                   "tests": [
+                       {
+                           "tcId": 1,
+                           "iv": "00000000000000000000000000000000",
+                           "key": "00000000000000000000000000000000",
+                           "pt": "F34481EC3CC627BACD5DC3FB08F273E6"
+                       },
+                       {
+                           "tcId": 2,
+                           "iv": "00000000000000000000000000000000",
+                           "key": "00000000000000000000000000000000",
+                           "pt": "9798C4640BAD75C7C3227DB910174E72"
+                       }
+                       ... additional tests ...
+                   ]
+               },
+               ... additional test groups ...
+               {
+                   "direction": "encrypt",
+                   "testType": "MCT",
+                   "keyLen": 128,
+                   "tests": [{
+                       "tcId": 2139,
+                       "iv": "036B918F3DAB01649FC9EA13675D714A",
+                       "key": "CC3CCB78B161504A9D5698FA75E88D49",
+                       "pt": "9CA6930792FA735C160011EC1C1B5118"
+                   }]
+               }
+               ... additional test groups ...
+           ]
+       }
+   ]
 
    If the server did not have enough time to generate the vector set for
    a given test session, the server may reply:
@@ -943,165 +2237,245 @@ Internet-Draft              Abbreviated Title                   May 2018
 
 
 
-
-
-
-
-
-
-Fussell                 Expires December 1, 2018               [Page 17]
+Fussell                  Expires January 6, 2019               [Page 40]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-   HTTP 1.0 200 OK
-   Status: 200 OK
-   Content-Type: application/json
-   Content-Length: <length of results>
    [
-     { "acvVersion": "0.4" },
+     { "acvVersion": "0.5" },
      { "vsId": 1437,
        "retry" : 10
      }
    ]
 
-                                 Figure 11
+   Where:
 
-   Where the retry value represents the number of seconds for the client
-   to wait before retrying the request.  The server may set the retry
-   value based on the current server load and expected processing time
-   to generate the vector set.
+      *retry* - represents the number of seconds for the client to wait
+      before retrying the request.
 
-11.4.  Submit Test Results
+   The server may set the "retry" value based on the current server load
+   and expected processing time to generate the vector set.
+
+11.8.3.  Cancel Testing of a Vector Set
+
+   *DELETE /testSessions/{testSessionId}/vectorSets/{vectorSetId}*
+
+   Cancel testing for a specific Vector Set.
+
+   There may be cases where a particular vector set may not be cancelled
+   and the entire Test Session will need to be cancelled instead.
+
+11.8.4.  Request Validation Results
+
+   *GET /testSessions/{testSessionId}/vectorSets/{vectorSetId}/results*
+
+   Request Validation Results for a Vector Set.
+
+11.8.4.1.  Response
+
+   The client will send this request to learn the validation results for
+   an individual vector set.  Properties are:
+
+      *vsId* - "number"
+
+      *disposition* - "string", the overall result for the vector set
+      with:
+
+         "fail" - indicates at least one test case has failed.
+
+         "unreceived" - indicates the server has not received responses
+         from the client for all the test cases.
+
+         "incomplete" - indicates not all tests have been processed by
+         the server, however none have failed thus far.
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 41]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+         "expired" - indicates not all the test case responses were
+         received from the client prior to expiry.
+
+         "passed" - indicates all test cases have been processed by the
+         server and have passed.
+
+      *tests* - array of test result objects,
+
+         *tcId* - "number"
+
+         *result* - "string", the result for a test case with:
+
+            "fail" - indicates the test case has failed.
+
+            "unreceived" - indicates the server has not received a
+            response from the client for the test case.
+
+            "incomplete" - indicates the server has not processed the
+            test case.
+
+            "expired" - indicates the client did not send the test case
+            response to the server prior to expiry.
+
+            "passed" - indicates the test case passed.
+
+         *reason* - "number", provides additional detail in case of a
+         "failed" "result" value.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 42]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+   [
+       {"acvVersion": "0.5"},
+       {"results": {
+           "vsId": 1437,
+           "disposition": "incomplete",
+           "tests": [
+               {
+                   "tcId": 12340,
+                   "result": "passed",
+                   "reason": ""
+               },
+               {
+                   "tcId": 12341,
+                   "result": "incomplete",
+                   "reason": ""
+               },
+               {
+                   "tcId": 12342,
+                   "result": "failed",
+                   "reason": "Authentication tag mismatch"
+               }
+           ]
+       }}
+   ]
+
+11.8.5.  Submit Results
+
+   *POST /testSessions/{testSessionId}/vectorSets/{vectorSetId}/results*
+
+   Initial Submission of Vector Set Test Results.
+
+11.8.5.1.  Request
 
    The client will send this request to submit the test results for an
    individual vector set.  Similar to the vector set download the format
    will vary depending on the specific sub-specification of the
    algorithm and testType being tested.
 
-   POST /validation/acvp/vectors?vsId=1437 HTTP1.0
-   Host: www.acvts.nist.gov/acvp
-   Authorization: Bearer JWT
-   Accept:
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 43]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
    [
-    { "acvVersion": "0.4" },
-    { "vsId": 1437,
-      "testResults": [
-      {
-      "tcId": 12340,
-      "iv": "01020304C077A707E56C22AC",
-      "ct": "",
-      "tag": "53B15E85E377F8B5B6BFC2DE915FD622"
-      },
-      {
-      "tcId": 12341,
-      "iv": "01020304D666587803BCBAD7",
-      "ct": "",
-      "tag": "E7B1F2D77D82C6EB3C9CEFF16C376D9C"
-      }, ...
+       {"acvVersion": "0.5"},
+       {
+           "vsId": 1437,
+           "testResults": [
+               {
+                   "tcId": 12340,
+                   "iv": "01020304C077A707E56C22AC",
+                   "ct": "",
+                   "tag": "53B15E85E377F8B5B6BFC2DE915FD622"
+               },
+               {
+                   "tcId": 12341,
+                   "iv": "01020304D666587803BCBAD7",
+                   "ct": "",
+                   "tag": "E7B1F2D77D82C6EB3C9CEFF16C376D9C"
+               }, ...
+           ]
+       }
    ]
 
-                                 Figure 12
+11.8.5.2.  Response
+
+   No content response.  Standard HTTP status codes will indicate
+   success or failure of the submission, but do not indicated the
+   disposition of the tests.
+
+11.8.6.  Update Results Submission
+
+   *PUT /testSessions/{testSessionId}/vectorSets/{vectorSetId}/results*
+
+   Update Vector Set Test Results Submission.
+
+   When one or more test cases fails, the client will need to correct
+   the issue in the crypto module and send the responses again.  The
+   resending of responses for failed test cases will occur for an entire
+   vector set.  Therefore, even if only a single test case in the vector
+   set failed, the client will need to download, process, and upload
+   responses to the server for the entire vector set (presumably after
+   the problem has been corrected in the implementation).  The resending
+   of vector set responses must occur prior to expiry.
+
+11.8.6.1.  Request
+
+   The request content is identical to the request content described in
+   Section 11.8.5.
 
 
 
-Fussell                 Expires December 1, 2018               [Page 18]
+
+
+Fussell                  Expires January 6, 2019               [Page 44]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-11.5.  Validation Results Request
+11.8.7.  Retrieve Expected Results
 
-   The client will send this request to learn the validation results for
-   an individual vector set.
+   *GET /testSessions/{testSessionId}/vectorSets/{vectorSetId}/expected*
 
-GET /validation/acvp/results?vsId=1437 HTTP1.0
-User Agent:
-Host: www.acvts.nist.gov/acvp
-Accept: /
+   Expected Test Results.
 
+11.8.7.1.  Response
 
-Response to GET is:
-
-HTTP 1.0 200 OK
-Status: 200 OK
-Content-Type: application/json
-Content-Length: <length of results>
-[
-  { "acvVersion": "0.4" },
-  { "results" : {
-      "vsId" : 1437,
-      "disposition" : "incomplete",
-      "tests" : [
-            { "tcId" : 12340, "result" : "passed", "reason" : ""},
-            { "tcId" : 12341, "result" : "incomplete", "reason" : ""},
-            { "tcId" : 12342, "result" : "failed", "reason" : "Authentication tag mismatch"}
-              ]
-   }
-]
-
-                                 Figure 13
-
-   The results request is an optional flow since some clients may not
-   require success/fail information.  Another possibility is to provide
-   an out of band management session on the server may provide access to
-   algorithm test results.
-
-   "disposition" is defined overall for the entire vector set as:
-
-   o  "fail" indicates at least one test case has failed.
-
-   o  "unreceived" indicates the server has not received responses from
-      the client for all the test cases.
-
-   o  "incomplete" indicates not all tests have been processed by the
-      server, however none have failed thus far.
-
-
-
-
-
-Fussell                 Expires December 1, 2018               [Page 19]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
-   o  "expired" indicates not all the test case responses were received
-      from the client prior to expiry.
-
-   o  "passed" indicates all test cases have been processed by the
-      server and have passed.
-
-   "result" is defined for individual test cases:
-
-   o  "fail" indicates the test case has failed.
-
-   o  "unreceived" indicates the server has not received a response from
-      the client for the test case.
-
-   o  "incomplete" indicates the server has not processed the test case.
-
-   o  "expired" indicates the client did not send the test case response
-      to the server prior to expiry.
-
-   o  "passed" indicates the test case passed.
-
-   o  "reason" provides additional detail for the test result.
-
-11.6.  Optional Flows
-
-   The cancel URI can be used by the client to free a session.  The
-   server is responsible for maintaining any database information for
-   traceability or debugging purposes it desires.  This may be important
-   for those cases where there are test failures.
-
-   POST /validation/acvp/cancel HTTP1.0
-   Host: www.acvts.nist.gov/acvp
-   Authorization: Bearer JWT
-
-                                 Figure 14
-
-   The server response will always be 200 OK.
+   The response is identical to the request content described in
+   Section 11.8.5.
 
 12.  Vector Set Expiration
 
@@ -1114,26 +2488,13 @@ Internet-Draft              Abbreviated Title                   May 2018
    server will reply with an expired response when the client attempts
    to download the vector set:
 
-
-
-
-Fussell                 Expires December 1, 2018               [Page 20]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
-   HTTP 1.0 200 OK
-   Status: 200 OK
-   Content-Type: application/json
-   Content-Length: <length of results>
    [
-     { "acvVersion": "0.4" },
-     { "vsId" : <vs-id>,
-       "status" : "expired"
-     }
+       {"acvVersion": "0.5"},
+       {
+           "vsId": <vs-id>,
+           "status": "expired"
+       }
    ]
-
-                                 Figure 15
 
    The ACVP protocol requires server implementations to generate test
    values and retain the data while the ACVP client processes and
@@ -1153,51 +2514,37 @@ Internet-Draft              Abbreviated Title                   May 2018
    to extend its lifetime subject to server policy.  The expiration
    timestamp must be in the 'expiry' JSON value, which is included in
    the JSON encoded vector set.  The expiry JSON value will be a string
+
+
+
+Fussell                  Expires January 6, 2019               [Page 45]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
    value of the UTC timestamp using form "YYYY-MM-DD HH:MM:SS".  The
    following figure shows a partial JSON encoded vector set that
    contains the expiry value.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 1, 2018               [Page 21]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
-                 [
-                   { "acvVersion": "0.4" },
-                   { "vsId": 1437,
-                     "expiry": "2018-12-31 23:59:59",
-                     "algorithm": "AES-GCM",
-                     "testGroups": [
-                       {
-                         "direction": "encrypt",
-                         "keyLen": 128,
-                         "ivLen": 96,
-                         "ptLen": 0,
-                         "aadLen": 128,
-                         "tagLen": 128,
-                         "tests": [
-                           {
-                             "tcId": 12340,
-                             "key": "1529BAC6229586F057FAA59353851686",
-                             "pt": "",
-                             "aad": "4B11160620475D8EE440C3795CF62D26"
-                           },
+   [
+       {"acvVersion": "0.5"},
+       {
+           "vsId": 1437,
+           "expiry": "2018-12-31 23:59:59",
+           "algorithm": "AES-GCM",
+           "testGroups": [{
+               "direction": "encrypt",
+               "keyLen": 128,
+               "ivLen": 96,
+               "ptLen": 0,
+               "aadLen": 128,
+               "tagLen": 128,
+               "tests": [{
+                   "tcId": 12340,
+                   "key": "1529BAC6229586F057FAA59353851686",
+                   "pt": "",
+                   "aad": "4B11160620475D8EE440C3795CF62D26"
+               },
                            .
                            .
                            .
@@ -1205,46 +2552,55 @@ Internet-Draft              Abbreviated Title                   May 2018
                            .
                            .
                            .
-             ]
+               ]
+           }]
+       }
+   ]
+
+13.  Paging Parameters
+
+   Some resources require paging in order to avoid returning large
+   amounts of data.  To faciliate paging the following Query parameters
+   should be allowed on resources where paging is necessary.
+
+      "limit" - the number of entries to return
+
+      "offset" - the offset into the list of entries
+
+   The response will indicate the offset and the total count using
+   "offset" and "total" properties.
 
 
-                                 Figure 16
 
-12.1.  Resending Test Responses
 
-   When one or more test cases fails, the client will need to correct
-   the issue in the crypto module and send the responses again.  The
-   resending of responses for failed test cases will occur for an entire
-   vector set.  Therefore, even if only a single test case in the vector
-   set failed, the client will need to download, process, and upload
-   responses to the server for the entire vector set (presumably after
-   the problem has been corrected in the DUT).  The resending of vector
-   set responses must occur prior to expiry.
+Fussell                  Expires January 6, 2019               [Page 46]
+
+Internet-Draft              Abbreviated Title                  July 2018
 
-13.  Error Codes
+
+14.  Error Codes
 
    Errors will follow HTTP[S] numbering scheme.  In addition errors as
    well as 200 messages may carry JSON encoded information that
    describes in detail the error and any associated troubleshooting
-
-
-
-Fussell                 Expires December 1, 2018               [Page 22]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    information.  A non-exhaustive list of JSON encoded error messages
    are in Appendix B.
 
-14.  Custom Specification Objects
+15.  Custom Specification Objects
 
-14.1.  BitString
+15.1.  Date
+
+   A date type is a time "string" formatted according to the rules of
+   RFC 3339 [RFC3339]; all date/times must use UTC time denoted by 'Z'
+   suffix with no local timezone adjustment.  Example is
+   "2018-06-01T20:10:33Z"
+
+15.2.  BitString
 
    Bitstrings are used to communicate a string of bits between the ACVP
    server and IUT.
 
-14.1.1.  Endianness
+15.2.1.  Endianness
 
    BitStrings should be considered in big endian order, unless otherwise
    specified by the algorithm.
@@ -1252,7 +2608,7 @@ Internet-Draft              Abbreviated Title                   May 2018
    The hex string "FA" (assuming all bits are considered) should
    represent the bits 11111010 (in MSb) or the value 250.
 
-14.1.2.  Hex to Bitstring Parsing
+15.2.2.  Hex to Bitstring Parsing
 
    "valueLen" will be used as the example, but it can apply to any bit
    length registration/vector set/etc parameters.
@@ -1268,7 +2624,17 @@ Internet-Draft              Abbreviated Title                   May 2018
    bits, meaning the lesser significant bits are the bits that are
    dropped.
 
-14.1.2.1.  Hex string parsing examples
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 47]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+15.2.2.1.  Hex string parsing examples
 
    o  valueLen: 8, value: "FA", should be parsed as the bits 11111010,
       or the value 250.
@@ -1282,133 +2648,88 @@ Internet-Draft              Abbreviated Title                   May 2018
    o  valueLen: 3, value: "FA", should be parsed as the bits 111, or the
       value 7.
 
-
-
-
-Fussell                 Expires December 1, 2018               [Page 23]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    o  valueLen: 0, value: "", MUST be interpreted as an empty bit
       string.
 
-14.2.  Range
+15.3.  Range
 
    The Range object can be used to convey a range of values.  It
    contains its own set of properties made up of "min", "max", and
    "increment".
 
-14.2.1.  Range JSON examples
+15.3.1.  Range JSON examples
 
    A range object specifying a minimum of 0, a maximum of 8, with an
    increment of 1.  This range object includes the values 1, 2, 3, 4, 5,
    6, 7, and 8.
 
 
-             {
-               "myRange" :
-               {
-                 "min" : 1,
-                 "max" : 8,
-                 "increment" : 1
-               }
-             }
+   {"myRange": {
+       "min": 1,
+       "max": 8,
+       "increment": 1
+   }}
 
-
-                                 Figure 17
 
    A range object specifying a minimum of 0, a maximum of 8, with an
    increment of 2.  This range object includes the values 0, 2, 4, 6,
    and 8.
 
 
-             {
-               "myRange" :
-               {
-                 "min" : 0,
-                 "max" : 8,
-                 "increment" : 2
-               }
-             }
-
-
-                                 Figure 18
+   {"myRange": {
+       "min": 0,
+       "max": 8,
+       "increment": 2
+   }}
 
 
 
 
-
-
-
-Fussell                 Expires December 1, 2018               [Page 24]
+Fussell                  Expires January 6, 2019               [Page 48]
 
-Internet-Draft              Abbreviated Title                   May 2018
+Internet-Draft              Abbreviated Title                  July 2018
 
 
-14.3.  Domain
+15.4.  Domain
 
    The Domain object can be used to specify a set of values similar to
    Range, albeit with more control.  A domain can be made up of an array
    of objects, where those objects can be literal values, and/or Range
    objects.
 
-14.3.1.  Domain JSON examples
+15.4.1.  Domain JSON examples
 
    Several sample domain objects that state 0, 8, 16, 32, 96, 128, 192,
    and 256 are valid values.
 
 
-             {
-               "myDomain" :
-               [
-                 {
-                   "min" : 0,
-                   "max" : 16,
-                   "increment" : 8
-                 },
-                 32,
-                 96,
-                 {
-                   "min" : 128,
-                   "max" : 256,
-                   "increment" : 64
-                 }
-               ]
-             }
-
-
-                                 Figure 19
-
-
-             {
-               "myDomain" :
-               [
-                 0, 8, 16, 32, 96, 128, 192, 256
-               ]
-             }
-
-
-                                 Figure 20
+   {"myDomain": [
+       {
+           "min": 0,
+           "max": 16,
+           "increment": 8
+       },
+       32,
+       96,
+       {
+           "min": 128,
+           "max": 256,
+           "increment": 64
+       }
+   ]}
 
 
 
+   {"myDomain": [ 0, 8, 16,  32, 96,  128, 192, 256 ]}
 
 
-
-
-Fussell                 Expires December 1, 2018               [Page 25]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
-14.3.2.  Additional Domain Information
+15.4.2.  Additional Domain Information
 
    Because the Domain is an array of objects consisting of (potentially)
    both literals and ranges, algorithms that use an array of integers
    can be used interchangably with the Domain object.
 
-15.  Other Considerations
+16.  Other Considerations
 
    When an ACVP client is attached to a cryptographic module that is in
    use, access to ACVP MUST be controlled so that only an administrator
@@ -1416,21 +2737,38 @@ Internet-Draft              Abbreviated Title                   May 2018
    because an attacker that has access to ACVP can potentially use it to
    probe for weaknesses in the cryptographic module.
 
-16.  Acknowledgements
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 49]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
+17.  Acknowledgements
 
    Original ACVP created by David McGrew, Bill Hudson and Anthony Grieco
    of Cisco Systems.
 
-17.  IANA Considerations
+18.  IANA Considerations
 
    This memo includes no request to IANA.
 
-18.  Normative References
+19.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
+              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
+              <https://www.rfc-editor.org/info/rfc3339>.
+
+   [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
+              (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
+              <https://www.rfc-editor.org/info/rfc7519>.
 
 Appendix A.  JSON Formatting Guidelines
 
@@ -1444,27 +2782,26 @@ Appendix A.  JSON Formatting Guidelines
    Keywords should be chosen such that they are informative and brief,
    for example:
 
-   [ { "acvVersion": "0.4" }, { "results" : { "disposition" :
-   "incomplete", } } ]
+   [ { "acvVersion": "0.5" }, { "results" : { "disposition" :
+   "incomplete" } } ]
 
    Metadata assigned to the keyword may use any format which best
    reflects the information being represented including hyphens,
-
-
-
-
-Fussell                 Expires December 1, 2018               [Page 26]
-
-Internet-Draft              Abbreviated Title                   May 2018
-
-
    underscores alternating case, numbers, etc.  However, brevity should
    be a major consideration, for example:
 
    "algorithms" : [ { "algorithm" : "AES-GCM", "mode" : "modes", "ivGen"
-   : "internal", "ivGenMode" : "8.2.1", } All metadata representing
+   : "internal", "ivGenMode" : "8.2.1" } All metadata representing
    strings or big numbers shall use double quotes at both ends.  Big
    numbers require conversion from strings to whatever format is used by
+
+
+
+Fussell                  Expires January 6, 2019               [Page 50]
+
+Internet-Draft              Abbreviated Title                  July 2018
+
+
    the DUT.  Numerical values of integer size or with decimal points may
    use quotations if those values are generally used as a string, for
    example the acvVersion would generally be used in displaying
@@ -1509,4 +2846,11 @@ Author's Address
 
 
 
-Fussell                 Expires December 1, 2018               [Page 27]
+
+
+
+
+
+
+
+Fussell                  Expires January 6, 2019               [Page 51]

--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -395,12 +395,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.9.6 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.9.9 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.4" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-03-01" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.5" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-07-05" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">March 1, 2018</td>
+<td class="right">July 5, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: September 2, 2018</td>
+<td class="left">Expires: January 6, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -433,7 +433,7 @@
   </table>
 
   <p class="title">ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subdrbg-0.4</span></p>
+  <span class="filename">draft-ietf-acvp-subdrbg-0.5</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification.</p>
@@ -441,7 +441,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on September 2, 2018.</p>
+<p>This Internet-Draft will expire on January 6, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -1220,9 +1220,21 @@
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">intendedUse</td>
+<td class="left">"both", "reSeed", "predResistance", "other"</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
 </tbody>
 </table>
-<p id="rfc.section.3.2.p.2">Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
+<p id="rfc.section.3.2.p.2">Each prediction resistance test group contains an array of one or more test vectors, typically two.  Such tests are generated when the implementation under test supports prediction resistance. Note that in this case both tests have non-empty entropy input.  Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
 <div id="rfc.table.9"></div>
 <div id="vs_prtc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1254,11 +1266,75 @@
 </tr>
 </tbody>
 </table>
+<p id="rfc.section.3.2.p.3">Each re-seed test group contains an array of one or more test vectors, typically three.  Such test vectors are generated when the implementation under test supports re-seeding. Note that when the implementation under test does not support prediction resistance only the first test has non-empty entropy input.  The additional input is non-empty for all three tests. Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
+<div id="rfc.table.10"></div>
+<div id="vs_prtc_table2"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Re-seed Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">additionalInput</td>
+<td class="left">value of the additional input string to use in re-seeding tests</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">entropyInput</td>
+<td class="left">value of the entropy input to use in re-seeding tests</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.3.2.p.4">When the implementation under test supports neither re-seeding nor prediction reistance each test group contains an array of two test vectors. Note that in this case both tests have empty entropy input.  The additional input is non-empty for both tests. Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
+<div id="rfc.table.11"></div>
+<div id="vs_prtc_table3"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Other Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">additionalInput</td>
+<td class="left">value of the additional input string to use in tests</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">entropyInput</td>
+<td class="left">empty string</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
 <h1 id="rfc.section.4">
 <a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
 </h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.10"></div>
+<div id="rfc.table.12"></div>
 <div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1296,7 +1372,7 @@
 </tbody>
 </table>
 <p id="rfc.section.4.p.2">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG test vector.</p>
-<div id="rfc.table.11"></div>
+<div id="rfc.table.13"></div>
 <div id="vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>DRBG Test Case Results JSON Object</caption>
@@ -1671,6 +1747,7 @@
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
                           "otherInput" : [
+                             "intendedUse" : "both",
                              {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
                             {"additionalInput" : "f5357737023e3304508a00b3ba02",
@@ -1683,6 +1760,7 @@
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
                           "otherInput" : [
+                             "intendedUse" : "both",
                              {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
                              {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
@@ -1718,6 +1796,7 @@
                           "nonce": "b991a820fac75fd02642ad8fa651eda4",
                           "persoString": "30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
                              {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
@@ -1730,6 +1809,7 @@
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
@@ -1765,6 +1845,7 @@
                           "nonce": "786f03ad697332d74fad7a14604cee44",
                           "persoString": "",
                           "otherInput" : [
+                               "intendedUse" : "predResistance",
                                {"additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
                                {"additionalInput" : "",
@@ -1777,6 +1858,7 @@
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
                              {"additionalInput" : "",
@@ -1812,6 +1894,7 @@
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
+                               "intendedUse" : "reSeed",
                                {"additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
@@ -1826,6 +1909,7 @@
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
                           "otherInput" : [
+                             "intendedUse" : "reSeed",
                              {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
                              {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
@@ -1863,6 +1947,7 @@
                           "nonce": "6f7c6bec9825079cabd9478d88f337c8",
                           "persoString": "c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
                           "otherInput" : [
+                               "intendedUse" : "other",
                                {"additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
                                 "entropyInput": ""},
                                {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
@@ -1875,6 +1960,7 @@
                           "nonce": "a97dfbaea505a3e36210a85636197b2d",
                           "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
                           "otherInput" : [
+                             "intendedUse" : "other",
                              {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
                               "entropyInput" : ""},
                              {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",

--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,7 +400,7 @@
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-07-05" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-07-06" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -421,10 +421,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">July 5, 2018</td>
+<td class="right">July 6, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: January 6, 2019</td>
+<td class="left">Expires: January 7, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -441,7 +441,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on January 6, 2019.</p>
+<p>This Internet-Draft will expire on January 7, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -1220,21 +1220,9 @@
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">intendedUse</td>
-<td class="left">"both", "reSeed", "predResistance", "other"</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
 </tbody>
 </table>
-<p id="rfc.section.3.2.p.2">Each prediction resistance test group contains an array of one or more test vectors, typically two.  Such tests are generated when the implementation under test supports prediction resistance. Note that in this case both tests have non-empty entropy input.  Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
+<p id="rfc.section.3.2.p.2">Each test group contains an array of one or more tests.  Each test object contains an otherInput object, which is an array of objects, each with the intendedUse property indicating if the particular test data is to be used for reSeed or generate - see <a href="#tests_table" class="xref">Table 7</a>.  Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
 <div id="rfc.table.9"></div>
 <div id="vs_prtc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1264,26 +1252,6 @@
 <td class="left">value</td>
 <td class="left">No</td>
 </tr>
-</tbody>
-</table>
-<p id="rfc.section.3.2.p.3">Each re-seed test group contains an array of one or more test vectors, typically three.  Such test vectors are generated when the implementation under test supports re-seeding. Note that when the implementation under test does not support prediction resistance only the first test has non-empty entropy input.  The additional input is non-empty for all three tests. Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
-<div id="rfc.table.10"></div>
-<div id="vs_prtc_table2"></div>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Re-seed Test Case JSON Object</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-<th class="left">Optional</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">additionalInput</td>
-<td class="left">value of the additional input string to use in re-seeding tests</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
 <tr>
 <td class="left"></td>
 <td class="left"></td>
@@ -1291,40 +1259,8 @@
 <td class="left"></td>
 </tr>
 <tr>
-<td class="left">entropyInput</td>
-<td class="left">value of the entropy input to use in re-seeding tests</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-</tbody>
-</table>
-<p id="rfc.section.3.2.p.4">When the implementation under test supports neither re-seeding nor prediction reistance each test group contains an array of two test vectors. Note that in this case both tests have empty entropy input.  The additional input is non-empty for both tests. Each test vector is a JSON object that represents a single test case to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG predcition resistance test vector.</p>
-<div id="rfc.table.11"></div>
-<div id="vs_prtc_table3"></div>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Other Test Case JSON Object</caption>
-<thead><tr>
-<th class="left">JSON Value</th>
-<th class="left">Description</th>
-<th class="left">JSON type</th>
-<th class="left">Optional</th>
-</tr></thead>
-<tbody>
-<tr>
-<td class="left">additionalInput</td>
-<td class="left">value of the additional input string to use in tests</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">entropyInput</td>
-<td class="left">empty string</td>
+<td class="left">intendedUse</td>
+<td class="left">"reSeed", "generate"</td>
 <td class="left">value</td>
 <td class="left">No</td>
 </tr>
@@ -1334,7 +1270,7 @@
 <a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
 </h1>
 <p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.12"></div>
+<div id="rfc.table.10"></div>
 <div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1372,7 +1308,7 @@
 </tbody>
 </table>
 <p id="rfc.section.4.p.2">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG test vector.</p>
-<div id="rfc.table.13"></div>
+<div id="rfc.table.11"></div>
 <div id="vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>DRBG Test Case Results JSON Object</caption>
@@ -1747,11 +1683,12 @@
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
                           "otherInput" : [
-                             "intendedUse" : "both",
-                             {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
+                             { "intendedUse" : "generate",
+                               "additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
-                            {"additionalInput" : "f5357737023e3304508a00b3ba02",
-                             "entropyInput" : "a0cdf5c1c670fd7b65a4f0a899e4"}
+                            { "intendedUse" : "generate",
+                              "additionalInput" : "f5357737023e3304508a00b3ba02",
+                              "entropyInput" : "a0cdf5c1c670fd7b65a4f0a899e4"}
                             ]
                           },
                         {
@@ -1760,10 +1697,11 @@
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
                           "otherInput" : [
-                             "intendedUse" : "both",
-                             {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
-                             {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
                               "entropyInput" : "a632ef16f20da17f02e484df4a41"}
                           ]
                         }
@@ -1796,10 +1734,11 @@
                           "nonce": "b991a820fac75fd02642ad8fa651eda4",
                           "persoString": "30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
+                             {"intendedUse" : "generate",
+                               "additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
-                             {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
                               "entropyInput" : "968ea185d1439fa2d67eb55ac93ba596b1ea679de7c6e44f80dc6f213455f1ed"}
                             ]
                           },
@@ -1809,10 +1748,11 @@
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
-                             {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
                               "entropyInput" : "acb63f3b5995608a1331641cd43208444a9ec95e4bb2a438f614156b6a77c8c3"}
                           ]
                         }
@@ -1845,10 +1785,11 @@
                           "nonce": "786f03ad697332d74fad7a14604cee44",
                           "persoString": "",
                           "otherInput" : [
-                               "intendedUse" : "predResistance",
-                               {"additionalInput": "",
+                               {"intendedUse" : "generate",
+                                "additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
-                               {"additionalInput" : "",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "",
                                 "entropyInput" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"}
                             ]
                           },
@@ -1858,10 +1799,11 @@
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput" : "",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
-                             {"additionalInput" : "",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "",
                               "entropyInput" : "fff51d05b1349506c354a0e6ee01edcff21c509dff5cbb582c8fdc01d6e8bd5b"}
                           ]
                         }
@@ -1894,12 +1836,14 @@
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
-                               "intendedUse" : "reSeed",
-                               {"additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                               {"intendedUse" : "reSeed",
+                                 "additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
-                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                               {"intendedUse" : "generate",
+                                 "additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
                                 "entropyInput" : ""},
-                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
                                 "entropyInput" : ""}
                             ]
                           },
@@ -1909,12 +1853,14 @@
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
                           "otherInput" : [
-                             "intendedUse" : "reSeed",
-                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                             {"intendedUse" : "reSeed",
+                              "additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
-                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
                               "entropyInput" : ""},
-                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
                               "entropyInput" : ""}
                           ]
                         }
@@ -1947,10 +1893,11 @@
                           "nonce": "6f7c6bec9825079cabd9478d88f337c8",
                           "persoString": "c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
                           "otherInput" : [
-                               "intendedUse" : "other",
-                               {"additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
+                               {"intendedUse" : "generate",
+                                "additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
                                 "entropyInput": ""},
-                               {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
                                 "entropyInput" : ""}
                             ]
                           },
@@ -1960,10 +1907,11 @@
                           "nonce": "a97dfbaea505a3e36210a85636197b2d",
                           "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
                           "otherInput" : [
-                             "intendedUse" : "other",
-                             {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
                               "entropyInput" : ""},
-                             {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
                               "entropyInput" : ""}
                           ]
                         }

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                              July 5, 2018
-Expires: January 6, 2019
+Intended status: Informational                              July 6, 2018
+Expires: January 7, 2019
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 6, 2019.
+   This Internet-Draft will expire on January 7, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 1]
+Vassilev                 Expires January 7, 2019                [Page 1]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -70,15 +70,15 @@ Table of Contents
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   9
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  10
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  12
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  15
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  15
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  16
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  16
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  16
-   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  16
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  22
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  31
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  33
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  14
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  15
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  15
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  15
+   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  15
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  21
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  29
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  31
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 2]
+Vassilev                 Expires January 7, 2019                [Page 2]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 3]
+Vassilev                 Expires January 7, 2019                [Page 3]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -221,7 +221,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 4]
+Vassilev                 Expires January 7, 2019                [Page 4]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -277,7 +277,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 5]
+Vassilev                 Expires January 7, 2019                [Page 5]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -333,7 +333,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 6]
+Vassilev                 Expires January 7, 2019                [Page 6]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -389,7 +389,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 7]
+Vassilev                 Expires January 7, 2019                [Page 7]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -445,7 +445,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 8]
+Vassilev                 Expires January 7, 2019                [Page 8]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -501,7 +501,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019                [Page 9]
+Vassilev                 Expires January 7, 2019                [Page 9]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -557,7 +557,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 10]
+Vassilev                 Expires January 7, 2019               [Page 10]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -613,7 +613,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 11]
+Vassilev                 Expires January 7, 2019               [Page 11]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -669,7 +669,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 12]
+Vassilev                 Expires January 7, 2019               [Page 12]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -692,17 +692,14 @@ Internet-Draft                DRBG Alg JSON                    July 2018
    | otherInput   | array of additonal              | array | No       |
    |              | input/entropy input value pairs |       |          |
    |              | for testing. See Table 9        |       |          |
-   |              |                                 |       |          |
-   | intendedUse  | "both", "reSeed",               | value | No       |
-   |              | "predResistance", "other"       |       |          |
    +--------------+---------------------------------+-------+----------+
 
                     Table 8: DRBG Test Case JSON Object
 
-   Each prediction resistance test group contains an array of one or
-   more test vectors, typically two.  Such tests are generated when the
-   implementation under test supports prediction resistance.  Note that
-   in this case both tests have non-empty entropy input.  Each test
+   Each test group contains an array of one or more tests.  Each test
+   object contains an otherInput object, which is an array of objects,
+   each with the intendedUse property indicating if the particular test
+   data is to be used for reSeed or generate - see Table 7.  Each test
    vector is a JSON object that represents a single test case to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each DRBG predcition resistance test vector.
@@ -718,6 +715,8 @@ Internet-Draft                DRBG Alg JSON                    July 2018
    | entropyInput    | value of the entropy input   | value | No       |
    |                 | to use in prediction         |       |          |
    |                 | resistance tests             |       |          |
+   |                 |                              |       |          |
+   | intendedUse     | "reSeed", "generate"         | value | No       |
    +-----------------+------------------------------+-------+----------+
 
            Table 9: Prediction Resistance Test Case JSON Object
@@ -725,63 +724,8 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 13]
-
-Internet-Draft                DRBG Alg JSON                    July 2018
 
-
-   Each re-seed test group contains an array of one or more test
-   vectors, typically three.  Such test vectors are generated when the
-   implementation under test supports re-seeding.  Note that when the
-   implementation under test does not support prediction resistance only
-   the first test has non-empty entropy input.  The additional input is
-   non-empty for all three tests.  Each test vector is a JSON object
-   that represents a single test case to be processed by the ACVP
-   client.  The following table describes the JSON elements for each
-   DRBG predcition resistance test vector.
-
-   +-----------------+------------------------------+-------+----------+
-   | JSON Value      | Description                  | JSON  | Optional |
-   |                 |                              | type  |          |
-   +-----------------+------------------------------+-------+----------+
-   | additionalInput | value of the additional      | value | No       |
-   |                 | input string to use in re-   |       |          |
-   |                 | seeding tests                |       |          |
-   |                 |                              |       |          |
-   | entropyInput    | value of the entropy input   | value | No       |
-   |                 | to use in re-seeding tests   |       |          |
-   +-----------------+------------------------------+-------+----------+
-
-                  Table 10: Re-seed Test Case JSON Object
-
-   When the implementation under test supports neither re-seeding nor
-   prediction reistance each test group contains an array of two test
-   vectors.  Note that in this case both tests have empty entropy input.
-   The additional input is non-empty for both tests.  Each test vector
-   is a JSON object that represents a single test case to be processed
-   by the ACVP client.  The following table describes the JSON elements
-   for each DRBG predcition resistance test vector.
-
-   +-----------------+------------------------------+-------+----------+
-   | JSON Value      | Description                  | JSON  | Optional |
-   |                 |                              | type  |          |
-   +-----------------+------------------------------+-------+----------+
-   | additionalInput | value of the additional      | value | No       |
-   |                 | input string to use in tests |       |          |
-   |                 |                              |       |          |
-   | entropyInput    | empty string                 | value | No       |
-   +-----------------+------------------------------+-------+----------+
-
-                   Table 11: Other Test Case JSON Object
-
-
-
-
-
-
-
-
-Vassilev                 Expires January 6, 2019               [Page 14]
+Vassilev                 Expires January 7, 2019               [Page 13]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -807,7 +751,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
    |             | JSON schema as defined in Section 3.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 12: Vector Set Response JSON Object
+                 Table 10: Vector Set Response JSON Object
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -826,7 +770,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
    |              | output                          |       |          |
    +--------------+---------------------------------+-------+----------+
 
-               Table 13: DRBG Test Case Results JSON Object
+               Table 11: DRBG Test Case Results JSON Object
 
 5.  Acknowledgements
 
@@ -837,7 +781,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 15]
+Vassilev                 Expires January 7, 2019               [Page 14]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -893,7 +837,7 @@ Appendix A.  Example DRBG Capabilities JSON Object
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 16]
+Vassilev                 Expires January 7, 2019               [Page 15]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -949,7 +893,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 17]
+Vassilev                 Expires January 7, 2019               [Page 16]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1005,7 +949,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 18]
+Vassilev                 Expires January 7, 2019               [Page 17]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1061,7 +1005,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 19]
+Vassilev                 Expires January 7, 2019               [Page 18]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1117,7 +1061,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 20]
+Vassilev                 Expires January 7, 2019               [Page 19]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1173,7 +1117,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 21]
+Vassilev                 Expires January 7, 2019               [Page 20]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1207,33 +1151,6 @@ Appendix B.  Example Test Vectors JSON Object
    The following is a example JSON object for ctrDRBG test vectors sent
    from the ACVP server to the crypto module.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                 Expires January 6, 2019               [Page 22]
-
-Internet-Draft                DRBG Alg JSON                    July 2018
-
-
               [
                 { "acvVersion": "0.4" },
                 { "vectorSetId": 1133,
@@ -1253,14 +1170,23 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                         {
                           "tcId": 1815,
                           "entropyInput":"78aac2cb444594e29dc97b0195b5",
+
+
+
+Vassilev                 Expires January 7, 2019               [Page 21]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
                           "otherInput" : [
-                             "intendedUse" : "both",
-                             {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
+                             { "intendedUse" : "generate",
+                               "additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
-                            {"additionalInput" : "f5357737023e3304508a00b3ba02",
-                             "entropyInput" : "a0cdf5c1c670fd7b65a4f0a899e4"}
+                            { "intendedUse" : "generate",
+                              "additionalInput" : "f5357737023e3304508a00b3ba02",
+                              "entropyInput" : "a0cdf5c1c670fd7b65a4f0a899e4"}
                             ]
                           },
                         {
@@ -1269,10 +1195,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
                           "otherInput" : [
-                             "intendedUse" : "both",
-                             {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
-                             {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
                               "entropyInput" : "a632ef16f20da17f02e484df4a41"}
                           ]
                         }
@@ -1281,14 +1208,6 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                   ]
                 }
             ]
-
-
-
-
-Vassilev                 Expires January 6, 2019               [Page 23]
-
-Internet-Draft                DRBG Alg JSON                    July 2018
-
 
    The following is a example JSON object for hmacDRBG test vectors sent
    from the ACVP server to the crypto module.
@@ -1310,38 +1229,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                 Expires January 6, 2019               [Page 24]
+Vassilev                 Expires January 7, 2019               [Page 22]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1367,10 +1255,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "b991a820fac75fd02642ad8fa651eda4",
                           "persoString": "30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
+                             {"intendedUse" : "generate",
+                               "additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
-                             {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
                               "entropyInput" : "968ea185d1439fa2d67eb55ac93ba596b1ea679de7c6e44f80dc6f213455f1ed"}
                             ]
                           },
@@ -1380,10 +1269,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
-                             {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
                               "entropyInput" : "acb63f3b5995608a1331641cd43208444a9ec95e4bb2a438f614156b6a77c8c3"}
                           ]
                         }
@@ -1395,9 +1285,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-
-
-Vassilev                 Expires January 6, 2019               [Page 25]
+Vassilev                 Expires January 7, 2019               [Page 23]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1453,7 +1341,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 26]
+Vassilev                 Expires January 7, 2019               [Page 24]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1479,10 +1367,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "786f03ad697332d74fad7a14604cee44",
                           "persoString": "",
                           "otherInput" : [
-                               "intendedUse" : "predResistance",
-                               {"additionalInput": "",
+                               {"intendedUse" : "generate",
+                                "additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
-                               {"additionalInput" : "",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "",
                                 "entropyInput" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"}
                             ]
                           },
@@ -1492,10 +1381,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput" : "",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
-                             {"additionalInput" : "",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "",
                               "entropyInput" : "fff51d05b1349506c354a0e6ee01edcff21c509dff5cbb582c8fdc01d6e8bd5b"}
                           ]
                         }
@@ -1507,9 +1397,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-
-
-Vassilev                 Expires January 6, 2019               [Page 27]
+Vassilev                 Expires January 7, 2019               [Page 25]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1540,12 +1428,14 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
-                               "intendedUse" : "reSeed",
-                               {"additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                               {"intendedUse" : "reSeed",
+                                 "additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
-                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                               {"intendedUse" : "generate",
+                                 "additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
                                 "entropyInput" : ""},
-                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
                                 "entropyInput" : ""}
                             ]
                           },
@@ -1555,21 +1445,23 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
                           "otherInput" : [
-                             "intendedUse" : "reSeed",
-                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                             {"intendedUse" : "reSeed",
+                              "additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
-                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
-                              "entropyInput" : ""},
-                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
-                              "entropyInput" : ""}
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 28]
+Vassilev                 Expires January 7, 2019               [Page 26]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
 
+                              "entropyInput" : ""},
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                              "entropyInput" : ""}
                           ]
                         }
                       ]
@@ -1617,11 +1509,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-
-
-
-
-Vassilev                 Expires January 6, 2019               [Page 29]
+Vassilev                 Expires January 7, 2019               [Page 27]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1647,10 +1535,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "6f7c6bec9825079cabd9478d88f337c8",
                           "persoString": "c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
                           "otherInput" : [
-                               "intendedUse" : "other",
-                               {"additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
+                               {"intendedUse" : "generate",
+                                "additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
                                 "entropyInput": ""},
-                               {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
                                 "entropyInput" : ""}
                             ]
                           },
@@ -1660,10 +1549,11 @@ Internet-Draft                DRBG Alg JSON                    July 2018
                           "nonce": "a97dfbaea505a3e36210a85636197b2d",
                           "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
                           "otherInput" : [
-                             "intendedUse" : "other",
-                             {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
                               "entropyInput" : ""},
-                             {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
                               "entropyInput" : ""}
                           ]
                         }
@@ -1675,9 +1565,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-
-
-Vassilev                 Expires January 6, 2019               [Page 30]
+Vassilev                 Expires January 7, 2019               [Page 28]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1733,7 +1621,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 31]
+Vassilev                 Expires January 7, 2019               [Page 29]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1789,7 +1677,7 @@ Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 32]
+Vassilev                 Expires January 7, 2019               [Page 30]
 
 Internet-Draft                DRBG Alg JSON                    July 2018
 
@@ -1845,4 +1733,4 @@ Author's Address
 
 
 
-Vassilev                 Expires January 6, 2019               [Page 33]
+Vassilev                 Expires January 7, 2019               [Page 31]

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,13 +4,13 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                             March 1, 2018
-Expires: September 2, 2018
+Intended status: Informational                              July 5, 2018
+Expires: January 6, 2019
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
                              Specification
-                      draft-ietf-acvp-subdrbg-0.4
+                      draft-ietf-acvp-subdrbg-0.5
 
 Abstract
 
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 2, 2018.
+   This Internet-Draft will expire on January 6, 2019.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Vassilev                Expires September 2, 2018               [Page 1]
+Vassilev                 Expires January 6, 2019                [Page 1]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 Table of Contents
@@ -70,15 +70,15 @@ Table of Contents
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   9
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  10
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  12
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  13
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  15
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  15
-   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  15
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  21
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  29
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  31
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  15
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  15
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  16
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  16
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  16
+   Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  16
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  22
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  31
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  33
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Vassilev                Expires September 2, 2018               [Page 2]
+Vassilev                 Expires January 6, 2019                [Page 2]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    values.  The specific details and restrictions on each of these input
@@ -165,9 +165,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 3]
+Vassilev                 Expires January 6, 2019                [Page 3]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    Note 1: The ctrDRBG algorithm in TDES mode shall only be used with
@@ -221,9 +221,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 4]
+Vassilev                 Expires January 6, 2019                [Page 4]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    self-contained JSON object.  The following JSON values are used for
@@ -277,9 +277,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 5]
+Vassilev                 Expires January 6, 2019                [Page 5]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    |                |           |        | increment. Set  |           |
@@ -333,9 +333,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 6]
+Vassilev                 Expires January 6, 2019                [Page 6]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    Each DRBG algorithm capability advertised is a self-contained JSON
@@ -389,9 +389,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 7]
+Vassilev                 Expires January 6, 2019                [Page 7]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    |                  | the capabil |            |           |         |
@@ -445,9 +445,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 8]
+Vassilev                 Expires January 6, 2019                [Page 8]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    Note 9: ACVP allows bit length values for persoString ranging from
@@ -501,9 +501,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018               [Page 9]
+Vassilev                 Expires January 6, 2019                [Page 9]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    +-------------+---------------------------------------------+-------+
@@ -557,9 +557,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018              [Page 10]
+Vassilev                 Expires January 6, 2019               [Page 10]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    +-------------------+-----------------------+------------+----------+
@@ -613,9 +613,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018              [Page 11]
+Vassilev                 Expires January 6, 2019               [Page 11]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    Note 11: According to SP 800-90A [SP800-90A], a DRBG implementation
@@ -669,9 +669,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018              [Page 12]
+Vassilev                 Expires January 6, 2019               [Page 12]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    +--------------+---------------------------------+-------+----------+
@@ -692,15 +692,20 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    | otherInput   | array of additonal              | array | No       |
    |              | input/entropy input value pairs |       |          |
    |              | for testing. See Table 9        |       |          |
+   |              |                                 |       |          |
+   | intendedUse  | "both", "reSeed",               | value | No       |
+   |              | "predResistance", "other"       |       |          |
    +--------------+---------------------------------+-------+----------+
 
                     Table 8: DRBG Test Case JSON Object
 
    Each prediction resistance test group contains an array of one or
-   more test vectors, typically two.  Each test vector is a JSON object
-   that represents a single test case to be processed by the ACVP
-   client.  The following table describes the JSON elements for each
-   DRBG predcition resistance test vector.
+   more test vectors, typically two.  Such tests are generated when the
+   implementation under test supports prediction resistance.  Note that
+   in this case both tests have non-empty entropy input.  Each test
+   vector is a JSON object that represents a single test case to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each DRBG predcition resistance test vector.
 
    +-----------------+------------------------------+-------+----------+
    | JSON Value      | Description                  | JSON  | Optional |
@@ -717,19 +722,74 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
            Table 9: Prediction Resistance Test Case JSON Object
 
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 13]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
+   Each re-seed test group contains an array of one or more test
+   vectors, typically three.  Such test vectors are generated when the
+   implementation under test supports re-seeding.  Note that when the
+   implementation under test does not support prediction resistance only
+   the first test has non-empty entropy input.  The additional input is
+   non-empty for all three tests.  Each test vector is a JSON object
+   that represents a single test case to be processed by the ACVP
+   client.  The following table describes the JSON elements for each
+   DRBG predcition resistance test vector.
+
+   +-----------------+------------------------------+-------+----------+
+   | JSON Value      | Description                  | JSON  | Optional |
+   |                 |                              | type  |          |
+   +-----------------+------------------------------+-------+----------+
+   | additionalInput | value of the additional      | value | No       |
+   |                 | input string to use in re-   |       |          |
+   |                 | seeding tests                |       |          |
+   |                 |                              |       |          |
+   | entropyInput    | value of the entropy input   | value | No       |
+   |                 | to use in re-seeding tests   |       |          |
+   +-----------------+------------------------------+-------+----------+
+
+                  Table 10: Re-seed Test Case JSON Object
+
+   When the implementation under test supports neither re-seeding nor
+   prediction reistance each test group contains an array of two test
+   vectors.  Note that in this case both tests have empty entropy input.
+   The additional input is non-empty for both tests.  Each test vector
+   is a JSON object that represents a single test case to be processed
+   by the ACVP client.  The following table describes the JSON elements
+   for each DRBG predcition resistance test vector.
+
+   +-----------------+------------------------------+-------+----------+
+   | JSON Value      | Description                  | JSON  | Optional |
+   |                 |                              | type  |          |
+   +-----------------+------------------------------+-------+----------+
+   | additionalInput | value of the additional      | value | No       |
+   |                 | input string to use in tests |       |          |
+   |                 |                              |       |          |
+   | entropyInput    | empty string                 | value | No       |
+   +-----------------+------------------------------+-------+----------+
+
+                   Table 11: Other Test Case JSON Object
+
+
+
+
+
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 14]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
 4.  Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
-
-
-
-
-Vassilev                Expires September 2, 2018              [Page 13]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
    table describes the JSON object that represents a vector set
    response.
 
@@ -747,7 +807,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    |             | JSON schema as defined in Section 3.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 10: Vector Set Response JSON Object
+                 Table 12: Vector Set Response JSON Object
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -766,25 +826,25 @@ Internet-Draft                DRBG Alg JSON                   March 2018
    |              | output                          |       |          |
    +--------------+---------------------------------+-------+----------+
 
-               Table 11: DRBG Test Case Results JSON Object
+               Table 13: DRBG Test Case Results JSON Object
 
 5.  Acknowledgements
 
    TBD...
 
+
+
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 15]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
 6.  IANA Considerations
 
    This memo includes no request to IANA.
-
-
-
-
-
-
-Vassilev                Expires September 2, 2018              [Page 14]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
 
 7.  Security Considerations
 
@@ -830,18 +890,18 @@ Appendix A.  Example DRBG Capabilities JSON Object
         256
       ],
       "persoStringLen": [
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 16]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
         256
       ],
       "additionalInputLen": [
         256
-
-
-
-Vassilev                Expires September 2, 2018              [Page 15]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
       ],
       "returnedBitsLen": 512
     },
@@ -886,18 +946,18 @@ Internet-Draft                DRBG Alg JSON                   March 2018
         232
       ],
       "nonceLen": [
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 17]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
         232
       ],
       "persoStringLen": [
         232
-
-
-
-Vassilev                Expires September 2, 2018              [Page 16]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
       ],
       "additionalInputLen": [
         232
@@ -942,18 +1002,18 @@ Internet-Draft                DRBG Alg JSON                   March 2018
       "mode": "AES-256",
       "derFuncEnabled": false,
       "entropyInputLen": [
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 18]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
         384
       ],
       "nonceLen": [
         384
-
-
-
-Vassilev                Expires September 2, 2018              [Page 17]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
       ],
       "persoStringLen": [
         384
@@ -998,18 +1058,18 @@ Internet-Draft                DRBG Alg JSON                   March 2018
   "capabilities": [
     {
       "mode": "SHA-1",
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 19]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
       "derFuncEnabled": false,
       "entropyInputLen": [
         160
       ],
-
-
-
-Vassilev                Expires September 2, 2018              [Page 18]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
       "nonceLen": [
         160
       ],
@@ -1054,18 +1114,18 @@ Internet-Draft                DRBG Alg JSON                   March 2018
         256
       ],
       "returnedBitsLen": 1024
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 20]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
     },
     {
       "mode": "SHA2-384",
       "derFuncEnabled": false,
-
-
-
-Vassilev                Expires September 2, 2018              [Page 19]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
       "entropyInputLen": [
         384
       ],
@@ -1110,18 +1170,18 @@ Internet-Draft                DRBG Alg JSON                   March 2018
         224
       ],
       "additionalInputLen": [
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 21]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
         224
       ],
       "returnedBitsLen": 896
     },
-
-
-
-Vassilev                Expires September 2, 2018              [Page 20]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
     {
       "mode": "SHA2-512/256",
       "derFuncEnabled": false,
@@ -1169,13 +1229,9 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
-
-
-
-Vassilev                Expires September 2, 2018              [Page 21]
+Vassilev                 Expires January 6, 2019               [Page 22]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
               [
@@ -1200,6 +1256,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
                           "otherInput" : [
+                             "intendedUse" : "both",
                              {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
                             {"additionalInput" : "f5357737023e3304508a00b3ba02",
@@ -1212,6 +1269,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
                           "otherInput" : [
+                             "intendedUse" : "both",
                              {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
                              {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
@@ -1224,14 +1282,68 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                 }
             ]
 
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 23]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
    The following is a example JSON object for hmacDRBG test vectors sent
    from the ACVP server to the crypto module.
 
 
 
-Vassilev                Expires September 2, 2018              [Page 22]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 24]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
               [
@@ -1255,6 +1367,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "b991a820fac75fd02642ad8fa651eda4",
                           "persoString": "30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
                              {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
@@ -1267,6 +1380,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
@@ -1279,19 +1393,70 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                 }
              ]
 
+
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 25]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
    The following is a example JSON object for hashDRBG test vectors sent
    from the ACVP server to the crypto module.  In this example the
-
-
-
-
-Vassilev                Expires September 2, 2018              [Page 23]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
-
    implementation is tested without additional input and personalization
    data.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 26]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
 
               [
                 { "acvVersion": "0.4" },
@@ -1314,6 +1479,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "786f03ad697332d74fad7a14604cee44",
                           "persoString": "",
                           "otherInput" : [
+                               "intendedUse" : "predResistance",
                                {"additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
                                {"additionalInput" : "",
@@ -1326,6 +1492,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
                              {"additionalInput" : "",
@@ -1341,66 +1508,16 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018              [Page 24]
+
+Vassilev                 Expires January 6, 2019               [Page 27]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
    The following is a example JSON object for hashDRBG test vectors sent
    from the ACVP server to the crypto module.  In this example the
    implementation is tested with "predResistance": "no", "reSeed" :
    "yes" options.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                Expires September 2, 2018              [Page 25]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
 
               [
                 { "acvVersion": "0.4" },
@@ -1423,6 +1540,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
+                               "intendedUse" : "reSeed",
                                {"additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
@@ -1437,12 +1555,21 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
                           "otherInput" : [
+                             "intendedUse" : "reSeed",
                              {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
                              {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
                               "entropyInput" : ""},
                              {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
                               "entropyInput" : ""}
+
+
+
+Vassilev                 Expires January 6, 2019               [Page 28]
+
+Internet-Draft                DRBG Alg JSON                    July 2018
+
+
                           ]
                         }
                       ]
@@ -1450,13 +1577,6 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                   ]
                 }
              ]
-
-
-
-Vassilev                Expires September 2, 2018              [Page 26]
-
-Internet-Draft                DRBG Alg JSON                   March 2018
-
 
    The following is a example JSON object for hashDRBG test vectors sent
    from the ACVP server to the crypto module.  In this example the
@@ -1501,17 +1621,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-
-
-
-
-
-
-
-
-Vassilev                Expires September 2, 2018              [Page 27]
+Vassilev                 Expires January 6, 2019               [Page 29]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
               [
@@ -1535,6 +1647,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "6f7c6bec9825079cabd9478d88f337c8",
                           "persoString": "c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
                           "otherInput" : [
+                               "intendedUse" : "other",
                                {"additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
                                 "entropyInput": ""},
                                {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
@@ -1547,6 +1660,7 @@ Internet-Draft                DRBG Alg JSON                   March 2018
                           "nonce": "a97dfbaea505a3e36210a85636197b2d",
                           "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
                           "otherInput" : [
+                             "intendedUse" : "other",
                              {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
                               "entropyInput" : ""},
                              {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
@@ -1563,11 +1677,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-
-
-Vassilev                Expires September 2, 2018              [Page 28]
+Vassilev                 Expires January 6, 2019               [Page 30]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
 Appendix C.  Example Test Results JSON Object
@@ -1621,9 +1733,9 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-Vassilev                Expires September 2, 2018              [Page 29]
+Vassilev                 Expires January 6, 2019               [Page 31]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
               [
@@ -1677,9 +1789,9 @@ Internet-Draft                DRBG Alg JSON                   March 2018
 
 
 
-Vassilev                Expires September 2, 2018              [Page 30]
+Vassilev                 Expires January 6, 2019               [Page 32]
 
-Internet-Draft                DRBG Alg JSON                   March 2018
+Internet-Draft                DRBG Alg JSON                    July 2018
 
 
               [
@@ -1733,4 +1845,4 @@ Author's Address
 
 
 
-Vassilev                Expires September 2, 2018              [Page 31]
+Vassilev                 Expires January 6, 2019               [Page 33]

--- a/src/acvp_protocol.xml
+++ b/src/acvp_protocol.xml
@@ -461,8 +461,10 @@
     </section>
 
     <section title="Authentication">
-      <t>It is recommended that an authentication scheme be used. Depending on the target
-        environment and usage objectives, that can be as weak as basic HTTP authentication or as
+      <t>It is recommended that an authentication scheme be used. Typically, a JSON Web Token (JWT) is created by the server
+       upon successful client authentication and returned to the client to use as an authorization mechanism for accessing
+       the server resources - see <xref target="jwtToken">JWT specification</xref>  below for more information.  Depending on the target
+        environment and usage objectives, the authentication can be as weak as basic HTTP authentication or as
         strong as TLS mutual certificate authentication. Definition of an authentication scheme will
         not be discussed here, but should be agreed upon between the client and server owning
         entities including the servers owned by the validation authorities. For the purposes of the
@@ -556,6 +558,120 @@
             Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibmlzdC5vcmciLCJleHAiOiAxNDYyOTg0OTUzLCJjb21wYW55IjogIkNpc2NvIiwianRpIjo0NTh9.zDhd3WrLcb1Xf5-VKOX6k-G70mACbi1tdir8qHAMPyQ
            ]]></artwork>
         </figure>
+        
+        <texttable anchor="authorizationFlow_table" title="Workflow authorization flows">
+          <preamble>
+            <spanx style="emph">All exchanges below are over HTTP."</spanx>
+          </preamble>
+          <ttcol align="left" width="10%">Client</ttcol>
+          <ttcol align="left" width="60%"/>
+          <ttcol align="left" width="10%">Server</ttcol>
+          <ttcol align="left" width="20%">Notes</ttcol>
+          <c/>
+          <c>POST to /login or similar with appropriate credentials</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>--------------------------------&gt;</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>receive the access token</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>&lt;-  -  -  -  -  -  -  -  -  -  - </c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>POST to /register with access token in header</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>-------------------------------&gt;</c>
+          <c/>
+          <c>the token from login is used</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>receive the session info and a session access token</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>&lt;-  -  -  -  -  -  -  -  -  -  - </c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+                    <c/>
+          <c>GET /vectors?vsID=&lt;ID&gt; with session access token in header</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>-------------------------------&gt;</c>
+          <c/>
+          <c>the token from registration is used to retrieve vector sets, submit answers etc.</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+                   <c/>
+          <c>receive vectors</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>&lt;-  -  -  -  -  -  -  -  -  -  - </c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>POST to /vectors?vsID=&lt;ID&gt; with session access token in header and answers in body</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>-------------------------------&gt;</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>GET /results?vsID=&lt;ID&gt; with session access token in body</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>-------------------------------&gt;</c>
+          <c/>
+          <c/>
+           <c/>
+          <c/>
+          <c/>
+          <c/>
+                             <c/>
+          <c>receive results</c>
+          <c/>
+          <c/>
+          <c/>
+          <c>&lt;-  -  -  -  -  -  -  -  -  -  - </c>
+          <c/>
+          <c/>
+          </texttable>
       </section>
 
       <section anchor="vendors" title="Vendor Resources">
@@ -916,8 +1032,7 @@
               for this resource</t>
             <t><spanx style="strong">name</spanx> - <spanx style="verb">string</spanx></t>
             <t><spanx style="strong">dependencyUrls</spanx> - an array of
-              <spanx style="verb">string</spanx>s which identify the <xref target="dependencies"
-                >dependencies</xref> which comprise this OE.</t>
+              <spanx style="verb">string</spanx>s which identify the <xref target="dependencies">dependencies</xref> which comprise this OE.</t>
           </list>
         </t>
         <section anchor="oes_get" title="List Operational Environments">
@@ -1029,8 +1144,7 @@
               for this resource</t>
             <t><spanx style="strong">type</spanx> - <spanx style="verb">string</spanx></t>
             <t><spanx style="verb">{varies}</spanx> depending on the value of
-              <spanx style="verb">type</spanx> as defined by the response of <xref
-                target="dependencies_properties_get"/></t>
+              <spanx style="verb">type</spanx> as defined by the response of <xref target="dependencies_properties_get"/></t>
           </list>
         </t>
         <section anchor="dependencies_get" title="List Dependencies">
@@ -1752,16 +1866,14 @@
             in the implementation). The resending of vector set responses must occur prior to
             expiry.</t>
           <section title="Request">
-            <t>The request content is identical to the request content described in <xref
-                target="vectorSet_results_post"/>.</t>
+            <t>The request content is identical to the request content described in <xref target="vectorSet_results_post"/>.</t>
           </section>
         </section>
         <section anchor="vectorSet_expected_get" title="Retrieve Expected Results">
           <t><spanx style="strong">GET /testSessions/{testSessionId}/vectorSets/{vectorSetId}/expected</spanx></t>
           <t>Expected Test Results.</t>
           <section title="Response">
-            <t>The response is identical to the request content described in <xref
-                target="vectorSet_results_post"/>.</t>
+            <t>The response is identical to the request content described in <xref target="vectorSet_results_post"/>.</t>
           </section>
         </section>
       </section>

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -624,18 +624,11 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>array of additonal input/entropy input value pairs for testing. See <xref target="vs_prtc_table"/></c>
 		<c>array</c>
 		<c>No</c>
-    <c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>intendedUse</c>
-		<c>"both", "reSeed", "predResistance", "other"</c>
-		<c>value</c>
-		<c>No</c>
 	    </texttable>
 
-	    <t>Each prediction resistance test group contains an array of one or more test vectors, typically two.  Such tests are
-	     generated when the implementation under test supports prediction resistance. Note that in this case both tests have non-empty entropy input.  
+	    <t>Each test group contains an array of one or more tests.  Each test object contains an otherInput object,
+	     which is an array of objects, each with the intendedUse property indicating if the particular test data is to be used for 
+	     reSeed or generate - see <xref target="tests_table"/>. 
 	     Each test vector is a JSON object
 		that represents a single test case to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each DRBG predcition resistance test vector.</t>
@@ -656,57 +649,15 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>value of the entropy input to use in prediction resistance tests</c>
 		<c>value</c>
 		<c>No</c>	
+    <c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>intendedUse</c>
+		<c>"reSeed", "generate"</c>
+		<c>value</c>
+		<c>No</c>
 	    </texttable>
-
-<t>Each re-seed test group contains an array of one or more test vectors, typically three.  Such test vectors are generated
- when the implementation under test supports re-seeding. Note that when the implementation under test does not
- support prediction resistance only the first test has non-empty entropy input. 
- The additional input is non-empty for all three tests. Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
-	    the JSON elements for each DRBG predcition resistance test vector.</t>
-	    <texttable anchor="vs_prtc_table2" title="Re-seed Test Case JSON Object">
-		<ttcol align="left">JSON Value</ttcol>
-		<ttcol align="left">Description</ttcol>
-		<ttcol align="left">JSON type</ttcol>
-		<ttcol align="left">Optional</ttcol>
-				<c>additionalInput</c>
-		<c>value of the additional input string to use in re-seeding tests</c>
-		<c>value</c>
-		<c>No</c>	
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>entropyInput</c>
-		<c>value of the entropy input to use in re-seeding tests</c>
-		<c>value</c>
-		<c>No</c>	
-	    </texttable>
-
-<t> When the implementation under test supports neither re-seeding nor prediction reistance each test group contains an array 
-of two test vectors. Note that in this case both tests have empty entropy input. 
- The additional input is non-empty for both tests. Each test vector is a JSON object
-		that represents a single test case to be processed by the ACVP client.  The following table describes
-	    the JSON elements for each DRBG predcition resistance test vector.</t>
-	    <texttable anchor="vs_prtc_table3" title="Other Test Case JSON Object">
-		<ttcol align="left">JSON Value</ttcol>
-		<ttcol align="left">Description</ttcol>
-		<ttcol align="left">JSON type</ttcol>
-		<ttcol align="left">Optional</ttcol>
-				<c>additionalInput</c>
-		<c>value of the additional input string to use in tests</c>
-		<c>value</c>
-		<c>No</c>	
-		<c/>
-		<c/>
-		<c/>
-		<c/>
-		<c>entropyInput</c>
-		<c>empty string</c>
-		<c>value</c>
-		<c>No</c>	
-	    </texttable>
-
 	</section>
     </section>
 
@@ -1134,11 +1085,12 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
                           "otherInput" : [
-                             "intendedUse" : "both",
-                             {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
+                             { "intendedUse" : "generate",
+                               "additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
-                            {"additionalInput" : "f5357737023e3304508a00b3ba02",
-                             "entropyInput" : "a0cdf5c1c670fd7b65a4f0a899e4"}
+                            { "intendedUse" : "generate",
+                              "additionalInput" : "f5357737023e3304508a00b3ba02",
+                              "entropyInput" : "a0cdf5c1c670fd7b65a4f0a899e4"}
                             ]
                           },
                         {
@@ -1147,10 +1099,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
                           "otherInput" : [
-                             "intendedUse" : "both",
-                             {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
-                             {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
                               "entropyInput" : "a632ef16f20da17f02e484df4a41"}
                           ]
                         }
@@ -1186,10 +1139,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "b991a820fac75fd02642ad8fa651eda4",
                           "persoString": "30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
+                             {"intendedUse" : "generate",
+                               "additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
-                             {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
                               "entropyInput" : "968ea185d1439fa2d67eb55ac93ba596b1ea679de7c6e44f80dc6f213455f1ed"}
                             ]
                           },
@@ -1199,10 +1153,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
-                             {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
                               "entropyInput" : "acb63f3b5995608a1331641cd43208444a9ec95e4bb2a438f614156b6a77c8c3"}
                           ]
                         }
@@ -1237,10 +1192,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "786f03ad697332d74fad7a14604cee44",
                           "persoString": "",
                           "otherInput" : [
-                               "intendedUse" : "predResistance",
-                               {"additionalInput": "",
+                               {"intendedUse" : "generate",
+                                "additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
-                               {"additionalInput" : "",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "",
                                 "entropyInput" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"}
                             ]
                           },
@@ -1250,10 +1206,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
                           "otherInput" : [
-                             "intendedUse" : "predResistance",
-                             {"additionalInput" : "",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
-                             {"additionalInput" : "",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "",
                               "entropyInput" : "fff51d05b1349506c354a0e6ee01edcff21c509dff5cbb582c8fdc01d6e8bd5b"}
                           ]
                         }
@@ -1288,12 +1245,14 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
-                               "intendedUse" : "reSeed",
-                               {"additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
+                               {"intendedUse" : "reSeed",
+                                 "additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
-                               {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
+                               {"intendedUse" : "generate",
+                                 "additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
                                 "entropyInput" : ""},
-                               {"additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "edb884991dd2507de07647901b8880d9db48b0f07d90a9ca8cb399581fa4dd55",
                                 "entropyInput" : ""}
                             ]
                           },
@@ -1303,12 +1262,14 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
                           "otherInput" : [
-                             "intendedUse" : "reSeed",
-                             {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
+                             {"intendedUse" : "reSeed",
+                              "additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
-                             {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
                               "entropyInput" : ""},
-                             {"additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "a554bb9b5986b89161332649dd400b2a157656f8a1a8cf4a8fb875fa3d568140",
                               "entropyInput" : ""}
                           ]
                         }
@@ -1343,10 +1304,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "6f7c6bec9825079cabd9478d88f337c8",
                           "persoString": "c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
                           "otherInput" : [
-                               "intendedUse" : "other",
-                               {"additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
+                               {"intendedUse" : "generate",
+                                "additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
                                 "entropyInput": ""},
-                               {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
+                               {"intendedUse" : "generate",
+                                "additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
                                 "entropyInput" : ""}
                             ]
                           },
@@ -1356,10 +1318,11 @@ of two test vectors. Note that in this case both tests have empty entropy input.
                           "nonce": "a97dfbaea505a3e36210a85636197b2d",
                           "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
                           "otherInput" : [
-                             "intendedUse" : "other",
-                             {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
                               "entropyInput" : ""},
-                             {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",
                               "entropyInput" : ""}
                           ]
                         }

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subdrbg-0.4" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subdrbg-0.5" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"
@@ -69,7 +69,7 @@
       </address>
     </author>
 
-    <date month="March" year="2018"/>
+    <date month="July" year="2018"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -624,9 +624,19 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c>array of additonal input/entropy input value pairs for testing. See <xref target="vs_prtc_table"/></c>
 		<c>array</c>
 		<c>No</c>
+    <c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>intendedUse</c>
+		<c>"both", "reSeed", "predResistance", "other"</c>
+		<c>value</c>
+		<c>No</c>
 	    </texttable>
 
-	    <t>Each prediction resistance test group contains an array of one or more test vectors, typically two.  Each test vector is a JSON object
+	    <t>Each prediction resistance test group contains an array of one or more test vectors, typically two.  Such tests are
+	     generated when the implementation under test supports prediction resistance. Note that in this case both tests have non-empty entropy input.  
+	     Each test vector is a JSON object
 		that represents a single test case to be processed by the ACVP client.  The following table describes
 	    the JSON elements for each DRBG predcition resistance test vector.</t>
 	    <texttable anchor="vs_prtc_table" title="Prediction Resistance Test Case JSON Object">
@@ -644,6 +654,55 @@ the bit lengths the supported values shall be specified explicitly. </t>
 		<c/>
 		<c>entropyInput</c>
 		<c>value of the entropy input to use in prediction resistance tests</c>
+		<c>value</c>
+		<c>No</c>	
+	    </texttable>
+
+<t>Each re-seed test group contains an array of one or more test vectors, typically three.  Such test vectors are generated
+ when the implementation under test supports re-seeding. Note that when the implementation under test does not
+ support prediction resistance only the first test has non-empty entropy input. 
+ The additional input is non-empty for all three tests. Each test vector is a JSON object
+		that represents a single test case to be processed by the ACVP client.  The following table describes
+	    the JSON elements for each DRBG predcition resistance test vector.</t>
+	    <texttable anchor="vs_prtc_table2" title="Re-seed Test Case JSON Object">
+		<ttcol align="left">JSON Value</ttcol>
+		<ttcol align="left">Description</ttcol>
+		<ttcol align="left">JSON type</ttcol>
+		<ttcol align="left">Optional</ttcol>
+				<c>additionalInput</c>
+		<c>value of the additional input string to use in re-seeding tests</c>
+		<c>value</c>
+		<c>No</c>	
+		<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>entropyInput</c>
+		<c>value of the entropy input to use in re-seeding tests</c>
+		<c>value</c>
+		<c>No</c>	
+	    </texttable>
+
+<t> When the implementation under test supports neither re-seeding nor prediction reistance each test group contains an array 
+of two test vectors. Note that in this case both tests have empty entropy input. 
+ The additional input is non-empty for both tests. Each test vector is a JSON object
+		that represents a single test case to be processed by the ACVP client.  The following table describes
+	    the JSON elements for each DRBG predcition resistance test vector.</t>
+	    <texttable anchor="vs_prtc_table3" title="Other Test Case JSON Object">
+		<ttcol align="left">JSON Value</ttcol>
+		<ttcol align="left">Description</ttcol>
+		<ttcol align="left">JSON type</ttcol>
+		<ttcol align="left">Optional</ttcol>
+				<c>additionalInput</c>
+		<c>value of the additional input string to use in tests</c>
+		<c>value</c>
+		<c>No</c>	
+		<c/>
+		<c/>
+		<c/>
+		<c/>
+		<c>entropyInput</c>
+		<c>empty string</c>
 		<c>value</c>
 		<c>No</c>	
 	    </texttable>
@@ -1075,6 +1134,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce":"41ef9c67ffe438",
                           "persoString":"b8e84de200a9239a043a7a9a6a03",
                           "otherInput" : [
+                             "intendedUse" : "both",
                              {"additionalInput":"f1e8edf002b331ec49ec0c1f18fa",
                                "entropyInput": "6cd4096638bbaeda28289582a10d"},
                             {"additionalInput" : "f5357737023e3304508a00b3ba02",
@@ -1087,6 +1147,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "f1bcc6ff60dd37",
                           "persoString" : "018c1f9d22f3c7f701a5f1cab07d",
                           "otherInput" : [
+                             "intendedUse" : "both",
                              {"additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
                              {"additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
@@ -1125,6 +1186,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "b991a820fac75fd02642ad8fa651eda4",
                           "persoString": "30f3a50b0e2309dab93ea2aa095e5df8e4b2a42690572b31e53fb79a195481e5",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput":"4ea46abe95b2e4184113f908ae30123207d481908b7af7ef348657bbf3b4a002",
                                "entropyInput": "e4413a2e404f12c644b0b1d7a49a0fbf3d8703d571ffd02168c11b4ade6fc903"},
                              {"additionalInput" : "61b7204c8fef294f2a9f2e73a83a8a7a04c38e3b3eaaed1b920abfceab912492",
@@ -1137,6 +1199,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "b671308068fc7909a360c772f62a4c5e",
                           "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"additionalInput" : "d4b24c74538e3a1083a2cc0a4414a9f558f0a2dc186e3b9a5294cd541acdad87",
@@ -1174,6 +1237,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "786f03ad697332d74fad7a14604cee44",
                           "persoString": "",
                           "otherInput" : [
+                               "intendedUse" : "predResistance",
                                {"additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
                                {"additionalInput" : "",
@@ -1186,6 +1250,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "36dff124f908a95a022edf615618cd31",
                           "persoString" : "",
                           "otherInput" : [
+                             "intendedUse" : "predResistance",
                              {"additionalInput" : "",
                               "entropyInput" : "648bbdc4d40571905c69e7e2b15e36e08c812a6c509cef68bf75281e87f7a154"},
                              {"additionalInput" : "",
@@ -1223,6 +1288,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
+                               "intendedUse" : "reSeed",
                                {"additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"additionalInput" : "ddfa41eb363d76e3943689a13d31ebd38408f26d51a83289e3d52c2081b96ad0",
@@ -1237,6 +1303,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "4bb34ab1e882d97687c3f8935913ee0f",
                           "persoString" : "c5b03354a9fad34a8eb5bd28613ac34e48898979501b10ce92e9a46e19c6de42",
                           "otherInput" : [
+                             "intendedUse" : "reSeed",
                              {"additionalInput" : "6e3fa8e58779fec2b5028b28fae40d25023d8d4725a91b132219fd3d3eb6e1f0",
                               "entropyInput" : "afd7e6b0b48a526e896dab46cc9689fce20df47a0a50fad812f08b310b96bccf"},
                              {"additionalInput" : "deb8ed574906115a3e46b822c86dbf59f33c78052451f3a68f0eb08973bc1047",
@@ -1276,6 +1343,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "6f7c6bec9825079cabd9478d88f337c8",
                           "persoString": "c2f1a5980619779253dc54e2d4a52bf17aed023f566cfaa109ae96e031b64bd0",
                           "otherInput" : [
+                               "intendedUse" : "other",
                                {"additionalInput": "3fc72d3cc74b6124d49fa3269be61888e5e0e7a79d16def1d24aa9c7bcb9244b",
                                 "entropyInput": ""},
                                {"additionalInput" : "968a3e79dbf0d3a46c715ee2d65d7cc5dc6f74d4256ab63d41250de5ba3ddbfc",
@@ -1288,6 +1356,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                           "nonce": "a97dfbaea505a3e36210a85636197b2d",
                           "persoString" : "7d0de87d097551feffb7c5232645878df2579ff93a2ed07d5f357295bd5753d8",
                           "otherInput" : [
+                             "intendedUse" : "other",
                              {"additionalInput" : "fe1adf1da7c5275b1eaa3fe3010655ed9d5539eb47cc64c864b6c1fa920b0d07",
                               "entropyInput" : ""},
                              {"additionalInput" : "1df719a96103c452e644f6a4d0fd8d80865328314ec4af24ef9fdf6da4d2cd8e",


### PR DESCRIPTION
This update provides detailed discussion of various test options for DRBG implementations with various reSeed and predResistance options. 

It also introduces an explicit property "intendedUse" in otherInput objects to indicate to the client how to use the test data contained in the additionalInput and entropyInput properties. 

This addresses issue #395.