### PR TITLE
Add EdDSA Specification

### DIFF
--- a/artifacts/acvp_sub_eddsa.html
+++ b/artifacts/acvp_sub_eddsa.html
@@ -973,7 +973,7 @@
 </tr>
 <tr>
 <td class="left">testType</td>
-<td class="left">The testType for the group</td>
+<td class="left">The testType for the group. Either AFT or BFT.</td>
 <td class="left">value</td>
 <td class="left">No</td>
 </tr>
@@ -1499,7 +1499,27 @@
                         "message": "A81C8A22735A260CB1A8105A2964646097D8A9B110701AB0D49C9071836CAD39E31F5020D24B2C841FAC58F44F3F3F814495B063A686F6F93C5C6D9FDF45B9099C609A69E6A9F6483C5038066A560D413C6FB73D76499A7D8836C9C89368D557B2C24A5D817CF1FBD226AC41037E3005250007B49C6CCCE7BD1BE5D7A5C96EE8"
                     }
                 ]
-            }
+            },
+			{
+				"tgId": 5,
+				"testType": "bft",
+				"curve": "ed-25519",
+				"preHash": false,
+				"tests": [
+					{
+						"tcId": 41,
+						"message": "F27E9F9D"
+					},
+					{
+						"tcId": 42,
+						"message": "F27E9F9C"
+					},
+					{
+						"tcId": 43,
+						"message": "F27E9F9F"
+					}
+				]
+			}
         ]
     }
 ]
@@ -1524,7 +1544,25 @@
 						"signature": "772990B0E53B3E21DC8BD139CECB39892D75BD70DAFFDC73E241E29515E67CC642CB2A6B479FFEF4F3F16B5BC3DDF06AB25A92028F2DC0464B3CFDFD3B8F4D08"
 					}
 				]
-            }
+            },
+			{
+				"tgId": 5,
+				"q": "ADD51513B67540E3A392721742C7E81F1BAE77DEFC16314E32A06976BA9BBFF7",
+				"tests": [
+					{
+						"tcId": 41,
+						"signature": "6EA857E68CEC0825EAD378A2F445BB17993D151CF9A168A44F47E13D356F6DC9AA67517DE4A2FB22BA24E1732DA0234427A2572CBE80294277F2141498E7F50E"
+					},
+					{
+						"tcId": 42,
+						"signature": "883B0336036509FC44CD2E507C5E916696213F9CF2429796E248516EFBDFAFE5C98EE6DBF82314B6FB5403383BC2E4ECCC89C7D686FE3A630B74866A0126740C"
+					},
+					{
+						"tcId": 43,
+						"signature": "E402705AC2EFC216EB7FA1AC5461A8451CE6F72B0AFA63D75BFBD5C4DD98A07207168CC6A542F01AAC6C31EC1C09062B053A54F6C93B801460FE33348B87DD03"
+					}
+				]
+			}
         ]
     }
 ]

--- a/artifacts/acvp_sub_eddsa.html
+++ b/artifacts/acvp_sub_eddsa.html
@@ -1,0 +1,1617 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>ACVP EDDSA Algorithm JSON Specification</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents">
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
+<link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
+<link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration">
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for EDDSA Validations">
+<link href="#rfc.section.2.2" rel="Chapter" title="2.2 EDDSA Algorithm Capabilities Registration">
+<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Supported EDDSA Modes Capabilities">
+<link href="#rfc.section.2.3.1" rel="Chapter" title="2.3.1 The keyGen Mode Capabilities">
+<link href="#rfc.section.2.3.1.1" rel="Chapter" title="2.3.1.1 keyGen Full Set of Capabilities">
+<link href="#rfc.section.2.3.2" rel="Chapter" title="2.3.2 The keyVer Mode Capabilities">
+<link href="#rfc.section.2.3.2.1" rel="Chapter" title="2.3.2.1 keyVer Full Set of Capabilities">
+<link href="#rfc.section.2.3.3" rel="Chapter" title="2.3.3 The sigGen Mode Capabilities">
+<link href="#rfc.section.2.3.3.1" rel="Chapter" title="2.3.3.1 sigGen Full Set of Capabilities">
+<link href="#rfc.section.2.3.4" rel="Chapter" title="2.3.4 The sigVer Mode Capabilities">
+<link href="#rfc.section.2.3.4.1" rel="Chapter" title="2.3.4.1 sigVer Full Set of Capabilities">
+<link href="#rfc.section.2.4" rel="Chapter" title="2.4 Test Vectors">
+<link href="#rfc.section.2.4.1" rel="Chapter" title="2.4.1 Test Groups JSON Schema">
+<link href="#rfc.section.2.4.2" rel="Chapter" title="2.4.2 Test Case JSON Schema">
+<link href="#rfc.section.2.5" rel="Chapter" title="2.5 Test Vector Responses">
+<link href="#rfc.section.2.6" rel="Chapter" title="2.6 Acknowledgements">
+<link href="#rfc.section.2.7" rel="Chapter" title="2.7 IANA Considerations">
+<link href="#rfc.section.2.8" rel="Chapter" title="2.8 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="3 Normative References">
+<link href="#rfc.appendix.A" rel="Chapter" title="A Example EDDSA JSON Object">
+<link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 Example EDDSA KeyGen Capabilities JSON Object">
+<link href="#rfc.appendix.A.2" rel="Chapter" title="A.2 Example EDDSA KeyVer Capabilities JSON Object">
+<link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 Example EDDSA SigGen Capabilities JSON Object">
+<link href="#rfc.appendix.A.4" rel="Chapter" title="A.4 Example EDDSA SigVer Capabilities JSON Object">
+<link href="#rfc.appendix.A.5" rel="Chapter" title="A.5 Example Test EDDSA KeyGen JSON Object">
+<link href="#rfc.appendix.A.6" rel="Chapter" title="A.6 Example Test EDDSA KeyVer JSON Object">
+<link href="#rfc.appendix.A.7" rel="Chapter" title="A.7 Example Test EDDSA Signature Generation JSON Object">
+<link href="#rfc.appendix.A.8" rel="Chapter" title="A.8 Example Test EDDSA SigVer JSON Object">
+<link href="#rfc.authors" rel="Chapter">
+
+
+  <meta name="generator" content="xml2rfc version 2.10.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Celi, C., Ed." />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subeddsa-0.5" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-08-27" />
+  <meta name="dct.abstract" content="This document defines the JSON schema for using EDDSA algorithms with the ACVP specification." />
+  <meta name="description" content="This document defines the JSON schema for using EDDSA algorithms with the ACVP specification." />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+<td class="left">TBD</td>
+<td class="right">C. Celi, Ed.</td>
+</tr>
+<tr>
+<td class="left">Internet-Draft</td>
+<td class="right">National Institute of Standards and Technology</td>
+</tr>
+<tr>
+<td class="left">Intended status: Informational</td>
+<td class="right">August 27, 2018</td>
+</tr>
+<tr>
+<td class="left">Expires: February 28, 2019</td>
+<td class="right"></td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">ACVP EDDSA Algorithm JSON Specification<br />
+  <span class="filename">draft-ietf-acvp-subeddsa-0.5</span></p>
+  
+  <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
+<p>This document defines the JSON schema for using EDDSA algorithms with the ACVP specification.</p>
+<h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on February 28, 2019.</p>
+<h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
+<p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a>
+</li>
+<ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a>
+</li>
+</ul><li>2.   <a href="#rfc.section.2">Capabilities Registration</a>
+</li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for EDDSA Validations</a>
+</li>
+<li>2.2.   <a href="#rfc.section.2.2">EDDSA Algorithm Capabilities Registration</a>
+</li>
+<li>2.3.   <a href="#rfc.section.2.3">Supported EDDSA Modes Capabilities</a>
+</li>
+<ul><li>2.3.1.   <a href="#rfc.section.2.3.1">The keyGen Mode Capabilities</a>
+</li>
+<ul><li>2.3.1.1.   <a href="#rfc.section.2.3.1.1">keyGen Full Set of Capabilities</a>
+</li>
+</ul><li>2.3.2.   <a href="#rfc.section.2.3.2">The keyVer Mode Capabilities</a>
+</li>
+<ul><li>2.3.2.1.   <a href="#rfc.section.2.3.2.1">keyVer Full Set of Capabilities</a>
+</li>
+</ul><li>2.3.3.   <a href="#rfc.section.2.3.3">The sigGen Mode Capabilities</a>
+</li>
+<ul><li>2.3.3.1.   <a href="#rfc.section.2.3.3.1">sigGen Full Set of Capabilities</a>
+</li>
+</ul><li>2.3.4.   <a href="#rfc.section.2.3.4">The sigVer Mode Capabilities</a>
+</li>
+<ul><li>2.3.4.1.   <a href="#rfc.section.2.3.4.1">sigVer Full Set of Capabilities</a>
+</li>
+</ul></ul><li>2.4.   <a href="#rfc.section.2.4">Test Vectors</a>
+</li>
+<ul><li>2.4.1.   <a href="#rfc.section.2.4.1">Test Groups JSON Schema</a>
+</li>
+<li>2.4.2.   <a href="#rfc.section.2.4.2">Test Case JSON Schema</a>
+</li>
+</ul><li>2.5.   <a href="#rfc.section.2.5">Test Vector Responses</a>
+</li>
+<li>2.6.   <a href="#rfc.section.2.6">Acknowledgements</a>
+</li>
+<li>2.7.   <a href="#rfc.section.2.7">IANA Considerations</a>
+</li>
+<li>2.8.   <a href="#rfc.section.2.8">Security Considerations</a>
+</li>
+</ul><li>3.   <a href="#rfc.references">Normative References</a>
+</li>
+<li>Appendix A.   <a href="#rfc.appendix.A">Example EDDSA JSON Object</a>
+</li>
+<ul><li>A.1.   <a href="#rfc.appendix.A.1">Example EDDSA KeyGen Capabilities JSON Object</a>
+</li>
+<li>A.2.   <a href="#rfc.appendix.A.2">Example EDDSA KeyVer Capabilities JSON Object</a>
+</li>
+<li>A.3.   <a href="#rfc.appendix.A.3">Example EDDSA SigGen Capabilities JSON Object</a>
+</li>
+<li>A.4.   <a href="#rfc.appendix.A.4">Example EDDSA SigVer Capabilities JSON Object</a>
+</li>
+<li>A.5.   <a href="#rfc.appendix.A.5">Example Test EDDSA KeyGen JSON Object</a>
+</li>
+<li>A.6.   <a href="#rfc.appendix.A.6">Example Test EDDSA KeyVer JSON Object</a>
+</li>
+<li>A.7.   <a href="#rfc.appendix.A.7">Example Test EDDSA Signature Generation JSON Object</a>
+</li>
+<li>A.8.   <a href="#rfc.appendix.A.8">Example Test EDDSA SigVer JSON Object</a>
+</li>
+</ul><li><a href="#rfc.authors">Author's Address</a>
+</li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1">
+<a href="#rfc.section.1">1.</a> Introduction</h1>
+<p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module. The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more. The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation. A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms. Each sub-specification addresses a specific class of crypto algorithms. This sub-specification defines the JSON constructs for testing EDDSA algorithms using ACVP.</p>
+<h1 id="rfc.section.1.1">
+<a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
+<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
+<h1 id="rfc.section.2">
+<a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
+</h1>
+<p id="rfc.section.2.p.1">ACVP requires crypto modules to register their capabilities. This allows the crypto	module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of EDDSA algorithms to the ACVP server.</p>
+<p id="rfc.section.2.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each	array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message.</p>
+<h1 id="rfc.section.2.1">
+<a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for EDDSA Validations</a>
+</h1>
+<p id="rfc.section.2.1.p.1">Each EDDSA implementation relies on other cryptographic primitives. For example, EDDSA uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<div id="rfc.table.1"></div>
+<div id="rereqs_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Required EDDSA Prerequisite Algorithms JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">a prerequisite algorithm</td>
+<td class="left">value</td>
+<td class="left">DRBG, DRBG_OPT2, SHA, SHA_OPT2, SHA_OPT3</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">valValue</td>
+<td class="left">algorithm validation number</td>
+<td class="left">value</td>
+<td class="left">actual number or "same"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqAlgVal</td>
+<td class="left">prerequistie algorithm validation</td>
+<td class="left">object with algorithm and valValue properties</td>
+<td class="left">see above</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqVals</td>
+<td class="left">prerequistie algorithm validations</td>
+<td class="left">array of prereqAlgVal objects</td>
+<td class="left">see above</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.2">
+<a href="#rfc.section.2.2">2.2.</a> <a href="#eddsa_caps_reg" id="eddsa_caps_reg">EDDSA Algorithm Capabilities Registration</a>
+</h1>
+<p id="rfc.section.2.2.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values</p>
+<div id="rfc.table.2"></div>
+<div id="caps_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>EDDSA Algorithm Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The algorithm under test</td>
+<td class="left">value</td>
+<td class="left">"EDDSA"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">The EDDSA mode to be validated</td>
+<td class="left">value</td>
+<td class="left">"keyGen", "keyVer", "sigGen", or "sigVer"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqVals</td>
+<td class="left">prerequistie algorithm validations</td>
+<td class="left">array of prereqAlgVal objects</td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algSpecs</td>
+<td class="left">array of JSON objects, each with fields pertaining to the global EDDSA mode indicated above and identified uniquely by the combination of the EDDSA "mode" and indicated properties</td>
+<td class="left">Array of JSON objects</td>
+<td class="left">See <a href="#supported_modes" class="xref">Section 2.3</a> </td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.3">
+<a href="#rfc.section.2.3">2.3.</a> <a href="#supported_modes" id="supported_modes">Supported EDDSA Modes Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.p.1">The EDDSA mode capabilities are advertised as JSON objects within the 'algSpecs' value of the ACVP registration message - see <a href="#caps_table" class="xref">Table 2</a>. The 'algSpecs' value is an array, where each array element is a JSON object corresponding to a particular EDDSA mode defined in this section. The 'algSpecs'	value is part of the 'capability_exchange' element of the ACVP JSON registration message.	See the ACVP specification for details on the registration message.  </p>
+<p id="rfc.section.2.3.p.2">Each EDDSA mode's capabilities are advertised as JSON objects.</p>
+<h1 id="rfc.section.2.3.1">
+<a href="#rfc.section.2.3.1">2.3.1.</a> <a href="#mode_keyGen" id="mode_keyGen">The keyGen Mode Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.1.p.1">The EDDSA keyGen mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.3.1.p.2">Each EDDSA keyGen mode capability set is advertised as a self-contained JSON object.</p>
+<h1 id="rfc.section.2.3.1.1">
+<a href="#rfc.section.2.3.1.1">2.3.1.1.</a> <a href="#mode_keyGenFullSet" id="mode_keyGenFullSet">keyGen Full Set of Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.1.1.p.1">The complete list of EDDSA key generation capabilities may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.3"></div>
+<div id="keyGen_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>EDDSA keyGen Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">curve</td>
+<td class="left">The curve names supported for the IUT in keyGen.</td>
+<td class="left">array</td>
+<td class="left">Any non-empty subset of {"ed-25519", "ed-448"}</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">secretGenerationMode</td>
+<td class="left">The method used to generate the randomness incoporated in the key.</td>
+<td class="left">array</td>
+<td class="left">Any non-empty subset of {"extra bits", "testing candidates"}</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.3.2">
+<a href="#rfc.section.2.3.2">2.3.2.</a> <a href="#mode_keyVer" id="mode_keyVer">The keyVer Mode Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.2.p.1">The EDDSA keyVer mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.3.2.p.2">Each EDDSA keyVer mode capability set is advertised as a self-contained JSON object.</p>
+<h1 id="rfc.section.2.3.2.1">
+<a href="#rfc.section.2.3.2.1">2.3.2.1.</a> <a href="#mode_keyVerFullSet" id="mode_keyVerFullSet">keyVer Full Set of Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.2.1.p.1">The complete list of EDDSA key verification capabilities may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.4"></div>
+<div id="keyVer_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>EDDSA keyVer Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody><tr>
+<td class="left">curve</td>
+<td class="left">The curve names supported for the IUT in keyVer.</td>
+<td class="left">array</td>
+<td class="left">Any non-empty subset of {"ed-25519", "ed-448"}</td>
+<td class="left">No</td>
+</tr></tbody>
+</table>
+<h1 id="rfc.section.2.3.3">
+<a href="#rfc.section.2.3.3">2.3.3.</a> <a href="#mode_sigGen" id="mode_sigGen">The sigGen Mode Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.3.p.1">The EDDSA sigGen mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.3.3.p.2">Each EDDSA sigGen mode capability set is advertised as a self-contained JSON object.</p>
+<h1 id="rfc.section.2.3.3.1">
+<a href="#rfc.section.2.3.3.1">2.3.3.1.</a> <a href="#mode_sigGenFullSet" id="mode_sigGenFullSet">sigGen Full Set of Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.3.1.p.1">The complete list of EDDSA signature generation capabilities may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.5"></div>
+<div id="sigGen_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>EDDSA sigGen Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">curve</td>
+<td class="left">The curve names supported for the IUT in sigGen.</td>
+<td class="left">array</td>
+<td class="left">Any non-empty subset of {"ed-25519", "ed-448"}</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">pure</td>
+<td class="left">If the IUT supports normal 'pure' sigGen functionality</td>
+<td class="left">bool</td>
+<td class="left">true/false</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">preHash</td>
+<td class="left">If the IUT supports accepting a preHashed message to sign</td>
+<td class="left">bool</td>
+<td class="left">true/false</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.3.4">
+<a href="#rfc.section.2.3.4">2.3.4.</a> <a href="#mode_sigVer" id="mode_sigVer">The sigVer Mode Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.4.p.1">The EDDSA sigVer mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</p>
+<p id="rfc.section.2.3.4.p.2">Each EDDSA sigVer mode capability set is advertised as a self-contained JSON object.</p>
+<h1 id="rfc.section.2.3.4.1">
+<a href="#rfc.section.2.3.4.1">2.3.4.1.</a> <a href="#mode_sigVerFullSet" id="mode_sigVerFullSet">sigVer Full Set of Capabilities</a>
+</h1>
+<p id="rfc.section.2.3.4.1.p.1">The complete list of EDDSA signature verification capabilities may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.6"></div>
+<div id="sigVer_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>EDDSA sigVer Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">curve</td>
+<td class="left">The curve names supported for the IUT in sigVer.</td>
+<td class="left">array</td>
+<td class="left">Any non-empty subset of {"ed-25519", "ed-448"}</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">pure</td>
+<td class="left">If the IUT supports normal 'pure' sigGen functionality</td>
+<td class="left">bool</td>
+<td class="left">true/false</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">preHash</td>
+<td class="left">If the IUT supports accepting a preHashed message to sign</td>
+<td class="left">bool</td>
+<td class="left">true/false</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.4">
+<a href="#rfc.section.2.4">2.4.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+</h1>
+<p id="rfc.section.2.4.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual EDDSA function. This section describes the JSON schema for a test vector set used with EDDSA algorithms.</p>
+<p id="rfc.section.2.4.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy.</p>
+<div id="rfc.table.7"></div>
+<div id="vs_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Vector Set JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">EDDSA</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">The EDDSA mode used for the test vectors</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 2.4.1</a> </td>
+<td class="left">array</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.4.1">
+<a href="#rfc.section.2.4.1">2.4.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
+</h1>
+<p id="rfc.section.2.4.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted	in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.2.4.1.p.2">The test group for EDDSA is as follows:</p>
+<div id="rfc.table.8"></div>
+<div id="vs_tg_table5"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Vector Group JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">curve</td>
+<td class="left">The curve type used for the test vectors.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">secretGenerationMode</td>
+<td class="left">The method of generating a secret used for key generation in the test vectors.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testType</td>
+<td class="left">The testType for the group</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">q</td>
+<td class="left">The encoded public key point</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">preHash</td>
+<td class="left">Denotes whether or not the IUT should accept the message as a preHashed message before signing</td>
+<td class="left">bool</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 2.4.2</a> </td>
+<td class="left">array</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.4.2">
+<a href="#rfc.section.2.4.2">2.4.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
+</h1>
+<p id="rfc.section.2.4.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object	that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each EDDSA test vector.</p>
+<div id="rfc.table.9"></div>
+<div id="vs_tc_table5"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">q</td>
+<td class="left">The encoded public key curve point</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">signature</td>
+<td class="left">The signature</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">message</td>
+<td class="left">The message used to generate signature or verify signature</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">context</td>
+<td class="left">The context used to generate signature or verify signature</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.5">
+<a href="#rfc.section.2.5">2.5.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
+</h1>
+<p id="rfc.section.2.5.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.10"></div>
+<div id="vr_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Vector Set Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of JSON objects that represent each test group of results, as defined by the tables below</td>
+<td class="left">array</td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.2.5.p.2">The following table describes the JSON object that represents a test group response for EDDSA.</p>
+<div id="rfc.table.11"></div>
+<div id="vr_top_table2"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Test Group Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">Unique numeric identifier for the test group</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">q</td>
+<td class="left">Optional encoded public key for the group</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">Array of JSON objects that represent each result, as defined by the table below</td>
+<td class="left">array</td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.2.5.p.3">The following table describes the JSON object that represents a test case response for EDDSA.</p>
+<div id="rfc.table.12"></div>
+<div id="vr_top_table5"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Test Case Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">d</td>
+<td class="left">The encoded private key point</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">q</td>
+<td class="left">The encoded public key point </td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">signature</td>
+<td class="left">The signature component S</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testPassed</td>
+<td class="left">The pass or fail result of the verify or validation</td>
+<td class="left">true/false</td>
+<td class="left">Yes</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.2.6">
+<a href="#rfc.section.2.6">2.6.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
+</h1>
+<p id="rfc.section.2.6.p.1">TBD...</p>
+<h1 id="rfc.section.2.7">
+<a href="#rfc.section.2.7">2.7.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+</h1>
+<p id="rfc.section.2.7.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.2.8">
+<a href="#rfc.section.2.8">2.8.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.2.8.p.1">Security considerations are addressed by the ACVP specification.</p>
+<h1 id="rfc.references">
+<a href="#rfc.references">3.</a> Normative References</h1>
+<table><tbody>
+<tr>
+<td class="reference"><b id="ACVP">[ACVP]</b></td>
+<td class="top">
+<a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC2119">[RFC2119]</b></td>
+<td class="top">
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+</tbody></table>
+<h1 id="rfc.appendix.A">
+<a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example EDDSA JSON Object</a>
+</h1>
+<p id="rfc.section.A.p.1">The following sections contain example JSON for the various EDDSA modes: keyGen, keyVer, sigGen, and sigVer. Note that all binary HEX representations are in big-endian byte order but little-endian bit format.</p>
+<h1 id="rfc.appendix.A.1">
+<a href="#rfc.appendix.A.1">A.1.</a> <a href="#app-reg-ex2" id="app-reg-ex2">Example EDDSA KeyGen Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.A.1.p.1">The following is a example JSON object advertising support for EDDSA keyGen.</p>
+<pre>
+						
+{
+    "algorithm": "EDDSA",
+    "mode": "keyGen",
+    "prereqVals": [
+      {
+          "algorithm": "SHA",
+          "valValue": "123456"
+      },
+      {
+          "algorithm": "DRBG",
+          "valValue": "123456"
+      }
+    ],
+	"curve": [
+		"ed-25519",
+		"ed-448"
+	],
+	"secretGenerationMode": [
+		"extra bits",
+		"testing candidates"
+	]
+}
+            
+					</pre>
+<h1 id="rfc.appendix.A.2">
+<a href="#rfc.appendix.A.2">A.2.</a> <a href="#app-reg-ex1" id="app-reg-ex1">Example EDDSA KeyVer Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.A.2.p.1">The following is a example JSON object advertising support for EDDSA keyVer.</p>
+<pre>
+						
+{
+    "algorithm": "EDDSA",
+    "mode": "keyVer",
+    "prereqVals": [
+        {
+            "algorithm": "SHA",
+            "valValue": "123456"
+        },
+        {
+            "algorithm": "DRBG",
+            "valValue": "123456"
+        }
+    ],
+    "curve": [
+        "ed-25519",
+		"ed-448"
+    ]
+}
+            
+					</pre>
+<h1 id="rfc.appendix.A.3">
+<a href="#rfc.appendix.A.3">A.3.</a> <a href="#app-reg-ex3" id="app-reg-ex3">Example EDDSA SigGen Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.A.3.p.1">The following is a example JSON object advertising support for EDDSA sigGen.</p>
+<pre>
+						
+{
+    "algorithm": "EDDSA",
+    "mode": "sigGen",
+    "prereqVals": [
+        {
+            "algorithm": "SHA",
+            "valValue": "123456"
+        },
+        {
+            "algorithm": "DRBG",
+            "valValue": "123456"
+        }
+    ],
+	"pure": true,
+	"preHash": true,
+	"curve": [
+		"ed-25519",
+		"ed-448"
+    ]
+}
+            
+					</pre>
+<h1 id="rfc.appendix.A.4">
+<a href="#rfc.appendix.A.4">A.4.</a> <a href="#app-reg-ex4" id="app-reg-ex4">Example EDDSA SigVer Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.A.4.p.1">The following is a example JSON object advertising support for EDDSA sigVer.</p>
+<pre>
+						
+{
+	"algorithm": "EDDSA",
+	"mode": "sigVer",
+	"prereqVals": [
+        {
+            "algorithm": "SHA",
+            "valValue": "123456"
+        },
+        {
+            "algorithm": "DRBG",
+            "valValue": "123456"
+        }
+    ],
+	"pure": true,
+	"preHash": true,
+	"curve": [
+		"ed-25519",
+		"ed-448"
+	]
+}
+            
+					</pre>
+<h1 id="rfc.appendix.A.5">
+<a href="#rfc.appendix.A.5">A.5.</a> <a href="#app-vs-ex5" id="app-vs-ex5">Example Test EDDSA KeyGen JSON Object</a>
+</h1>
+<p id="rfc.section.A.5.p.1">The following is a example JSON object for EDDSA KeyGen, test vectors sent from the ACVP server to the crypto module and the response.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "keyGen",
+        "testGroups": [
+            {
+                "curve": "ed-25519",
+                "secretGenerationMode": "extra bits",
+				"testType": "AFT",
+                "tests": [
+                    {
+                        "tcId": 1
+                    }
+                ]
+            }
+        ]
+    }
+]
+            
+					</pre>
+<p id="rfc.section.A.5.p.2">The following is a example JSON object for EDDSA KeyGen test results sent from the crypto module to the ACVP server.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "testGroups": [
+            {
+				"tgId": 1,
+				"tests": [
+					{
+						"tcId": 1,
+						"q": "D51FB3D405A636227833A0950A2F4EDAF547F50448D7F371D0E9353F207B2B09",
+						"d": "147BA261D11CD323331D87C22E215724E9CD5E6B6BEAC85A9808241D9E80781F"
+					}
+				]
+            }
+        ]
+    }
+]
+            
+					</pre>
+<h1 id="rfc.appendix.A.6">
+<a href="#rfc.appendix.A.6">A.6.</a> <a href="#app-vs-ex6" id="app-vs-ex6">Example Test EDDSA KeyVer JSON Object</a>
+</h1>
+<p id="rfc.section.A.6.p.1">The following is a example JSON object for EDDSA KeyVer, test vectors sent from the ACVP server to the crypto module and the response.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "keyVer",
+        "testGroups": [
+            {
+				"tgId": 1,
+                "curve": "ed-25519",
+				"testType": "AFT",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "q": "227093C50F7D04A41121CEFDF076CC8B21D44E7506F341F8BFAB269CE06F2B7E",
+                    }
+                ]
+            }
+        ]
+    }
+]
+            
+					</pre>
+<p id="rfc.section.A.6.p.2">The following is a example JSON object for EDDSA KeyVer test results sent from the crypto module to the ACVP server.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+		"testGroups": [
+			{
+				"tgId": 1,
+				"tests": [
+					{
+						"tcId": 1,
+						"testPassed": true
+					}
+				]
+            }
+        ]
+    }
+]
+            
+					</pre>
+<h1 id="rfc.appendix.A.7">
+<a href="#rfc.appendix.A.7">A.7.</a> <a href="#app-vs-ex8" id="app-vs-ex8">Example Test EDDSA Signature Generation JSON Object</a>
+</h1>
+<p id="rfc.section.A.7.p.1">The following is a example JSON object for EDDSA SigGen, test vectors sent from the ACVP server to the crypto module and the response.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "sigGen",
+        "testGroups": [
+            {
+				"tgId": 1,
+				"testType": "AFT",
+                "curve": "ed-25519",
+				"preHash": false,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "A81C8A22735A260CB1A8105A2964646097D8A9B110701AB0D49C9071836CAD39E31F5020D24B2C841FAC58F44F3F3F814495B063A686F6F93C5C6D9FDF45B9099C609A69E6A9F6483C5038066A560D413C6FB73D76499A7D8836C9C89368D557B2C24A5D817CF1FBD226AC41037E3005250007B49C6CCCE7BD1BE5D7A5C96EE8"
+                    }
+                ]
+            }
+        ]
+    }
+]
+            
+					</pre>
+<p id="rfc.section.A.7.p.2">The following is a example JSON object for EDDSA SigGen test results sent from the crypto module to the ACVP server.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "testGroups": [
+            {
+				"tgId": 1,
+				"q": "4BA34FE699DBDC89750FF006AA35E282BF71C180B53C2DE620676C8707A14E48",
+				"tests": [
+					{
+						"tcId": 1,
+						"signature": "772990B0E53B3E21DC8BD139CECB39892D75BD70DAFFDC73E241E29515E67CC642CB2A6B479FFEF4F3F16B5BC3DDF06AB25A92028F2DC0464B3CFDFD3B8F4D08"
+					}
+				]
+            }
+        ]
+    }
+]
+          
+					</pre>
+<h1 id="rfc.appendix.A.8">
+<a href="#rfc.appendix.A.8">A.8.</a> <a href="#app-vs-ex9" id="app-vs-ex9">Example Test EDDSA SigVer JSON Object</a>
+</h1>
+<p id="rfc.section.A.8.p.1">The following is a example JSON object for EDDSA SigVer, test vectors sent from the ACVP server to the crypto module and the response.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "sigVer",
+        "testGroups": [
+            {
+				"tgId": 1,
+				"testType": "AFT"
+                "curve": "ed-25519",
+                "preHash": false,
+				"q": "502A28FAF736CBCF1B51A3816CADC61D6B46699149A442BA741B378386B7120C",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "BED1D245D569D5C10693F408A195D0404D3F27DFD0C670034A99AFD5F33E84690812516F4335ED6B2D5FD824075B061D7BA5731DCA4EF01040167AC2D40320DEB7FC63A8B34CE5C05CF22EC0D7B11AC55C84D8131D3C656CBA05BB29F64A5D5C20AFD5212163A254B9915A30BBAB15FB3F710C325F408E8D1E840B55A09F52B7",
+                        "signature": "9C09C0FF50B61E4443DBA5D1262B7CE6DDD3742BCAF288B0A17078F78ECB2480976448A177FFBB6E39FC9C02ABFA63806D664248C67803E4023A681E9930550F"
+                    }
+                ]
+            }
+        ]
+    }
+]
+            
+					</pre>
+<p id="rfc.section.A.8.p.2">The following is a example JSON object for EDDSA generation test results sent from the crypto module to the ACVP server.</p>
+<pre>
+						
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "testGroups": [
+            {
+				"tgId": 1,
+				"tests": [
+					{
+                		"tcId": 1,
+                		"testPassed": false
+					}
+				]
+            }
+        ]
+    }
+]
+          
+					</pre>
+<h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Christopher Celi</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name">Celi</span>
+	  </span>
+	</span>
+	<span class="org vcardline">National Institute of Standards and Technology</span>
+	<span class="adr">
+	  <span class="vcardline">100 Bureau Dr.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Gaithersburg</span>,  
+		<span class="region">MD</span> 
+		<span class="code">20850</span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:christopher.celi@nist.gov">christopher.celi@nist.gov</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/artifacts/acvp_sub_eddsa.txt
+++ b/artifacts/acvp_sub_eddsa.txt
@@ -1,0 +1,1400 @@
+
+
+
+
+TBD                                                         C. Celi, Ed.
+Internet-Draft            National Institute of Standards and Technology
+Intended status: Informational                           August 27, 2018
+Expires: February 28, 2019
+
+
+                ACVP EDDSA Algorithm JSON Specification
+                      draft-ietf-acvp-subeddsa-0.5
+
+Abstract
+
+   This document defines the JSON schema for using EDDSA algorithms with
+   the ACVP specification.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on February 28, 2019.
+
+Copyright Notice
+
+   Copyright (c) 2018 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 1]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
+   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
+     2.1.  Required Prerequisite Algorithms for EDDSA Validations  .   3
+     2.2.  EDDSA Algorithm Capabilities Registration . . . . . . . .   4
+     2.3.  Supported EDDSA Modes Capabilities  . . . . . . . . . . .   5
+       2.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   6
+         2.3.1.1.  keyGen Full Set of Capabilities . . . . . . . . .   6
+       2.3.2.  The keyVer Mode Capabilities  . . . . . . . . . . . .   6
+         2.3.2.1.  keyVer Full Set of Capabilities . . . . . . . . .   7
+       2.3.3.  The sigGen Mode Capabilities  . . . . . . . . . . . .   7
+         2.3.3.1.  sigGen Full Set of Capabilities . . . . . . . . .   7
+       2.3.4.  The sigVer Mode Capabilities  . . . . . . . . . . . .   8
+         2.3.4.1.  sigVer Full Set of Capabilities . . . . . . . . .   8
+     2.4.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . .   9
+       2.4.1.  Test Groups JSON Schema . . . . . . . . . . . . . . .  10
+       2.4.2.  Test Case JSON Schema . . . . . . . . . . . . . . . .  11
+     2.5.  Test Vector Responses . . . . . . . . . . . . . . . . . .  12
+     2.6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . .  13
+     2.7.  IANA Considerations . . . . . . . . . . . . . . . . . . .  13
+     2.8.  Security Considerations . . . . . . . . . . . . . . . . .  13
+   3.  Normative References  . . . . . . . . . . . . . . . . . . . .  14
+   Appendix A.  Example EDDSA JSON Object  . . . . . . . . . . . . .  14
+     A.1.  Example EDDSA KeyGen Capabilities JSON Object . . . . . .  14
+     A.2.  Example EDDSA KeyVer Capabilities JSON Object . . . . . .  15
+     A.3.  Example EDDSA SigGen Capabilities JSON Object . . . . . .  15
+     A.4.  Example EDDSA SigVer Capabilities JSON Object . . . . . .  16
+     A.5.  Example Test EDDSA KeyGen JSON Object . . . . . . . . . .  17
+     A.6.  Example Test EDDSA KeyVer JSON Object . . . . . . . . . .  19
+     A.7.  Example Test EDDSA Signature Generation JSON Object . . .  21
+     A.8.  Example Test EDDSA SigVer JSON Object . . . . . . . . . .  23
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  25
+
+1.  Introduction
+
+   The Automated Crypto Validation Protocol (ACVP) defines a mechanism
+   to automatically verify the cryptographic implementation of a
+   software or hardware crypto module.  The ACVP specification defines
+   how a crypto module communicates with an ACVP server, including
+   crypto capabilities negotiation, session management, authentication,
+   vector processing and more.  The ACVP specification does not define
+   algorithm specific JSON constructs for performing the crypto
+   validation.  A series of ACVP sub-specifications define the
+   constructs for testing individual crypto algorithms.  Each sub-
+   specification addresses a specific class of crypto algorithms.  This
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 2]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   sub-specification defines the JSON constructs for testing EDDSA
+   algorithms using ACVP.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted in RFC 2119 [RFC2119].
+
+2.  Capabilities Registration
+
+   ACVP requires crypto modules to register their capabilities.  This
+   allows the crypto module to advertise support for specific
+   algorithms, notifying the ACVP server which algorithms need test
+   vectors generated for the validation process.  This section describes
+   the constructs for advertising support of EDDSA algorithms to the
+   ACVP server.
+
+   The algorithm capabilities are advertised as JSON objects within the
+   'algorithms' value of the ACVP registration message.  The
+   'algorithms' value is an array, where each array element is an
+   individual JSON object defined in this section.  The 'algorithms'
+   value is part of the 'capability_exchange' element of the ACVP JSON
+   registration message.  See the ACVP specification for details on the
+   registration message.
+
+2.1.  Required Prerequisite Algorithms for EDDSA Validations
+
+   Each EDDSA implementation relies on other cryptographic primitives.
+   For example, EDDSA uses an underlying SHA algorithm.  Each of these
+   underlying algorithm primitives must be validated, either separately
+   or as part of the same submission.  ACVP provides a mechanism for
+   specifying the required prerequisites:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 3]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +-------------+--------------+--------------+------------+----------+
+   | JSON Value  | Description  | JSON type    | Valid      | Optional |
+   |             |              |              | Values     |          |
+   +-------------+--------------+--------------+------------+----------+
+   | algorithm   | a            | value        | DRBG,      | No       |
+   |             | prerequisite |              | DRBG_OPT2, |          |
+   |             | algorithm    |              | SHA,       |          |
+   |             |              |              | SHA_OPT2,  |          |
+   |             |              |              | SHA_OPT3   |          |
+   |             |              |              |            |          |
+   | valValue    | algorithm    | value        | actual     | No       |
+   |             | validation   |              | number or  |          |
+   |             | number       |              | "same"     |          |
+   |             |              |              |            |          |
+   | prereqAlgVa | prerequistie | object with  | see above  | No       |
+   | l           | algorithm    | algorithm    |            |          |
+   |             | validation   | and valValue |            |          |
+   |             |              | properties   |            |          |
+   |             |              |              |            |          |
+   | prereqVals  | prerequistie | array of     | see above  | No       |
+   |             | algorithm    | prereqAlgVal |            |          |
+   |             | validations  | objects      |            |          |
+   +-------------+--------------+--------------+------------+----------+
+
+        Table 1: Required EDDSA Prerequisite Algorithms JSON Values
+
+2.2.  EDDSA Algorithm Capabilities Registration
+
+   Each algorithm capability advertised is a self-contained JSON object
+   using the following values
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 4]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+----------------+--------------+-----------+----------+
+   | JSON Value | Description    | JSON type    | Valid     | Optional |
+   |            |                |              | Values    |          |
+   +------------+----------------+--------------+-----------+----------+
+   | algorithm  | The algorithm  | value        | "EDDSA"   | No       |
+   |            | under test     |              |           |          |
+   |            |                |              |           |          |
+   | mode       | The EDDSA mode | value        | "keyGen", | No       |
+   |            | to be          |              | "keyVer", |          |
+   |            | validated      |              | "sigGen", |          |
+   |            |                |              | or        |          |
+   |            |                |              | "sigVer"  |          |
+   |            |                |              |           |          |
+   | prereqVals | prerequistie   | array of     | See Secti | No       |
+   |            | algorithm      | prereqAlgVal | on 2.1    |          |
+   |            | validations    | objects      |           |          |
+   |            |                |              |           |          |
+   | algSpecs   | array of JSON  | Array of     | See Secti |
+   |            | objects, each  | JSON objects | on 2.3    |
+   |            | with fields    |              |           |
+   |            | pertaining to  |              |           |
+   |            | the global     |              |           |
+   |            | EDDSA mode     |              |           |
+   |            | indicated      |              |           |
+   |            | above and      |              |           |
+   |            | identified     |              |           |
+   |            | uniquely by    |              |           |
+   |            | the            |              |           |
+   |            | combination of |              |           |
+   |            | the EDDSA      |              |           |
+   |            | "mode" and     |              |           |
+   |            | indicated      |              |           |
+   |            | properties     |              |           |
+   +------------+----------------+--------------+-----------+----------+
+
+             Table 2: EDDSA Algorithm Capabilities JSON Values
+
+2.3.  Supported EDDSA Modes Capabilities
+
+   The EDDSA mode capabilities are advertised as JSON objects within the
+   'algSpecs' value of the ACVP registration message - see Table 2.  The
+   'algSpecs' value is an array, where each array element is a JSON
+   object corresponding to a particular EDDSA mode defined in this
+   section.  The 'algSpecs' value is part of the 'capability_exchange'
+   element of the ACVP JSON registration message.  See the ACVP
+   specification for details on the registration message.
+
+   Each EDDSA mode's capabilities are advertised as JSON objects.
+
+
+
+Celi                    Expires February 28, 2019               [Page 5]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+2.3.1.  The keyGen Mode Capabilities
+
+   The EDDSA keyGen mode capabilities are advertised as JSON objects,
+   which are elements of the 'algSpecs' array in the ACVP registration
+   message.  See the ACVP specification for details on the registration
+   message.
+
+   Each EDDSA keyGen mode capability set is advertised as a self-
+   contained JSON object.
+
+2.3.1.1.  keyGen Full Set of Capabilities
+
+   The complete list of EDDSA key generation capabilities may be
+   advertised by the ACVP compliant crypto module:
+
+   +--------------------+------------+-------+--------------+----------+
+   | JSON Value         | Descriptio | JSON  | Valid Values | Optional |
+   |                    | n          | type  |              |          |
+   +--------------------+------------+-------+--------------+----------+
+   | curve              | The curve  | array | Any non-     | No       |
+   |                    | names      |       | empty subset |          |
+   |                    | supported  |       | of           |          |
+   |                    | for the    |       | {"ed-25519", |          |
+   |                    | IUT in     |       | "ed-448"}    |          |
+   |                    | keyGen.    |       |              |          |
+   |                    |            |       |              |          |
+   | secretGenerationMo | The method | array | Any non-     | No       |
+   | de                 | used to    |       | empty subset |          |
+   |                    | generate   |       | of {"extra   |          |
+   |                    | the        |       | bits",       |          |
+   |                    | randomness |       | "testing     |          |
+   |                    | incoporate |       | candidates"} |          |
+   |                    | d in the   |       |              |          |
+   |                    | key.       |       |              |          |
+   +--------------------+------------+-------+--------------+----------+
+
+              Table 3: EDDSA keyGen Capabilities JSON Values
+
+2.3.2.  The keyVer Mode Capabilities
+
+   The EDDSA keyVer mode capabilities are advertised as JSON objects,
+   which are elements of the 'algSpecs' array in the ACVP registration
+   message.  See the ACVP specification for details on the registration
+   message.
+
+   Each EDDSA keyVer mode capability set is advertised as a self-
+   contained JSON object.
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 6]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+2.3.2.1.  keyVer Full Set of Capabilities
+
+   The complete list of EDDSA key verification capabilities may be
+   advertised by the ACVP compliant crypto module:
+
+   +-------+-------------------+-------+--------------------+----------+
+   | JSON  | Description       | JSON  | Valid Values       | Optional |
+   | Value |                   | type  |                    |          |
+   +-------+-------------------+-------+--------------------+----------+
+   | curve | The curve names   | array | Any non-empty      | No       |
+   |       | supported for the |       | subset of          |          |
+   |       | IUT in keyVer.    |       | {"ed-25519",       |          |
+   |       |                   |       | "ed-448"}          |          |
+   +-------+-------------------+-------+--------------------+----------+
+
+              Table 4: EDDSA keyVer Capabilities JSON Values
+
+2.3.3.  The sigGen Mode Capabilities
+
+   The EDDSA sigGen mode capabilities are advertised as JSON objects,
+   which are elements of the 'algSpecs' array in the ACVP registration
+   message.  See the ACVP specification for details on the registration
+   message.
+
+   Each EDDSA sigGen mode capability set is advertised as a self-
+   contained JSON object.
+
+2.3.3.1.  sigGen Full Set of Capabilities
+
+   The complete list of EDDSA signature generation capabilities may be
+   advertised by the ACVP compliant crypto module:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 7]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +---------+--------------------+-------+-----------------+----------+
+   | JSON    | Description        | JSON  | Valid Values    | Optional |
+   | Value   |                    | type  |                 |          |
+   +---------+--------------------+-------+-----------------+----------+
+   | curve   | The curve names    | array | Any non-empty   | No       |
+   |         | supported for the  |       | subset of       |          |
+   |         | IUT in sigGen.     |       | {"ed-25519",    |          |
+   |         |                    |       | "ed-448"}       |          |
+   |         |                    |       |                 |          |
+   | pure    | If the IUT         | bool  | true/false      | No       |
+   |         | supports normal    |       |                 |          |
+   |         | 'pure' sigGen      |       |                 |          |
+   |         | functionality      |       |                 |          |
+   |         |                    |       |                 |          |
+   | preHash | If the IUT         | bool  | true/false      | No       |
+   |         | supports accepting |       |                 |          |
+   |         | a preHashed        |       |                 |          |
+   |         | message to sign    |       |                 |          |
+   +---------+--------------------+-------+-----------------+----------+
+
+              Table 5: EDDSA sigGen Capabilities JSON Values
+
+2.3.4.  The sigVer Mode Capabilities
+
+   The EDDSA sigVer mode capabilities are advertised as JSON objects,
+   which are elements of the 'algSpecs' array in the ACVP registration
+   message.  See the ACVP specification for details on the registration
+   message.
+
+   Each EDDSA sigVer mode capability set is advertised as a self-
+   contained JSON object.
+
+2.3.4.1.  sigVer Full Set of Capabilities
+
+   The complete list of EDDSA signature verification capabilities may be
+   advertised by the ACVP compliant crypto module:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 8]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +---------+--------------------+-------+-----------------+----------+
+   | JSON    | Description        | JSON  | Valid Values    | Optional |
+   | Value   |                    | type  |                 |          |
+   +---------+--------------------+-------+-----------------+----------+
+   | curve   | The curve names    | array | Any non-empty   | No       |
+   |         | supported for the  |       | subset of       |          |
+   |         | IUT in sigVer.     |       | {"ed-25519",    |          |
+   |         |                    |       | "ed-448"}       |          |
+   |         |                    |       |                 |          |
+   | pure    | If the IUT         | bool  | true/false      | No       |
+   |         | supports normal    |       |                 |          |
+   |         | 'pure' sigGen      |       |                 |          |
+   |         | functionality      |       |                 |          |
+   |         |                    |       |                 |          |
+   | preHash | If the IUT         | bool  | true/false      | No       |
+   |         | supports accepting |       |                 |          |
+   |         | a preHashed        |       |                 |          |
+   |         | message to sign    |       |                 |          |
+   +---------+--------------------+-------+-----------------+----------+
+
+              Table 6: EDDSA sigVer Capabilities JSON Values
+
+2.4.  Test Vectors
+
+   The ACVP server provides test vectors to the ACVP client, which are
+   then processed and returned to the ACVP server for validation.  A
+   typical ACVP validation session would require multiple test vector
+   sets to be downloaded and processed by the ACVP client.  Each test
+   vector set represents an individual EDDSA function.  This section
+   describes the JSON schema for a test vector set used with EDDSA
+   algorithms.
+
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
+   test vectors to be processed by the ACVP client.The following table
+   describes the JSON elements at the top level of the hierarchy.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019               [Page 9]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | algorithm  | EDDSA                                       | value  |
+   |            |                                             |        |
+   | mode       | The EDDSA mode used for the test vectors    | value  |
+   |            |                                             |        |
+   | testGroups | Array of test group JSON objects, which are | array  |
+   |            | defined in Section 2.4.1                    |        |
+   +------------+---------------------------------------------+--------+
+
+                      Table 7: Vector Set JSON Object
+
+2.4.1.  Test Groups JSON Schema
+
+   The testGroups element at the top level in the test vector JSON
+   object is an array of test groups.  Test vectors are grouped into
+   similar test cases to reduce the amount of data transmitted in the
+   vector set.  For instance, all test vectors that use the same key
+   size would be grouped together.  The Test Group JSON object contains
+   meta data that applies to all test vectors within the group.  The
+   following table describes the secure hash JSON elements of the Test
+   Group JSON object.
+
+   The test group for EDDSA is as follows:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 10]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +----------------------+-------------------------+-------+----------+
+   | JSON Value           | Description             | JSON  | Optional |
+   |                      |                         | type  |          |
+   +----------------------+-------------------------+-------+----------+
+   | curve                | The curve type used for | value | No       |
+   |                      | the test vectors.       |       |          |
+   |                      |                         |       |          |
+   | secretGenerationMode | The method of           | value | Yes      |
+   |                      | generating a secret     |       |          |
+   |                      | used for key generation |       |          |
+   |                      | in the test vectors.    |       |          |
+   |                      |                         |       |          |
+   | testType             | The testType for the    | value | No       |
+   |                      | group                   |       |          |
+   |                      |                         |       |          |
+   | q                    | The encoded public key  | value | Yes      |
+   |                      | point                   |       |          |
+   |                      |                         |       |          |
+   | preHash              | Denotes whether or not  | bool  | Yes      |
+   |                      | the IUT should accept   |       |          |
+   |                      | the message as a        |       |          |
+   |                      | preHashed message       |       |          |
+   |                      | before signing          |       |          |
+   |                      |                         |       |          |
+   | tests                | Array of individual     | array | No       |
+   |                      | test vector JSON        |       |          |
+   |                      | objects, which are      |       |          |
+   |                      | defined in              |       |          |
+   |                      | Section 2.4.2           |       |          |
+   +----------------------+-------------------------+-------+----------+
+
+                     Table 8: Vector Group JSON Object
+
+2.4.2.  Test Case JSON Schema
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each EDDSA test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 11]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +-----------+------------------------------------+-------+----------+
+   | JSON      | Description                        | JSON  | Optional |
+   | Value     |                                    | type  |          |
+   +-----------+------------------------------------+-------+----------+
+   | tcId      | Numeric identifier for the test    | value | No       |
+   |           | case, unique across the entire     |       |          |
+   |           | vector set.                        |       |          |
+   |           |                                    |       |          |
+   | q         | The encoded public key curve point | value | Yes      |
+   |           |                                    |       |          |
+   | signature | The signature                      | value | Yes      |
+   |           |                                    |       |          |
+   | message   | The message used to generate       | value | Yes      |
+   |           | signature or verify signature      |       |          |
+   |           |                                    |       |          |
+   | context   | The context used to generate       | value | Yes      |
+   |           | signature or verify signature      |       |          |
+   +-----------+------------------------------------+-------+----------+
+
+                      Table 9: Test Case JSON Object
+
+2.5.  Test Vector Responses
+
+   After the ACVP client downloads and processes a vector set, it must
+   send the response vectors back to the ACVP server.  The following
+   table describes the JSON object that represents a vector set
+   response.
+
+   +------------+----------------------------------------------+-------+
+   | JSON Value | Description                                  | JSON  |
+   |            |                                              | type  |
+   +------------+----------------------------------------------+-------+
+   | acvVersion | Protocol version identifier                  | value |
+   |            |                                              |       |
+   | vsId       | Unique numeric identifier for the vector set | value |
+   |            |                                              |       |
+   | testGroups | Array of JSON objects that represent each    | array |
+   |            | test group of results, as defined by the     |       |
+   |            | tables below                                 |       |
+   +------------+----------------------------------------------+-------+
+
+                 Table 10: Vector Set Response JSON Object
+
+   The following table describes the JSON object that represents a test
+   group response for EDDSA.
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 12]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +---------+------------------------------------------------+--------+
+   | JSON    | Description                                    | JSON   |
+   | Value   |                                                | type   |
+   +---------+------------------------------------------------+--------+
+   | tgId    | Unique numeric identifier for the test group   | value  |
+   |         |                                                |        |
+   | q       | Optional encoded public key for the group      | value  |
+   |         |                                                |        |
+   | tests   | Array of JSON objects that represent each      | array  |
+   |         | result, as defined by the table below          |        |
+   +---------+------------------------------------------------+--------+
+
+                 Table 11: Test Group Response JSON Object
+
+   The following table describes the JSON object that represents a test
+   case response for EDDSA.
+
+   +------------+------------------------------+------------+----------+
+   | JSON Value | Description                  | JSON type  | Optional |
+   +------------+------------------------------+------------+----------+
+   | d          | The encoded private key      | value      | Yes      |
+   |            | point                        |            |          |
+   |            |                              |            |          |
+   | q          | The encoded public key point | value      | Yes      |
+   |            |                              |            |          |
+   | signature  | The signature component S    | value      | Yes      |
+   |            |                              |            |          |
+   | testPassed | The pass or fail result of   | true/false | Yes      |
+   |            | the verify or validation     |            |          |
+   +------------+------------------------------+------------+----------+
+
+                 Table 12: Test Case Response JSON Object
+
+2.6.  Acknowledgements
+
+   TBD...
+
+2.7.  IANA Considerations
+
+   This memo includes no request to IANA.
+
+2.8.  Security Considerations
+
+   Security considerations are addressed by the ACVP specification.
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 13]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+3.  Normative References
+
+   [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+Appendix A.  Example EDDSA JSON Object
+
+   The following sections contain example JSON for the various EDDSA
+   modes: keyGen, keyVer, sigGen, and sigVer.  Note that all binary HEX
+   representations are in big-endian byte order but little-endian bit
+   format.
+
+A.1.  Example EDDSA KeyGen Capabilities JSON Object
+
+   The following is a example JSON object advertising support for EDDSA
+   keyGen.
+
+
+   {
+       "algorithm": "EDDSA",
+       "mode": "keyGen",
+       "prereqVals": [
+         {
+             "algorithm": "SHA",
+             "valValue": "123456"
+         },
+         {
+             "algorithm": "DRBG",
+             "valValue": "123456"
+         }
+       ],
+           "curve": [
+                   "ed-25519",
+                   "ed-448"
+           ],
+           "secretGenerationMode": [
+                   "extra bits",
+                   "testing candidates"
+           ]
+   }
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 14]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+A.2.  Example EDDSA KeyVer Capabilities JSON Object
+
+   The following is a example JSON object advertising support for EDDSA
+   keyVer.
+
+
+   {
+       "algorithm": "EDDSA",
+       "mode": "keyVer",
+       "prereqVals": [
+           {
+               "algorithm": "SHA",
+               "valValue": "123456"
+           },
+           {
+               "algorithm": "DRBG",
+               "valValue": "123456"
+           }
+       ],
+       "curve": [
+           "ed-25519",
+                   "ed-448"
+       ]
+   }
+
+
+A.3.  Example EDDSA SigGen Capabilities JSON Object
+
+   The following is a example JSON object advertising support for EDDSA
+   sigGen.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 15]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   {
+       "algorithm": "EDDSA",
+       "mode": "sigGen",
+       "prereqVals": [
+           {
+               "algorithm": "SHA",
+               "valValue": "123456"
+           },
+           {
+               "algorithm": "DRBG",
+               "valValue": "123456"
+           }
+       ],
+           "pure": true,
+           "preHash": true,
+           "curve": [
+                   "ed-25519",
+                   "ed-448"
+       ]
+   }
+
+
+A.4.  Example EDDSA SigVer Capabilities JSON Object
+
+   The following is a example JSON object advertising support for EDDSA
+   sigVer.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 16]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   {
+           "algorithm": "EDDSA",
+           "mode": "sigVer",
+           "prereqVals": [
+           {
+               "algorithm": "SHA",
+               "valValue": "123456"
+           },
+           {
+               "algorithm": "DRBG",
+               "valValue": "123456"
+           }
+       ],
+           "pure": true,
+           "preHash": true,
+           "curve": [
+                   "ed-25519",
+                   "ed-448"
+           ]
+   }
+
+
+A.5.  Example Test EDDSA KeyGen JSON Object
+
+   The following is a example JSON object for EDDSA KeyGen, test vectors
+   sent from the ACVP server to the crypto module and the response.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 17]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   [
+       {
+           "acvVersion": "0.5"
+       },
+       {
+           "vsId": 1564,
+           "algorithm": "EDDSA",
+           "mode": "keyGen",
+           "testGroups": [
+               {
+                   "curve": "ed-25519",
+                   "secretGenerationMode": "extra bits",
+                                   "testType": "AFT",
+                   "tests": [
+                       {
+                           "tcId": 1
+                       }
+                   ]
+               }
+           ]
+       }
+   ]
+
+
+   The following is a example JSON object for EDDSA KeyGen test results
+   sent from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 18]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "testGroups": [
+            {
+                                "tgId": 1,
+                                "tests": [
+                                        {
+                                                "tcId": 1,
+                                                "q": "D51FB3D405A636227833A0950A2F4EDAF547F50448D7F371D0E9353F207B2B09",
+                                                "d": "147BA261D11CD323331D87C22E215724E9CD5E6B6BEAC85A9808241D9E80781F"
+                                        }
+                                ]
+            }
+        ]
+    }
+]
+
+
+A.6.  Example Test EDDSA KeyVer JSON Object
+
+   The following is a example JSON object for EDDSA KeyVer, test vectors
+   sent from the ACVP server to the crypto module and the response.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 19]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "keyVer",
+        "testGroups": [
+            {
+                                "tgId": 1,
+                "curve": "ed-25519",
+                                "testType": "AFT",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "q": "227093C50F7D04A41121CEFDF076CC8B21D44E7506F341F8BFAB269CE06F2B7E",
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+
+   The following is a example JSON object for EDDSA KeyVer test results
+   sent from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 20]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   [
+       {
+           "acvVersion": "0.5"
+       },
+       {
+           "vsId": 1564,
+                   "testGroups": [
+                           {
+                                   "tgId": 1,
+                                   "tests": [
+                                           {
+                                                   "tcId": 1,
+                                                   "testPassed": true
+                                           }
+                                   ]
+               }
+           ]
+       }
+   ]
+
+
+A.7.  Example Test EDDSA Signature Generation JSON Object
+
+   The following is a example JSON object for EDDSA SigGen, test vectors
+   sent from the ACVP server to the crypto module and the response.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 21]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "sigGen",
+        "testGroups": [
+            {
+                                "tgId": 1,
+                                "testType": "AFT",
+                "curve": "ed-25519",
+                                "preHash": false,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "A81C8A22735A260CB1A8105A2964646097D8A9B110701AB0D49C9071836CAD39E31F5020D24B2C841FAC58F44F3F3F814495B063A686F6F93C5C6D9FDF45B9099C609A69E6A9F6483C5038066A560D413C6FB73D76499A7D8836C9C89368D557B2C24A5D817CF1FBD226AC41037E3005250007B49C6CCCE7BD1BE5D7A5C96EE8"
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+
+   The following is a example JSON object for EDDSA SigGen test results
+   sent from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 22]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "testGroups": [
+            {
+                                "tgId": 1,
+                                "q": "4BA34FE699DBDC89750FF006AA35E282BF71C180B53C2DE620676C8707A14E48",
+                                "tests": [
+                                        {
+                                                "tcId": 1,
+                                                "signature": "772990B0E53B3E21DC8BD139CECB39892D75BD70DAFFDC73E241E29515E67CC642CB2A6B479FFEF4F3F16B5BC3DDF06AB25A92028F2DC0464B3CFDFD3B8F4D08"
+                                        }
+                                ]
+            }
+        ]
+    }
+]
+
+
+A.8.  Example Test EDDSA SigVer JSON Object
+
+   The following is a example JSON object for EDDSA SigVer, test vectors
+   sent from the ACVP server to the crypto module and the response.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 23]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+[
+    {
+        "acvVersion": "0.5"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "sigVer",
+        "testGroups": [
+            {
+                                "tgId": 1,
+                                "testType": "AFT"
+                "curve": "ed-25519",
+                "preHash": false,
+                                "q": "502A28FAF736CBCF1B51A3816CADC61D6B46699149A442BA741B378386B7120C",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "BED1D245D569D5C10693F408A195D0404D3F27DFD0C670034A99AFD5F33E84690812516F4335ED6B2D5FD824075B061D7BA5731DCA4EF01040167AC2D40320DEB7FC63A8B34CE5C05CF22EC0D7B11AC55C84D8131D3C656CBA05BB29F64A5D5C20AFD5212163A254B9915A30BBAB15FB3F710C325F408E8D1E840B55A09F52B7",
+                        "signature": "9C09C0FF50B61E4443DBA5D1262B7CE6DDD3742BCAF288B0A17078F78ECB2480976448A177FFBB6E39FC9C02ABFA63806D664248C67803E4023A681E9930550F"
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+
+   The following is a example JSON object for EDDSA generation test
+   results sent from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 24]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   [
+       {
+           "acvVersion": "0.5"
+       },
+       {
+           "vsId": 1564,
+           "testGroups": [
+               {
+                                   "tgId": 1,
+                                   "tests": [
+                                           {
+                                   "tcId": 1,
+                                   "testPassed": false
+                                           }
+                                   ]
+               }
+           ]
+       }
+   ]
+
+
+Author's Address
+
+   Christopher Celi (editor)
+   National Institute of Standards and Technology
+   100 Bureau Dr.
+   Gaithersburg, MD  20850
+   USA
+
+   Email: christopher.celi@nist.gov
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                    Expires February 28, 2019              [Page 25]

--- a/artifacts/acvp_sub_eddsa.txt
+++ b/artifacts/acvp_sub_eddsa.txt
@@ -575,7 +575,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                      | in the test vectors.    |       |          |
    |                      |                         |       |          |
    | testType             | The testType for the    | value | No       |
-   |                      | group                   |       |          |
+   |                      | group. Either AFT or    |       |          |
+   |                      | BFT.                    |       |          |
    |                      |                         |       |          |
    | q                    | The encoded public key  | value | Yes      |
    |                      | point                   |       |          |
@@ -601,7 +602,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each EDDSA test vector.
-
 
 
 
@@ -1198,7 +1198,27 @@ Internet-Draft                Sym Alg JSON                   August 2018
                         "message": "A81C8A22735A260CB1A8105A2964646097D8A9B110701AB0D49C9071836CAD39E31F5020D24B2C841FAC58F44F3F3F814495B063A686F6F93C5C6D9FDF45B9099C609A69E6A9F6483C5038066A560D413C6FB73D76499A7D8836C9C89368D557B2C24A5D817CF1FBD226AC41037E3005250007B49C6CCCE7BD1BE5D7A5C96EE8"
                     }
                 ]
-            }
+            },
+                        {
+                                "tgId": 5,
+                                "testType": "bft",
+                                "curve": "ed-25519",
+                                "preHash": false,
+                                "tests": [
+                                        {
+                                                "tcId": 41,
+                                                "message": "F27E9F9D"
+                                        },
+                                        {
+                                                "tcId": 42,
+                                                "message": "F27E9F9C"
+                                        },
+                                        {
+                                                "tcId": 43,
+                                                "message": "F27E9F9F"
+                                        }
+                                ]
+                        }
         ]
     }
 ]
@@ -1206,26 +1226,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The following is a example JSON object for EDDSA SigGen test results
    sent from the crypto module to the ACVP server.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -1250,7 +1250,25 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                                 "signature": "772990B0E53B3E21DC8BD139CECB39892D75BD70DAFFDC73E241E29515E67CC642CB2A6B479FFEF4F3F16B5BC3DDF06AB25A92028F2DC0464B3CFDFD3B8F4D08"
                                         }
                                 ]
-            }
+            },
+                        {
+                                "tgId": 5,
+                                "q": "ADD51513B67540E3A392721742C7E81F1BAE77DEFC16314E32A06976BA9BBFF7",
+                                "tests": [
+                                        {
+                                                "tcId": 41,
+                                                "signature": "6EA857E68CEC0825EAD378A2F445BB17993D151CF9A168A44F47E13D356F6DC9AA67517DE4A2FB22BA24E1732DA0234427A2572CBE80294277F2141498E7F50E"
+                                        },
+                                        {
+                                                "tcId": 42,
+                                                "signature": "883B0336036509FC44CD2E507C5E916696213F9CF2429796E248516EFBDFAFE5C98EE6DBF82314B6FB5403383BC2E4ECCC89C7D686FE3A630B74866A0126740C"
+                                        },
+                                        {
+                                                "tcId": 43,
+                                                "signature": "E402705AC2EFC216EB7FA1AC5461A8451CE6F72B0AFA63D75BFBD5C4DD98A07207168CC6A542F01AAC6C31EC1C09062B053A54F6C93B801460FE33348B87DD03"
+                                        }
+                                ]
+                        }
         ]
     }
 ]
@@ -1260,24 +1278,6 @@ A.8.  Example Test EDDSA SigVer JSON Object
 
    The following is a example JSON object for EDDSA SigVer, test vectors
    sent from the ACVP server to the crypto module and the response.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/acvp_sub_eddsa.xml
+++ b/src/acvp_sub_eddsa.xml
@@ -252,6 +252,18 @@
 							<c>array</c>
 							<c>Any non-empty subset of {"ed-25519", "ed-448"}</c>
 							<c>No</c>
+							<c/><c/><c/><c/><c/>
+							<c>pure</c>
+							<c>If the IUT supports normal 'pure' sigGen functionality</c>
+							<c>bool</c>
+							<c>true/false</c>
+							<c>No</c>
+							<c/><c/><c/><c/><c/>
+							<c>preHash</c>
+							<c>If the IUT supports accepting a preHashed message to sign</c>
+							<c>bool</c>
+							<c>true/false</c>
+							<c>No</c>
 						</texttable>
 					</section>
 				</section>
@@ -270,6 +282,18 @@
 							<c>The curve names supported for the IUT in sigVer.</c>
 							<c>array</c>
 							<c>Any non-empty subset of {"ed-25519", "ed-448"}</c>
+							<c>No</c>
+							<c/><c/><c/><c/><c/>
+							<c>pure</c>
+							<c>If the IUT supports normal 'pure' sigGen functionality</c>
+							<c>bool</c>
+							<c>true/false</c>
+							<c>No</c>
+							<c/><c/><c/><c/><c/>
+							<c>preHash</c>
+							<c>If the IUT supports accepting a preHashed message to sign</c>
+							<c>bool</c>
+							<c>true/false</c>
 							<c>No</c>
 						</texttable>
 					</section>
@@ -336,9 +360,25 @@
 						<c/>
 						<c/>
 						<c/>
-						<c>hashAlg</c>
-						<c>SHA version used</c>
+						<c>testType</c>
+						<c>The testType for the group</c>
 						<c>value</c>
+						<c>No</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>q</c>
+						<c>The encoded public key point</c>
+						<c>value</c>
+						<c>Yes</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>preHash</c>
+						<c>Denotes whether or not the IUT should accept the message as a preHashed message before signing</c>
+						<c>bool</c>
 						<c>Yes</c>
 						<c/>
 						<c/>
@@ -416,12 +456,33 @@
 					<c/>
 					<c/>
 					<c/>
-					<c>testResults</c>
-					<c>Array of JSON objects that represent each test vector result, as defined by the tables below</c>
+					<c>testGroups</c>
+					<c>Array of JSON objects that represent each test group of results, as defined by the tables below</c>
 					<c>array</c>
 				</texttable>
-				<t>The following table describes the JSON object that represents a vector set response for EDDSA.</t>
-				<texttable anchor="vr_top_table5" title="Vector Set Response JSON Object">
+				<t>The following table describes the JSON object that represents a test group response for EDDSA.</t>
+				<texttable anchor="vr_top_table2" title="Test Group Response JSON Object">
+					<ttcol align="left">JSON Value</ttcol>
+					<ttcol align="left">Description</ttcol>
+					<ttcol align="left">JSON type</ttcol>
+					<c>tgId</c>
+					<c>Unique numeric identifier for the test group</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>q</c>
+					<c>Optional encoded public key for the group</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>tests</c>
+					<c>Array of JSON objects that represent each result, as defined by the table below</c>
+					<c>array</c>
+				</texttable>
+				<t>The following table describes the JSON object that represents a test case response for EDDSA.</t>
+				<texttable anchor="vr_top_table5" title="Test Case Response JSON Object">
 					<ttcol align="left">JSON Value</ttcol>
 					<ttcol align="left">Description</ttcol>
 					<ttcol align="left">JSON type</ttcol>
@@ -485,7 +546,7 @@
 			</reference>
 		</references>
 		<section anchor="app-reg-ex" title="Example EDDSA JSON Object">
-			<t>The following sections contain example JSON for the various EDDSA modes: keyGen, keyVer, sigGen, and sigVer. Note that all binary HEX representations are in big-endian format.</t>
+			<t>The following sections contain example JSON for the various EDDSA modes: keyGen, keyVer, sigGen, and sigVer. Note that all binary HEX representations are in big-endian byte order but little-endian bit format.</t>
 			<section anchor="app-reg-ex2" title="Example EDDSA KeyGen Capabilities JSON Object">
 				<t>The following is a example JSON object advertising support for EDDSA keyGen.</t>
 				<figure>
@@ -504,21 +565,11 @@
           "valValue": "123456"
       }
     ],
-	"Curve": [
-		"p-224",
-		"p-256",
-		"p-384",
-		"p-521",
-		"b-233",
-		"b-283",
-		"b-409",
-		"b-571",
-		"k-233",
-		"k-283",
-		"k-409",
-		"k-571"
+	"curve": [
+		"ed-25519",
+		"ed-448"
 	],
-	"SecretGenerationMode": [
+	"secretGenerationMode": [
 		"extra bits",
 		"testing candidates"
 	]
@@ -546,21 +597,8 @@
         }
     ],
     "curve": [
-        "p-192",
-        "p-224",
-        "p-256",
-        "p-384",
-        "p-521",
-        "b-163",
-        "b-233",
-        "b-283",
-        "b-409",
-        "b-571",
-        "k-163",
-        "k-233",
-        "k-283",
-        "k-409",
-        "k-571"
+        "ed-25519",
+		"ed-448"
     ]
 }
             ]]>
@@ -585,31 +623,11 @@
             "valValue": "123456"
         }
     ],
-    "capabilities": [
-        {
-            "curve": [
-                "p-224",
-                "p-256",
-                "p-384",
-                "p-521",
-                "b-233",
-                "b-283",
-                "b-409",
-                "b-571",
-                "k-233",
-                "k-283",
-                "k-409",
-                "k-571"
-            ],
-            "hashAlg": [
-                "SHA2-224",
-                "SHA2-256",
-                "SHA2-384",
-                "SHA2-512",
-                "SHA2-512/224",
-                "SHA2-512/256"
-            ]
-        }
+	"pure": true,
+	"preHash": true,
+	"curve": [
+		"ed-25519",
+		"ed-448"
     ]
 }
             ]]>
@@ -622,9 +640,9 @@
 					<artwork>
 						<![CDATA[
 {
-    "algorithm": "EDDSA",
-    "mode": "sigVer",
-    "prereqVals": [
+	"algorithm": "EDDSA",
+	"mode": "sigVer",
+	"prereqVals": [
         {
             "algorithm": "SHA",
             "valValue": "123456"
@@ -634,36 +652,12 @@
             "valValue": "123456"
         }
     ],
-    "capabilities": [
-        {
-            "curve": [
-                "p-192",
-                "p-224",
-                "p-256",
-                "p-384",
-                "p-521",
-                "b-163",
-                "b-233",
-                "b-283",
-                "b-409",
-                "b-571",
-                "k-163",
-                "k-233",
-                "k-283",
-                "k-409",
-                "k-571"
-            ],
-            "hashAlg": [
-                "SHA-1",
-                "SHA2-224",
-                "SHA2-256",
-                "SHA2-384",
-                "SHA2-512",
-                "SHA2-512/224",
-                "SHA2-512/256"
-            ]
-        }
-    ]
+	"pure": true,
+	"preHash": true,
+	"curve": [
+		"ed-25519",
+		"ed-448"
+	]
 }
             ]]>
 					</artwork>
@@ -676,7 +670,7 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
@@ -684,8 +678,9 @@
         "mode": "keyGen",
         "testGroups": [
             {
-                "curve": "p-224",
+                "curve": "ed-25519",
                 "secretGenerationMode": "extra bits",
+				"testType": "AFT",
                 "tests": [
                     {
                         "tcId": 1
@@ -704,16 +699,20 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
-        "testResults": [
+        "testGroups": [
             {
-                "tcId": 1,
-                "qx": "7B1AA6BE712542282B8D088C233168CA4409E20264E32897C201ABA9",
-                "qy": "BCC9213347A7F988A2FF9EF14C85254B23AF0096F947CECB6C3311D2",
-                "d": "38524F26660BBA72E74EB39DEF38558EB07CB15255A09652B222CCE0"
+				"tgId": 1,
+				"tests": [
+					{
+						"tcId": 1,
+						"q": "D51FB3D405A636227833A0950A2F4EDAF547F50448D7F371D0E9353F207B2B09",
+						"d": "147BA261D11CD323331D87C22E215724E9CD5E6B6BEAC85A9808241D9E80781F"
+					}
+				]
             }
         ]
     }
@@ -729,7 +728,7 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
@@ -737,12 +736,13 @@
         "mode": "keyVer",
         "testGroups": [
             {
-                "curve": "p-192",
+				"tgId": 1,
+                "curve": "ed-25519",
+				"testType": "AFT",
                 "tests": [
                     {
                         "tcId": 1,
-                        "qx": "01ED77E3F1591D2EC730D0ED6D592F8DD24158D0E696408DBD",
-                        "qy": "BF31C6463EB1B6B55C8930550B88CF8D1F6432A832B40FB4"
+                        "q": "227093C50F7D04A41121CEFDF076CC8B21D44E7506F341F8BFAB269CE06F2B7E",
                     }
                 ]
             }
@@ -758,14 +758,19 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
-        "testResults": [
-            {
-                "tcId": 1,
-                "result": "failed"
+		"testGroups": [
+			{
+				"tgId": 1,
+				"tests": [
+					{
+						"tcId": 1,
+						"testPassed": true
+					}
+				]
             }
         ]
     }
@@ -781,7 +786,7 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
@@ -789,12 +794,14 @@
         "mode": "sigGen",
         "testGroups": [
             {
-                "curve": "p-224",
-                "hashAlg": "SHA2-224",
+				"tgId": 1,
+				"testType": "AFT",
+                "curve": "ed-25519",
+				"preHash": false,
                 "tests": [
                     {
                         "tcId": 1,
-                        "message": "AB6F57713A3BD323B4AFDCFBE202EE00A9CF5C787D19FD9094323C57FEA8B7FBE31559EC1CAC6D29C3229A58811CF2BAE2B78183DFDABD055B741EA86496454F085D17D5BCD1B82B533B533A1E5804B2DAA0ED43F8BF59FBEB16BDD4D7C065165CB9B085CECD5BCFFA794339D5A81B1949F569CAACA208B9E3E6A217A1B3A596"
+                        "message": "A81C8A22735A260CB1A8105A2964646097D8A9B110701AB0D49C9071836CAD39E31F5020D24B2C841FAC58F44F3F3F814495B063A686F6F93C5C6D9FDF45B9099C609A69E6A9F6483C5038066A560D413C6FB73D76499A7D8836C9C89368D557B2C24A5D817CF1FBD226AC41037E3005250007B49C6CCCE7BD1BE5D7A5C96EE8"
                     }
                 ]
             }
@@ -810,17 +817,20 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
-        "testResults": [
+        "testGroups": [
             {
-                "tcId": 1,
-                "qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
-                "qy": "E56F7B7C9E6355E573B7B3B6C0E1ECD70E4ABDF1554EAD8A68ABA1A4",
-                "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
-                "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
+				"tgId": 1,
+				"q": "4BA34FE699DBDC89750FF006AA35E282BF71C180B53C2DE620676C8707A14E48",
+				"tests": [
+					{
+						"tcId": 1,
+						"signature": "772990B0E53B3E21DC8BD139CECB39892D75BD70DAFFDC73E241E29515E67CC642CB2A6B479FFEF4F3F16B5BC3DDF06AB25A92028F2DC0464B3CFDFD3B8F4D08"
+					}
+				]
             }
         ]
     }
@@ -836,7 +846,7 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
@@ -844,16 +854,16 @@
         "mode": "sigVer",
         "testGroups": [
             {
-                "curve": "p-192",
-                "hashAlg": "SHA-1",
+				"tgId": 1,
+				"testType": "AFT"
+                "curve": "ed-25519",
+                "preHash": false,
+				"q": "502A28FAF736CBCF1B51A3816CADC61D6B46699149A442BA741B378386B7120C",
                 "tests": [
                     {
                         "tcId": 1,
-                        "message": "D38A81D0C5201BA4A06A8C4760AC15DB266B17B48B13EA69775D1E896486D9D986A464D3469941F93FC65556E2CB8AB5F113E7ADCB8D50375DC76907195B6AF6C06F13EB6106EF0E19E241DB4B4831E06437E5CF7C9A499A8FC6DA36A75BDB81A2A19E14ACEFECD7E364471527E0FE37FD1162F5DD0D975E83C0DA4EDDD37261",
-                        "qx": "B08AFEAC74E42C66EBAF13807E2EB5769F5123645C0B8491",
-                        "qy": "55847857E5E48025BE9053952E0E1ECFB1D883CF9F085386",
-                        "r": "E31121E544D476DC3FA79B4DCB0A7252B6E80468BBF22843",
-                        "s": "6E3F47F2327E36AD936E0F4BE245C05F264BA9300E9E7DD9"
+                        "message": "BED1D245D569D5C10693F408A195D0404D3F27DFD0C670034A99AFD5F33E84690812516F4335ED6B2D5FD824075B061D7BA5731DCA4EF01040167AC2D40320DEB7FC63A8B34CE5C05CF22EC0D7B11AC55C84D8131D3C656CBA05BB29F64A5D5C20AFD5212163A254B9915A30BBAB15FB3F710C325F408E8D1E840B55A09F52B7",
+                        "signature": "9C09C0FF50B61E4443DBA5D1262B7CE6DDD3742BCAF288B0A17078F78ECB2480976448A177FFBB6E39FC9C02ABFA63806D664248C67803E4023A681E9930550F"
                     }
                 ]
             }
@@ -869,14 +879,19 @@
 						<![CDATA[
 [
     {
-        "acvVersion": "0.4"
+        "acvVersion": "0.5"
     },
     {
         "vsId": 1564,
-        "testResults": [
+        "testGroups": [
             {
-                "tcId": 1,
-                "result": "failed"
+				"tgId": 1,
+				"tests": [
+					{
+                		"tcId": 1,
+                		"testPassed": false
+					}
+				]
             }
         ]
     }

--- a/src/acvp_sub_eddsa.xml
+++ b/src/acvp_sub_eddsa.xml
@@ -1,0 +1,890 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
+]>
+<?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
+<!-- used by XSLT processors -->
+<!-- For a complete list and description of processing instructions (PIs),
+     please see http://xml.resource.org/authoring/README.html. -->
+<!-- Below are generally applicable Processing Instructions (PIs) that most I-Ds might want to use.
+     (Here they are set differently than their defaults in xml2rfc v1.32) -->
+<?rfc strict="yes" ?>
+<!-- give errors regarding ID-nits and DTD validation -->
+<!-- control the table of contents (ToC) -->
+<?rfc toc="yes"?>
+<!-- generate a ToC -->
+<?rfc tocdepth="4"?>
+<!-- the number of levels of subsections in ToC. default: 3 -->
+<!-- control references -->
+<?rfc symrefs="yes"?>
+<!-- use symbolic references tags, i.e, [RFC2119] instead of [1] -->
+<?rfc sortrefs="yes" ?>
+<!-- sort the reference entries alphabetically -->
+<!-- control vertical white space
+     (using these PIs as follows is recommended by the RFC Editor) -->
+<?rfc compact="yes" ?>
+<!-- do not start each main section on a new page -->
+<?rfc subcompact="no" ?>
+<!-- keep one blank line between list items -->
+<!-- end of list of popular I-D processing instructions -->
+<rfc category="info" docName="draft-ietf-acvp-subeddsa-0.5" ipr="trust200902">
+	<!-- category values: std, bcp, info, exp, and historic
+     ipr values: full3667, noModification3667, noDerivatives3667
+     you can add the attributes updates="NNNN" and obsoletes="NNNN"
+     they will automatically be output with "(if approved)" -->
+	<!-- ***** FRONT MATTER ***** -->
+	<front>
+		<!-- The abbreviated title is used in the page header - it is only necessary if the
+         full title is longer than 39 characters -->
+		<title abbrev="Sym Alg JSON">ACVP EDDSA Algorithm JSON Specification</title>
+		<!-- add 'role="editor"' below for the editors if appropriate -->
+		<!-- Another author who claims to be an editor -->
+		<author fullname="Christopher Celi" initials="C.C." role="editor" surname="Celi">
+			<organization>National Institute of Standards and Technology</organization>
+			<address>
+				<postal>
+					<street>100 Bureau Dr.</street>
+					<!-- Reorder these if your country does things differently -->
+					<city>Gaithersburg</city>
+					<region>MD</region>
+					<code>20850</code>
+					<country>USA</country>
+				</postal>
+				<email>christopher.celi@nist.gov</email>
+				<!-- uri and facsimile elements may also be added -->
+			</address>
+		</author>
+		<date month="August" year="2018" />
+		<!-- If the month and year are both specified and are the current ones, xml2rfc will fill
+         in the current day for you. If only the current year is specified, xml2rfc will fill
+	 in the current day and month for you. If the year is not the current one, it is
+	 necessary to specify at least a month (xml2rfc assumes day="1" if not specified for the
+	 purpose of calculating the expiry date).  With drafts it is normally sufficient to
+	 specify just the year. -->
+		<!-- Meta-data Declarations -->
+		<area>General</area>
+		<workgroup>TBD</workgroup>
+		<!-- WG name at the upperleft corner of the doc,
+         IETF is fine for individual submissions.
+	 If this element is not present, the default is "Network Working Group",
+         which is used by the RFC Editor as a nod to the history of the IETF. -->
+		<keyword>acvp</keyword>
+		<keyword>crypto</keyword>
+		<!-- Keywords will be incorporated into HTML output
+         files in a meta tag but they have no effect on text or nroff
+         output. If you submit your draft to the RFC Editor, the
+         keywords will be used for the search engine. -->
+		<abstract>
+			<t>This document defines the JSON schema for using EDDSA algorithms with the ACVP specification.</t>
+		</abstract>
+	</front>
+	<middle>
+		<section title="Introduction">
+			<t>The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module. The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more. The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation. A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms. Each sub-specification addresses a specific class of crypto algorithms. This sub-specification defines the JSON constructs for testing EDDSA algorithms using ACVP.</t>
+			<section title="Requirements Language">
+				<t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in																															
+					<xref target="RFC2119">RFC 2119</xref>.																								
+				</t>
+			</section>
+		</section>
+		<section anchor="caps_reg" title="Capabilities Registration">
+			<t>ACVP requires crypto modules to register their capabilities. This allows the crypto	module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of EDDSA algorithms to the ACVP server.</t>
+			<t>The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each	array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message.</t>
+			<section anchor="prereq_algs" title="Required Prerequisite Algorithms for EDDSA Validations">
+				<t>Each EDDSA implementation relies on other cryptographic primitives. For example, EDDSA uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</t>
+				<texttable anchor="rereqs_table" title="Required EDDSA Prerequisite Algorithms JSON Values">
+					<ttcol align="left">JSON Value</ttcol>
+					<ttcol align="left">Description</ttcol>
+					<ttcol align="left">JSON type</ttcol>
+					<ttcol align="left">Valid Values</ttcol>
+					<ttcol align="left">Optional</ttcol>
+					<c>algorithm</c>
+					<c>a prerequisite algorithm</c>
+					<c>value</c>
+					<c>DRBG, DRBG_OPT2, SHA, SHA_OPT2, SHA_OPT3</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>valValue</c>
+					<c>algorithm validation number</c>
+					<c>value</c>
+					<c>actual number or "same"</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>prereqAlgVal</c>
+					<c>prerequistie algorithm validation</c>
+					<c>object with algorithm and valValue properties</c>
+					<c>see above</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>prereqVals</c>
+					<c>prerequistie algorithm validations</c>
+					<c>array of prereqAlgVal objects</c>
+					<c>see above</c>
+					<c>No</c>
+				</texttable>
+			</section>
+			<section anchor="eddsa_caps_reg" title="EDDSA Algorithm Capabilities Registration">
+				<t>Each algorithm capability advertised is a self-contained JSON object using the following values</t>
+				<texttable anchor="caps_table" title="EDDSA Algorithm Capabilities JSON Values">
+					<ttcol align="left">JSON Value</ttcol>
+					<ttcol align="left">Description</ttcol>
+					<ttcol align="left">JSON type</ttcol>
+					<ttcol align="left">Valid Values</ttcol>
+					<ttcol align="left">Optional</ttcol>
+					<c>algorithm</c>
+					<c>The algorithm under test</c>
+					<c>value</c>
+					<c>"EDDSA"</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>mode</c>
+					<c>The EDDSA mode to be validated</c>
+					<c>value</c>
+					<c>"keyGen", "keyVer", "sigGen", or "sigVer"</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>prereqVals</c>
+					<c>prerequistie algorithm validations</c>
+					<c>array of prereqAlgVal objects</c>
+					<c>See 																																				
+						<xref target="prereq_algs" />
+					</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>algSpecs</c>
+					<c>array of JSON objects, each with fields pertaining to the global EDDSA mode indicated above and identified uniquely by the combination of the EDDSA "mode" and indicated properties</c>
+					<c>Array of JSON objects</c>
+					<c>See                                                                                                 																		
+						<xref target="supported_modes" />
+					</c>
+				</texttable>
+			</section>
+			<section anchor="supported_modes" title="Supported EDDSA Modes Capabilities">
+				<t>The EDDSA mode capabilities are advertised as JSON objects within the 'algSpecs' value of the ACVP registration message - see                                                             															
+					<xref target="caps_table"/>. The 'algSpecs' value is an array, where each array element is a JSON object corresponding to a particular EDDSA mode defined in this section. The 'algSpecs'	value is part of the 'capability_exchange' element of the ACVP JSON registration message.	See the ACVP specification for details on the registration message.                                                												
+				</t>
+				<t>Each EDDSA mode's capabilities are advertised as JSON objects.</t>
+				<section anchor="mode_keyGen" title="The keyGen Mode Capabilities">
+					<t>The EDDSA keyGen mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</t>
+					<t>Each EDDSA keyGen mode capability set is advertised as a self-contained JSON object.</t>
+					<section anchor="mode_keyGenFullSet" title="keyGen Full Set of Capabilities">
+						<t>The complete list of EDDSA key generation capabilities may be advertised by the ACVP compliant crypto module:</t>
+						<texttable anchor="keyGen_table" title="EDDSA keyGen Capabilities JSON Values">
+							<ttcol align="left">JSON Value</ttcol>
+							<ttcol align="left">Description</ttcol>
+							<ttcol align="left">JSON type</ttcol>
+							<ttcol align="left">Valid Values</ttcol>
+							<ttcol align="left">Optional</ttcol>
+							<c>curve</c>
+							<c>The curve names supported for the IUT in keyGen.</c>
+							<c>array</c>
+							<c>Any non-empty subset of {"ed-25519", "ed-448"}</c>
+							<c>No</c>
+							<c/>
+							<c/>
+							<c/>
+							<c/>
+							<c/>
+							<c>secretGenerationMode</c>
+							<c>The method used to generate the randomness incoporated in the key.</c>
+							<c>array</c>
+							<c>Any non-empty subset of {"extra bits", "testing candidates"}</c>
+							<c>No</c>
+						</texttable>
+					</section>
+				</section>
+				<section anchor="mode_keyVer" title="The keyVer Mode Capabilities">
+					<t>The EDDSA keyVer mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</t>
+					<t>Each EDDSA keyVer mode capability set is advertised as a self-contained JSON object.</t>
+					<section anchor="mode_keyVerFullSet" title="keyVer Full Set of Capabilities">
+						<t>The complete list of EDDSA key verification capabilities may be advertised by the ACVP compliant crypto module:</t>
+						<texttable anchor="keyVer_table" title="EDDSA keyVer Capabilities JSON Values">
+							<ttcol align="left">JSON Value</ttcol>
+							<ttcol align="left">Description</ttcol>
+							<ttcol align="left">JSON type</ttcol>
+							<ttcol align="left">Valid Values</ttcol>
+							<ttcol align="left">Optional</ttcol>
+							<c>curve</c>
+							<c>The curve names supported for the IUT in keyVer.</c>
+							<c>array</c>
+							<c>Any non-empty subset of {"ed-25519", "ed-448"}</c>
+							<c>No</c>
+						</texttable>
+					</section>
+				</section>
+				<section anchor="mode_sigGen" title="The sigGen Mode Capabilities">
+					<t>The EDDSA sigGen mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</t>
+					<t>Each EDDSA sigGen mode capability set is advertised as a self-contained JSON object.</t>
+					<section anchor="mode_sigGenFullSet" title="sigGen Full Set of Capabilities">
+						<t>The complete list of EDDSA signature generation capabilities may be advertised by the ACVP compliant crypto module:</t>
+						<texttable anchor="sigGen_table" title="EDDSA sigGen Capabilities JSON Values">
+							<ttcol align="left">JSON Value</ttcol>
+							<ttcol align="left">Description</ttcol>
+							<ttcol align="left">JSON type</ttcol>
+							<ttcol align="left">Valid Values</ttcol>
+							<ttcol align="left">Optional</ttcol>
+							<c>curve</c>
+							<c>The curve names supported for the IUT in sigGen.</c>
+							<c>array</c>
+							<c>Any non-empty subset of {"ed-25519", "ed-448"}</c>
+							<c>No</c>
+						</texttable>
+					</section>
+				</section>
+				<section anchor="mode_sigVer" title="The sigVer Mode Capabilities">
+					<t>The EDDSA sigVer mode capabilities are advertised as JSON objects, which are elements of the 'algSpecs' array in the ACVP registration message. See the ACVP specification for details on the registration message.</t>
+					<t>Each EDDSA sigVer mode capability set is advertised as a self-contained JSON object.</t>
+					<section anchor="mode_sigVerFullSet" title="sigVer Full Set of Capabilities">
+						<t>The complete list of EDDSA signature verification capabilities may be advertised by the ACVP compliant crypto module:</t>
+						<texttable anchor="sigVer_table" title="EDDSA sigVer Capabilities JSON Values">
+							<ttcol align="left">JSON Value</ttcol>
+							<ttcol align="left">Description</ttcol>
+							<ttcol align="left">JSON type</ttcol>
+							<ttcol align="left">Valid Values</ttcol>
+							<ttcol align="left">Optional</ttcol>
+							<c>curve</c>
+							<c>The curve names supported for the IUT in sigVer.</c>
+							<c>array</c>
+							<c>Any non-empty subset of {"ed-25519", "ed-448"}</c>
+							<c>No</c>
+						</texttable>
+					</section>
+				</section>
+			</section>
+			<section anchor="test_vectors" title="Test Vectors">
+				<t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual EDDSA function. This section describes the JSON schema for a test vector set used with EDDSA algorithms.</t>
+				<t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy.</t>
+				<texttable anchor="vs_top_table" title="Vector Set JSON Object">
+					<ttcol align="left">JSON Value</ttcol>
+					<ttcol align="left">Description</ttcol>
+					<ttcol align="left">JSON type</ttcol>
+					<c>acvVersion</c>
+					<c>Protocol version identifier</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>vsId</c>
+					<c>Unique numeric identifier for the vector set</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>algorithm</c>
+					<c>EDDSA</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>mode</c>
+					<c>The EDDSA mode used for the test vectors</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>testGroups</c>
+					<c>Array of test group JSON objects, which are defined in 																																	
+						<xref target="tgjs" />
+					</c>
+					<c>array</c>
+				</texttable>
+				<section title="Test Groups JSON Schema" anchor="tgjs">
+					<t>The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted	in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</t>
+					<t> The test group for EDDSA is as follows:</t>
+					<texttable anchor="vs_tg_table5" title="Vector Group JSON Object">
+						<ttcol align="left">JSON Value</ttcol>
+						<ttcol align="left">Description</ttcol>
+						<ttcol align="left">JSON type</ttcol>
+						<ttcol align="left">Optional</ttcol>
+						<c>curve</c>
+						<c>The curve type used for the test vectors.</c>
+						<c>value</c>
+						<c>No</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>secretGenerationMode</c>
+						<c>The method of generating a secret used for key generation in the test vectors.</c>
+						<c>value</c>
+						<c>Yes</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>hashAlg</c>
+						<c>SHA version used</c>
+						<c>value</c>
+						<c>Yes</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>tests</c>
+						<c>Array of individual test vector JSON objects, which are defined in 																																							
+							<xref target="tvjs" />
+						</c>
+						<c>array</c>
+						<c>No</c>
+					</texttable>
+				</section>
+				<section title="Test Case JSON Schema" anchor="tvjs">
+					<t>Each test group contains an array of one or more test cases. Each test case is a JSON object	that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each EDDSA test vector.</t>
+					<texttable anchor="vs_tc_table5" title="Test Case JSON Object">
+						<ttcol align="left">JSON Value</ttcol>
+						<ttcol align="left">Description</ttcol>
+						<ttcol align="left">JSON type</ttcol>
+						<ttcol align="left">Optional</ttcol>
+						<c>tcId</c>
+						<c>Numeric identifier for the test case, unique across the entire vector set.</c>
+						<c>value</c>
+						<c>No</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>q</c>
+						<c>The encoded public key curve point</c>
+						<c>value</c>
+						<c>Yes</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>signature</c>
+						<c>The signature</c>
+						<c>value</c>
+						<c>Yes</c>
+						<c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>message</c>
+						<c>The message used to generate signature or verify signature</c>
+						<c>value</c>
+						<c>Yes</c>
+                        <c/>
+						<c/>
+						<c/>
+						<c/>
+						<c>context</c>
+						<c>The context used to generate signature or verify signature</c>
+						<c>value</c>
+						<c>Yes</c>
+					</texttable>
+				</section>
+			</section>
+			<section anchor="vector_responses" title="Test Vector Responses">
+				<t>After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</t>
+				<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">
+					<ttcol align="left">JSON Value</ttcol>
+					<ttcol align="left">Description</ttcol>
+					<ttcol align="left">JSON type</ttcol>
+					<c>acvVersion</c>
+					<c>Protocol version identifier</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>vsId</c>
+					<c>Unique numeric identifier for the vector set</c>
+					<c>value</c>
+					<c/>
+					<c/>
+					<c/>
+					<c>testResults</c>
+					<c>Array of JSON objects that represent each test vector result, as defined by the tables below</c>
+					<c>array</c>
+				</texttable>
+				<t>The following table describes the JSON object that represents a vector set response for EDDSA.</t>
+				<texttable anchor="vr_top_table5" title="Vector Set Response JSON Object">
+					<ttcol align="left">JSON Value</ttcol>
+					<ttcol align="left">Description</ttcol>
+					<ttcol align="left">JSON type</ttcol>
+					<ttcol align="left">Optional</ttcol>
+					<c>d</c>
+					<c>The encoded private key point</c>
+					<c>value</c>
+					<c>Yes</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>q</c>
+					<c>The encoded public key point </c>
+					<c>value</c>
+					<c>Yes</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>signature</c>
+					<c>The signature component S</c>
+					<c>value</c>
+					<c>Yes</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c>testPassed</c>
+					<c>The pass or fail result of the verify or validation</c>
+					<c>true/false</c>
+					<c>Yes</c>
+				</texttable>
+			</section>
+			<!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
+			<section anchor="Acknowledgements" title="Acknowledgements">
+				<t>TBD...</t>
+			</section>
+			<!-- Possibly a 'Contributors' section ... -->
+			<section anchor="IANA" title="IANA Considerations">
+				<t>This memo includes no request to IANA.</t>
+			</section>
+			<section anchor="Security" title="Security Considerations">
+				<t>Security considerations are addressed by the ACVP specification.</t>
+			</section>
+		</section>
+	</middle>
+	<!--  *****BACK MATTER ***** -->
+	<back>
+		<references title="Normative References">
+			<!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?-->      &RFC2119;      																					
+			<reference anchor="ACVP">
+				<!-- the following is the minimum to make xml2rfc happy -->
+				<front>
+					<title>ACVP Specification</title>
+					<author initials="authInitials" surname="authSurName">
+						<organization>NIST</organization>
+					</author>
+					<date year="2016" />
+				</front>
+			</reference>
+		</references>
+		<section anchor="app-reg-ex" title="Example EDDSA JSON Object">
+			<t>The following sections contain example JSON for the various EDDSA modes: keyGen, keyVer, sigGen, and sigVer. Note that all binary HEX representations are in big-endian format.</t>
+			<section anchor="app-reg-ex2" title="Example EDDSA KeyGen Capabilities JSON Object">
+				<t>The following is a example JSON object advertising support for EDDSA keyGen.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+{
+    "algorithm": "EDDSA",
+    "mode": "keyGen",
+    "prereqVals": [
+      {
+          "algorithm": "SHA",
+          "valValue": "123456"
+      },
+      {
+          "algorithm": "DRBG",
+          "valValue": "123456"
+      }
+    ],
+	"Curve": [
+		"p-224",
+		"p-256",
+		"p-384",
+		"p-521",
+		"b-233",
+		"b-283",
+		"b-409",
+		"b-571",
+		"k-233",
+		"k-283",
+		"k-409",
+		"k-571"
+	],
+	"SecretGenerationMode": [
+		"extra bits",
+		"testing candidates"
+	]
+}
+            ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-reg-ex1" title="Example EDDSA KeyVer Capabilities JSON Object">
+				<t>The following is a example JSON object advertising support for EDDSA keyVer.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+{
+    "algorithm": "EDDSA",
+    "mode": "keyVer",
+    "prereqVals": [
+        {
+            "algorithm": "SHA",
+            "valValue": "123456"
+        },
+        {
+            "algorithm": "DRBG",
+            "valValue": "123456"
+        }
+    ],
+    "curve": [
+        "p-192",
+        "p-224",
+        "p-256",
+        "p-384",
+        "p-521",
+        "b-163",
+        "b-233",
+        "b-283",
+        "b-409",
+        "b-571",
+        "k-163",
+        "k-233",
+        "k-283",
+        "k-409",
+        "k-571"
+    ]
+}
+            ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-reg-ex3" title="Example EDDSA SigGen Capabilities JSON Object">
+				<t>The following is a example JSON object advertising support for EDDSA sigGen.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+{
+    "algorithm": "EDDSA",
+    "mode": "sigGen",
+    "prereqVals": [
+        {
+            "algorithm": "SHA",
+            "valValue": "123456"
+        },
+        {
+            "algorithm": "DRBG",
+            "valValue": "123456"
+        }
+    ],
+    "capabilities": [
+        {
+            "curve": [
+                "p-224",
+                "p-256",
+                "p-384",
+                "p-521",
+                "b-233",
+                "b-283",
+                "b-409",
+                "b-571",
+                "k-233",
+                "k-283",
+                "k-409",
+                "k-571"
+            ],
+            "hashAlg": [
+                "SHA2-224",
+                "SHA2-256",
+                "SHA2-384",
+                "SHA2-512",
+                "SHA2-512/224",
+                "SHA2-512/256"
+            ]
+        }
+    ]
+}
+            ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-reg-ex4" title="Example EDDSA SigVer Capabilities JSON Object">
+				<t>The following is a example JSON object advertising support for EDDSA sigVer.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+{
+    "algorithm": "EDDSA",
+    "mode": "sigVer",
+    "prereqVals": [
+        {
+            "algorithm": "SHA",
+            "valValue": "123456"
+        },
+        {
+            "algorithm": "DRBG",
+            "valValue": "123456"
+        }
+    ],
+    "capabilities": [
+        {
+            "curve": [
+                "p-192",
+                "p-224",
+                "p-256",
+                "p-384",
+                "p-521",
+                "b-163",
+                "b-233",
+                "b-283",
+                "b-409",
+                "b-571",
+                "k-163",
+                "k-233",
+                "k-283",
+                "k-409",
+                "k-571"
+            ],
+            "hashAlg": [
+                "SHA-1",
+                "SHA2-224",
+                "SHA2-256",
+                "SHA2-384",
+                "SHA2-512",
+                "SHA2-512/224",
+                "SHA2-512/256"
+            ]
+        }
+    ]
+}
+            ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-vs-ex5" title="Example Test EDDSA KeyGen JSON Object">
+				<t>The following is a example JSON object for EDDSA KeyGen, test vectors sent from the ACVP server to the crypto module and the response.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "keyGen",
+        "testGroups": [
+            {
+                "curve": "p-224",
+                "secretGenerationMode": "extra bits",
+                "tests": [
+                    {
+                        "tcId": 1
+                    }
+                ]
+            }
+        ]
+    }
+]
+            ]]>
+					</artwork>
+				</figure>
+				<t>The following is a example JSON object for EDDSA KeyGen test results sent from the crypto module to the ACVP server.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "testResults": [
+            {
+                "tcId": 1,
+                "qx": "7B1AA6BE712542282B8D088C233168CA4409E20264E32897C201ABA9",
+                "qy": "BCC9213347A7F988A2FF9EF14C85254B23AF0096F947CECB6C3311D2",
+                "d": "38524F26660BBA72E74EB39DEF38558EB07CB15255A09652B222CCE0"
+            }
+        ]
+    }
+]
+            ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-vs-ex6" title="Example Test EDDSA KeyVer JSON Object">
+				<t>The following is a example JSON object for EDDSA KeyVer, test vectors sent from the ACVP server to the crypto module and the response.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "keyVer",
+        "testGroups": [
+            {
+                "curve": "p-192",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "qx": "01ED77E3F1591D2EC730D0ED6D592F8DD24158D0E696408DBD",
+                        "qy": "BF31C6463EB1B6B55C8930550B88CF8D1F6432A832B40FB4"
+                    }
+                ]
+            }
+        ]
+    }
+]
+            ]]>
+					</artwork>
+				</figure>
+				<t>The following is a example JSON object for EDDSA KeyVer test results sent from the crypto module to the ACVP server.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "testResults": [
+            {
+                "tcId": 1,
+                "result": "failed"
+            }
+        ]
+    }
+]
+            ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-vs-ex8" title="Example Test EDDSA Signature Generation JSON Object">
+				<t>The following is a example JSON object for EDDSA SigGen, test vectors sent from the ACVP server to the crypto module and the response.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "sigGen",
+        "testGroups": [
+            {
+                "curve": "p-224",
+                "hashAlg": "SHA2-224",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "AB6F57713A3BD323B4AFDCFBE202EE00A9CF5C787D19FD9094323C57FEA8B7FBE31559EC1CAC6D29C3229A58811CF2BAE2B78183DFDABD055B741EA86496454F085D17D5BCD1B82B533B533A1E5804B2DAA0ED43F8BF59FBEB16BDD4D7C065165CB9B085CECD5BCFFA794339D5A81B1949F569CAACA208B9E3E6A217A1B3A596"
+                    }
+                ]
+            }
+        ]
+    }
+]
+            ]]>
+					</artwork>
+				</figure>
+				<t>The following is a example JSON object for EDDSA SigGen test results sent from the crypto module to the ACVP server.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "testResults": [
+            {
+                "tcId": 1,
+                "qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
+                "qy": "E56F7B7C9E6355E573B7B3B6C0E1ECD70E4ABDF1554EAD8A68ABA1A4",
+                "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
+            }
+        ]
+    }
+]
+          ]]>
+					</artwork>
+				</figure>
+			</section>
+			<section anchor="app-vs-ex9" title="Example Test EDDSA SigVer JSON Object">
+				<t>The following is a example JSON object for EDDSA SigVer, test vectors sent from the ACVP server to the crypto module and the response.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "algorithm": "EDDSA",
+        "mode": "sigVer",
+        "testGroups": [
+            {
+                "curve": "p-192",
+                "hashAlg": "SHA-1",
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "D38A81D0C5201BA4A06A8C4760AC15DB266B17B48B13EA69775D1E896486D9D986A464D3469941F93FC65556E2CB8AB5F113E7ADCB8D50375DC76907195B6AF6C06F13EB6106EF0E19E241DB4B4831E06437E5CF7C9A499A8FC6DA36A75BDB81A2A19E14ACEFECD7E364471527E0FE37FD1162F5DD0D975E83C0DA4EDDD37261",
+                        "qx": "B08AFEAC74E42C66EBAF13807E2EB5769F5123645C0B8491",
+                        "qy": "55847857E5E48025BE9053952E0E1ECFB1D883CF9F085386",
+                        "r": "E31121E544D476DC3FA79B4DCB0A7252B6E80468BBF22843",
+                        "s": "6E3F47F2327E36AD936E0F4BE245C05F264BA9300E9E7DD9"
+                    }
+                ]
+            }
+        ]
+    }
+]
+            ]]>
+					</artwork>
+				</figure>
+				<t>The following is a example JSON object for EDDSA generation test results sent from the crypto module to the ACVP server.</t>
+				<figure>
+					<artwork>
+						<![CDATA[
+[
+    {
+        "acvVersion": "0.4"
+    },
+    {
+        "vsId": 1564,
+        "testResults": [
+            {
+                "tcId": 1,
+                "result": "failed"
+            }
+        ]
+    }
+]
+          ]]>
+					</artwork>
+				</figure>
+			</section>
+		</section>
+	</back>
+</rfc>

--- a/src/acvp_sub_eddsa.xml
+++ b/src/acvp_sub_eddsa.xml
@@ -361,7 +361,7 @@
 						<c/>
 						<c/>
 						<c>testType</c>
-						<c>The testType for the group</c>
+						<c>The testType for the group. Either AFT or BFT.</c>
 						<c>value</c>
 						<c>No</c>
 						<c/>
@@ -804,7 +804,27 @@
                         "message": "A81C8A22735A260CB1A8105A2964646097D8A9B110701AB0D49C9071836CAD39E31F5020D24B2C841FAC58F44F3F3F814495B063A686F6F93C5C6D9FDF45B9099C609A69E6A9F6483C5038066A560D413C6FB73D76499A7D8836C9C89368D557B2C24A5D817CF1FBD226AC41037E3005250007B49C6CCCE7BD1BE5D7A5C96EE8"
                     }
                 ]
-            }
+            },
+			{
+				"tgId": 5,
+				"testType": "bft",
+				"curve": "ed-25519",
+				"preHash": false,
+				"tests": [
+					{
+						"tcId": 41,
+						"message": "F27E9F9D"
+					},
+					{
+						"tcId": 42,
+						"message": "F27E9F9C"
+					},
+					{
+						"tcId": 43,
+						"message": "F27E9F9F"
+					}
+				]
+			}
         ]
     }
 ]
@@ -831,7 +851,25 @@
 						"signature": "772990B0E53B3E21DC8BD139CECB39892D75BD70DAFFDC73E241E29515E67CC642CB2A6B479FFEF4F3F16B5BC3DDF06AB25A92028F2DC0464B3CFDFD3B8F4D08"
 					}
 				]
-            }
+            },
+			{
+				"tgId": 5,
+				"q": "ADD51513B67540E3A392721742C7E81F1BAE77DEFC16314E32A06976BA9BBFF7",
+				"tests": [
+					{
+						"tcId": 41,
+						"signature": "6EA857E68CEC0825EAD378A2F445BB17993D151CF9A168A44F47E13D356F6DC9AA67517DE4A2FB22BA24E1732DA0234427A2572CBE80294277F2141498E7F50E"
+					},
+					{
+						"tcId": 42,
+						"signature": "883B0336036509FC44CD2E507C5E916696213F9CF2429796E248516EFBDFAFE5C98EE6DBF82314B6FB5403383BC2E4ECCC89C7D686FE3A630B74866A0126740C"
+					},
+					{
+						"tcId": 43,
+						"signature": "E402705AC2EFC216EB7FA1AC5461A8451CE6F72B0AFA63D75BFBD5C4DD98A07207168CC6A542F01AAC6C31EC1C09062B053A54F6C93B801460FE33348B87DD03"
+					}
+				]
+			}
         ]
     }
 ]


### PR DESCRIPTION
Adds an initial EdDSA spec for FIPS 186-5 (not yet officially released). 

This specification is versioned for v0.5. The goal is to have all modes of EdDSA available once v0.5 becomes available. 

In terms of implementation details, while the specification is not officially released, EdDSA will only be available on the demo server; not on the production server. The intention is to allow implementations to be tested on demo and ready for the official release to prod when the specification is released.