### PR TITLE
Cmac updates capabilities

### DIFF
--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -662,21 +662,7 @@
 <td class="left">algorithm</td>
 <td class="left">The MAC algorithm to be validated.</td>
 <td class="left">value</td>
-<td class="left">CMAC</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">mode</td>
-<td class="left">The mode to be validated.</td>
-<td class="left">value</td>
-<td class="left">AES</td>
+<td class="left">CMAC-AES</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -815,8 +801,7 @@
 <pre>
                             
 {
-  "algorithm": "CMAC",
-  "mode": "AES",
+  "algorithm": "CMAC-AES",
   "capabilities": [
     {
       "direction": "gen",
@@ -974,16 +959,6 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The algorithm used for the test vectors.</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">mode</td>
-<td class="left">The mode used for the test vectors.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1160,8 +1135,7 @@
                             
 {
     "vsId": 1,
-	"algorithm": "CMAC",
-	"mode": "AES",
+	"algorithm": "CMAC-AES",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -1482,8 +1456,7 @@
 {
 	"vsId": 1,
     "algorithm": "CMAC",
-    "mode": "AES",
-	"testGroups": [{
+    "testGroups": [{
 			"tgId": 4,
 			"tests": [{
 					"tcId": 25,
@@ -1630,21 +1603,7 @@
 <td class="left">algorithm</td>
 <td class="left">The MAC algorithm to be validated.</td>
 <td class="left">value</td>
-<td class="left">CMAC</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">mode</td>
-<td class="left">The mode to be validated.</td>
-<td class="left">value</td>
-<td class="left">TDES</td>
+<td class="left">CMAC-TDES</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -1782,8 +1741,7 @@
 <pre>
                             
 {
-  "algorithm": "CMAC",
-  "mode": "TDES",
+  "algorithm": "CMAC-TDES",
   "capabilities": [
     {
       "direction": "gen",
@@ -1881,16 +1839,6 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The algorithm used for the test vectors.</td>
-<td class="left">value</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">mode</td>
-<td class="left">The mode used for the test vectors.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -2067,8 +2015,7 @@
                             
 {
 	"vsId": 1,
-	"algorithm": "CMAC",
-	"mode": "TDES",
+	"algorithm": "CMAC-TDES",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -2474,8 +2421,7 @@
                             
 {
     "vsId": 1,
-	"algorithm": "CMAC",
-	"mode": "TDES",
+	"algorithm": "CMAC-TDES",
 	"testGroups": [{
 			"tgId": 4,
 			"tests": [{

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -376,42 +376,42 @@
   <link href="#rfc.toc" rel="Contents">
 <link href="#rfc.section.1" rel="Chapter" title="1 Introduction">
 <link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
-<link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration">
-<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for MAC Validations">
-<link href="#rfc.section.3" rel="Chapter" title="3 CMAC-AES">
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 CMAC-AES Algorithm Capabilities Registration">
-<link href="#rfc.section.3.1.1" rel="Chapter" title="3.1.1 Example CMAC-AES Capabilities JSON Object">
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 CMAC-AES Test Vectors">
-<link href="#rfc.section.3.2.1" rel="Chapter" title="3.2.1 CMAC-AES Test Groups JSON Schema">
-<link href="#rfc.section.3.2.2" rel="Chapter" title="3.2.2 CMAC-AES Test Case JSON Schema">
-<link href="#rfc.section.3.2.3" rel="Chapter" title="3.2.3 Example CMAC-AES Test Vector JSON Object">
-<link href="#rfc.section.3.3" rel="Chapter" title="3.3 CMAC-AES Test Vector Responses">
-<link href="#rfc.section.3.3.1" rel="Chapter" title="3.3.1 Example CMAC-AES Test Vector Response JSON Object">
-<link href="#rfc.section.4" rel="Chapter" title="4 CMAC-TDES">
-<link href="#rfc.section.4.1" rel="Chapter" title="4.1 CMAC-TDES Algorithm Capabilities Registration">
-<link href="#rfc.section.4.1.1" rel="Chapter" title="4.1.1 Example CMAC-TDES Capabilities JSON Object">
-<link href="#rfc.section.4.2" rel="Chapter" title="4.2 CMAC-TDES Test Vectors">
-<link href="#rfc.section.4.2.1" rel="Chapter" title="4.2.1 CMAC-TDES Test Groups JSON Schema">
-<link href="#rfc.section.4.2.2" rel="Chapter" title="4.2.2 CMAC-TDES Test Case JSON Schema">
-<link href="#rfc.section.4.2.3" rel="Chapter" title="4.2.3 Example CMAC-TDES Test Vector JSON Object">
-<link href="#rfc.section.4.3" rel="Chapter" title="4.3 CMAC-TDES Test Vector Responses">
-<link href="#rfc.section.4.3.1" rel="Chapter" title="4.3.1 Example CMAC-TDES Test Vector Response JSON Object">
-<link href="#rfc.section.5" rel="Chapter" title="5 HMAC">
-<link href="#rfc.section.5.1" rel="Chapter" title="5.1 HMAC Algorithm Capabilities Registration">
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Supported HMAC Algorithms">
-<link href="#rfc.section.5.2.1" rel="Chapter" title="5.2.1 Example HMAC Capabilities JSON Object">
-<link href="#rfc.section.5.3" rel="Chapter" title="5.3 HMAC Test Vectors">
-<link href="#rfc.section.5.3.1" rel="Chapter" title="5.3.1 HMAC Test Groups JSON Schema">
-<link href="#rfc.section.5.3.2" rel="Chapter" title="5.3.2 HMAC Test Case JSON Schema">
-<link href="#rfc.section.5.3.3" rel="Chapter" title="5.3.3 Example HMAC Test Vector JSON Object">
-<link href="#rfc.section.5.4" rel="Chapter" title="5.4 HMAC Test Vector Responses">
-<link href="#rfc.section.5.4.1" rel="Chapter" title="5.4.1 Example HMAC Test Vector Response JSON Object">
-<link href="#rfc.section.6" rel="Chapter" title="6 Test Types and Test Coverage">
-<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Test Coverage">
-<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 CMAC Requirements Covered">
-<link href="#rfc.section.6.1.2" rel="Chapter" title="6.1.2 CMACRequirements Not Covered">
-<link href="#rfc.section.6.1.3" rel="Chapter" title="6.1.3 HMAC Requirements Covered">
-<link href="#rfc.section.6.1.4" rel="Chapter" title="6.1.4 HMAC Requirements Not Covered">
+<link href="#rfc.section.2" rel="Chapter" title="2 Test Types and Test Coverage">
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Test Coverage">
+<link href="#rfc.section.2.1.1" rel="Chapter" title="2.1.1 CMAC Requirements Covered">
+<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 CMACRequirements Not Covered">
+<link href="#rfc.section.2.1.3" rel="Chapter" title="2.1.3 HMAC Requirements Covered">
+<link href="#rfc.section.2.1.4" rel="Chapter" title="2.1.4 HMAC Requirements Not Covered">
+<link href="#rfc.section.3" rel="Chapter" title="3 Capabilities Registration">
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Required Prerequisite Algorithms for MAC Validations">
+<link href="#rfc.section.4" rel="Chapter" title="4 CMAC-AES">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 CMAC-AES Algorithm Capabilities Registration">
+<link href="#rfc.section.4.1.1" rel="Chapter" title="4.1.1 Example CMAC-AES Capabilities JSON Object">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 CMAC-AES Test Vectors">
+<link href="#rfc.section.4.2.1" rel="Chapter" title="4.2.1 CMAC-AES Test Groups JSON Schema">
+<link href="#rfc.section.4.2.2" rel="Chapter" title="4.2.2 CMAC-AES Test Case JSON Schema">
+<link href="#rfc.section.4.2.3" rel="Chapter" title="4.2.3 Example CMAC-AES Test Vector JSON Object">
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 CMAC-AES Test Vector Responses">
+<link href="#rfc.section.4.3.1" rel="Chapter" title="4.3.1 Example CMAC-AES Test Vector Response JSON Object">
+<link href="#rfc.section.5" rel="Chapter" title="5 CMAC-TDES">
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 CMAC-TDES Algorithm Capabilities Registration">
+<link href="#rfc.section.5.1.1" rel="Chapter" title="5.1.1 Example CMAC-TDES Capabilities JSON Object">
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 CMAC-TDES Test Vectors">
+<link href="#rfc.section.5.2.1" rel="Chapter" title="5.2.1 CMAC-TDES Test Groups JSON Schema">
+<link href="#rfc.section.5.2.2" rel="Chapter" title="5.2.2 CMAC-TDES Test Case JSON Schema">
+<link href="#rfc.section.5.2.3" rel="Chapter" title="5.2.3 Example CMAC-TDES Test Vector JSON Object">
+<link href="#rfc.section.5.3" rel="Chapter" title="5.3 CMAC-TDES Test Vector Responses">
+<link href="#rfc.section.5.3.1" rel="Chapter" title="5.3.1 Example CMAC-TDES Test Vector Response JSON Object">
+<link href="#rfc.section.6" rel="Chapter" title="6 HMAC">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 HMAC Algorithm Capabilities Registration">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Supported HMAC Algorithms">
+<link href="#rfc.section.6.2.1" rel="Chapter" title="6.2.1 Example HMAC Capabilities JSON Object">
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 HMAC Test Vectors">
+<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 HMAC Test Groups JSON Schema">
+<link href="#rfc.section.6.3.2" rel="Chapter" title="6.3.2 HMAC Test Case JSON Schema">
+<link href="#rfc.section.6.3.3" rel="Chapter" title="6.3.3 Example HMAC Test Vector JSON Object">
+<link href="#rfc.section.6.4" rel="Chapter" title="6.4 HMAC Test Vector Responses">
+<link href="#rfc.section.6.4.1" rel="Chapter" title="6.4.1 Example HMAC Test Vector Response JSON Object">
 <link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
 <link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
 <link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
@@ -424,7 +424,7 @@
   <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
-  <meta name="dct.creator" content="Fussell, B., Ed. and G2, Inc." />
+  <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-submac-0.5" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-8" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
@@ -447,7 +447,7 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">R. , Ed.</td>
+<td class="right">R. Hammett, Ed.</td>
 </tr>
 <tr>
 <td class="left">Expires: February 2, 2019</td>
@@ -485,77 +485,77 @@
 </li>
 <ul><li>1.1.   <a href="#rfc.section.1.1">Requirements Language</a>
 </li>
-</ul><li>2.   <a href="#rfc.section.2">Capabilities Registration</a>
+</ul><li>2.   <a href="#rfc.section.2">Test Types and Test Coverage</a>
 </li>
-<ul><li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for MAC Validations</a>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Test Coverage</a>
 </li>
-</ul><li>3.   <a href="#rfc.section.3">CMAC-AES</a>
+<ul><li>2.1.1.   <a href="#rfc.section.2.1.1">CMAC Requirements Covered</a>
 </li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">CMAC-AES Algorithm Capabilities Registration</a>
+<li>2.1.2.   <a href="#rfc.section.2.1.2">CMACRequirements Not Covered</a>
 </li>
-<ul><li>3.1.1.   <a href="#rfc.section.3.1.1">Example CMAC-AES Capabilities JSON Object</a>
+<li>2.1.3.   <a href="#rfc.section.2.1.3">HMAC Requirements Covered</a>
 </li>
-</ul><li>3.2.   <a href="#rfc.section.3.2">CMAC-AES Test Vectors</a>
+<li>2.1.4.   <a href="#rfc.section.2.1.4">HMAC Requirements Not Covered</a>
 </li>
-<ul><li>3.2.1.   <a href="#rfc.section.3.2.1">CMAC-AES Test Groups JSON Schema</a>
+</ul></ul><li>3.   <a href="#rfc.section.3">Capabilities Registration</a>
 </li>
-<li>3.2.2.   <a href="#rfc.section.3.2.2">CMAC-AES Test Case JSON Schema</a>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Required Prerequisite Algorithms for MAC Validations</a>
 </li>
-<li>3.2.3.   <a href="#rfc.section.3.2.3">Example CMAC-AES Test Vector JSON Object</a>
+</ul><li>4.   <a href="#rfc.section.4">CMAC-AES</a>
 </li>
-</ul><li>3.3.   <a href="#rfc.section.3.3">CMAC-AES Test Vector Responses</a>
+<ul><li>4.1.   <a href="#rfc.section.4.1">CMAC-AES Algorithm Capabilities Registration</a>
 </li>
-<ul><li>3.3.1.   <a href="#rfc.section.3.3.1">Example CMAC-AES Test Vector Response JSON Object</a>
+<ul><li>4.1.1.   <a href="#rfc.section.4.1.1">Example CMAC-AES Capabilities JSON Object</a>
 </li>
-</ul></ul><li>4.   <a href="#rfc.section.4">CMAC-TDES</a>
+</ul><li>4.2.   <a href="#rfc.section.4.2">CMAC-AES Test Vectors</a>
 </li>
-<ul><li>4.1.   <a href="#rfc.section.4.1">CMAC-TDES Algorithm Capabilities Registration</a>
+<ul><li>4.2.1.   <a href="#rfc.section.4.2.1">CMAC-AES Test Groups JSON Schema</a>
 </li>
-<ul><li>4.1.1.   <a href="#rfc.section.4.1.1">Example CMAC-TDES Capabilities JSON Object</a>
+<li>4.2.2.   <a href="#rfc.section.4.2.2">CMAC-AES Test Case JSON Schema</a>
 </li>
-</ul><li>4.2.   <a href="#rfc.section.4.2">CMAC-TDES Test Vectors</a>
+<li>4.2.3.   <a href="#rfc.section.4.2.3">Example CMAC-AES Test Vector JSON Object</a>
 </li>
-<ul><li>4.2.1.   <a href="#rfc.section.4.2.1">CMAC-TDES Test Groups JSON Schema</a>
+</ul><li>4.3.   <a href="#rfc.section.4.3">CMAC-AES Test Vector Responses</a>
 </li>
-<li>4.2.2.   <a href="#rfc.section.4.2.2">CMAC-TDES Test Case JSON Schema</a>
+<ul><li>4.3.1.   <a href="#rfc.section.4.3.1">Example CMAC-AES Test Vector Response JSON Object</a>
 </li>
-<li>4.2.3.   <a href="#rfc.section.4.2.3">Example CMAC-TDES Test Vector JSON Object</a>
+</ul></ul><li>5.   <a href="#rfc.section.5">CMAC-TDES</a>
 </li>
-</ul><li>4.3.   <a href="#rfc.section.4.3">CMAC-TDES Test Vector Responses</a>
+<ul><li>5.1.   <a href="#rfc.section.5.1">CMAC-TDES Algorithm Capabilities Registration</a>
 </li>
-<ul><li>4.3.1.   <a href="#rfc.section.4.3.1">Example CMAC-TDES Test Vector Response JSON Object</a>
+<ul><li>5.1.1.   <a href="#rfc.section.5.1.1">Example CMAC-TDES Capabilities JSON Object</a>
 </li>
-</ul></ul><li>5.   <a href="#rfc.section.5">HMAC</a>
+</ul><li>5.2.   <a href="#rfc.section.5.2">CMAC-TDES Test Vectors</a>
 </li>
-<ul><li>5.1.   <a href="#rfc.section.5.1">HMAC Algorithm Capabilities Registration</a>
+<ul><li>5.2.1.   <a href="#rfc.section.5.2.1">CMAC-TDES Test Groups JSON Schema</a>
 </li>
-<li>5.2.   <a href="#rfc.section.5.2">Supported HMAC Algorithms</a>
+<li>5.2.2.   <a href="#rfc.section.5.2.2">CMAC-TDES Test Case JSON Schema</a>
 </li>
-<ul><li>5.2.1.   <a href="#rfc.section.5.2.1">Example HMAC Capabilities JSON Object</a>
+<li>5.2.3.   <a href="#rfc.section.5.2.3">Example CMAC-TDES Test Vector JSON Object</a>
 </li>
-</ul><li>5.3.   <a href="#rfc.section.5.3">HMAC Test Vectors</a>
+</ul><li>5.3.   <a href="#rfc.section.5.3">CMAC-TDES Test Vector Responses</a>
 </li>
-<ul><li>5.3.1.   <a href="#rfc.section.5.3.1">HMAC Test Groups JSON Schema</a>
+<ul><li>5.3.1.   <a href="#rfc.section.5.3.1">Example CMAC-TDES Test Vector Response JSON Object</a>
 </li>
-<li>5.3.2.   <a href="#rfc.section.5.3.2">HMAC Test Case JSON Schema</a>
+</ul></ul><li>6.   <a href="#rfc.section.6">HMAC</a>
 </li>
-<li>5.3.3.   <a href="#rfc.section.5.3.3">Example HMAC Test Vector JSON Object</a>
+<ul><li>6.1.   <a href="#rfc.section.6.1">HMAC Algorithm Capabilities Registration</a>
 </li>
-</ul><li>5.4.   <a href="#rfc.section.5.4">HMAC Test Vector Responses</a>
+<li>6.2.   <a href="#rfc.section.6.2">Supported HMAC Algorithms</a>
 </li>
-<ul><li>5.4.1.   <a href="#rfc.section.5.4.1">Example HMAC Test Vector Response JSON Object</a>
+<ul><li>6.2.1.   <a href="#rfc.section.6.2.1">Example HMAC Capabilities JSON Object</a>
 </li>
-</ul></ul><li>6.   <a href="#rfc.section.6">Test Types and Test Coverage</a>
+</ul><li>6.3.   <a href="#rfc.section.6.3">HMAC Test Vectors</a>
 </li>
-<ul><li>6.1.   <a href="#rfc.section.6.1">Test Coverage</a>
+<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">HMAC Test Groups JSON Schema</a>
 </li>
-<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">CMAC Requirements Covered</a>
+<li>6.3.2.   <a href="#rfc.section.6.3.2">HMAC Test Case JSON Schema</a>
 </li>
-<li>6.1.2.   <a href="#rfc.section.6.1.2">CMACRequirements Not Covered</a>
+<li>6.3.3.   <a href="#rfc.section.6.3.3">Example HMAC Test Vector JSON Object</a>
 </li>
-<li>6.1.3.   <a href="#rfc.section.6.1.3">HMAC Requirements Covered</a>
+</ul><li>6.4.   <a href="#rfc.section.6.4">HMAC Test Vector Responses</a>
 </li>
-<li>6.1.4.   <a href="#rfc.section.6.1.4">HMAC Requirements Not Covered</a>
+<ul><li>6.4.1.   <a href="#rfc.section.6.4.1">Example HMAC Test Vector Response JSON Object</a>
 </li>
 </ul></ul><li>7.   <a href="#rfc.section.7">Acknowledgements</a>
 </li>
@@ -582,14 +582,65 @@
 <a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
 <p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>. </p>
 <h1 id="rfc.section.2">
-<a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
+<a href="#rfc.section.2">2.</a> <a href="#test_types" id="test_types">Test Types and Test Coverage</a>
 </h1>
-<p id="rfc.section.2.p.1">ACVP requires crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of HMAC and CMAC algorithms to the ACVP server.</p>
-<p id="rfc.section.2.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message. Each algorithm capability advertised is a self-contained JSON object. </p>
+<p id="rfc.section.2.p.1">The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. This section describes the design of the tests used to validate implementations of MAC algorithms. There is a single test type for MACs (broken into subsections for CMACs). the single test type, algorithm functional test (AFT) can be described as follows: </p>
+
+<ul class="empty"><li>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an additional "ver" direction present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</li></ul>
+
+<p> </p>
 <h1 id="rfc.section.2.1">
-<a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for MAC Validations</a>
+<a href="#rfc.section.2.1">2.1.</a> <a href="#test_coverage" id="test_coverage">Test Coverage</a>
 </h1>
-<p id="rfc.section.2.1.p.1">Each MAC implementation relies on other cryptographic primitives. For example, CMAC uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<p id="rfc.section.2.1.p.1">The tests described in this document have the intention of ensuring an implementation is conformant to <a href="#SP-800-38B" class="xref">[SP-800-38B]</a> and <a href="#FIPS-198-1" class="xref">[FIPS-198-1]</a>.</p>
+<h1 id="rfc.section.2.1.1">
+<a href="#rfc.section.2.1.1">2.1.1.</a> <a href="#requirements_covered_cmac" id="requirements_covered_cmac">CMAC Requirements Covered</a>
+</h1>
+<p></p>
+
+<ul class="empty">
+<li>SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys and messages for the IUT to process, then compares the IUT's result to the ACVP result. </li>
+<li>SP 800-38b - 6.3 Mac Verification. ACVP server creates random sets of keys, messages, and macs. These test vectors are then randomly altered to ensure the MAC will not match the given key and message. Using the provided test case, the IUT is expected to validate the mac against the provided key and message. </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.2.1.2">
+<a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#requirements_not_covered_cmac" id="requirements_not_covered_cmac">CMACRequirements Not Covered</a>
+</h1>
+<p></p>
+
+<ul class="empty">
+<li>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are intermediate values, are not validated via current testing.</li>
+<li>SP 800-38b - 5.5 Input and Output Data. The mlen is currently provided and not inferred.</li>
+<li>SP 800-38b - Appendix A. Length of MAC. The ACVP server will generate vectors as per the IUT's specified criteria. The IUT should register its entire range of supported MAC lengths, regardless of security strength.  The ACVP server will test a random sampling of valid MAC lengths as per the IUT registration - this generally includes the minimum and maximum mac length. </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.2.1.3">
+<a href="#rfc.section.2.1.3">2.1.3.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
+</h1>
+<p></p>
+
+<ul class="empty">
+<li>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending on the nature of the IUT capabilities registration, keys that are below, at, or above the hashing algorithm block size.</li>
+<li>FIPS 198-1 - 4 HMAC Specification. Mac Generation. ACVP server creates random sets of keys and messages for the IUT to process, then compares the IUT's result to the ACVP result.</li>
+<li>FIPS 198-1 - 5 Truncation. The ACVP server is capable of generating MACs as per the capability registration of the IUT. Groups will be created containing a random sampling of valid MAC lengths from the IUT registration.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.2.1.4">
+<a href="#rfc.section.2.1.4">2.1.4.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
+</h1>
+<p id="rfc.section.2.1.4.p.1">N/A</p>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
+</h1>
+<p id="rfc.section.3.p.1">ACVP requires crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of HMAC and CMAC algorithms to the ACVP server.</p>
+<p id="rfc.section.3.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message. Each algorithm capability advertised is a self-contained JSON object. </p>
+<h1 id="rfc.section.3.1">
+<a href="#rfc.section.3.1">3.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for MAC Validations</a>
+</h1>
+<p id="rfc.section.3.1.p.1">Each MAC implementation relies on other cryptographic primitives. For example, CMAC uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
 <div id="rfc.table.1"></div>
 <div id="rereqs_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -639,13 +690,13 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3">
-<a href="#rfc.section.3">3.</a> <a href="#cmac_aes_root" id="cmac_aes_root">CMAC-AES</a>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#cmac_aes_root" id="cmac_aes_root">CMAC-AES</a>
 </h1>
-<h1 id="rfc.section.3.1">
-<a href="#rfc.section.3.1">3.1.</a> <a href="#cmac_aes_caps_reg" id="cmac_aes_caps_reg">CMAC-AES Algorithm Capabilities Registration</a>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> <a href="#cmac_aes_caps_reg" id="cmac_aes_caps_reg">CMAC-AES Algorithm Capabilities Registration</a>
 </h1>
-<p id="rfc.section.3.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<p id="rfc.section.4.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
 <div id="rfc.table.2"></div>
 <div id="cmac_aes_caps_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -674,9 +725,9 @@
 </tr>
 <tr>
 <td class="left">prereqVals</td>
-<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 2.1</a> for examples </td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 3.1</a> for examples </td>
 <td class="left">array of prereqAlgVal objects</td>
-<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 3.1</a> </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -702,7 +753,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.3.1.p.2">Each capability object describes a separate permutation of direction and key length.</p>
+<p id="rfc.section.4.1.p.2">Each capability object describes a separate permutation of direction and key length.</p>
 <div id="rfc.table.3"></div>
 <div id="cmac_aes_capabilities"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -773,7 +824,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.3.1.p.3">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.4.1.p.3">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
@@ -783,7 +834,7 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.3.1.p.5">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.4.1.p.5">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
@@ -794,10 +845,10 @@
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.3.1.1">
-<a href="#rfc.section.3.1.1">3.1.1.</a> <a href="#cmac_aes_app-reg-ex" id="cmac_aes_app-reg-ex">Example CMAC-AES Capabilities JSON Object</a>
+<h1 id="rfc.section.4.1.1">
+<a href="#rfc.section.4.1.1">4.1.1.</a> <a href="#cmac_aes_app-reg-ex" id="cmac_aes_app-reg-ex">Example CMAC-AES Capabilities JSON Object</a>
 </h1>
-<p id="rfc.section.3.1.1.p.1">The following is an example JSON object advertising support for CMAC-AES.</p>
+<p id="rfc.section.4.1.1.p.1">The following is an example JSON object advertising support for CMAC-AES.</p>
 <pre>
                             
 {
@@ -921,11 +972,11 @@
 }
             
                         </pre>
-<h1 id="rfc.section.3.2">
-<a href="#rfc.section.3.2">3.2.</a> <a href="#cmac_aes_test_vectors" id="cmac_aes_test_vectors">CMAC-AES Test Vectors</a>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> <a href="#cmac_aes_test_vectors" id="cmac_aes_test_vectors">CMAC-AES Test Vectors</a>
 </h1>
-<p id="rfc.section.3.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
-<p id="rfc.section.3.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<p id="rfc.section.4.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
+<p id="rfc.section.4.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
 <div id="rfc.table.4"></div>
 <div id="cmac_aes_vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -968,15 +1019,15 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#cmac_aes_tgjs" class="xref">Section 3.2.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#cmac_aes_tgjs" class="xref">Section 4.2.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3.2.1">
-<a href="#rfc.section.3.2.1">3.2.1.</a> <a href="#cmac_aes_tgjs" id="cmac_aes_tgjs">CMAC-AES Test Groups JSON Schema</a>
+<h1 id="rfc.section.4.2.1">
+<a href="#rfc.section.4.2.1">4.2.1.</a> <a href="#cmac_aes_tgjs" id="cmac_aes_tgjs">CMAC-AES Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.3.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.4.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
 <div id="rfc.table.5"></div>
 <div id="cmac_aes_vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1062,16 +1113,16 @@
 </tr>
 <tr>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#cmac_aes_tvjs" class="xref">Section 3.2.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#cmac_aes_tvjs" class="xref">Section 4.2.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3.2.2">
-<a href="#rfc.section.3.2.2">3.2.2.</a> <a href="#cmac_aes_tvjs" id="cmac_aes_tvjs">CMAC-AES Test Case JSON Schema</a>
+<h1 id="rfc.section.4.2.2">
+<a href="#rfc.section.4.2.2">4.2.2.</a> <a href="#cmac_aes_tvjs" id="cmac_aes_tvjs">CMAC-AES Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.3.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<p id="rfc.section.4.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
 <div id="rfc.table.6"></div>
 <div id="cmac_aes_vs_tc_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1127,14 +1178,14 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3.2.3">
-<a href="#rfc.section.3.2.3">3.2.3.</a> <a href="#cmac_aes_test_vector_json" id="cmac_aes_test_vector_json">Example CMAC-AES Test Vector JSON Object</a>
+<h1 id="rfc.section.4.2.3">
+<a href="#rfc.section.4.2.3">4.2.3.</a> <a href="#cmac_aes_test_vector_json" id="cmac_aes_test_vector_json">Example CMAC-AES Test Vector JSON Object</a>
 </h1>
-<p id="rfc.section.3.2.3.p.1">The following is an example JSON test vector object for CMAC-AES.</p>
+<p id="rfc.section.4.2.3.p.1">The following is an example JSON test vector object for CMAC-AES.</p>
 <pre>
                             
 {
-    "vsId": 1,
+	"vsId": 1,
 	"algorithm": "CMAC-AES",
 	"testGroups": [{
 			"tgId": 4,
@@ -1318,10 +1369,10 @@
 }
             
                         </pre>
-<h1 id="rfc.section.3.3">
-<a href="#rfc.section.3.3">3.3.</a> <a href="#cmac_aes_vector_responses" id="cmac_aes_vector_responses">CMAC-AES Test Vector Responses</a>
+<h1 id="rfc.section.4.3">
+<a href="#rfc.section.4.3">4.3.</a> <a href="#cmac_aes_vector_responses" id="cmac_aes_vector_responses">CMAC-AES Test Vector Responses</a>
 </h1>
-<p id="rfc.section.3.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<p id="rfc.section.4.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
 <div id="rfc.table.7"></div>
 <div id="cmac_aes_vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1364,7 +1415,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.3.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<p id="rfc.section.4.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
 <div id="rfc.table.8"></div>
 <div id="cmac_aes_vr_group_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1397,7 +1448,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.3.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<p id="rfc.section.4.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
 <div id="rfc.table.9"></div>
 <div id="cmac_aes_vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1447,10 +1498,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3.3.1">
-<a href="#rfc.section.3.3.1">3.3.1.</a> <a href="#cmac_aes_test_vector_response_json" id="cmac_aes_test_vector_response_json">Example CMAC-AES Test Vector Response JSON Object</a>
+<h1 id="rfc.section.4.3.1">
+<a href="#rfc.section.4.3.1">4.3.1.</a> <a href="#cmac_aes_test_vector_response_json" id="cmac_aes_test_vector_response_json">Example CMAC-AES Test Vector Response JSON Object</a>
 </h1>
-<p id="rfc.section.3.3.1.p.1">The following is an example JSON test vector response object for CMAC-AES.</p>
+<p id="rfc.section.4.3.1.p.1">The following is an example JSON test vector response object for CMAC-AES.</p>
 <pre>
                             
 {
@@ -1580,13 +1631,13 @@
 }
             
                         </pre>
-<h1 id="rfc.section.4">
-<a href="#rfc.section.4">4.</a> <a href="#cmac_tdes_root" id="cmac_tdes_root">CMAC-TDES</a>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> <a href="#cmac_tdes_root" id="cmac_tdes_root">CMAC-TDES</a>
 </h1>
-<h1 id="rfc.section.4.1">
-<a href="#rfc.section.4.1">4.1.</a> <a href="#cmac_tdes_caps_reg" id="cmac_tdes_caps_reg">CMAC-TDES Algorithm Capabilities Registration</a>
+<h1 id="rfc.section.5.1">
+<a href="#rfc.section.5.1">5.1.</a> <a href="#cmac_tdes_caps_reg" id="cmac_tdes_caps_reg">CMAC-TDES Algorithm Capabilities Registration</a>
 </h1>
-<p id="rfc.section.4.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<p id="rfc.section.5.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
 <div id="rfc.table.10"></div>
 <div id="cmac_tdes_caps_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1615,9 +1666,9 @@
 </tr>
 <tr>
 <td class="left">prereqVals</td>
-<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 2.1</a> for examples </td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 3.1</a> for examples </td>
 <td class="left">array of prereqAlgVal objects</td>
-<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 3.1</a> </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -1713,7 +1764,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.1.p.2">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.5.1.p.2">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
@@ -1723,7 +1774,7 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.4.1.p.4">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.5.1.p.4">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
@@ -1734,10 +1785,10 @@
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.4.1.1">
-<a href="#rfc.section.4.1.1">4.1.1.</a> <a href="#cmac_tdes_app-reg-ex" id="cmac_tdes_app-reg-ex">Example CMAC-TDES Capabilities JSON Object</a>
+<h1 id="rfc.section.5.1.1">
+<a href="#rfc.section.5.1.1">5.1.1.</a> <a href="#cmac_tdes_app-reg-ex" id="cmac_tdes_app-reg-ex">Example CMAC-TDES Capabilities JSON Object</a>
 </h1>
-<p id="rfc.section.4.1.1.p.1">The following is an example JSON object advertising support for CMAC-TDES.</p>
+<p id="rfc.section.5.1.1.p.1">The following is an example JSON object advertising support for CMAC-TDES.</p>
 <pre>
                             
 {
@@ -1801,11 +1852,11 @@
 }
             
                         </pre>
-<h1 id="rfc.section.4.2">
-<a href="#rfc.section.4.2">4.2.</a> <a href="#cmac_tdes_test_vectors" id="cmac_tdes_test_vectors">CMAC-TDES Test Vectors</a>
+<h1 id="rfc.section.5.2">
+<a href="#rfc.section.5.2">5.2.</a> <a href="#cmac_tdes_test_vectors" id="cmac_tdes_test_vectors">CMAC-TDES Test Vectors</a>
 </h1>
-<p id="rfc.section.4.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-TDES, etc. This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
-<p id="rfc.section.4.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<p id="rfc.section.5.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-TDES, etc. This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
+<p id="rfc.section.5.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
 <div id="rfc.table.12"></div>
 <div id="cmac_tdes_vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1848,15 +1899,15 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#cmac_tdes_tgjs" class="xref">Section 4.2.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#cmac_tdes_tgjs" class="xref">Section 5.2.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.4.2.1">
-<a href="#rfc.section.4.2.1">4.2.1.</a> <a href="#cmac_tdes_tgjs" id="cmac_tdes_tgjs">CMAC-TDES Test Groups JSON Schema</a>
+<h1 id="rfc.section.5.2.1">
+<a href="#rfc.section.5.2.1">5.2.1.</a> <a href="#cmac_tdes_tgjs" id="cmac_tdes_tgjs">CMAC-TDES Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.4.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.5.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
 <div id="rfc.table.13"></div>
 <div id="cmac_tdes_vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1942,16 +1993,16 @@
 </tr>
 <tr>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#cmac_tdes_tvjs" class="xref">Section 4.2.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#cmac_tdes_tvjs" class="xref">Section 5.2.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.4.2.2">
-<a href="#rfc.section.4.2.2">4.2.2.</a> <a href="#cmac_tdes_tvjs" id="cmac_tdes_tvjs">CMAC-TDES Test Case JSON Schema</a>
+<h1 id="rfc.section.5.2.2">
+<a href="#rfc.section.5.2.2">5.2.2.</a> <a href="#cmac_tdes_tvjs" id="cmac_tdes_tvjs">CMAC-TDES Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.4.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<p id="rfc.section.5.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
 <div id="rfc.table.14"></div>
 <div id="cmac_tdes_vs_tc_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2007,10 +2058,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.4.2.3">
-<a href="#rfc.section.4.2.3">4.2.3.</a> <a href="#cmac_tdes_test_vector_json" id="cmac_tdes_test_vector_json">Example CMAC-TDES Test Vector JSON Object</a>
+<h1 id="rfc.section.5.2.3">
+<a href="#rfc.section.5.2.3">5.2.3.</a> <a href="#cmac_tdes_test_vector_json" id="cmac_tdes_test_vector_json">Example CMAC-TDES Test Vector JSON Object</a>
 </h1>
-<p id="rfc.section.4.2.3.p.1">The following is an example JSON test vector object for CMAC-TDES.</p>
+<p id="rfc.section.5.2.3.p.1">The following is an example JSON test vector object for CMAC-TDES.</p>
 <pre>
                             
 {
@@ -2284,10 +2335,10 @@
 }
             
                         </pre>
-<h1 id="rfc.section.4.3">
-<a href="#rfc.section.4.3">4.3.</a> <a href="#cmac_tdes_vector_responses" id="cmac_tdes_vector_responses">CMAC-TDES Test Vector Responses</a>
+<h1 id="rfc.section.5.3">
+<a href="#rfc.section.5.3">5.3.</a> <a href="#cmac_tdes_vector_responses" id="cmac_tdes_vector_responses">CMAC-TDES Test Vector Responses</a>
 </h1>
-<p id="rfc.section.4.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<p id="rfc.section.5.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
 <div id="rfc.table.15"></div>
 <div id="cmac_tdes_vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2330,7 +2381,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<p id="rfc.section.5.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
 <div id="rfc.table.16"></div>
 <div id="cmac_tdes_vr_group_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2363,7 +2414,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<p id="rfc.section.5.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
 <div id="rfc.table.17"></div>
 <div id="cmac_tdes_vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2413,10 +2464,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.4.3.1">
-<a href="#rfc.section.4.3.1">4.3.1.</a> <a href="#cmac_tdes_test_vector_response_json" id="cmac_tdes_test_vector_response_json">Example CMAC-TDES Test Vector Response JSON Object</a>
+<h1 id="rfc.section.5.3.1">
+<a href="#rfc.section.5.3.1">5.3.1.</a> <a href="#cmac_tdes_test_vector_response_json" id="cmac_tdes_test_vector_response_json">Example CMAC-TDES Test Vector Response JSON Object</a>
 </h1>
-<p id="rfc.section.4.3.1.p.1">The following is an example JSON test vector response object for CMAC-TDES.</p>
+<p id="rfc.section.5.3.1.p.1">The following is an example JSON test vector response object for CMAC-TDES.</p>
 <pre>
                             
 {
@@ -2546,13 +2597,13 @@
 }
             
                         </pre>
-<h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> <a href="#hmac_root" id="hmac_root">HMAC</a>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#hmac_root" id="hmac_root">HMAC</a>
 </h1>
-<h1 id="rfc.section.5.1">
-<a href="#rfc.section.5.1">5.1.</a> <a href="#hmac_caps_reg" id="hmac_caps_reg">HMAC Algorithm Capabilities Registration</a>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#hmac_caps_reg" id="hmac_caps_reg">HMAC Algorithm Capabilities Registration</a>
 </h1>
-<p id="rfc.section.5.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<p id="rfc.section.6.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
 <div id="rfc.table.18"></div>
 <div id="hmac_caps_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2569,7 +2620,7 @@
 <td class="left">algorithm</td>
 <td class="left">The MAC algorithm and mode to be validated.</td>
 <td class="left">value</td>
-<td class="left">See <a href="#hmac_supported_algs" class="xref">Section 5.2</a> </td>
+<td class="left">See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -2581,9 +2632,9 @@
 </tr>
 <tr>
 <td class="left">prereqVals</td>
-<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 2.1</a> for examples </td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 3.1</a> for examples </td>
 <td class="left">array of prereqAlgVal objects</td>
-<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 3.1</a> </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -2609,7 +2660,7 @@
 </tr>
 <tr>
 <td class="left">macLen</td>
-<td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#hmac_supported_algs" class="xref">Section 5.2</a>). </td>
+<td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#hmac_supported_algs" class="xref">Section 6.2</a>). </td>
 <td class="left">Domain</td>
 <td class="left">32-512</td>
 <td class="left">No</td>
@@ -2623,17 +2674,17 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.5.1.p.2">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.6.1.p.2">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
-<li>2 values below the Hash's block length. See <a href="#hmac_supported_algs" class="xref">Section 5.2</a> </li>
+<li>2 values below the Hash's block length. See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> </li>
 <li>The Hash's block length.</li>
 <li>2 values above the Hash's block length.</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.5.1.p.4">macLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.6.1.p.4">macLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
@@ -2643,10 +2694,10 @@
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.5.2">
-<a href="#rfc.section.5.2">5.2.</a> <a href="#hmac_supported_algs" id="hmac_supported_algs">Supported HMAC Algorithms</a>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#hmac_supported_algs" id="hmac_supported_algs">Supported HMAC Algorithms</a>
 </h1>
-<p id="rfc.section.5.2.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.6.2.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.19"></div>
 <div id="hmac_table_algInfo"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2769,10 +2820,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.2.1">
-<a href="#rfc.section.5.2.1">5.2.1.</a> <a href="#hmac_app-reg-ex" id="hmac_app-reg-ex">Example HMAC Capabilities JSON Object</a>
+<h1 id="rfc.section.6.2.1">
+<a href="#rfc.section.6.2.1">6.2.1.</a> <a href="#hmac_app-reg-ex" id="hmac_app-reg-ex">Example HMAC Capabilities JSON Object</a>
 </h1>
-<p id="rfc.section.5.2.1.p.1">The following is an example JSON object advertising support for HMAC.</p>
+<p id="rfc.section.6.2.1.p.1">The following is an example JSON object advertising support for HMAC.</p>
 <pre>
                             
 {
@@ -2794,11 +2845,11 @@
 }
             
                         </pre>
-<h1 id="rfc.section.5.3">
-<a href="#rfc.section.5.3">5.3.</a> <a href="#hmac_test_vectors" id="hmac_test_vectors">HMAC Test Vectors</a>
+<h1 id="rfc.section.6.3">
+<a href="#rfc.section.6.3">6.3.</a> <a href="#hmac_test_vectors" id="hmac_test_vectors">HMAC Test Vectors</a>
 </h1>
-<p id="rfc.section.5.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC crypto algorithms.</p>
-<p id="rfc.section.5.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<p id="rfc.section.6.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC crypto algorithms.</p>
+<p id="rfc.section.6.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
 <div id="rfc.table.20"></div>
 <div id="hmac_vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2831,7 +2882,7 @@
 </tr>
 <tr>
 <td class="left">algorithm</td>
-<td class="left">The algorithm and mode used for the test vectors. See <a href="#hmac_supported_algs" class="xref">Section 5.2</a> for possible values. </td>
+<td class="left">The algorithm and mode used for the test vectors. See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> for possible values. </td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -2841,15 +2892,15 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#hmac_tgjs" class="xref">Section 5.3.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#hmac_tgjs" class="xref">Section 6.3.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.3.1">
-<a href="#rfc.section.5.3.1">5.3.1.</a> <a href="#hmac_tgjs" id="hmac_tgjs">HMAC Test Groups JSON Schema</a>
+<h1 id="rfc.section.6.3.1">
+<a href="#rfc.section.6.3.1">6.3.1.</a> <a href="#hmac_tgjs" id="hmac_tgjs">HMAC Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.5.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.6.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
 <div id="rfc.table.21"></div>
 <div id="hmac_vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2923,16 +2974,16 @@
 </tr>
 <tr>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#hmac_tvjs" class="xref">Section 5.3.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#hmac_tvjs" class="xref">Section 6.3.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.3.2">
-<a href="#rfc.section.5.3.2">5.3.2.</a> <a href="#hmac_tvjs" id="hmac_tvjs">HMAC Test Case JSON Schema</a>
+<h1 id="rfc.section.6.3.2">
+<a href="#rfc.section.6.3.2">6.3.2.</a> <a href="#hmac_tvjs" id="hmac_tvjs">HMAC Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.5.3.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<p id="rfc.section.6.3.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
 <div id="rfc.table.22"></div>
 <div id="hmac_vs_tc_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -2982,10 +3033,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.3.3">
-<a href="#rfc.section.5.3.3">5.3.3.</a> <a href="#hmac_test_vector_json" id="hmac_test_vector_json">Example HMAC Test Vector JSON Object</a>
+<h1 id="rfc.section.6.3.3">
+<a href="#rfc.section.6.3.3">6.3.3.</a> <a href="#hmac_test_vector_json" id="hmac_test_vector_json">Example HMAC Test Vector JSON Object</a>
 </h1>
-<p id="rfc.section.5.3.3.p.1">The following is an example JSON test vector object for HMAC.</p>
+<p id="rfc.section.6.3.3.p.1">The following is an example JSON test vector object for HMAC.</p>
 <pre>
                             
 {
@@ -3052,10 +3103,10 @@
 }
             
                         </pre>
-<h1 id="rfc.section.5.4">
-<a href="#rfc.section.5.4">5.4.</a> <a href="#hmac_vector_responses" id="hmac_vector_responses">HMAC Test Vector Responses</a>
+<h1 id="rfc.section.6.4">
+<a href="#rfc.section.6.4">6.4.</a> <a href="#hmac_vector_responses" id="hmac_vector_responses">HMAC Test Vector Responses</a>
 </h1>
-<p id="rfc.section.5.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<p id="rfc.section.6.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
 <div id="rfc.table.23"></div>
 <div id="hmac_vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -3098,7 +3149,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.5.4.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<p id="rfc.section.6.4.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
 <div id="rfc.table.24"></div>
 <div id="hmac_vr_group_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -3131,7 +3182,7 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.5.4.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<p id="rfc.section.6.4.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
 <div id="rfc.table.25"></div>
 <div id="hmac_vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -3169,10 +3220,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.4.1">
-<a href="#rfc.section.5.4.1">5.4.1.</a> <a href="#hmac_test_vector_response_json" id="hmac_test_vector_response_json">Example HMAC Test Vector Response JSON Object</a>
+<h1 id="rfc.section.6.4.1">
+<a href="#rfc.section.6.4.1">6.4.1.</a> <a href="#hmac_test_vector_response_json" id="hmac_test_vector_response_json">Example HMAC Test Vector Response JSON Object</a>
 </h1>
-<p id="rfc.section.5.4.1.p.1">The following is an example JSON test vector response object for HMAC.</p>
+<p id="rfc.section.6.4.1.p.1">The following is an example JSON test vector response object for HMAC.</p>
 <pre>
                             
 {
@@ -3225,57 +3276,6 @@
 }
             
                         </pre>
-<h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#test_types" id="test_types">Test Types and Test Coverage</a>
-</h1>
-<p id="rfc.section.6.p.1">The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. This section describes the design of the tests used to validate implementations of MAC algorithms. There is a single test type for MACs (broken into subsections for CMACs). the single test type, algorithm functional test (AFT) can be described as follows: </p>
-
-<ul class="empty"><li>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an additional "ver" direction present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</li></ul>
-
-<p> </p>
-<h1 id="rfc.section.6.1">
-<a href="#rfc.section.6.1">6.1.</a> <a href="#test_coverage" id="test_coverage">Test Coverage</a>
-</h1>
-<p id="rfc.section.6.1.p.1">The tests described in this document have the intention of ensuring an implementation is conformant to <a href="#SP-800-38B" class="xref">[SP-800-38B]</a> and <a href="#FIPS-198-1" class="xref">[FIPS-198-1]</a>.</p>
-<h1 id="rfc.section.6.1.1">
-<a href="#rfc.section.6.1.1">6.1.1.</a> <a href="#requirements_covered_cmac" id="requirements_covered_cmac">CMAC Requirements Covered</a>
-</h1>
-<p></p>
-
-<ul class="empty">
-<li>SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys and messages for the IUT to process, then compares the IUT's result to the ACVP result. </li>
-<li>SP 800-38b - 6.3 Mac Verification. ACVP server creates random sets of keys, messages, and macs. These test vectors are then randomly altered to ensure the MAC will not match the given key and message. Using the provided test case, the IUT is expected to validate the mac against the provided key and message. </li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.section.6.1.2">
-<a href="#rfc.section.6.1.2">6.1.2.</a> <a href="#requirements_not_covered_cmac" id="requirements_not_covered_cmac">CMACRequirements Not Covered</a>
-</h1>
-<p></p>
-
-<ul class="empty">
-<li>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are intermediate values, are not validated via current testing.</li>
-<li>SP 800-38b - 5.5 Input and Output Data. The mlen is currently provided and not inferred.</li>
-<li>SP 800-38b - Appendix A. Length of MAC. The ACVP server will generate vectors as per the IUT's specified criteria. The IUT should register its entire range of supported MAC lengths, regardless of security strength.  The ACVP server will test a random sampling of valid MAC lengths as per the IUT registration - this generally includes the minimum and maximum mac length. </li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.section.6.1.3">
-<a href="#rfc.section.6.1.3">6.1.3.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
-</h1>
-<p></p>
-
-<ul class="empty">
-<li>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending on the nature of the IUT capabilities registration, keys that are below, at, or above the hashing algorithm block size.</li>
-<li>FIPS 198-1 - 4 HMAC Specification. Mac Generation. ACVP server creates random sets of keys and messages for the IUT to process, then compares the IUT's result to the ACVP result.</li>
-<li>FIPS 198-1 - 5 Truncation. The ACVP server is capable of generating MACs as per the capability registration of the IUT. Groups will be created containing a random sampling of valid MAC lengths from the IUT registration.</li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.section.6.1.4">
-<a href="#rfc.section.6.1.4">6.1.4.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
-</h1>
-<p id="rfc.section.6.1.4.p.1">N/A</p>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
@@ -3366,7 +3366,7 @@
 	<span class="vcardline">
 	  <span class="fn">Russell Hammett</span> (editor)
 	  <span class="n hidden">
-		<span class="family-name"></span>
+		<span class="family-name">Hammett</span>
 	  </span>
 	</span>
 	<span class="org vcardline">G2, Inc.</span>

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -418,7 +418,7 @@
   <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
-  <meta name="dct.creator" content="Fussell, B., Ed." />
+  <meta name="dct.creator" content="Fussell, B., Ed. and G2, Inc." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-submac-0.5" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-8" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
@@ -441,11 +441,15 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">August 2018</td>
+<td class="right">R. , Ed.</td>
 </tr>
 <tr>
 <td class="left">Expires: February 2, 2019</td>
-<td class="right"></td>
+<td class="right">G2, Inc.</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="right">August 2018</td>
 </tr>
 
     	
@@ -547,7 +551,7 @@
 </li>
 <li>9.2.   <a href="#rfc.references.2">Informative References</a>
 </li>
-</ul><li><a href="#rfc.authors">Author's Address</a>
+</ul><li><a href="#rfc.authors">Authors' Addresses</a>
 </li>
 
 
@@ -3309,7 +3313,7 @@
 <a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm Validation System (SHAVS)</a>", 2014.</td>
 </tr>
 </tbody></table>
-<h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
+<h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
 <div class="avoidbreak">
   <address class="vcard">
 	<span class="vcardline">
@@ -3330,6 +3334,28 @@
 	  <span class="country-name vcardline">USA</span>
 	</span>
 	<span class="vcardline">EMail: <a href="mailto:bfussell@cisco.com">bfussell@cisco.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Russell Hammett</span> (editor)
+	  <span class="n hidden">
+		<span class="family-name"></span>
+	  </span>
+	</span>
+	<span class="org vcardline">G2, Inc.</span>
+	<span class="adr">
+	  <span class="vcardline">302 Sentinel Dr Suite 300</span>
+
+	  <span class="vcardline">
+		<span class="locality">Annapolis Junction </span>,  
+		<span class="region">MD</span> 
+		<span class="code">20701</span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:russ.hammett@g2-inc.com">russ.hammett@g2-inc.com</a></span>
 
   </address>
 </div>

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -408,12 +408,10 @@
 <link href="#rfc.section.5.4.1" rel="Chapter" title="5.4.1 Example HMAC Test Vector Response JSON Object">
 <link href="#rfc.section.6" rel="Chapter" title="6 Test Types and Test Coverage">
 <link href="#rfc.section.6.1" rel="Chapter" title="6.1 Test Coverage">
-<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 CMAC-AES Requirements Covered">
-<link href="#rfc.section.6.1.2" rel="Chapter" title="6.1.2 CMAC-AES Requirements Not Covered">
-<link href="#rfc.section.6.1.3" rel="Chapter" title="6.1.3 CMAC-TDES Requirements Covered">
-<link href="#rfc.section.6.1.4" rel="Chapter" title="6.1.4 CMAC-TDES Requirements Not Covered">
-<link href="#rfc.section.6.1.5" rel="Chapter" title="6.1.5 HMAC Requirements Covered">
-<link href="#rfc.section.6.1.6" rel="Chapter" title="6.1.6 HMAC Requirements Not Covered">
+<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 CMAC Requirements Covered">
+<link href="#rfc.section.6.1.2" rel="Chapter" title="6.1.2 CMACRequirements Not Covered">
+<link href="#rfc.section.6.1.3" rel="Chapter" title="6.1.3 HMAC Requirements Covered">
+<link href="#rfc.section.6.1.4" rel="Chapter" title="6.1.4 HMAC Requirements Not Covered">
 <link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
 <link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
 <link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
@@ -551,17 +549,13 @@
 </li>
 <ul><li>6.1.   <a href="#rfc.section.6.1">Test Coverage</a>
 </li>
-<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">CMAC-AES Requirements Covered</a>
+<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">CMAC Requirements Covered</a>
 </li>
-<li>6.1.2.   <a href="#rfc.section.6.1.2">CMAC-AES Requirements Not Covered</a>
+<li>6.1.2.   <a href="#rfc.section.6.1.2">CMACRequirements Not Covered</a>
 </li>
-<li>6.1.3.   <a href="#rfc.section.6.1.3">CMAC-TDES Requirements Covered</a>
+<li>6.1.3.   <a href="#rfc.section.6.1.3">HMAC Requirements Covered</a>
 </li>
-<li>6.1.4.   <a href="#rfc.section.6.1.4">CMAC-TDES Requirements Not Covered</a>
-</li>
-<li>6.1.5.   <a href="#rfc.section.6.1.5">HMAC Requirements Covered</a>
-</li>
-<li>6.1.6.   <a href="#rfc.section.6.1.6">HMAC Requirements Not Covered</a>
+<li>6.1.4.   <a href="#rfc.section.6.1.4">HMAC Requirements Not Covered</a>
 </li>
 </ul></ul><li>7.   <a href="#rfc.section.7">Acknowledgements</a>
 </li>
@@ -3288,9 +3282,9 @@
 <h1 id="rfc.section.6">
 <a href="#rfc.section.6">6.</a> <a href="#test_types" id="test_types">Test Types and Test Coverage</a>
 </h1>
-<p id="rfc.section.6.p.1">The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc.  This section describes the design of the tests used to validate implementations of MAC algorithms.  There is a single test type for MACs (broken into subsections for CMACs).  the single test type, algorithm functional test (AFT) can be described as follows: </p>
+<p id="rfc.section.6.p.1">The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. This section describes the design of the tests used to validate implementations of MAC algorithms. There is a single test type for MACs (broken into subsections for CMACs). the single test type, algorithm functional test (AFT) can be described as follows: </p>
 
-<ul class="empty"><li>"AFT" - Algorithm Function Test.  The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an addition "ver" direction present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</li></ul>
+<ul class="empty"><li>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an additional "ver" direction present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</li></ul>
 
 <p> </p>
 <h1 id="rfc.section.6.1">
@@ -3298,23 +3292,44 @@
 </h1>
 <p id="rfc.section.6.1.p.1">The tests described in this document have the intention of ensuring an implementation is conformant to <a href="#SP-800-38B" class="xref">[SP-800-38B]</a> and <a href="#FIPS-198-1" class="xref">[FIPS-198-1]</a>.</p>
 <h1 id="rfc.section.6.1.1">
-<a href="#rfc.section.6.1.1">6.1.1.</a> <a href="#requirements_covered_cmac_aes" id="requirements_covered_cmac_aes">CMAC-AES Requirements Covered</a>
+<a href="#rfc.section.6.1.1">6.1.1.</a> <a href="#requirements_covered_cmac" id="requirements_covered_cmac">CMAC Requirements Covered</a>
 </h1>
+<p></p>
+
+<ul class="empty">
+<li>SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys and messages for the IUT to process, then compares the IUT's result to the ACVP result. </li>
+<li>SP 800-38b - 6.3 Mac Verification. ACVP server creates random sets of keys, messages, and macs. These test vectors are then randomly altered to ensure the MAC will not match the given key and message. Using the provided test case, the IUT is expected to validate the mac against the provided key and message. </li>
+</ul>
+
+<p> </p>
 <h1 id="rfc.section.6.1.2">
-<a href="#rfc.section.6.1.2">6.1.2.</a> <a href="#requirements_not_covered_cmac_aes" id="requirements_not_covered_cmac_aes">CMAC-AES Requirements Not Covered</a>
+<a href="#rfc.section.6.1.2">6.1.2.</a> <a href="#requirements_not_covered_cmac" id="requirements_not_covered_cmac">CMACRequirements Not Covered</a>
 </h1>
+<p></p>
+
+<ul class="empty">
+<li>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are intermediate values, are not validated via current testing.</li>
+<li>SP 800-38b - 5.5 Input and Output Data. The mlen is currently provided and not inferred.</li>
+<li>SP 800-38b - Appendix A. Length of MAC. The ACVP server will generate vectors as per the IUT's specified criteria. The IUT should register its entire range of supported MAC lengths, regardless of security strength.  The ACVP server will test a random sampling of valid MAC lengths as per the IUT registration - this generally includes the minimum and maximum mac length. </li>
+</ul>
+
+<p> </p>
 <h1 id="rfc.section.6.1.3">
-<a href="#rfc.section.6.1.3">6.1.3.</a> <a href="#requirements_covered_cmac_tdes" id="requirements_covered_cmac_tdes">CMAC-TDES Requirements Covered</a>
+<a href="#rfc.section.6.1.3">6.1.3.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
 </h1>
+<p></p>
+
+<ul class="empty">
+<li>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending on the nature of the IUT capabilities registration, keys that are below, at, or above the hashing algorithm block size.</li>
+<li>FIPS 198-1 - 4 HMAC Specification. Mac Generation. ACVP server creates random sets of keys and messages for the IUT to process, then compares the IUT's result to the ACVP result.</li>
+<li>FIPS 198-1 - 5 Truncation. The ACVP server is capable of generating MACs as per the capability registration of the IUT. Groups will be created containing a random sampling of valid MAC lengths from the IUT registration.</li>
+</ul>
+
+<p> </p>
 <h1 id="rfc.section.6.1.4">
-<a href="#rfc.section.6.1.4">6.1.4.</a> <a href="#requirements_not_covered_cmac_tdes" id="requirements_not_covered_cmac_tdes">CMAC-TDES Requirements Not Covered</a>
+<a href="#rfc.section.6.1.4">6.1.4.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
 </h1>
-<h1 id="rfc.section.6.1.5">
-<a href="#rfc.section.6.1.5">6.1.5.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
-</h1>
-<h1 id="rfc.section.6.1.6">
-<a href="#rfc.section.6.1.6">6.1.6.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
-</h1>
+<p id="rfc.section.6.1.4.p.1">N/A</p>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -406,12 +406,20 @@
 <link href="#rfc.section.5.3.3" rel="Chapter" title="5.3.3 Example HMAC Test Vector JSON Object">
 <link href="#rfc.section.5.4" rel="Chapter" title="5.4 HMAC Test Vector Responses">
 <link href="#rfc.section.5.4.1" rel="Chapter" title="5.4.1 Example HMAC Test Vector Response JSON Object">
-<link href="#rfc.section.6" rel="Chapter" title="6 Acknowledgements">
-<link href="#rfc.section.7" rel="Chapter" title="7 IANA Considerations">
-<link href="#rfc.section.8" rel="Chapter" title="8 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="9 References">
-<link href="#rfc.references.1" rel="Chapter" title="9.1 Normative References">
-<link href="#rfc.references.2" rel="Chapter" title="9.2 Informative References">
+<link href="#rfc.section.6" rel="Chapter" title="6 Test Types and Test Coverage">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Test Coverage">
+<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 CMAC-AES Requirements Covered">
+<link href="#rfc.section.6.1.2" rel="Chapter" title="6.1.2 CMAC-AES Requirements Not Covered">
+<link href="#rfc.section.6.1.3" rel="Chapter" title="6.1.3 CMAC-TDES Requirements Covered">
+<link href="#rfc.section.6.1.4" rel="Chapter" title="6.1.4 CMAC-TDES Requirements Not Covered">
+<link href="#rfc.section.6.1.5" rel="Chapter" title="6.1.5 HMAC Requirements Covered">
+<link href="#rfc.section.6.1.6" rel="Chapter" title="6.1.6 HMAC Requirements Not Covered">
+<link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
+<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
+<link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="10 References">
+<link href="#rfc.references.1" rel="Chapter" title="10.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="10.2 Informative References">
 <link href="#rfc.authors" rel="Chapter">
 
 
@@ -539,17 +547,33 @@
 </li>
 <ul><li>5.4.1.   <a href="#rfc.section.5.4.1">Example HMAC Test Vector Response JSON Object</a>
 </li>
-</ul></ul><li>6.   <a href="#rfc.section.6">Acknowledgements</a>
+</ul></ul><li>6.   <a href="#rfc.section.6">Test Types and Test Coverage</a>
 </li>
-<li>7.   <a href="#rfc.section.7">IANA Considerations</a>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Test Coverage</a>
 </li>
-<li>8.   <a href="#rfc.section.8">Security Considerations</a>
+<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">CMAC-AES Requirements Covered</a>
 </li>
-<li>9.   <a href="#rfc.references">References</a>
+<li>6.1.2.   <a href="#rfc.section.6.1.2">CMAC-AES Requirements Not Covered</a>
 </li>
-<ul><li>9.1.   <a href="#rfc.references.1">Normative References</a>
+<li>6.1.3.   <a href="#rfc.section.6.1.3">CMAC-TDES Requirements Covered</a>
 </li>
-<li>9.2.   <a href="#rfc.references.2">Informative References</a>
+<li>6.1.4.   <a href="#rfc.section.6.1.4">CMAC-TDES Requirements Not Covered</a>
+</li>
+<li>6.1.5.   <a href="#rfc.section.6.1.5">HMAC Requirements Covered</a>
+</li>
+<li>6.1.6.   <a href="#rfc.section.6.1.6">HMAC Requirements Not Covered</a>
+</li>
+</ul></ul><li>7.   <a href="#rfc.section.7">Acknowledgements</a>
+</li>
+<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+</li>
+<li>9.   <a href="#rfc.section.9">Security Considerations</a>
+</li>
+<li>10.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>10.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>10.2.   <a href="#rfc.references.2">Informative References</a>
 </li>
 </ul><li><a href="#rfc.authors">Authors' Addresses</a>
 </li>
@@ -3262,21 +3286,51 @@
             
                         </pre>
 <h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
+<a href="#rfc.section.6">6.</a> <a href="#test_types" id="test_types">Test Types and Test Coverage</a>
 </h1>
-<p id="rfc.section.6.p.1">TBD...</p>
+<p id="rfc.section.6.p.1">The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc.  This section describes the design of the tests used to validate implementations of MAC algorithms.  There is a single test type for MACs (broken into subsections for CMACs).  the single test type, algorithm functional test (AFT) can be described as follows: </p>
+
+<ul class="empty"><li>"AFT" - Algorithm Function Test.  The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an addition "ver" direction present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</li></ul>
+
+<p> </p>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#test_coverage" id="test_coverage">Test Coverage</a>
+</h1>
+<p id="rfc.section.6.1.p.1">The tests described in this document have the intention of ensuring an implementation is conformant to <a href="#SP-800-38B" class="xref">[SP-800-38B]</a> and <a href="#FIPS-198-1" class="xref">[FIPS-198-1]</a>.</p>
+<h1 id="rfc.section.6.1.1">
+<a href="#rfc.section.6.1.1">6.1.1.</a> <a href="#requirements_covered_cmac_aes" id="requirements_covered_cmac_aes">CMAC-AES Requirements Covered</a>
+</h1>
+<h1 id="rfc.section.6.1.2">
+<a href="#rfc.section.6.1.2">6.1.2.</a> <a href="#requirements_not_covered_cmac_aes" id="requirements_not_covered_cmac_aes">CMAC-AES Requirements Not Covered</a>
+</h1>
+<h1 id="rfc.section.6.1.3">
+<a href="#rfc.section.6.1.3">6.1.3.</a> <a href="#requirements_covered_cmac_tdes" id="requirements_covered_cmac_tdes">CMAC-TDES Requirements Covered</a>
+</h1>
+<h1 id="rfc.section.6.1.4">
+<a href="#rfc.section.6.1.4">6.1.4.</a> <a href="#requirements_not_covered_cmac_tdes" id="requirements_not_covered_cmac_tdes">CMAC-TDES Requirements Not Covered</a>
+</h1>
+<h1 id="rfc.section.6.1.5">
+<a href="#rfc.section.6.1.5">6.1.5.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
+</h1>
+<h1 id="rfc.section.6.1.6">
+<a href="#rfc.section.6.1.6">6.1.6.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
+</h1>
 <h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+<a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
-<p id="rfc.section.7.p.1">This memo includes no request to IANA.</p>
+<p id="rfc.section.7.p.1">TBD...</p>
 <h1 id="rfc.section.8">
-<a href="#rfc.section.8">8.</a> <a href="#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.8">8.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.8.p.1">Security considerations are addressed by the ACVP specification.</p>
+<p id="rfc.section.8.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.9">
+<a href="#rfc.section.9">9.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.9.p.1">Security considerations are addressed by the ACVP specification.</p>
 <h1 id="rfc.references">
-<a href="#rfc.references">9.</a> References</h1>
+<a href="#rfc.references">10.</a> References</h1>
 <h1 id="rfc.references.1">
-<a href="#rfc.references.1">9.1.</a> Normative References</h1>
+<a href="#rfc.references.1">10.1.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
@@ -3290,12 +3344,17 @@
 </tr>
 </tbody></table>
 <h1 id="rfc.references.2">
-<a href="#rfc.references.2">9.2.</a> Informative References</h1>
+<a href="#rfc.references.2">10.2.</a> Informative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="CMACVS">[CMACVS]</b></td>
 <td class="top">
 <a title="NIST">Sharon S. Keller, SSK.</a>, "<a>The CMAC Validation System (CMACVS)</a>", 2011.</td>
+</tr>
+<tr>
+<td class="reference"><b id="FIPS-198-1">[FIPS-198-1]</b></td>
+<td class="top">
+<a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.198-1.pdf">The Keyed-Hash Message Authentication Code (HMAC)</a>", 2008.</td>
 </tr>
 <tr>
 <td class="reference"><b id="HMACVS">[HMACVS]</b></td>
@@ -3311,6 +3370,11 @@
 <td class="reference"><b id="SHAVS">[SHAVS]</b></td>
 <td class="top">
 <a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm Validation System (SHAVS)</a>", 2014.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SP-800-38B">[SP-800-38B]</b></td>
+<td class="top">
+<a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf">Recommendation for Block Cipher Modes of Operation: The CMAC Mode for Authentication</a>", 2005.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -378,30 +378,49 @@
 <link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
 <link href="#rfc.section.2" rel="Chapter" title="2 Capabilities Registration">
 <link href="#rfc.section.2.1" rel="Chapter" title="2.1 Required Prerequisite Algorithms for MAC Validations">
-<link href="#rfc.section.2.2" rel="Chapter" title="2.2 MAC Algorithm Capabilities Registration">
-<link href="#rfc.section.2.3" rel="Chapter" title="2.3 Supported MAC Algorithms">
-<link href="#rfc.section.3" rel="Chapter" title="3 Test Vectors">
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Test Groups JSON Schema">
-<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Test Case JSON Schema">
-<link href="#rfc.section.4" rel="Chapter" title="4 Test Vector Responses">
-<link href="#rfc.section.5" rel="Chapter" title="5 Acknowledgements">
-<link href="#rfc.section.6" rel="Chapter" title="6 IANA Considerations">
-<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="8 References">
-<link href="#rfc.references.1" rel="Chapter" title="8.1 Normative References">
-<link href="#rfc.references.2" rel="Chapter" title="8.2 Informative References">
-<link href="#rfc.appendix.A" rel="Chapter" title="A Example MAC Capabilities JSON Object">
-<link href="#rfc.appendix.B" rel="Chapter" title="B Example Test Vectors JSON Object">
-<link href="#rfc.appendix.C" rel="Chapter" title="C Example Test Results JSON Object">
+<link href="#rfc.section.3" rel="Chapter" title="3 CMAC-AES">
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 CMAC-AES Algorithm Capabilities Registration">
+<link href="#rfc.section.3.1.1" rel="Chapter" title="3.1.1 Example CMAC-AES Capabilities JSON Object">
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 CMAC-AES Test Vectors">
+<link href="#rfc.section.3.2.1" rel="Chapter" title="3.2.1 CMAC-AES Test Groups JSON Schema">
+<link href="#rfc.section.3.2.2" rel="Chapter" title="3.2.2 CMAC-AES Test Case JSON Schema">
+<link href="#rfc.section.3.2.3" rel="Chapter" title="3.2.3 Example CMAC-AES Test Vector JSON Object">
+<link href="#rfc.section.3.3" rel="Chapter" title="3.3 CMAC-AES Test Vector Responses">
+<link href="#rfc.section.3.3.1" rel="Chapter" title="3.3.1 Example CMAC-AES Test Vector Response JSON Object">
+<link href="#rfc.section.4" rel="Chapter" title="4 CMAC-TDES">
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 CMAC-TDES Algorithm Capabilities Registration">
+<link href="#rfc.section.4.1.1" rel="Chapter" title="4.1.1 Example CMAC-TDES Capabilities JSON Object">
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 CMAC-TDES Test Vectors">
+<link href="#rfc.section.4.2.1" rel="Chapter" title="4.2.1 CMAC-TDES Test Groups JSON Schema">
+<link href="#rfc.section.4.2.2" rel="Chapter" title="4.2.2 CMAC-TDES Test Case JSON Schema">
+<link href="#rfc.section.4.2.3" rel="Chapter" title="4.2.3 Example CMAC-TDES Test Vector JSON Object">
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 CMAC-TDES Test Vector Responses">
+<link href="#rfc.section.4.3.1" rel="Chapter" title="4.3.1 Example CMAC-TDES Test Vector Response JSON Object">
+<link href="#rfc.section.5" rel="Chapter" title="5 HMAC">
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 HMAC Algorithm Capabilities Registration">
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Supported HMAC Algorithms">
+<link href="#rfc.section.5.2.1" rel="Chapter" title="5.2.1 Example HMAC Capabilities JSON Object">
+<link href="#rfc.section.5.3" rel="Chapter" title="5.3 HMAC Test Vectors">
+<link href="#rfc.section.5.3.1" rel="Chapter" title="5.3.1 HMAC Test Groups JSON Schema">
+<link href="#rfc.section.5.3.2" rel="Chapter" title="5.3.2 HMAC Test Case JSON Schema">
+<link href="#rfc.section.5.3.3" rel="Chapter" title="5.3.3 Example HMAC Test Vector JSON Object">
+<link href="#rfc.section.5.4" rel="Chapter" title="5.4 HMAC Test Vector Responses">
+<link href="#rfc.section.5.4.1" rel="Chapter" title="5.4.1 Example HMAC Test Vector Response JSON Object">
+<link href="#rfc.section.6" rel="Chapter" title="6 Acknowledgements">
+<link href="#rfc.section.7" rel="Chapter" title="7 IANA Considerations">
+<link href="#rfc.section.8" rel="Chapter" title="8 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="9 References">
+<link href="#rfc.references.1" rel="Chapter" title="9.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="9.2 Informative References">
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.10.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-submac-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-08-28" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-8" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
 
@@ -422,10 +441,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">August 28, 2018</td>
+<td class="right">August 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: March 1, 2019</td>
+<td class="left">Expires: February 2, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -440,12 +459,12 @@
 <p>This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification.</p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on March 1, 2019.</p>
+<p>This Internet-Draft will expire on February 2, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -460,37 +479,75 @@
 </li>
 <ul><li>2.1.   <a href="#rfc.section.2.1">Required Prerequisite Algorithms for MAC Validations</a>
 </li>
-<li>2.2.   <a href="#rfc.section.2.2">MAC Algorithm Capabilities Registration</a>
+</ul><li>3.   <a href="#rfc.section.3">CMAC-AES</a>
 </li>
-<li>2.3.   <a href="#rfc.section.2.3">Supported MAC Algorithms</a>
+<ul><li>3.1.   <a href="#rfc.section.3.1">CMAC-AES Algorithm Capabilities Registration</a>
 </li>
-</ul><li>3.   <a href="#rfc.section.3">Test Vectors</a>
+<ul><li>3.1.1.   <a href="#rfc.section.3.1.1">Example CMAC-AES Capabilities JSON Object</a>
 </li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">Test Groups JSON Schema</a>
+</ul><li>3.2.   <a href="#rfc.section.3.2">CMAC-AES Test Vectors</a>
 </li>
-<li>3.2.   <a href="#rfc.section.3.2">Test Case JSON Schema</a>
+<ul><li>3.2.1.   <a href="#rfc.section.3.2.1">CMAC-AES Test Groups JSON Schema</a>
 </li>
-</ul><li>4.   <a href="#rfc.section.4">Test Vector Responses</a>
+<li>3.2.2.   <a href="#rfc.section.3.2.2">CMAC-AES Test Case JSON Schema</a>
 </li>
-<li>5.   <a href="#rfc.section.5">Acknowledgements</a>
+<li>3.2.3.   <a href="#rfc.section.3.2.3">Example CMAC-AES Test Vector JSON Object</a>
 </li>
-<li>6.   <a href="#rfc.section.6">IANA Considerations</a>
+</ul><li>3.3.   <a href="#rfc.section.3.3">CMAC-AES Test Vector Responses</a>
 </li>
-<li>7.   <a href="#rfc.section.7">Security Considerations</a>
+<ul><li>3.3.1.   <a href="#rfc.section.3.3.1">Example CMAC-AES Test Vector Response JSON Object</a>
 </li>
-<li>8.   <a href="#rfc.references">References</a>
+</ul></ul><li>4.   <a href="#rfc.section.4">CMAC-TDES</a>
 </li>
-<ul><li>8.1.   <a href="#rfc.references.1">Normative References</a>
+<ul><li>4.1.   <a href="#rfc.section.4.1">CMAC-TDES Algorithm Capabilities Registration</a>
 </li>
-<li>8.2.   <a href="#rfc.references.2">Informative References</a>
+<ul><li>4.1.1.   <a href="#rfc.section.4.1.1">Example CMAC-TDES Capabilities JSON Object</a>
 </li>
-</ul><li>Appendix A.   <a href="#rfc.appendix.A">Example MAC Capabilities JSON Object</a>
+</ul><li>4.2.   <a href="#rfc.section.4.2">CMAC-TDES Test Vectors</a>
 </li>
-<li>Appendix B.   <a href="#rfc.appendix.B">Example Test Vectors JSON Object</a>
+<ul><li>4.2.1.   <a href="#rfc.section.4.2.1">CMAC-TDES Test Groups JSON Schema</a>
 </li>
-<li>Appendix C.   <a href="#rfc.appendix.C">Example Test Results JSON Object</a>
+<li>4.2.2.   <a href="#rfc.section.4.2.2">CMAC-TDES Test Case JSON Schema</a>
 </li>
-<li><a href="#rfc.authors">Author's Address</a>
+<li>4.2.3.   <a href="#rfc.section.4.2.3">Example CMAC-TDES Test Vector JSON Object</a>
+</li>
+</ul><li>4.3.   <a href="#rfc.section.4.3">CMAC-TDES Test Vector Responses</a>
+</li>
+<ul><li>4.3.1.   <a href="#rfc.section.4.3.1">Example CMAC-TDES Test Vector Response JSON Object</a>
+</li>
+</ul></ul><li>5.   <a href="#rfc.section.5">HMAC</a>
+</li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">HMAC Algorithm Capabilities Registration</a>
+</li>
+<li>5.2.   <a href="#rfc.section.5.2">Supported HMAC Algorithms</a>
+</li>
+<ul><li>5.2.1.   <a href="#rfc.section.5.2.1">Example HMAC Capabilities JSON Object</a>
+</li>
+</ul><li>5.3.   <a href="#rfc.section.5.3">HMAC Test Vectors</a>
+</li>
+<ul><li>5.3.1.   <a href="#rfc.section.5.3.1">HMAC Test Groups JSON Schema</a>
+</li>
+<li>5.3.2.   <a href="#rfc.section.5.3.2">HMAC Test Case JSON Schema</a>
+</li>
+<li>5.3.3.   <a href="#rfc.section.5.3.3">Example HMAC Test Vector JSON Object</a>
+</li>
+</ul><li>5.4.   <a href="#rfc.section.5.4">HMAC Test Vector Responses</a>
+</li>
+<ul><li>5.4.1.   <a href="#rfc.section.5.4.1">Example HMAC Test Vector Response JSON Object</a>
+</li>
+</ul></ul><li>6.   <a href="#rfc.section.6">Acknowledgements</a>
+</li>
+<li>7.   <a href="#rfc.section.7">IANA Considerations</a>
+</li>
+<li>8.   <a href="#rfc.section.8">Security Considerations</a>
+</li>
+<li>9.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>9.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>9.2.   <a href="#rfc.references.2">Informative References</a>
+</li>
+</ul><li><a href="#rfc.authors">Author's Address</a>
 </li>
 
 
@@ -498,19 +555,19 @@
 
   <h1 id="rfc.section.1">
 <a href="#rfc.section.1">1.</a> Introduction</h1>
-<p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module.  The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more.  The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms.  Each sub-specification addresses a specific class of crypto algorithms.  This sub-specification defines the JSON constructs for testing HMAC and CMAC crypto algorithms using ACVP.</p>
+<p id="rfc.section.1.p.1">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module. The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more. The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation. A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms.  Each sub-specification addresses a specific class of crypto algorithms. This sub-specification defines the JSON constructs for testing HMAC and CMAC crypto algorithms using ACVP.</p>
 <h1 id="rfc.section.1.1">
 <a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
-<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
+<p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>. </p>
 <h1 id="rfc.section.2">
 <a href="#rfc.section.2">2.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
 </h1>
-<p id="rfc.section.2.p.1">ACVP requires crypto modules to register their capabilities.  This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  This section describes the constructs for advertising support of HMAC and CMAC algorithms to the ACVP server.</p>
-<p id="rfc.section.2.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message.  The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section.  The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP specification for details on the registration message.  Each algorithm capability advertised is a self-contained JSON object. </p>
+<p id="rfc.section.2.p.1">ACVP requires crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of HMAC and CMAC algorithms to the ACVP server.</p>
+<p id="rfc.section.2.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message. Each algorithm capability advertised is a self-contained JSON object. </p>
 <h1 id="rfc.section.2.1">
 <a href="#rfc.section.2.1">2.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for MAC Validations</a>
 </h1>
-<p id="rfc.section.2.1.p.1">Each MAC implementation relies on other cryptographic primitives.  For example, CMAC uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<p id="rfc.section.2.1.p.1">Each MAC implementation relies on other cryptographic primitives. For example, CMAC uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
 <div id="rfc.table.1"></div>
 <div id="rereqs_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -560,14 +617,17 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.2.2">
-<a href="#rfc.section.2.2">2.2.</a> <a href="#mac_caps_reg" id="mac_caps_reg">MAC Algorithm Capabilities Registration</a>
+<h1 id="rfc.section.3">
+<a href="#rfc.section.3">3.</a> <a href="#cmac_aes_root" id="cmac_aes_root">CMAC-AES</a>
 </h1>
-<p id="rfc.section.2.2.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<h1 id="rfc.section.3.1">
+<a href="#rfc.section.3.1">3.1.</a> <a href="#cmac_aes_caps_reg" id="cmac_aes_caps_reg">CMAC-AES Algorithm Capabilities Registration</a>
+</h1>
+<p id="rfc.section.3.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
 <div id="rfc.table.2"></div>
-<div id="caps_table2"></div>
+<div id="cmac_aes_caps_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>MAC Algorithm Capabilities JSON Values</caption>
+<caption>CMAC-AES Algorithm Capabilities JSON Values</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -578,9 +638,23 @@
 <tbody>
 <tr>
 <td class="left">algorithm</td>
-<td class="left">The MAC algorithm and mode to be validated.</td>
+<td class="left">The MAC algorithm to be validated.</td>
 <td class="left">value</td>
-<td class="left">See						<a href="#supported_algs" class="xref">Section 2.3</a> </td>
+<td class="left">CMAC</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">The mode to be validated.</td>
+<td class="left">value</td>
+<td class="left">AES</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -592,9 +666,9 @@
 </tr>
 <tr>
 <td class="left">prereqVals</td>
-<td class="left">prerequistie algorithm validations, See						<a href="#app-reg-ex" class="xref">Appendix A</a> for examples</td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 2.1</a> for examples </td>
 <td class="left">array of prereqAlgVal objects</td>
-<td class="left">See						<a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -605,8 +679,37 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">capabilities</td>
+<td class="left">The CMAC-AES capabilities </td>
+<td class="left">array of capability objects</td>
+<td class="left">See <a href="#cmac_aes_capabilities" class="xref">Table 3</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.3.1.p.2">Each capability object describes a separate permutation of direction and key length.</p>
+<div id="rfc.table.3"></div>
+<div id="cmac_aes_capabilities"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
 <td class="left">direction</td>
-<td class="left">The MAC direction(s) to test. Only applies to CMAC.</td>
+<td class="left">The MAC direction(s) to test.</td>
 <td class="left">array</td>
 <td class="left">gen, ver</td>
 <td class="left">No</td>
@@ -620,38 +723,10 @@
 </tr>
 <tr>
 <td class="left">keyLen</td>
-<td class="left">The keyLen Domain supported by the IUT in bits. (HMAC only)</td>
-<td class="left">Domain</td>
-<td class="left">8-524288</td>
-<td class="left">Yes (required for HMAC)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">keyLen</td>
-<td class="left">The array of keyLens supported by the IUT in bits. (CMAC-AES only)</td>
-<td class="left">array</td>
+<td class="left">The keyLen supported</td>
+<td class="left">value</td>
 <td class="left">128, 192, 256</td>
-<td class="left">Yes (required for CMAC-AES)</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">keyingOption</td>
-<td class="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).  Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1).</td>
-<td class="left">array</td>
-<td class="left">1, 2</td>
-<td class="left">Yes (required for CMAC-TDES)</td>
+<td class="left">No</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -662,10 +737,10 @@
 </tr>
 <tr>
 <td class="left">msgLen</td>
-<td class="left">The CMAC message lengths supported in bits.  Min/max/increment and values must be mod 8.</td>
+<td class="left">The CMAC message lengths supported in bits. Min/max/increment and values must be mod 8.</td>
 <td class="left">Domain</td>
 <td class="left">0-524288</td>
-<td class="left">Yes</td>
+<td class="left">No</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -676,7 +751,1897 @@
 </tr>
 <tr>
 <td class="left">macLen</td>
-<td class="left">The supported mac sizes. (range dependent on algorithm, see						<a href="#supported_algs" class="xref">Section 2.3</a> ).</td>
+<td class="left">The supported mac sizes.</td>
+<td class="left">Domain</td>
+<td class="left">32-128</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.3.1.p.3">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p></p>
+
+<ul>
+<li>The smallest CMAC length supported</li>
+<li>A second CMAC length supported</li>
+<li>The largest CMAC length supported</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.3.1.p.5">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p></p>
+
+<ul>
+<li>The smallest message length supported</li>
+<li>Two message lengths divisible by block size</li>
+<li>Two message lengths NOT divisible by block size</li>
+<li>The largest message length supported</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.3.1.1">
+<a href="#rfc.section.3.1.1">3.1.1.</a> <a href="#cmac_aes_app-reg-ex" id="cmac_aes_app-reg-ex">Example CMAC-AES Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.3.1.1.p.1">The following is an example JSON object advertising support for CMAC-AES.</p>
+<pre>
+                            
+{
+  "algorithm": "CMAC",
+  "mode": "AES",
+  "capabilities": [
+    {
+      "direction": "gen",
+      "keyLen": 128,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 128,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "gen",
+      "keyLen": 192,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 192,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "gen",
+      "keyLen": 256,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 256,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    }
+  ]
+}
+            
+                        </pre>
+<h1 id="rfc.section.3.2">
+<a href="#rfc.section.3.2">3.2.</a> <a href="#cmac_aes_test_vectors" id="cmac_aes_test_vectors">CMAC-AES Test Vectors</a>
+</h1>
+<p id="rfc.section.3.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
+<p id="rfc.section.3.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<div id="rfc.table.4"></div>
+<div id="cmac_aes_vs_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Vector Set JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The algorithm used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">The mode used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#cmac_aes_tgjs" class="xref">Section 3.2.1</a> </td>
+<td class="left">array</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.3.2.1">
+<a href="#rfc.section.3.2.1">3.2.1.</a> <a href="#cmac_aes_tgjs" id="cmac_aes_tgjs">CMAC-AES Test Groups JSON Schema</a>
+</h1>
+<p id="rfc.section.3.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<div id="rfc.table.5"></div>
+<div id="cmac_aes_vs_tg_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Test Group JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">Numeric identifier for the test group, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testType</td>
+<td class="left">Test category type (AFT)</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The direction of the tests - gen or ver</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">Length of key in bits to use</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msgLen</td>
+<td class="left">Length of message/hash in bits</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">macLen</td>
+<td class="left">Length of MAC in bits to generate/verify</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#cmac_aes_tvjs" class="xref">Section 3.2.2</a> </td>
+<td class="left">array</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.3.2.2">
+<a href="#rfc.section.3.2.2">3.2.2.</a> <a href="#cmac_aes_tvjs" id="cmac_aes_tvjs">CMAC-AES Test Case JSON Schema</a>
+</h1>
+<p id="rfc.section.3.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<div id="rfc.table.6"></div>
+<div id="cmac_aes_vs_tc_table2"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">key</td>
+<td class="left">Encryption key to use AES</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msg</td>
+<td class="left">Value of the message</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mac</td>
+<td class="left">MAC value, for CMAC verify</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.3.2.3">
+<a href="#rfc.section.3.2.3">3.2.3.</a> <a href="#cmac_aes_test_vector_json" id="cmac_aes_test_vector_json">Example CMAC-AES Test Vector JSON Object</a>
+</h1>
+<p id="rfc.section.3.2.3.p.1">The following is an example JSON test vector object for CMAC-AES.</p>
+<pre>
+                            
+{
+    "vsId": 1,
+	"algorithm": "CMAC",
+	"mode": "AES",
+	"testGroups": [{
+			"tgId": 4,
+			"testType": "AFT",
+			"direction": "gen",
+			"keyLen": 128,
+			"msgLen": 2752,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 25,
+					"key": "E2547E38B28B2C24892C133FF4770688",
+					"message": "89DE09D747FB4B2669B59759A15BAAF068CAF31FD938DFCFFB38ECED53BA91DD659FD91E6CCCFEC5F972B1AD66BF78FE7FE319E58F514362FC75A346C144981B63FD18195A2AD482AF83711C9ADC449F7EAD32EBD5F4DB7EB93348404EAD496B8F4C89AB5FF7ACB2CFEFD96BD0FC9645B6F1F30AB02767ECA8771106DCA47188EE42183121FB9172B8E2133DE084F6CA3924E4BF3638ADA77DAAA6F06A6494E32CBAEFC6C6D0699BB12A425DCFE5974F687B6A71879D42DE08DF018A96429CFA40E32378D35E46A4956C5D7916B6877F353D33075FD4C64F32C3250D74FF070EA358135664CD8C9B82C9454EED75A12EEC758A9E514053533A884560FAC96DDBBA4AEEB8E473F4BFDB8447B22800D7782320D6E2DAC2599111F8CA598D6720CA7C6E4FC5EDC54FC3576460AAD1644B04E1D2C81B93EA49090FDB7E33374C243B2F19177405B94BEC3C69CC24CC686D8F2B01A6B2A350E394"
+				},
+				{
+					"tcId": 26,
+					"key": "D1D99979CD96C3401291905F53B2ECA4",
+					"message": "6D054A7D1CD161B21F80E6586E5821DDA97451D98F815663932872720BD2156752EA650AE0EC4AB9FEE5635B1CCF1B123CF0247D2487BCD3102B6A668B5F9882DB03278A6B5DCECDF176604B55668FFD8EFED2A454F16A7A75D168AFBA3C305E31B8C1ABCCAA110E94796F8F0231A479DA25A2BCBECA3A9DAFF4357C6C63476106627DF9DF692231BA906E8F8E196FAA4DD412019D36C1AEB2A015EFDCCB9E0308FDA871DBF14DED263FF28079ED3DC4E411470A664F5EAED458EB2D564971AD10E77DCCDE53BB95DF7951FCE595079ECD6C394D78AFEB85CA87C596872D66783BD816808B0B311E5EC0BA52D5283699EE725ABDC2AD85266808D80F72195599CB27241B2FF6112829FCFBFDD5548EA29637B0DCC731A060F345769D335B1B5ABE90A664CBCCD19F4F21EE630E786BDFA60C6A8D731329718CEFE80095604918600976413334AE01C524F0F0A22D50DB460CFE7D737B6334"
+				},
+				{
+					"tcId": 27,
+					"key": "672556E105B83BF39FC9E45268BD35D1",
+					"message": "39A3DD0652483A26FB9D71F30A5E29D326627FE16E29E3A3BF8EDF68645B477B5DE88499EDB3CF9E036F3D0D316241EE7C569F74925AD0BD3DCBBA21E73D9638ABA2554C4CA62AC5D7113B3FE7216E79AFC7A6FB94F21EB234D0401879A6B03EAE242EA0DCF1B523513467B00C048E7DE333C8977C455DD943323D01C97CF93EC24843769E52AD785E2340F2CC61E571D2099472E47286F29BCDF28A69144692263312F176618777A6AD0A0338F8A636BCA6150F0E1F72D539BAD726C95425682678EA7297A118E819A2925747C0AD72F3BCDF8E7D6C0A11A6AA938E4AA119390451C4E56B99F29C34927C1830197FCD4921C7E38E29BAEA5E560C8A3D4D7B96BBC370C78EF794BA9F6DB737576867B334D1DCC537D4FD751952DDFF549109ECCAD38198CCB49F25E7FEB88B9FD33D3B56601B473946693C5C3D7B2D1C7BB857F9560B94A3BD145019150BA11159B39480F97B0DE90243D6"
+				},
+				{
+					"tcId": 28,
+					"key": "1E220113298DA3B30E14F1432C16FCE8",
+					"message": "497E82B322B18B0295F3B4359AC0CFAF1D36B46F36C9E123B95B90985B06AC6AFAFB772E21CCA4665CEABFF9C1CE3D78F804BEBAC6F171C0ADA47FC718E7EC55EC7603D739C8B4DBF07B60A78A8EC83922A880485B99E0FED2B1F7D5A895E2BD9149888A085F21794C1953A6EF4471A47A285CFAA57E9F75000B375A4100F5432150ECFC3342627FA325C7FB0EE0090A0B39D69ED9030E7D46BBCC6ADFC49F14156187F94F7DDE50C736FEB3FCE530CC76171EE1150AA5A94A3B79119329B5A1D9C3E03EAC7F212A1AECA97EAD58B8BFCD5F94946578D8F5A0347970A7F93C70B4AB0BB5A4FE2B0AAC8459ED0045DDC3AC210ACF996A4DE478853CD88ACEAE73D9A9C48A1B64E0D82F2EFFB25C517BDD0C033E566C16197835271A85D65A38AB37B63E7B23E9C7EA7777E6B3E3820C930B1333C279E5291724E774E34F574F15E1E23568E486F03FC6B83B962E3E60A90A69DD26701A8D6C"
+				},
+				{
+					"tcId": 29,
+					"key": "B2EDB3F5189E14E1E860A8B70D5CF676",
+					"message": "EAF87567D104DF3DA93312EEB0B695409E927F6D2EF287AC12130AC82082D600DDCFDD0074DF3CFB41CE347FAC8BEADAA522D7CE33E539C7F8E9470E00210CDDB3BF799B913B627561B35368BA80955A210AE92C5F89C0566A6E3BD6559DAE9537EE0042E60BE58E4F3757F43CA43634C09CABAEB644CCB30260A776C9B2ACB8A7900DF0B556F7CDB9A0712C3CC2B711E505880156552645DFB598DDD99E2FC06394B6F3B51C3A499E0204DD89AB699A3E8015F9720F4D5D84C30CEF9F95CFBE7DFAD7A55DF591FBFFFB10A3B3AA08EBA53873A95CADBA3A3913E947173945AFA6B88791970ED2B12972A62D4A86716D0A2429E4447676058C6EB42FA6BB6DA5295B2A2518130FCF1CB81FD3B247A9EE438F0284DF6E0AD0DEA0A4A7DDEF6A48465974F375B5FD0DA809534F4654A53116921F1004B3FF9E4E9FDA1520B8D86F0766285878BF8062A00638DE0C5970B9B6C560B65F71AF6E"
+				},
+				{
+					"tcId": 30,
+					"key": "7BD39F41F80079D7D0DC0154F833086A",
+					"message": "AB1311F60133E446CEF81973E4FC67DB365441AD367BA0E38AFD564F137AE8AC7ED0C64551EBC7A5A5F49765835C67A33F38BA1A3EFDA4725962E2C9D9893A665D9CD04BA0A613F06F7FAADBEDF9466CC62FD84DE146494E1C67EB65DC362450CF855FC9C92DD217869B60874CC0D944C7BEFFFDDA09ECBC66997873BE9A8BD007F79CC73E0E2BC52DB257CD02B0E794DAAAFF68062C476B4C9DD7F4F3FFCADE6863383455B3EEC727062A2175395A3E8D6C738878F4333F2BF27A2DD653CC57D4CC065DEE75014D32785D3A6B725DC7CBAE47BF579EAB6FC126A95701214084409594D20025ECD52CCA272364F466D4497C4F16D80CED689F0783DB4B2D185A9CC12FD247A6431AC51FCC44074B774402F584197BDD466F68DC794440B1F5F80F2F6FDB3968CACE95CBF41E7C5544194CC38D412627890B9D683A1175D9E6B93E499A4C64C4088F36AA4105E8E3D8A2EEEE1E266A3441A9"
+				},
+				{
+					"tcId": 31,
+					"key": "64F8BD1CC49FD16A4DF0253F31917ED4",
+					"message": "340104D85093FDB0740B597207D25496D5670CAF006507470783EFE2071E2026CE2C333D86F5E7BBDA91F2440C4589366BE8C337CA0B59683E8ACD384FD842675066B79008BF7F989FD7BB5ACE46D2D5BB3EBB4985708D85BD3CFC058D869295ECC18ADF1A4475263249A7579117A53B905BBFE26E2E29DA46D1D57DE6B1E2462E4C71738262307A212978AE4BD35792BAE2B770CDC1E25D350C424BBF9650ABF8F22BE9A95F1E47CC8CA4518C5EE7881C9414365DDB3959361AD3A0A9FC07C57B050D335B7426CE19144B061B197809ADEC47C75BCBB00525865ED02E375C1793BF6A05679574645B6F020EE15EE094EB02D706149B85E50A74C8CFD9823E1B222C65FCAD630B84F25C62E0B1BB7AED5637526C537F44F9BC1869721966C1BE50B3C95B4C37CC3D6E2A85589441FE73E7E2369A418ECFEB88B2337AA179AF77B5F622B02E62CF8CD294FB226ACCABF0920AECC9DD76B572"
+				},
+				{
+					"tcId": 32,
+					"key": "AF2B918C3CC53D064688E1A517A33D2C",
+					"message": "8FC205EB22775C0570A1867E3FB6E2FCF2A743171107190B89CE8A2A04C1B46A0D45781207AAB25BEC6C55F35E21F662F660C68BED54DD08D40C95D4D24872C595E49F3519D85DB933306BEF10EE181FA25C727787494FAD7A91EA6563E58B575C65E2774098BF69D74DD53D015899BF71F9B95EA0CE2A775BE0CED8423507086E6C48A9AE89195CBB1345B1C0AB8D496A2D9A6AEEFAC4A40F900159F47A7C1DFF96E88EA104EC0C64A858657239085C3AC353BE53069E57FBE9AE9B967D041478B8EBC908C70CBEEBEE718D51C08EBD2C97D7F98EF4D6EA5FF156ADC2D8FAD535AA2501F734F411BCE2B329F0FE485297707490523ABE9DB9E2FEFCD8C8A09E18628B9912262DA0282A334D9290CC5DED2F7662771237C144382724D51C3BF02F45BABD5B35810ED3EBA38AFC03D6E107D31814B8D0E4D21FE7CF9434018BCCB42F506971D33106432F325BE456A914CD5C2561E8F01F80"
+				}
+			]
+		},
+		{
+			"tgId": 10,
+			"testType": "AFT",
+			"direction": "ver",
+			"keyLen": 128,
+			"msgLen": 0,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 73,
+					"key": "D5E09A89B2A4627BF987517B66A51564",
+					"message": "",
+					"mac": "CBBC968859633C24"
+				},
+				{
+					"tcId": 74,
+					"key": "646A150116ABAA37662FE9D8BB278693",
+					"message": "",
+					"mac": "21D069331196E579"
+				},
+				{
+					"tcId": 75,
+					"key": "5C185C01FBC57A40FC373F199374D1CC",
+					"message": "",
+					"mac": "9507F00153543DE6"
+				},
+				{
+					"tcId": 76,
+					"key": "4E3A4C7AE2DCA644FF752B8B74CACEF8",
+					"message": "",
+					"mac": "6D58E6464497A9B4"
+				},
+				{
+					"tcId": 77,
+					"key": "BA924D356A696E97BEF0477A9D600FCE",
+					"message": "",
+					"mac": "93FEA54132999B1D"
+				},
+				{
+					"tcId": 78,
+					"key": "DA877E0EFC098E1EAD8B2DC61A5B98D5",
+					"message": "",
+					"mac": "24E6ED4D00D7122C"
+				},
+				{
+					"tcId": 79,
+					"key": "61698DB0B49E2F252849590E940CBCF3",
+					"message": "",
+					"mac": "2C531F92D23D6B2B"
+				},
+				{
+					"tcId": 80,
+					"key": "BE149E46BE89BF16BDDE41D1A494AEA4",
+					"message": "",
+					"mac": "7A858023143F6B98"
+				},
+				{
+					"tcId": 81,
+					"key": "9A9F006EF8EDFDA0F1113FC6FEF2E84D",
+					"message": "",
+					"mac": "C0750CD586472C8A"
+				},
+				{
+					"tcId": 82,
+					"key": "F68A91DE6AC099F7D72D7B211245D8D9",
+					"message": "",
+					"mac": "C91C3DCC36F2BC21"
+				},
+				{
+					"tcId": 83,
+					"key": "23E9BEA8C4F14330B2836FDD0B6E803F",
+					"message": "",
+					"mac": "F884E64E0CA4D34F"
+				},
+				{
+					"tcId": 84,
+					"key": "02636CC18751A5CF27C56D2C69793BC4",
+					"message": "",
+					"mac": "1D5F5531BA263CC2"
+				},
+				{
+					"tcId": 85,
+					"key": "46D7DA4F123C37F05FC269FCF92B1FC1",
+					"message": "",
+					"mac": "06D743483812AAB4"
+				},
+				{
+					"tcId": 86,
+					"key": "C28DD76F2A31C90EE4A91313CB7D4ECC",
+					"message": "",
+					"mac": "09B6D2C848F8C9FD"
+				},
+				{
+					"tcId": 87,
+					"key": "810BAE6E85149F244179CA7F1488353B",
+					"message": "",
+					"mac": "68D7AFF612EAEDB4"
+				},
+				{
+					"tcId": 88,
+					"key": "C67C04544E0DDDE14FAE608135909FED",
+					"message": "",
+					"mac": "E9B7FE8ECF21DDD7"
+				},
+				{
+					"tcId": 89,
+					"key": "D9D5B9D32533DB3276BE4FFF3D79374A",
+					"message": "",
+					"mac": "081BAFA11BFDF238"
+				},
+				{
+					"tcId": 90,
+					"key": "D8A05E45602DD6ACBE989BD0F26CED9E",
+					"message": "",
+					"mac": "D84F8EE112352837"
+				},
+				{
+					"tcId": 91,
+					"key": "E09B79F64B11F00B48081EEEA0482821",
+					"message": "",
+					"mac": "4D927CED15907953"
+				},
+				{
+					"tcId": 92,
+					"key": "24B7BE1D4F72AE1A1C5FBDB2A3AC8287",
+					"message": "",
+					"mac": "548CBD558D8F6E3A"
+				}
+			]
+		}
+	]
+}
+            
+                        </pre>
+<h1 id="rfc.section.3.3">
+<a href="#rfc.section.3.3">3.3.</a> <a href="#cmac_aes_vector_responses" id="cmac_aes_vector_responses">CMAC-AES Test Vector Responses</a>
+</h1>
+<p id="rfc.section.3.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.7"></div>
+<div id="cmac_aes_vr_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Vector Set Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of JSON objects that represent each test vector group. See <a href="#cmac_aes_vr_group_table" class="xref">Table 8</a> </td>
+<td class="left">array</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.3.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<div id="rfc.table.8"></div>
+<div id="cmac_aes_vr_group_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Vector Set Group Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">The test group Id</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">The tests associated to the group specified in tgId</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.3.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<div id="rfc.table.9"></div>
+<div id="cmac_aes_vs_tr_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-AES Test Case Results JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mac</td>
+<td class="left">value of the computed MAC output</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testPassed</td>
+<td class="left">The result of CMAC verify</td>
+<td class="left">boolean</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.3.3.1">
+<a href="#rfc.section.3.3.1">3.3.1.</a> <a href="#cmac_aes_test_vector_response_json" id="cmac_aes_test_vector_response_json">Example CMAC-AES Test Vector Response JSON Object</a>
+</h1>
+<p id="rfc.section.3.3.1.p.1">The following is an example JSON test vector response object for CMAC-AES.</p>
+<pre>
+                            
+{
+	"vsId": 1,
+    "algorithm": "CMAC",
+    "mode": "AES",
+	"testGroups": [{
+			"tgId": 4,
+			"tests": [{
+					"tcId": 25,
+					"mac": "7AA2D56A0AE76620"
+				},
+				{
+					"tcId": 26,
+					"mac": "9E23524D3CD18C93"
+				},
+				{
+					"tcId": 27,
+					"mac": "4D51872CBFAA102A"
+				},
+				{
+					"tcId": 28,
+					"mac": "027BCA655EC9ACEB"
+				},
+				{
+					"tcId": 29,
+					"mac": "A86D99B6121507A6"
+				},
+				{
+					"tcId": 30,
+					"mac": "25E5F000F2B1E071"
+				},
+				{
+					"tcId": 31,
+					"mac": "F2DBA25F9A903C80"
+				},
+				{
+					"tcId": 32,
+					"mac": "1D35816BD32CA4DB"
+				}
+			]
+		},
+		{
+			"tgId": 10,
+			"tests": [{
+					"tcId": 73,
+					"testPassed": true
+				},
+				{
+					"tcId": 74,
+					"testPassed": true
+				},
+				{
+					"tcId": 75,
+					"testPassed": true
+				},
+				{
+					"tcId": 76,
+					"testPassed": true
+				},
+				{
+					"tcId": 77,
+					"testPassed": false
+				},
+				{
+					"tcId": 78,
+					"testPassed": true
+				},
+				{
+					"tcId": 79,
+					"testPassed": true
+				},
+				{
+					"tcId": 80,
+					"testPassed": true
+				},
+				{
+					"tcId": 81,
+					"testPassed": true
+				},
+				{
+					"tcId": 82,
+					"testPassed": true
+				},
+				{
+					"tcId": 83,
+					"testPassed": true
+				},
+				{
+					"tcId": 84,
+					"testPassed": true
+				},
+				{
+					"tcId": 85,
+					"testPassed": true
+				},
+				{
+					"tcId": 86,
+					"testPassed": false
+				},
+				{
+					"tcId": 87,
+					"testPassed": true
+				},
+				{
+					"tcId": 88,
+					"testPassed": false
+				},
+				{
+					"tcId": 89,
+					"testPassed": true
+				},
+				{
+					"tcId": 90,
+					"testPassed": false
+				},
+				{
+					"tcId": 91,
+					"testPassed": false
+				},
+				{
+					"tcId": 92,
+					"testPassed": false
+				}
+			]
+		}
+	]
+}
+            
+                        </pre>
+<h1 id="rfc.section.4">
+<a href="#rfc.section.4">4.</a> <a href="#cmac_tdes_root" id="cmac_tdes_root">CMAC-TDES</a>
+</h1>
+<h1 id="rfc.section.4.1">
+<a href="#rfc.section.4.1">4.1.</a> <a href="#cmac_tdes_caps_reg" id="cmac_tdes_caps_reg">CMAC-TDES Algorithm Capabilities Registration</a>
+</h1>
+<p id="rfc.section.4.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<div id="rfc.table.10"></div>
+<div id="cmac_tdes_caps_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Algorithm Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The MAC algorithm to be validated.</td>
+<td class="left">value</td>
+<td class="left">CMAC</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">The mode to be validated.</td>
+<td class="left">value</td>
+<td class="left">TDES</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqVals</td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 2.1</a> for examples </td>
+<td class="left">array of prereqAlgVal objects</td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">capabilities</td>
+<td class="left">The CMAC-TDES capabilities </td>
+<td class="left">array of capability objects</td>
+<td class="left">See <a href="#cmac_tdes_capabilities" class="xref">Table 11</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<div id="rfc.table.11"></div>
+<div id="cmac_tdes_capabilities"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">direction</td>
+<td class="left">The MAC direction(s) to test.</td>
+<td class="left">array</td>
+<td class="left">gen, ver</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyingOption</td>
+<td class="left">The Keying Option used in TDES. Keying option 1 (1) is 3 distinct keys (K1, K2, K3). Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1). Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1).</td>
+<td class="left">value</td>
+<td class="left">1, 2</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msgLen</td>
+<td class="left">The CMAC message lengths supported in bits. Min/max/increment and values must be mod 8.</td>
+<td class="left">Domain</td>
+<td class="left">0-524288</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">macLen</td>
+<td class="left">The supported mac sizes.</td>
+<td class="left">Domain</td>
+<td class="left">32-64</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.4.1.p.2">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p></p>
+
+<ul>
+<li>The smallest CMAC length supported</li>
+<li>A second CMAC length supported</li>
+<li>The largest CMAC length supported</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.4.1.p.4">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p></p>
+
+<ul>
+<li>The smallest message length supported</li>
+<li>Two message lengths divisible by block size</li>
+<li>Two message lengths NOT divisible by block size</li>
+<li>The largest message length supported</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.4.1.1">
+<a href="#rfc.section.4.1.1">4.1.1.</a> <a href="#cmac_tdes_app-reg-ex" id="cmac_tdes_app-reg-ex">Example CMAC-TDES Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.4.1.1.p.1">The following is an example JSON object advertising support for CMAC-TDES.</p>
+<pre>
+                            
+{
+  "algorithm": "CMAC",
+  "mode": "TDES",
+  "capabilities": [
+    {
+      "direction": "gen",
+      "keyingOption": 1,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 32,
+          "max": 64,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyingOption": 1,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 32,
+          "max": 64,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 32,
+          "max": 64,
+          "increment": 8
+        }
+      ]
+    }
+  ]
+}
+            
+                        </pre>
+<h1 id="rfc.section.4.2">
+<a href="#rfc.section.4.2">4.2.</a> <a href="#cmac_tdes_test_vectors" id="cmac_tdes_test_vectors">CMAC-TDES Test Vectors</a>
+</h1>
+<p id="rfc.section.4.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-TDES, etc. This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
+<p id="rfc.section.4.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<div id="rfc.table.12"></div>
+<div id="cmac_tdes_vs_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Vector Set JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The algorithm used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">The mode used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#cmac_tdes_tgjs" class="xref">Section 4.2.1</a> </td>
+<td class="left">array</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.4.2.1">
+<a href="#rfc.section.4.2.1">4.2.1.</a> <a href="#cmac_tdes_tgjs" id="cmac_tdes_tgjs">CMAC-TDES Test Groups JSON Schema</a>
+</h1>
+<p id="rfc.section.4.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<div id="rfc.table.13"></div>
+<div id="cmac_tdes_vs_tg_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Test Group JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">Numeric identifier for the test group, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testType</td>
+<td class="left">Test category type (AFT)</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The direction of the tests - gen or ver</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">Length of key in bits to use</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msgLen</td>
+<td class="left">Length of message/hash in bits</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">macLen</td>
+<td class="left">Length of MAC in bits to generate/verify</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#cmac_tdes_tvjs" class="xref">Section 4.2.2</a> </td>
+<td class="left">array</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.4.2.2">
+<a href="#rfc.section.4.2.2">4.2.2.</a> <a href="#cmac_tdes_tvjs" id="cmac_tdes_tvjs">CMAC-TDES Test Case JSON Schema</a>
+</h1>
+<p id="rfc.section.4.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<div id="rfc.table.14"></div>
+<div id="cmac_tdes_vs_tc_table2"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">key1, key2, key3</td>
+<td class="left">Encryption keys to use for TDES</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">msg</td>
+<td class="left">Value of the message</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mac</td>
+<td class="left">MAC value, for CMAC verify</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.4.2.3">
+<a href="#rfc.section.4.2.3">4.2.3.</a> <a href="#cmac_tdes_test_vector_json" id="cmac_tdes_test_vector_json">Example CMAC-TDES Test Vector JSON Object</a>
+</h1>
+<p id="rfc.section.4.2.3.p.1">The following is an example JSON test vector object for CMAC-TDES.</p>
+<pre>
+                            
+{
+	"vsId": 1,
+	"algorithm": "CMAC",
+	"mode": "TDES",
+	"testGroups": [{
+			"tgId": 4,
+			"testType": "AFT",
+			"direction": "gen",
+			"keyLen": 192,
+			"msgLen": 752,
+			"macLen": 32,
+			"tests": [{
+					"tcId": 25,
+					"key": "7FFDB31A3A06BF0D5201FFE83CC5253EBBECA60F1D631BB8",
+					"message": "4D2D07AE0224289BE111E0D4522A8AC127FAD537D7D4240613A73EA23CA673F8DC554B4C8CC69699C1DCB638D06FCA54D858DF68F595B7987A937599BDEA77974AB1441D7E63190762CBCD8E6D9F9A8940FB8DB43EBDAA2172C9B0A5CDF9",
+					"key1": "7FFDB31A3A06BF0D",
+					"key2": "5201FFE83CC5253E",
+					"key3": "BBECA60F1D631BB8"
+				},
+				{
+					"tcId": 26,
+					"key": "82E572E29C84009E28390918155E4891A0D24C94C306FE56",
+					"message": "7A70F3CE17598AC3553FBADA0CC562018FD40C6D25B098EC0B905B1BC9F67DFCBD797494E4B05E2C6C3C0F655F9E95FFFE16782E1454A5EE04D87E7586F7FF65A51979A1C46118080320C1CB9E9CC48A05E113C95C2316361B39F5FCB861",
+					"key1": "82E572E29C84009E",
+					"key2": "28390918155E4891",
+					"key3": "A0D24C94C306FE56"
+				},
+				{
+					"tcId": 27,
+					"key": "662A89E47D86F6A0CB9D612E199B4AD2AE3AEBA19FAB4340",
+					"message": "2DAF1E213A6AE9E88FEBC70458AACBFB9B668EB22F12662B281D29A57B568CA35146E073D6B4BECB3E10AD8D398CADF672464707207FB40D23F4D6F93528F83D79019106A03D41E26DAE32E3208920FE165FCD739305A4E24D81B118972C",
+					"key1": "662A89E47D86F6A0",
+					"key2": "CB9D612E199B4AD2",
+					"key3": "AE3AEBA19FAB4340"
+				},
+				{
+					"tcId": 28,
+					"key": "522729A011C73BE2079D67ECEBFCE42EF5F91F6ECD43F71E",
+					"message": "7F1170A442EEAFCAFD00925C8BD2DB22AB2458AAAB6F6C2B061EB56F005DAC0D11392ADAA0E07FF6074208E22D5E07F4C4B9A1C9DDFD2FAAEB1185C2E5B60D06E2BFBB92C6A0DC4CED36A8DB19583D8BE09A260E638FCCCDCBF17A7D2D6D",
+					"key1": "522729A011C73BE2",
+					"key2": "079D67ECEBFCE42E",
+					"key3": "F5F91F6ECD43F71E"
+				},
+				{
+					"tcId": 29,
+					"key": "B5FE32A150833A60A8C619C2A89BD8BCD8DFB2654AEB4923",
+					"message": "839733866DC749C9F2F3756E02FB1FEAAF0BC47814CD52159EE1AA1945F50D789483E4705437482712F26FE8505233638B9004A2938669670888BEB5EF5BBB62DBC6C0355FAB7BB4AE57FE7E345A9E5D9699750157E83F55B8431CD0ECF6",
+					"key1": "B5FE32A150833A60",
+					"key2": "A8C619C2A89BD8BC",
+					"key3": "D8DFB2654AEB4923"
+				},
+				{
+					"tcId": 30,
+					"key": "C2406CA7AA81A4A6FBB0D6A665B0D1410445F4CC132F46E6",
+					"message": "95FC92BAC8AE751818427F2090B3BCC76BD1A5A3CAE6C5B914AF59DA589BDED6A2CF0B7A17CB659B46C9FF3163AFEC505D3BBBAF42AD9FA077AA862E49BBE21773E3CF7C031A022681E85169873C639ADDA2953AB352B9724B0F941AF2E6",
+					"key1": "C2406CA7AA81A4A6",
+					"key2": "FBB0D6A665B0D141",
+					"key3": "0445F4CC132F46E6"
+				},
+				{
+					"tcId": 31,
+					"key": "AE90AF3424A99A304F0D54B1FDAAAA5B4D026169F067D997",
+					"message": "AECC231068148AE400B1F1922684C681FBEC9C836B1593BB0805C8A38340564C1CA39C341588913C3E425934B8D219FED6D58553BC3AE44B003999FA51C8265AE6AA653F839C56813F58BD4F6093F5A2FF196CAA9A3CF782E21FD06C0AD0",
+					"key1": "AE90AF3424A99A30",
+					"key2": "4F0D54B1FDAAAA5B",
+					"key3": "4D026169F067D997"
+				},
+				{
+					"tcId": 32,
+					"key": "B10CCB821E63EF98928D1BC20D797C5E9149B32BFC090140",
+					"message": "B19716D364D0680873D83F4991839465C169CADA64D5B57454ADDCDA64D1778219B204571593C5965E8F84C373CF0DBD10F4C8124D932FB6EF2B662966C698F79CB3199E40A45A8A7C186E948CA5A0BAD743A1FDC91336325145FC701D41",
+					"key1": "B10CCB821E63EF98",
+					"key2": "928D1BC20D797C5E",
+					"key3": "9149B32BFC090140"
+				}
+			],
+			"keyingOption": 1
+		},
+		{
+			"tgId": 10,
+			"testType": "AFT",
+			"direction": "ver",
+			"keyLen": 192,
+			"msgLen": 0,
+			"macLen": 32,
+			"tests": [{
+					"tcId": 73,
+					"key": "D127F902CFF69A82785D99EF117E5B5636D4CB2C34A3AF30",
+					"message": "",
+					"mac": "D78010B3",
+					"key1": "D127F902CFF69A82",
+					"key2": "785D99EF117E5B56",
+					"key3": "36D4CB2C34A3AF30"
+				},
+				{
+					"tcId": 74,
+					"key": "9D5DAC4D75E0A3496A55855C62D8C767CBD9FC7CCBDA8BE9",
+					"message": "",
+					"mac": "5313D9E8",
+					"key1": "9D5DAC4D75E0A349",
+					"key2": "6A55855C62D8C767",
+					"key3": "CBD9FC7CCBDA8BE9"
+				},
+				{
+					"tcId": 75,
+					"key": "B711BA268A1F3663AA83B2195E85BFC6AA1CFBC128AAE0FD",
+					"message": "",
+					"mac": "07B1926F",
+					"key1": "B711BA268A1F3663",
+					"key2": "AA83B2195E85BFC6",
+					"key3": "AA1CFBC128AAE0FD"
+				},
+				{
+					"tcId": 76,
+					"key": "4DB908F0A14A3959AC76D38D171114CA3651F7FF9C9B20B5",
+					"message": "",
+					"mac": "7C920795",
+					"key1": "4DB908F0A14A3959",
+					"key2": "AC76D38D171114CA",
+					"key3": "3651F7FF9C9B20B5"
+				},
+				{
+					"tcId": 77,
+					"key": "670AB0529BCE3007BDC7706FED307419291C6BA004943806",
+					"message": "",
+					"mac": "7988C839",
+					"key1": "670AB0529BCE3007",
+					"key2": "BDC7706FED307419",
+					"key3": "291C6BA004943806"
+				},
+				{
+					"tcId": 78,
+					"key": "62AA8060A173FD6A19FB1E39C09914E8453D89A318FEAA0A",
+					"message": "",
+					"mac": "14B588F8",
+					"key1": "62AA8060A173FD6A",
+					"key2": "19FB1E39C09914E8",
+					"key3": "453D89A318FEAA0A"
+				},
+				{
+					"tcId": 79,
+					"key": "9B954C62C795DD599807683D5531A513E88406D75B04CDC9",
+					"message": "",
+					"mac": "9BDD8078",
+					"key1": "9B954C62C795DD59",
+					"key2": "9807683D5531A513",
+					"key3": "E88406D75B04CDC9"
+				},
+				{
+					"tcId": 80,
+					"key": "E085046DF6F97A3D9B00E3EA82482EBFA1DCA6EC94ACFD7E",
+					"message": "",
+					"mac": "D44BA0CD",
+					"key1": "E085046DF6F97A3D",
+					"key2": "9B00E3EA82482EBF",
+					"key3": "A1DCA6EC94ACFD7E"
+				},
+				{
+					"tcId": 81,
+					"key": "526DE285D64F65A20F2E9F52E789AD59E6AE85200F95501F",
+					"message": "",
+					"mac": "F068F177",
+					"key1": "526DE285D64F65A2",
+					"key2": "0F2E9F52E789AD59",
+					"key3": "E6AE85200F95501F"
+				},
+				{
+					"tcId": 82,
+					"key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
+					"message": "",
+					"mac": "317B4969",
+					"key1": "97FBEF5ADADC68CC",
+					"key2": "DD5BAFB50853589E",
+					"key3": "DF4918593D29F5C0"
+				},
+				{
+					"tcId": 83,
+					"key": "1D80CD109B749DCE6AF893051C0969B6705A264BFA49F2B2",
+					"message": "",
+					"mac": "FAFE8358",
+					"key1": "1D80CD109B749DCE",
+					"key2": "6AF893051C0969B6",
+					"key3": "705A264BFA49F2B2"
+				},
+				{
+					"tcId": 84,
+					"key": "B48C715C2B4EB7F5D0865F7ABC0BFD1F2CD83EA54C5136D7",
+					"message": "",
+					"mac": "F456798B",
+					"key1": "B48C715C2B4EB7F5",
+					"key2": "D0865F7ABC0BFD1F",
+					"key3": "2CD83EA54C5136D7"
+				},
+				{
+					"tcId": 85,
+					"key": "A8944ECE678BBFFD45C1557E59A6044352EF3B8808FD54DC",
+					"message": "",
+					"mac": "7CEEF54C",
+					"key1": "A8944ECE678BBFFD",
+					"key2": "45C1557E59A60443",
+					"key3": "52EF3B8808FD54DC"
+				},
+				{
+					"tcId": 86,
+					"key": "B6CA0DD41423786CD0E524E69C2D21DE81522CB976796269",
+					"message": "",
+					"mac": "02E9CDE5",
+					"key1": "B6CA0DD41423786C",
+					"key2": "D0E524E69C2D21DE",
+					"key3": "81522CB976796269"
+				},
+				{
+					"tcId": 87,
+					"key": "C2A4D041516F0B7535D37F2B55FB38CFB75F24285D7BEF39",
+					"message": "",
+					"mac": "4A099862",
+					"key1": "C2A4D041516F0B75",
+					"key2": "35D37F2B55FB38CF",
+					"key3": "B75F24285D7BEF39"
+				},
+				{
+					"tcId": 88,
+					"key": "3F9879C2259E2C6E0E75799EC99FA126E9A59029ADCD6B7C",
+					"message": "",
+					"mac": "CB1FC90C",
+					"key1": "3F9879C2259E2C6E",
+					"key2": "0E75799EC99FA126",
+					"key3": "E9A59029ADCD6B7C"
+				},
+				{
+					"tcId": 89,
+					"key": "5059F4B1CA3C438F56FF7F3115E2B7ACC0970ADF892FBBA0",
+					"message": "",
+					"mac": "6F5CFAEC",
+					"key1": "5059F4B1CA3C438F",
+					"key2": "56FF7F3115E2B7AC",
+					"key3": "C0970ADF892FBBA0"
+				},
+				{
+					"tcId": 90,
+					"key": "DE8EB157BCE06D7A318ECE3D7E96B586FDDC6097E61C4F48",
+					"message": "",
+					"mac": "E67871E3",
+					"key1": "DE8EB157BCE06D7A",
+					"key2": "318ECE3D7E96B586",
+					"key3": "FDDC6097E61C4F48"
+				},
+				{
+					"tcId": 91,
+					"key": "840A1C616D0D776BFAF99C1444507BACD11881E87C8E0329",
+					"message": "",
+					"mac": "C2D06FE4",
+					"key1": "840A1C616D0D776B",
+					"key2": "FAF99C1444507BAC",
+					"key3": "D11881E87C8E0329"
+				},
+				{
+					"tcId": 92,
+					"key": "1A29B0ED9040FD2D6A7D20A4DF50E290AB1D497EC1D211AA",
+					"message": "",
+					"mac": "B5E61275",
+					"key1": "1A29B0ED9040FD2D",
+					"key2": "6A7D20A4DF50E290",
+					"key3": "AB1D497EC1D211AA"
+				}
+			],
+			"keyingOption": 1
+		}
+	]
+}
+            
+                        </pre>
+<h1 id="rfc.section.4.3">
+<a href="#rfc.section.4.3">4.3.</a> <a href="#cmac_tdes_vector_responses" id="cmac_tdes_vector_responses">CMAC-TDES Test Vector Responses</a>
+</h1>
+<p id="rfc.section.4.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.15"></div>
+<div id="cmac_tdes_vr_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Vector Set Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of JSON objects that represent each test vector group. See <a href="#cmac_tdes_vr_group_table" class="xref">Table 16</a> </td>
+<td class="left">array</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.4.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<div id="rfc.table.16"></div>
+<div id="cmac_tdes_vr_group_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Vector Set Group Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">The test group Id</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">The tests associated to the group specified in tgId</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.4.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<div id="rfc.table.17"></div>
+<div id="cmac_tdes_vs_tr_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>CMAC-TDES Test Case Results JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mac</td>
+<td class="left">value of the computed MAC output</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testPassed</td>
+<td class="left">The result of CMAC verify</td>
+<td class="left">boolean</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.4.3.1">
+<a href="#rfc.section.4.3.1">4.3.1.</a> <a href="#cmac_tdes_test_vector_response_json" id="cmac_tdes_test_vector_response_json">Example CMAC-TDES Test Vector Response JSON Object</a>
+</h1>
+<p id="rfc.section.4.3.1.p.1">The following is an example JSON test vector response object for CMAC-TDES.</p>
+<pre>
+                            
+{
+    "vsId": 1,
+	"algorithm": "CMAC",
+	"mode": "TDES",
+	"testGroups": [{
+			"tgId": 4,
+			"tests": [{
+					"tcId": 25,
+					"mac": "6FA27FDC"
+				},
+				{
+					"tcId": 26,
+					"mac": "89CE2842"
+				},
+				{
+					"tcId": 27,
+					"mac": "5E03D980"
+				},
+				{
+					"tcId": 28,
+					"mac": "EC68CA91"
+				},
+				{
+					"tcId": 29,
+					"mac": "ACAEF07C"
+				},
+				{
+					"tcId": 30,
+					"mac": "2207C5DF"
+				},
+				{
+					"tcId": 31,
+					"mac": "95248097"
+				},
+				{
+					"tcId": 32,
+					"mac": "33325023"
+				}
+			]
+		},
+		{
+			"tgId": 10,
+			"tests": [{
+					"tcId": 73,
+					"testPassed": true
+				},
+				{
+					"tcId": 74,
+					"testPassed": true
+				},
+				{
+					"tcId": 75,
+					"testPassed": true
+				},
+				{
+					"tcId": 76,
+					"testPassed": true
+				},
+				{
+					"tcId": 77,
+					"testPassed": false
+				},
+				{
+					"tcId": 78,
+					"testPassed": true
+				},
+				{
+					"tcId": 79,
+					"testPassed": true
+				},
+				{
+					"tcId": 80,
+					"testPassed": true
+				},
+				{
+					"tcId": 81,
+					"testPassed": false
+				},
+				{
+					"tcId": 82,
+					"testPassed": true
+				},
+				{
+					"tcId": 83,
+					"testPassed": true
+				},
+				{
+					"tcId": 84,
+					"testPassed": true
+				},
+				{
+					"tcId": 85,
+					"testPassed": true
+				},
+				{
+					"tcId": 86,
+					"testPassed": true
+				},
+				{
+					"tcId": 87,
+					"testPassed": true
+				},
+				{
+					"tcId": 88,
+					"testPassed": false
+				},
+				{
+					"tcId": 89,
+					"testPassed": true
+				},
+				{
+					"tcId": 90,
+					"testPassed": false
+				},
+				{
+					"tcId": 91,
+					"testPassed": true
+				},
+				{
+					"tcId": 92,
+					"testPassed": true
+				}
+			]
+		}
+	]
+}
+            
+                        </pre>
+<h1 id="rfc.section.5">
+<a href="#rfc.section.5">5.</a> <a href="#hmac_root" id="hmac_root">HMAC</a>
+</h1>
+<h1 id="rfc.section.5.1">
+<a href="#rfc.section.5.1">5.1.</a> <a href="#hmac_caps_reg" id="hmac_caps_reg">HMAC Algorithm Capabilities Registration</a>
+</h1>
+<p id="rfc.section.5.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<div id="rfc.table.18"></div>
+<div id="hmac_caps_table2"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>HMAC Algorithm Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The MAC algorithm and mode to be validated.</td>
+<td class="left">value</td>
+<td class="left">See <a href="#hmac_supported_algs" class="xref">Section 5.2</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqVals</td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 2.1</a> for examples </td>
+<td class="left">array of prereqAlgVal objects</td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 2.1</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">The keyLen Domain supported by the IUT in bits.</td>
+<td class="left">Domain</td>
+<td class="left">8-524288</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">macLen</td>
+<td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#hmac_supported_algs" class="xref">Section 5.2</a>). </td>
 <td class="left">Domain</td>
 <td class="left">32-512</td>
 <td class="left">No</td>
@@ -690,46 +2655,34 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.2.2.p.2">Note: Some optional values are required depending on the algorithm. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</p>
-<p id="rfc.section.2.2.p.3">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.5.1.p.2">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
-<li>2 values below the Hash's block length. See							<a href="#supported_algs" class="xref">Section 2.3</a> </li>
+<li>2 values below the Hash's block length. See <a href="#hmac_supported_algs" class="xref">Section 5.2</a> </li>
 <li>The Hash's block length.</li>
 <li>2 values above the Hash's block length.</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.2.2.p.5">macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.5.1.p.4">macLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
-<li>The smallest CMAC length supported</li>
-<li>A second CMAC length supported</li>
-<li>The largest CMAC length supported</li>
+<li>The smallest HMAC length supported</li>
+<li>A second HMAC length supported</li>
+<li>The largest HMAC length supported</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.2.2.p.7">msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</p>
-<p></p>
-
-<ul>
-<li>The smallest message length supported</li>
-<li>Two message lengths divisible by block size</li>
-<li>Two message lengths NOT divisible by block size</li>
-<li>The largest message length supported</li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.section.2.3">
-<a href="#rfc.section.2.3">2.3.</a> <a href="#supported_algs" id="supported_algs">Supported MAC Algorithms</a>
+<h1 id="rfc.section.5.2">
+<a href="#rfc.section.5.2">5.2.</a> <a href="#hmac_supported_algs" id="hmac_supported_algs">Supported HMAC Algorithms</a>
 </h1>
-<p id="rfc.section.2.3.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
-<div id="rfc.table.3"></div>
-<div id="table_algInfo"></div>
+<p id="rfc.section.5.2.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.19"></div>
+<div id="hmac_table_algInfo"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Algorithms w/ block size and max MAC length.</caption>
+<caption>Algorithms w/ block size and max CMAC length.</caption>
 <thead><tr>
 <th class="left">Algorithm Value</th>
 <th class="left">Block Length</th>
@@ -846,37 +2799,42 @@
 <td class="left"></td>
 <td class="left"></td>
 </tr>
-<tr>
-<td class="left">CMAC-AES</td>
-<td class="left">128</td>
-<td class="left">128</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">CMAC-TDES</td>
-<td class="left">64</td>
-<td class="left">64</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3">
-<a href="#rfc.section.3">3.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+<h1 id="rfc.section.5.2.1">
+<a href="#rfc.section.5.2.1">5.2.1.</a> <a href="#hmac_app-reg-ex" id="hmac_app-reg-ex">Example HMAC Capabilities JSON Object</a>
 </h1>
-<p id="rfc.section.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc.  This section describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</p>
-<p id="rfc.section.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
-<div id="rfc.table.4"></div>
-<div id="vs_top_table"></div>
+<p id="rfc.section.5.2.1.p.1">The following is an example JSON object advertising support for HMAC.</p>
+<pre>
+                            
+{
+  "algorithm": "HMAC-SHA-1",
+  "keyLen": [
+    {
+      "min": 8,
+      "max": 2048,
+      "increment": 8
+    }
+  ],
+  "macLen": [
+    {
+      "min": 80,
+      "max": 160,
+      "increment": 8
+    }
+  ]
+}
+            
+                        </pre>
+<h1 id="rfc.section.5.3">
+<a href="#rfc.section.5.3">5.3.</a> <a href="#hmac_test_vectors" id="hmac_test_vectors">HMAC Test Vectors</a>
+</h1>
+<p id="rfc.section.5.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC crypto algorithms.</p>
+<p id="rfc.section.5.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<div id="rfc.table.20"></div>
+<div id="hmac_vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Vector Set JSON Object</caption>
+<caption>HMAC Vector Set JSON Object</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -905,7 +2863,7 @@
 </tr>
 <tr>
 <td class="left">algorithm</td>
-<td class="left">The algorithm and mode used for the test vectors.  See					<a href="#supported_algs" class="xref">Section 2.3</a> for possible values.</td>
+<td class="left">The algorithm and mode used for the test vectors. See <a href="#hmac_supported_algs" class="xref">Section 5.2</a> for possible values. </td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -915,19 +2873,19 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in					<a href="#tgjs" class="xref">Section 3.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#hmac_tgjs" class="xref">Section 5.3.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3.1">
-<a href="#rfc.section.3.1">3.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
+<h1 id="rfc.section.5.3.1">
+<a href="#rfc.section.5.3.1">5.3.1.</a> <a href="#hmac_tgjs" id="hmac_tgjs">HMAC Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set.  For instance, all test vectors that use the same key size would be grouped together.  The Test Group JSON object contains meta data that applies to all test vectors within the group.  The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
-<div id="rfc.table.5"></div>
-<div id="vs_tg_table"></div>
+<p id="rfc.section.5.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<div id="rfc.table.21"></div>
+<div id="hmac_vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Test Group JSON Object</caption>
+<caption>HMAC Test Group JSON Object</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -960,22 +2918,10 @@
 <td class="left"></td>
 </tr>
 <tr>
-<td class="left">direction</td>
-<td class="left">The direction of the tests - gen or ver - only applies to CMAC</td>
-<td class="left">value</td>
-<td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
 <td class="left">keyLen</td>
 <td class="left">Length of key in bits to use</td>
 <td class="left">value</td>
-<td class="left">Yes</td>
+<td class="left">No</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1009,20 +2955,20 @@
 </tr>
 <tr>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in						<a href="#tvjs" class="xref">Section 3.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#hmac_tvjs" class="xref">Section 5.3.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.3.2">
-<a href="#rfc.section.3.2">3.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
+<h1 id="rfc.section.5.3.2">
+<a href="#rfc.section.5.3.2">5.3.2.</a> <a href="#hmac_tvjs" id="hmac_tvjs">HMAC Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.3.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each secure MAC test vector.</p>
-<div id="rfc.table.6"></div>
-<div id="vs_tc_table2"></div>
+<p id="rfc.section.5.3.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<div id="rfc.table.22"></div>
+<div id="hmac_vs_tc_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Test Case JSON Object</caption>
+<caption>HMAC Test Case JSON Object</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -1044,21 +2990,9 @@
 </tr>
 <tr>
 <td class="left">key</td>
-<td class="left">Encryption key to use AES</td>
+<td class="left">The value of the key</td>
 <td class="left">value</td>
 <td class="left">No</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">key1, key2, key3</td>
-<td class="left">Encryption keys to use for TDES</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1078,22 +3012,86 @@
 <td class="left"></td>
 <td class="left"></td>
 </tr>
-<tr>
-<td class="left">mac</td>
-<td class="left">MAC value, for CMAC verify</td>
-<td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
 </tbody>
 </table>
-<h1 id="rfc.section.4">
-<a href="#rfc.section.4">4.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
+<h1 id="rfc.section.5.3.3">
+<a href="#rfc.section.5.3.3">5.3.3.</a> <a href="#hmac_test_vector_json" id="hmac_test_vector_json">Example HMAC Test Vector JSON Object</a>
 </h1>
-<p id="rfc.section.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.7"></div>
-<div id="vr_top_table"></div>
+<p id="rfc.section.5.3.3.p.1">The following is an example JSON test vector object for HMAC.</p>
+<pre>
+                            
+{
+    "vsId": 1,
+	"algorithm": "HMAC-SHA-1",
+	"testGroups": [{
+		"tgId": 1,
+		"testType": "AFT",
+		"keyLen": 56,
+		"msgLen": 128,
+		"macLen": 80,
+		"tests": [{
+				"tcId": 1,
+				"key": "0CBB3AA866E4D1",
+				"msg": "28CD4091D45F28CD5709CC9B6F1E9D0D"
+			},
+			{
+				"tcId": 2,
+				"key": "7FB3F60ACB9FB7",
+				"msg": "9F224BF653F9BE143FFA0518D12761F7"
+			},
+			{
+				"tcId": 3,
+				"key": "3834463234DA39",
+				"msg": "F0FA740D261D5916B06F09AFBB04C94E"
+			},
+			{
+				"tcId": 4,
+				"key": "ED97154BE9D252",
+				"msg": "4B491408D929C33980C13091FF95DCD7"
+			},
+			{
+				"tcId": 5,
+				"key": "24D8F9E20EA536",
+				"msg": "DD0919DF2CDCB622E95D60E2E93E2B14"
+			},
+			{
+				"tcId": 6,
+				"key": "9AE463E4D85480",
+				"msg": "DF4653D381B8FFF3B507A5B28708DCF2"
+			},
+			{
+				"tcId": 7,
+				"key": "E82C2306DADB20",
+				"msg": "ABD9D90C4C912FC1F4208E8DC82C316A"
+			},
+			{
+				"tcId": 8,
+				"key": "98262DE8011B43",
+				"msg": "79DD85559EF4C577DE8808B875398A36"
+			},
+			{
+				"tcId": 9,
+				"key": "064251F70AD327",
+				"msg": "6719543EF69843BA4421EA9730470539"
+			},
+			{
+				"tcId": 10,
+				"key": "3B1887195138EC",
+				"msg": "F1D7716FFF84F4472E2214DAA1662583"
+			}
+		]
+	}]
+}
+            
+                        </pre>
+<h1 id="rfc.section.5.4">
+<a href="#rfc.section.5.4">5.4.</a> <a href="#hmac_vector_responses" id="hmac_vector_responses">HMAC Test Vector Responses</a>
+</h1>
+<p id="rfc.section.5.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.23"></div>
+<div id="hmac_vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Vector Set Response JSON Object</caption>
+<caption>HMAC Vector Set Response JSON Object</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -1122,7 +3120,7 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of JSON objects that represent each test vector group. See					<a href="#vr_group_table" class="xref">Table 8</a> </td>
+<td class="left">Array of JSON objects that represent each test vector group. See <a href="#hmac_vr_group_table" class="xref">Table 24</a> </td>
 <td class="left">array</td>
 </tr>
 <tr>
@@ -1132,11 +3130,11 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors.  Several algorithms SHALL require the client to send back group level properties in their response.  This structure helps accommodate that.</p>
-<div id="rfc.table.8"></div>
-<div id="vr_group_table"></div>
+<p id="rfc.section.5.4.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<div id="rfc.table.24"></div>
+<div id="hmac_vr_group_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Vector Set Group Response JSON Object</caption>
+<caption>HMAC Vector Set Group Response JSON Object</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -1165,11 +3163,11 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.p.3">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each DRBG test vector.</p>
-<div id="rfc.table.9"></div>
-<div id="vs_tr_table"></div>
+<p id="rfc.section.5.4.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<div id="rfc.table.25"></div>
+<div id="hmac_vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>MAC Test Case Results JSON Object</caption>
+<caption>HMAC Test Case Results JSON Object</caption>
 <thead><tr>
 <th class="left">JSON Value</th>
 <th class="left">Description</th>
@@ -1193,19 +3191,7 @@
 <td class="left">mac</td>
 <td class="left">value of the computed MAC output</td>
 <td class="left">value</td>
-<td class="left">Yes</td>
-</tr>
-<tr>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-<td class="left"></td>
-</tr>
-<tr>
-<td class="left">testPassed</td>
-<td class="left">The result of CMAC verify</td>
-<td class="left">boolean</td>
-<td class="left">Yes</td>
+<td class="left">No</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1215,22 +3201,78 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
+<h1 id="rfc.section.5.4.1">
+<a href="#rfc.section.5.4.1">5.4.1.</a> <a href="#hmac_test_vector_response_json" id="hmac_test_vector_response_json">Example HMAC Test Vector Response JSON Object</a>
 </h1>
-<p id="rfc.section.5.p.1">TBD...</p>
+<p id="rfc.section.5.4.1.p.1">The following is an example JSON test vector response object for HMAC.</p>
+<pre>
+                            
+{
+	"vsId": 1,
+	"algorithm": "HMAC-SHA-1",
+	"testGroups": [{
+		"tgId": 1,
+		"tests": [{
+				"tcId": 1,
+				"mac": "0970D053D6829C251070"
+			},
+			{
+				"tcId": 2,
+				"mac": "3A476E0407D7ADF14792"
+			},
+			{
+				"tcId": 3,
+				"mac": "5B219B4C4862242DB175"
+			},
+			{
+				"tcId": 4,
+				"mac": "07A689738031C215C55C"
+			},
+			{
+				"tcId": 5,
+				"mac": "1A2633ADC7D119FBCD67"
+			},
+			{
+				"tcId": 6,
+				"mac": "4C41990B6E99AA39D03F"
+			},
+			{
+				"tcId": 7,
+				"mac": "9097773C9429DA776C16"
+			},
+			{
+				"tcId": 8,
+				"mac": "2F86E2DF1E5D65793373"
+			},
+			{
+				"tcId": 9,
+				"mac": "AE7222EA6DA826814612"
+			},
+			{
+				"tcId": 10,
+				"mac": "3CA58B0FA50E7EC66D0D"
+			}
+		]
+	}]
+}
+            
+                        </pre>
 <h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+<a href="#rfc.section.6">6.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
-<p id="rfc.section.6.p.1">This memo includes no request to IANA.</p>
+<p id="rfc.section.6.p.1">TBD...</p>
 <h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.7">7.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.7.p.1">Security considerations are addressed by the ACVP specification.</p>
+<p id="rfc.section.7.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.8">
+<a href="#rfc.section.8">8.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.8.p.1">Security considerations are addressed by the ACVP specification.</p>
 <h1 id="rfc.references">
-<a href="#rfc.references">8.</a> References</h1>
+<a href="#rfc.references">9.</a> References</h1>
 <h1 id="rfc.references.1">
-<a href="#rfc.references.1">8.1.</a> Normative References</h1>
+<a href="#rfc.references.1">9.1.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
@@ -1240,11 +3282,11 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.references.2">
-<a href="#rfc.references.2">8.2.</a> Informative References</h1>
+<a href="#rfc.references.2">9.2.</a> Informative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="CMACVS">[CMACVS]</b></td>
@@ -1267,284 +3309,6 @@
 <a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm Validation System (SHAVS)</a>", 2014.</td>
 </tr>
 </tbody></table>
-<h1 id="rfc.appendix.A">
-<a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example MAC Capabilities JSON Object</a>
-</h1>
-<p id="rfc.section.A.p.1">The following is an example JSON object advertising support for HMAC-SHA-1.</p>
-<pre>
-
-
-            {
-                "algorithm": "HMAC-SHA2-256",
-                "prereqVals" : [{"algorithm" : "SHA", "valValue" : "123456"}],
-                "keyLen": [ { "min": 256, "max": 2048, "increment": 8 } ],
-                "macLen": [ 192 ]
-            }
-            				</pre>
-<p id="rfc.section.A.p.2">The following is an example JSON object advertising support for CMAC-AES.</p>
-<pre>
-
-
-            {
-                "algorithm": "CMAC-AES",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-		                {"algorithm" : "TDES", "valValue" : "123456"}],
-                "direction" : [ "gen", "ver" ],
-                "keyLen" : [ 128, 192 ],
-                "macLen" : [ 64 ],
-                "msgLen" : [ 0 ]
-            }
-            				</pre>
-<p id="rfc.section.A.p.3">The following is an example JSON object advertising support for CMAC-TDES.</p>
-<pre>
-
-
-            {
-                "algorithm": "CMAC-TDES",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-		                {"algorithm" : "TDES", "valValue" : "123456"}],
-                "direction" : [ "gen", "ver" ],
-                "keyingOption" : [ 1, 2 ],
-                "macLen" : [ 8, 64 ],
-                "msgLen" : [ 0, 256, 120, 248, 320 ]
-            }
-            				</pre>
-<h1 id="rfc.appendix.B">
-<a href="#rfc.appendix.B">Appendix B.</a> <a href="#app-vs-ex" id="app-vs-ex">Example Test Vectors JSON Object</a>
-</h1>
-<p id="rfc.section.B.p.1">The following is an example JSON object for HMAC test vectors sent from the ACVP server to the crypto module.</p>
-<pre>
-[{
-		"acvVersion": &lt;acvp-version&gt;
-	},
-	{
-		"vsId": 1565,
-		"algorithm": "HMAC-SHA-1",
-		"testGroups": [{
-			"tgId": 1,
-			"testType": "AFT",
-			"keyLen": 256,
-			"msgLen": 160,
-			"macLen": 80,
-			"tests": [{
-					"tcId": 2172,
-					"key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-					"msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-				},
-				{
-					"tcId": 2173,
-					"key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-					"msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-				}
-			]
-		}]
-	}
-]
-            				</pre>
-<p id="rfc.section.B.p.2">The following is an example JSON object for CMAC-AES test vectors sent from the ACVP server to the crypto module.</p>
-<pre>
-[{
-		"acvVersion": &lt;acvp-version&gt;
-	},
-	{
-		"vsId": 3500,
-		"algorithm": "CMAC-AES",
-		"testGroups": [{
-			"tgId": 1,
-			"testType": "AFT",
-			"direction": "gen",
-			"keyLen": 128,
-			"msgLen": 0,
-			"macLen": 64,
-			"tests": [{
-					"tcId": 2750,
-					"key": "f28effca41cb11819a81eb3ebf3b7e83",
-					"msg": ""
-				},
-				{
-					"tcId": 2751,
-					"key": "ab566f4af532efc8bc56555fe07696fd",
-					"msg": ""
-				}
-			]
-		}]
-	},
-	{
-		"tgId": 2,
-		"testType": "AFT",
-		"direction": "ver",
-		"keyLen": 128,
-		"msgLen": 0,
-		"macLen": 64,
-		"tests": [{
-				"tcId": 2752,
-				"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-				"msg": "",
-				"mac": "2eef1e38fcc7c568"
-			},
-			{
-				"tcId": 2753,
-				"key": "eb87fb7a5fb60caecb9b23564befe513",
-				"msg": "",
-				"mac": "cafecafecafecafe"
-			}
-		]
-	}
-]
-            				</pre>
-<p id="rfc.section.B.p.3">The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP server to the crypto module.</p>
-<pre>
-[{
-		"acvVersion": &lt;acvp-version&gt;
-	},
-	{
-		"vsId": 1566,
-		"algorithm": "CMAC-TDES",
-		"testGroups": [{
-				"tgId": 1,
-				"testType": "AFT",
-				"direction": "gen",
-				"keyingOption": 1,
-				"msgLen": 0,
-				"macLen": 40,
-				"tests": [{
-						"tcId": 2175,
-						"key1": "c479f813ad1a45d5",
-						"key2": "dc43459da4c85e85",
-						"key3": "1cda518af886bf1f",
-						"msg": ""
-					},
-					{
-						"tcId": 2176,
-						"key1": "731331866754588f",
-						"key2": "d332ef51e0ce1925",
-						"key3": "d586cba70440f44f",
-						"msg": ""
-					}
-				]
-			},
-			{
-				"tgId": 2,
-				"testType": "AFT",
-				"direction": "ver",
-				"keyingOption": 1,
-				"msgLen": 0,
-				"macLen": 40,
-				"tests": [{
-						"tcId": 2177,
-						"key1": "d586cba70440f44f",
-						"key2": "d332ef51e0ce1925",
-						"key3": "dc43459da4c85e85",
-						"msg": "",
-						"mac": "cafecafecafecafecafecafecafecafecafecafe"
-					},
-					{
-						"tcId": 2177,
-						"key1": "dc43459da4c85e85",
-						"key2": "c479f813ad1a45d5",
-						"key3": "1cda518af886bf1f",
-						"msg": "",
-						"mac": "cafecafecafecafecafecafecafecafecafecafe"
-					}
-				]
-			}
-		]
-	}
-]
-            				</pre>
-<h1 id="rfc.appendix.C">
-<a href="#rfc.appendix.C">Appendix C.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Object</a>
-</h1>
-<p id="rfc.section.C.p.1">The following is an example JSON object for HMAC test results sent from the crypto module to the ACVP server.</p>
-<pre>
-[{
-		"acvVersion": &lt;acvp-version&gt;
-	},
-	{
-		"vsId": 1565,
-		"testGroups": [{
-			"tgId": 1,
-			"tests": [{
-					"tcId": 2172,
-					"mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
-				},
-				{
-					"tcId": 2173,
-					"mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-				}
-			]
-		}]
-	}
-]
-            				</pre>
-<p id="rfc.section.C.p.2">The following is an example JSON object for CMAC-AES test results sent from the crypto module to the ACVP server.</p>
-<pre>
-[{
-		"acvVersion": &lt;acvp-version&gt;
-	},
-	{
-		"vsId": 3500,
-		"testGroups": [{
-			"tgId": 1,
-			"tests": [{
-					"tcId": 2750,
-					"mac": "e77145f0d6c77ad5"
-				},
-				{
-					"tcId": 2751,
-					"mac": "6b078f7e53b6d183"
-				}
-			]
-		}, {
-			"tgId": 2,
-			"tests": [{
-					"tcId": 2752,
-					"testPassed": true
-				},
-				{
-					"tcId": 2753,
-					"testPassed": false
-				}
-			]
-		}]
-	}
-]
-            				</pre>
-<p id="rfc.section.C.p.3">The following is an example JSON object for CMAC-TDES test results sent from the crypto module to the ACVP server.</p>
-<pre>
-[{
-		"acvVersion": &lt;acvp-version&gt;
-	},
-	{
-		"vsId": 1566,
-		"testGroups": [{
-				"tgId": 1,
-				"tests": [{
-						"tcId": 2175,
-						"mac": "fea01c84a7"
-					},
-					{
-						"tcId": 2176,
-						"mac": "164bdb8582"
-					}
-				]
-			},
-			{
-				"tgId": 2,
-				"tests": [{
-						"tcId": 2177,
-						"testPassed": false
-					},
-					{
-						"tcId": 2178,
-						"testPassed": false
-					}
-				]
-			}
-		]
-	}
-]
-            				</pre>
 <h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>
 <div class="avoidbreak">
   <address class="vcard">

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -4,8 +4,8 @@
 
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                           August 28, 2018
-Expires: March 1, 2019
+Intended status: Informational                               August 2018
+Expires: February 2, 2019
 
 
         ACVP Message Authentication Algorithm JSON Specification
@@ -24,14 +24,14 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at https://datatracker.ietf.org/drafts/current/.
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 1, 2019.
+   This Internet-Draft will expire on February 2, 2019.
 
 Copyright Notice
 
@@ -40,7 +40,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (https://trustee.ietf.org/license-info) in effect on the date of
+   (http://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 1]
+Fussell                 Expires February 2, 2019                [Page 1]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -61,25 +61,44 @@ Internet-Draft                Sym Alg JSON                   August 2018
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
    2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
      2.1.  Required Prerequisite Algorithms for MAC Validations  . .   3
-     2.2.  MAC Algorithm Capabilities Registration . . . . . . . . .   4
-     2.3.  Supported MAC Algorithms  . . . . . . . . . . . . . . . .   6
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   7
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   8
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   9
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  10
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  11
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  11
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  12
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  12
-   Appendix A.  Example MAC Capabilities JSON Object . . . . . . . .  12
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  13
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  17
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  19
+   3.  CMAC-AES  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+     3.1.  CMAC-AES Algorithm Capabilities Registration  . . . . . .   4
+       3.1.1.  Example CMAC-AES Capabilities JSON Object . . . . . .   6
+     3.2.  CMAC-AES Test Vectors . . . . . . . . . . . . . . . . . .   9
+       3.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .  10
+       3.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  11
+       3.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  12
+     3.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  16
+       3.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  17
+   4.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  20
+     4.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  20
+       4.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  23
+     4.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  24
+       4.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  25
+       4.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  26
+       4.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  27
+     4.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  33
+       4.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  34
+   5.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  37
+     5.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  37
+     5.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  39
+       5.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  39
+     5.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  40
+       5.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  41
+       5.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  42
+       5.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  43
+     5.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  44
+       5.4.1.  Example HMAC Test Vector Response JSON Object . . . .  45
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  46
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  46
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  47
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  47
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  47
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  47
 
 1.  Introduction
 
@@ -87,6 +106,14 @@ Table of Contents
    to automatically verify the cryptographic implementation of a
    software or hardware crypto module.  The ACVP specification defines
    how a crypto module communicates with an ACVP server, including
+
+
+
+Fussell                 Expires February 2, 2019                [Page 2]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
    crypto capabilities negotiation, session management, authentication,
    vector processing and more.  The ACVP specification does not define
    algorithm specific JSON constructs for performing the crypto
@@ -101,18 +128,6 @@ Table of Contents
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted in RFC 2119 [RFC2119].
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                 [Page 2]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
 2.  Capabilities Registration
 
@@ -140,6 +155,21 @@ Internet-Draft                Sym Alg JSON                   August 2018
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
 
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 3]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
    +--------------+--------------+---------------+----------+----------+
    | JSON Value   | Description  | JSON type     | Valid    | Optional |
    |              |              |               | Values   |          |
@@ -161,126 +191,122 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
          Table 1: Required MAC Prerequisite Algorithms JSON Values
 
+3.  CMAC-AES
 
-
-
-
-Fussell                   Expires March 1, 2019                 [Page 3]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-2.2.  MAC Algorithm Capabilities Registration
+3.1.  CMAC-AES Algorithm Capabilities Registration
 
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
-   +------------+-----------------+-------------+----------+-----------+
-   | JSON Value | Description     | JSON type   | Valid    | Optional  |
-   |            |                 |             | Values   |           |
-   +------------+-----------------+-------------+----------+-----------+
-   | algorithm  | The MAC         | value       | See      | No        |
-   |            | algorithm and   |             | Section  |           |
-   |            | mode to be      |             | 2.3      |           |
-   |            | validated.      |             |          |           |
-   |            |                 |             |          |           |
-   | prereqVals | prerequistie    | array of pr | See      | No        |
-   |            | algorithm       | ereqAlgVal  | Section  |           |
-   |            | validations,    | objects     | 2.1      |           |
-   |            | See             |             |          |           |
-   |            | Appendix A for  |             |          |           |
-   |            | examples        |             |          |           |
-   |            |                 |             |          |           |
-   | direction  | The MAC         | array       | gen, ver | No        |
-   |            | direction(s) to |             |          |           |
-   |            | test. Only      |             |          |           |
-   |            | applies to      |             |          |           |
-   |            | CMAC.           |             |          |           |
-   |            |                 |             |          |           |
-   | keyLen     | The keyLen      | Domain      | 8-524288 | Yes       |
-   |            | Domain          |             |          | (required |
-   |            | supported by    |             |          | for HMAC) |
-   |            | the IUT in      |             |          |           |
-   |            | bits. (HMAC     |             |          |           |
-   |            | only)           |             |          |           |
-   |            |                 |             |          |           |
-   | keyLen     | The array of    | array       | 128,     | Yes       |
-   |            | keyLens         |             | 192, 256 | (required |
-   |            | supported by    |             |          | for CMAC- |
-   |            | the IUT in      |             |          | AES)      |
-   |            | bits. (CMAC-AES |             |          |           |
-   |            | only)           |             |          |           |
-   |            |                 |             |          |           |
-   | keyingOpti | The Keying      | array       | 1, 2     | Yes       |
-   | on         | Option used in  |             |          | (required |
-   |            | TDES.  Keying   |             |          | for CMAC- |
-   |            | option 1 (1) is |             |          | TDES)     |
-   |            | 3 distinct keys |             |          |           |
-   |            | (K1, K2, K3).   |             |          |           |
-   |            | Keying Option 2 |             |          |           |
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 4]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 4]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   |            | (2) is 2        |             |          |           |
-   |            | distinct only   |             |          |           |
-   |            | suitable for    |             |          |           |
-   |            | decrypt (K1,    |             |          |           |
-   |            | K2, K1).        |             |          |           |
-   |            | Keying option 3 |             |          |           |
-   |            | (No longer      |             |          |           |
-   |            | valid for       |             |          |           |
-   |            | testing, save   |             |          |           |
-   |            | TDES KATs) is a |             |          |           |
-   |            | single key, now |             |          |           |
-   |            | deprecated (K1, |             |          |           |
-   |            | K1, K1).        |             |          |           |
-   |            |                 |             |          |           |
-   | msgLen     | The CMAC        | Domain      | 0-524288 | Yes       |
-   |            | message lengths |             |          |           |
-   |            | supported in    |             |          |           |
-   |            | bits.  Min/max/ |             |          |           |
-   |            | increment and   |             |          |           |
-   |            | values must be  |             |          |           |
-   |            | mod 8.          |             |          |           |
-   |            |                 |             |          |           |
-   | macLen     | The supported   | Domain      | 32-512   | No        |
-   |            | mac sizes.      |             |          |           |
-   |            | (range          |             |          |           |
-   |            | dependent on    |             |          |           |
-   |            | algorithm, see  |             |          |           |
-   |            | Section 2.3 ).  |             |          |           |
-   |            |                 |             |          |           |
-   +------------+-----------------+-------------+----------+-----------+
+   +--------------+----------------+--------------+---------+----------+
+   | JSON Value   | Description    | JSON type    | Valid   | Optional |
+   |              |                |              | Values  |          |
+   +--------------+----------------+--------------+---------+----------+
+   | algorithm    | The MAC        | value        | CMAC    | No       |
+   |              | algorithm to   |              |         |          |
+   |              | be validated.  |              |         |          |
+   |              |                |              |         |          |
+   | mode         | The mode to be | value        | AES     | No       |
+   |              | validated.     |              |         |          |
+   |              |                |              |         |          |
+   | prereqVals   | prerequistie   | array of     | See     | No       |
+   |              | algorithm      | prereqAlgVal | Section |          |
+   |              | validations,   | objects      | 2.1     |          |
+   |              | See Section    |              |         |          |
+   |              | 2.1 for        |              |         |          |
+   |              | examples       |              |         |          |
+   |              |                |              |         |          |
+   | capabilities | The CMAC-AES   | array of     | See     | No       |
+   |              | capabilities   | capability   | Table 3 |          |
+   |              |                | objects      |         |          |
+   |              |                |              |         |          |
+   +--------------+----------------+--------------+---------+----------+
 
-              Table 2: MAC Algorithm Capabilities JSON Values
+           Table 2: CMAC-AES Algorithm Capabilities JSON Values
 
-   Note: Some optional values are required depending on the algorithm.
-   Failure to provide these values will result in the ACVP server
-   returning an error to the ACVP client during registration.
+   Each capability object describes a separate permutation of direction
+   and key length.
 
-   keyLen for HMAC contains a Domain of values, the server may choose
-   values defined by these rules:
 
-   o  2 values below the Hash's block length.  See Section 2.3
 
-   o  The Hash's block length.
 
-   o  2 values above the Hash's block length.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 5]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +-----------+------------------------+--------+----------+----------+
+   | JSON      | Description            | JSON   | Valid    | Optional |
+   | Value     |                        | type   | Values   |          |
+   +-----------+------------------------+--------+----------+----------+
+   | direction | The MAC direction(s)   | array  | gen, ver | No       |
+   |           | to test.               |        |          |          |
+   |           |                        |        |          |          |
+   | keyLen    | The keyLen supported   | value  | 128,     | No       |
+   |           |                        |        | 192, 256 |          |
+   |           |                        |        |          |          |
+   | msgLen    | The CMAC message       | Domain | 0-524288 | No       |
+   |           | lengths supported in   |        |          |          |
+   |           | bits.                  |        |          |          |
+   |           | Min/max/increment and  |        |          |          |
+   |           | values must be mod 8.  |        |          |          |
+   |           |                        |        |          |          |
+   | macLen    | The supported mac      | Domain | 32-128   | No       |
+   |           | sizes.                 |        |          |          |
+   |           |                        |        |          |          |
+   +-----------+------------------------+--------+----------+----------+
+
+                Table 3: CMAC-AES Capabilities JSON Values
 
    macLen for CMAC contains a Domain of values, the server may choose
    values defined by these rules:
-
-
-
-Fussell                   Expires March 1, 2019                 [Page 5]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
    o  The smallest CMAC length supported
 
@@ -299,79 +325,158 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  The largest message length supported
 
-2.3.  Supported MAC Algorithms
+3.1.1.  Example CMAC-AES Capabilities JSON Object
 
-   The following algorithms may be advertised by the ACVP compliant
-   crypto module:
-
-
+   The following is an example JSON object advertising support for CMAC-
+   AES.
 
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                 [Page 6]
+Fussell                 Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-           +-------------------+--------------+----------------+
-           | Algorithm Value   | Block Length | Max MAC Length |
-           +-------------------+--------------+----------------+
-           | HMAC-SHA-1        | 512          | 160            |
-           |                   |              |                |
-           | HMAC-SHA2-224     | 512          | 224            |
-           |                   |              |                |
-           | HMAC-SHA2-256     | 512          | 256            |
-           |                   |              |                |
-           | HMAC-SHA2-384     | 1024         | 384            |
-           |                   |              |                |
-           | HMAC-SHA2-512     | 1024         | 512            |
-           |                   |              |                |
-           | HMAC-SHA2-512/224 | 1024         | 224            |
-           |                   |              |                |
-           | HMAC-SHA2-512/256 | 1024         | 256            |
-           |                   |              |                |
-           | HMAC-SHA3-224     | 1152         | 224            |
-           |                   |              |                |
-           | HMAC-SHA3-256     | 1088         | 256            |
-           |                   |              |                |
-           | HMAC-SHA3-384     | 832          | 384            |
-           |                   |              |                |
-           | HMAC-SHA3-512     | 576          | 512            |
-           |                   |              |                |
-           | CMAC-AES          | 128          | 128            |
-           |                   |              |                |
-           | CMAC-TDES         | 64           | 64             |
-           |                   |              |                |
-           +-------------------+--------------+----------------+
+   {
+     "algorithm": "CMAC",
+     "mode": "AES",
+     "capabilities": [
+       {
+         "direction": "gen",
+         "keyLen": 128,
+         "keyingOption": 0,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 64,
+             "max": 128,
+             "increment": 8
+           }
+         ]
+       },
+       {
+         "direction": "ver",
+         "keyLen": 128,
+         "keyingOption": 0,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 64,
+             "max": 128,
+             "increment": 8
+           }
+         ]
+       },
+       {
+         "direction": "gen",
+         "keyLen": 192,
+         "keyingOption": 0,
+         "msgLen": [
+           {
 
-           Table 3: Algorithms w/ block size and max MAC length.
 
-3.  Test Vectors
+
+Fussell                 Expires February 2, 2019                [Page 7]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 64,
+             "max": 128,
+             "increment": 8
+           }
+         ]
+       },
+       {
+         "direction": "ver",
+         "keyLen": 192,
+         "keyingOption": 0,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 64,
+             "max": 128,
+             "increment": 8
+           }
+         ]
+       },
+       {
+         "direction": "gen",
+         "keyLen": 256,
+         "keyingOption": 0,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 64,
+             "max": 128,
+             "increment": 8
+
+
+
+Fussell                 Expires February 2, 2019                [Page 8]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+           }
+         ]
+       },
+       {
+         "direction": "ver",
+         "keyLen": 256,
+         "keyingOption": 0,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 64,
+             "max": 128,
+             "increment": 8
+           }
+         ]
+       }
+     ]
+   }
+
+
+3.2.  CMAC-AES Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -389,31 +494,38 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 7]
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   +------------+----------------------------------------------+-------+
-   | JSON Value | Description                                  | JSON  |
-   |            |                                              | type  |
-   +------------+----------------------------------------------+-------+
-   | acvVersion | Protocol version identifier                  | value |
-   |            |                                              |       |
-   | vsId       | Unique numeric identifier for the vector set | value |
-   |            |                                              |       |
-   | algorithm  | The algorithm and mode used for the test     | value |
-   |            | vectors.  See                                |       |
-   |            | Section 2.3 for possible values.             |       |
-   |            |                                              |       |
-   | testGroups | Array of test group JSON objects, which are  | array |
-   |            | defined in                                   |       |
-   |            | Section 3.1                                  |       |
-   +------------+----------------------------------------------+-------+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | algorithm  | The algorithm used for the test vectors.    | value  |
+   |            |                                             |        |
+   | mode       | The mode used for the test vectors.         | value  |
+   |            |                                             |        |
+   | testGroups | Array of test group JSON objects, which are | array  |
+   |            | defined in Section 3.2.1                    |        |
+   +------------+---------------------------------------------+--------+
 
-                      Table 4: Vector Set JSON Object
+                 Table 4: CMAC-AES Vector Set JSON Object
 
-3.1.  Test Groups JSON Schema
+3.2.1.  CMAC-AES Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -445,7 +557,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 8]
+Fussell                 Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -461,9 +573,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | testType  | Test category type (AFT)           | value | No       |
    |           |                                    |       |          |
    | direction | The direction of the tests - gen   | value | No       |
-   |           | or ver - only applies to CMAC      |       |          |
+   |           | or ver                             |       |          |
    |           |                                    |       |          |
-   | keyLen    | Length of key in bits to use       | value | Yes      |
+   | keyLen    | Length of key in bits to use       | value | No       |
    |           |                                    |       |          |
    | msgLen    | Length of message/hash in bits     | value | No       |
    |           |                                    |       |          |
@@ -472,12 +584,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |           |                                    |       |          |
    | tests     | Array of individual test vector    | array | No       |
    |           | JSON objects, which are defined in |       |          |
-   |           | Section 3.2                        |       |          |
+   |           | Section 3.2.2                      |       |          |
    +-----------+------------------------------------+-------+----------+
 
-                      Table 5: Test Group JSON Object
+                 Table 5: CMAC-AES Test Group JSON Object
 
-3.2.  Test Case JSON Schema
+3.2.2.  CMAC-AES Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -501,33 +613,251 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 9]
+Fussell                 Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   +----------+-------------------------------------+-------+----------+
-   | JSON     | Description                         | JSON  | Optional |
-   | Value    |                                     | type  |          |
-   +----------+-------------------------------------+-------+----------+
-   | tcId     | Numeric identifier for the test     | value | No       |
-   |          | case, unique across the entire      |       |          |
-   |          | vector set.                         |       |          |
-   |          |                                     |       |          |
-   | key      | Encryption key to use AES           | value | No       |
-   |          |                                     |       |          |
-   | key1,    | Encryption keys to use for TDES     | value | Yes      |
-   | key2,    |                                     |       |          |
-   | key3     |                                     |       |          |
-   |          |                                     |       |          |
-   | msg      | Value of the message                | value | No       |
-   |          |                                     |       |          |
-   | mac      | MAC value, for CMAC verify          | value | Yes      |
-   +----------+-------------------------------------+-------+----------+
+   +--------+---------------------------------------+-------+----------+
+   | JSON   | Description                           | JSON  | Optional |
+   | Value  |                                       | type  |          |
+   +--------+---------------------------------------+-------+----------+
+   | tcId   | Numeric identifier for the test case, | value | No       |
+   |        | unique across the entire vector set.  |       |          |
+   |        |                                       |       |          |
+   | key    | Encryption key to use AES             | value | No       |
+   |        |                                       |       |          |
+   | msg    | Value of the message                  | value | No       |
+   |        |                                       |       |          |
+   | mac    | MAC value, for CMAC verify            | value | Yes      |
+   +--------+---------------------------------------+-------+----------+
 
-                      Table 6: Test Case JSON Object
+                  Table 6: CMAC-AES Test Case JSON Object
 
-4.  Test Vector Responses
+3.2.3.  Example CMAC-AES Test Vector JSON Object
+
+   The following is an example JSON test vector object for CMAC-AES.
+
+
+{
+    "vsId": 1,
+        "algorithm": "CMAC",
+        "mode": "AES",
+        "testGroups": [{
+                        "tgId": 4,
+                        "testType": "AFT",
+                        "direction": "gen",
+                        "keyLen": 128,
+                        "msgLen": 2752,
+                        "macLen": 64,
+                        "tests": [{
+                                        "tcId": 25,
+                                        "key": "E2547E38B28B2C24892C133FF4770688",
+                                        "message": "89DE09D747FB4B2669B59759A15BAAF068CAF31FD938DFCFFB38ECED53BA91DD659FD91E6CCCFEC5F972B1AD66BF78FE7FE319E58F514362FC75A346C144981B63FD18195A2AD482AF83711C9ADC449F7EAD32EBD5F4DB7EB93348404EAD496B8F4C89AB5FF7ACB2CFEFD96BD0FC9645B6F1F30AB02767ECA8771106DCA47188EE42183121FB9172B8E2133DE084F6CA3924E4BF3638ADA77DAAA6F06A6494E32CBAEFC6C6D0699BB12A425DCFE5974F687B6A71879D42DE08DF018A96429CFA40E32378D35E46A4956C5D7916B6877F353D33075FD4C64F32C3250D74FF070EA358135664CD8C9B82C9454EED75A12EEC758A9E514053533A884560FAC96DDBBA4AEEB8E473F4BFDB8447B22800D7782320D6E2DAC2599111F8CA598D6720CA7C6E4FC5EDC54FC3576460AAD1644B04E1D2C81B93EA49090FDB7E33374C243B2F19177405B94BEC3C69CC24CC686D8F2B01A6B2A350E394"
+                                },
+                                {
+                                        "tcId": 26,
+                                        "key": "D1D99979CD96C3401291905F53B2ECA4",
+                                        "message": "6D054A7D1CD161B21F80E6586E5821DDA97451D98F815663932872720BD2156752EA650AE0EC4AB9FEE5635B1CCF1B123CF0247D2487BCD3102B6A668B5F9882DB03278A6B5DCECDF176604B55668FFD8EFED2A454F16A7A75D168AFBA3C305E31B8C1ABCCAA110E94796F8F0231A479DA25A2BCBECA3A9DAFF4357C6C63476106627DF9DF692231BA906E8F8E196FAA4DD412019D36C1AEB2A015EFDCCB9E0308FDA871DBF14DED263FF28079ED3DC4E411470A664F5EAED458EB2D564971AD10E77DCCDE53BB95DF7951FCE595079ECD6C394D78AFEB85CA87C596872D66783BD816808B0B311E5EC0BA52D5283699EE725ABDC2AD85266808D80F72195599CB27241B2FF6112829FCFBFDD5548EA29637B0DCC731A060F345769D335B1B5ABE90A664CBCCD19F4F21EE630E786BDFA60C6A8D731329718CEFE80095604918600976413334AE01C524F0F0A22D50DB460CFE7D737B6334"
+                                },
+                                {
+                                        "tcId": 27,
+                                        "key": "672556E105B83BF39FC9E45268BD35D1",
+                                        "message": "39A3DD0652483A26FB9D71F30A5E29D326627FE16E29E3A3BF8EDF68645B477B5DE88499EDB3CF9E036F3D0D316241EE7C569F74925AD0BD3DCBBA21E73D9638ABA2554C4CA62AC5D7113B3FE7216E79AFC7A6FB94F21EB234D0401879A6B03EAE242EA0DCF1B523513467B00C048E7DE333C8977C455DD943323D01C97CF93EC24843769E52AD785E2340F2CC61E571D2099472E47286F29BCDF28A69144692263312F176618777A6AD0A0338F8A636BCA6150F0E1F72D539BAD726C95425682678EA7297A118E819A2925747C0AD72F3BCDF8E7D6C0A11A6AA938E4AA119390451C4E56B99F29C34927C1830197FCD4921C7E38E29BAEA5E560C8A3D4D7B96BBC370C78EF794BA9F6DB737576867B334D1DCC537D4FD751952DDFF549109ECCAD38198CCB49F25E7FEB88B9FD33D3B56601B473946693C5C3D7B2D1C7BB857F9560B94A3BD145019150BA11159B39480F97B0DE90243D6"
+                                },
+                                {
+
+
+
+Fussell                 Expires February 2, 2019               [Page 12]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "tcId": 28,
+                                        "key": "1E220113298DA3B30E14F1432C16FCE8",
+                                        "message": "497E82B322B18B0295F3B4359AC0CFAF1D36B46F36C9E123B95B90985B06AC6AFAFB772E21CCA4665CEABFF9C1CE3D78F804BEBAC6F171C0ADA47FC718E7EC55EC7603D739C8B4DBF07B60A78A8EC83922A880485B99E0FED2B1F7D5A895E2BD9149888A085F21794C1953A6EF4471A47A285CFAA57E9F75000B375A4100F5432150ECFC3342627FA325C7FB0EE0090A0B39D69ED9030E7D46BBCC6ADFC49F14156187F94F7DDE50C736FEB3FCE530CC76171EE1150AA5A94A3B79119329B5A1D9C3E03EAC7F212A1AECA97EAD58B8BFCD5F94946578D8F5A0347970A7F93C70B4AB0BB5A4FE2B0AAC8459ED0045DDC3AC210ACF996A4DE478853CD88ACEAE73D9A9C48A1B64E0D82F2EFFB25C517BDD0C033E566C16197835271A85D65A38AB37B63E7B23E9C7EA7777E6B3E3820C930B1333C279E5291724E774E34F574F15E1E23568E486F03FC6B83B962E3E60A90A69DD26701A8D6C"
+                                },
+                                {
+                                        "tcId": 29,
+                                        "key": "B2EDB3F5189E14E1E860A8B70D5CF676",
+                                        "message": "EAF87567D104DF3DA93312EEB0B695409E927F6D2EF287AC12130AC82082D600DDCFDD0074DF3CFB41CE347FAC8BEADAA522D7CE33E539C7F8E9470E00210CDDB3BF799B913B627561B35368BA80955A210AE92C5F89C0566A6E3BD6559DAE9537EE0042E60BE58E4F3757F43CA43634C09CABAEB644CCB30260A776C9B2ACB8A7900DF0B556F7CDB9A0712C3CC2B711E505880156552645DFB598DDD99E2FC06394B6F3B51C3A499E0204DD89AB699A3E8015F9720F4D5D84C30CEF9F95CFBE7DFAD7A55DF591FBFFFB10A3B3AA08EBA53873A95CADBA3A3913E947173945AFA6B88791970ED2B12972A62D4A86716D0A2429E4447676058C6EB42FA6BB6DA5295B2A2518130FCF1CB81FD3B247A9EE438F0284DF6E0AD0DEA0A4A7DDEF6A48465974F375B5FD0DA809534F4654A53116921F1004B3FF9E4E9FDA1520B8D86F0766285878BF8062A00638DE0C5970B9B6C560B65F71AF6E"
+                                },
+                                {
+                                        "tcId": 30,
+                                        "key": "7BD39F41F80079D7D0DC0154F833086A",
+                                        "message": "AB1311F60133E446CEF81973E4FC67DB365441AD367BA0E38AFD564F137AE8AC7ED0C64551EBC7A5A5F49765835C67A33F38BA1A3EFDA4725962E2C9D9893A665D9CD04BA0A613F06F7FAADBEDF9466CC62FD84DE146494E1C67EB65DC362450CF855FC9C92DD217869B60874CC0D944C7BEFFFDDA09ECBC66997873BE9A8BD007F79CC73E0E2BC52DB257CD02B0E794DAAAFF68062C476B4C9DD7F4F3FFCADE6863383455B3EEC727062A2175395A3E8D6C738878F4333F2BF27A2DD653CC57D4CC065DEE75014D32785D3A6B725DC7CBAE47BF579EAB6FC126A95701214084409594D20025ECD52CCA272364F466D4497C4F16D80CED689F0783DB4B2D185A9CC12FD247A6431AC51FCC44074B774402F584197BDD466F68DC794440B1F5F80F2F6FDB3968CACE95CBF41E7C5544194CC38D412627890B9D683A1175D9E6B93E499A4C64C4088F36AA4105E8E3D8A2EEEE1E266A3441A9"
+                                },
+                                {
+                                        "tcId": 31,
+                                        "key": "64F8BD1CC49FD16A4DF0253F31917ED4",
+                                        "message": "340104D85093FDB0740B597207D25496D5670CAF006507470783EFE2071E2026CE2C333D86F5E7BBDA91F2440C4589366BE8C337CA0B59683E8ACD384FD842675066B79008BF7F989FD7BB5ACE46D2D5BB3EBB4985708D85BD3CFC058D869295ECC18ADF1A4475263249A7579117A53B905BBFE26E2E29DA46D1D57DE6B1E2462E4C71738262307A212978AE4BD35792BAE2B770CDC1E25D350C424BBF9650ABF8F22BE9A95F1E47CC8CA4518C5EE7881C9414365DDB3959361AD3A0A9FC07C57B050D335B7426CE19144B061B197809ADEC47C75BCBB00525865ED02E375C1793BF6A05679574645B6F020EE15EE094EB02D706149B85E50A74C8CFD9823E1B222C65FCAD630B84F25C62E0B1BB7AED5637526C537F44F9BC1869721966C1BE50B3C95B4C37CC3D6E2A85589441FE73E7E2369A418ECFEB88B2337AA179AF77B5F622B02E62CF8CD294FB226ACCABF0920AECC9DD76B572"
+                                },
+                                {
+                                        "tcId": 32,
+                                        "key": "AF2B918C3CC53D064688E1A517A33D2C",
+                                        "message": "8FC205EB22775C0570A1867E3FB6E2FCF2A743171107190B89CE8A2A04C1B46A0D45781207AAB25BEC6C55F35E21F662F660C68BED54DD08D40C95D4D24872C595E49F3519D85DB933306BEF10EE181FA25C727787494FAD7A91EA6563E58B575C65E2774098BF69D74DD53D015899BF71F9B95EA0CE2A775BE0CED8423507086E6C48A9AE89195CBB1345B1C0AB8D496A2D9A6AEEFAC4A40F900159F47A7C1DFF96E88EA104EC0C64A858657239085C3AC353BE53069E57FBE9AE9B967D041478B8EBC908C70CBEEBEE718D51C08EBD2C97D7F98EF4D6EA5FF156ADC2D8FAD535AA2501F734F411BCE2B329F0FE485297707490523ABE9DB9E2FEFCD8C8A09E18628B9912262DA0282A334D9290CC5DED2F7662771237C144382724D51C3BF02F45BABD5B35810ED3EBA38AFC03D6E107D31814B8D0E4D21FE7CF9434018BCCB42F506971D33106432F325BE456A914CD5C2561E8F01F80"
+                                }
+                        ]
+                },
+                {
+                        "tgId": 10,
+                        "testType": "AFT",
+                        "direction": "ver",
+                        "keyLen": 128,
+                        "msgLen": 0,
+                        "macLen": 64,
+                        "tests": [{
+                                        "tcId": 73,
+                                        "key": "D5E09A89B2A4627BF987517B66A51564",
+                                        "message": "",
+                                        "mac": "CBBC968859633C24"
+                                },
+                                {
+                                        "tcId": 74,
+                                        "key": "646A150116ABAA37662FE9D8BB278693",
+                                        "message": "",
+                                        "mac": "21D069331196E579"
+                                },
+                                {
+                                        "tcId": 75,
+                                        "key": "5C185C01FBC57A40FC373F199374D1CC",
+
+
+
+Fussell                 Expires February 2, 2019               [Page 13]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "message": "",
+                                        "mac": "9507F00153543DE6"
+                                },
+                                {
+                                        "tcId": 76,
+                                        "key": "4E3A4C7AE2DCA644FF752B8B74CACEF8",
+                                        "message": "",
+                                        "mac": "6D58E6464497A9B4"
+                                },
+                                {
+                                        "tcId": 77,
+                                        "key": "BA924D356A696E97BEF0477A9D600FCE",
+                                        "message": "",
+                                        "mac": "93FEA54132999B1D"
+                                },
+                                {
+                                        "tcId": 78,
+                                        "key": "DA877E0EFC098E1EAD8B2DC61A5B98D5",
+                                        "message": "",
+                                        "mac": "24E6ED4D00D7122C"
+                                },
+                                {
+                                        "tcId": 79,
+                                        "key": "61698DB0B49E2F252849590E940CBCF3",
+                                        "message": "",
+                                        "mac": "2C531F92D23D6B2B"
+                                },
+                                {
+                                        "tcId": 80,
+                                        "key": "BE149E46BE89BF16BDDE41D1A494AEA4",
+                                        "message": "",
+                                        "mac": "7A858023143F6B98"
+                                },
+                                {
+                                        "tcId": 81,
+                                        "key": "9A9F006EF8EDFDA0F1113FC6FEF2E84D",
+                                        "message": "",
+                                        "mac": "C0750CD586472C8A"
+                                },
+                                {
+                                        "tcId": 82,
+                                        "key": "F68A91DE6AC099F7D72D7B211245D8D9",
+                                        "message": "",
+                                        "mac": "C91C3DCC36F2BC21"
+                                },
+                                {
+                                        "tcId": 83,
+                                        "key": "23E9BEA8C4F14330B2836FDD0B6E803F",
+
+
+
+Fussell                 Expires February 2, 2019               [Page 14]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "message": "",
+                                        "mac": "F884E64E0CA4D34F"
+                                },
+                                {
+                                        "tcId": 84,
+                                        "key": "02636CC18751A5CF27C56D2C69793BC4",
+                                        "message": "",
+                                        "mac": "1D5F5531BA263CC2"
+                                },
+                                {
+                                        "tcId": 85,
+                                        "key": "46D7DA4F123C37F05FC269FCF92B1FC1",
+                                        "message": "",
+                                        "mac": "06D743483812AAB4"
+                                },
+                                {
+                                        "tcId": 86,
+                                        "key": "C28DD76F2A31C90EE4A91313CB7D4ECC",
+                                        "message": "",
+                                        "mac": "09B6D2C848F8C9FD"
+                                },
+                                {
+                                        "tcId": 87,
+                                        "key": "810BAE6E85149F244179CA7F1488353B",
+                                        "message": "",
+                                        "mac": "68D7AFF612EAEDB4"
+                                },
+                                {
+                                        "tcId": 88,
+                                        "key": "C67C04544E0DDDE14FAE608135909FED",
+                                        "message": "",
+                                        "mac": "E9B7FE8ECF21DDD7"
+                                },
+                                {
+                                        "tcId": 89,
+                                        "key": "D9D5B9D32533DB3276BE4FFF3D79374A",
+                                        "message": "",
+                                        "mac": "081BAFA11BFDF238"
+                                },
+                                {
+                                        "tcId": 90,
+                                        "key": "D8A05E45602DD6ACBE989BD0F26CED9E",
+                                        "message": "",
+                                        "mac": "D84F8EE112352837"
+                                },
+                                {
+                                        "tcId": 91,
+                                        "key": "E09B79F64B11F00B48081EEEA0482821",
+
+
+
+Fussell                 Expires February 2, 2019               [Page 15]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "message": "",
+                                        "mac": "4D927CED15907953"
+                                },
+                                {
+                                        "tcId": 92,
+                                        "key": "24B7BE1D4F72AE1A1C5FBDB2A3AC8287",
+                                        "message": "",
+                                        "mac": "548CBD558D8F6E3A"
+                                }
+                        ]
+                }
+        ]
+}
+
+
+3.3.  CMAC-AES Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
@@ -544,26 +874,29 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | testGroups | Array of JSON objects that represent each   | array  |
-   |            | test vector group. See                      |        |
-   |            | Table 8                                     |        |
+   |            | test vector group. See Table 8              |        |
    |            |                                             |        |
    +------------+---------------------------------------------+--------+
 
-                 Table 7: Vector Set Response JSON Object
+             Table 7: CMAC-AES Vector Set Response JSON Object
 
    The testGroups section is used to organize the ACVP client response
    in a similar manner to how it receives vectors.  Several algorithms
+   SHALL require the client to send back group level properties in their
+   response.  This structure helps accommodate that.
 
 
 
 
-Fussell                   Expires March 1, 2019                [Page 10]
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 16]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
-
-   SHALL require the client to send back group level properties in their
-   response.  This structure helps accommodate that.
 
    +-----------+--------------------------------------------+----------+
    | JSON      | Description                                | JSON     |
@@ -576,7 +909,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |           |                                            |          |
    +-----------+--------------------------------------------+----------+
 
-              Table 8: Vector Set Group Response JSON Object
+          Table 8: CMAC-AES Vector Set Group Response JSON Object
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -598,13 +931,1641 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                 |         |          |
    +------------+---------------------------------+---------+----------+
 
-                Table 9: MAC Test Case Results JSON Object
+              Table 9: CMAC-AES Test Case Results JSON Object
 
-5.  Acknowledgements
+3.3.1.  Example CMAC-AES Test Vector Response JSON Object
+
+   The following is an example JSON test vector response object for
+   CMAC-AES.
+
+
+   {
+           "vsId": 1,
+       "algorithm": "CMAC",
+       "mode": "AES",
+           "testGroups": [{
+                           "tgId": 4,
+                           "tests": [{
+
+
+
+Fussell                 Expires February 2, 2019               [Page 17]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                           "tcId": 25,
+                                           "mac": "7AA2D56A0AE76620"
+                                   },
+                                   {
+                                           "tcId": 26,
+                                           "mac": "9E23524D3CD18C93"
+                                   },
+                                   {
+                                           "tcId": 27,
+                                           "mac": "4D51872CBFAA102A"
+                                   },
+                                   {
+                                           "tcId": 28,
+                                           "mac": "027BCA655EC9ACEB"
+                                   },
+                                   {
+                                           "tcId": 29,
+                                           "mac": "A86D99B6121507A6"
+                                   },
+                                   {
+                                           "tcId": 30,
+                                           "mac": "25E5F000F2B1E071"
+                                   },
+                                   {
+                                           "tcId": 31,
+                                           "mac": "F2DBA25F9A903C80"
+                                   },
+                                   {
+                                           "tcId": 32,
+                                           "mac": "1D35816BD32CA4DB"
+                                   }
+                           ]
+                   },
+                   {
+                           "tgId": 10,
+                           "tests": [{
+                                           "tcId": 73,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 74,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 75,
+                                           "testPassed": true
+                                   },
+                                   {
+
+
+
+Fussell                 Expires February 2, 2019               [Page 18]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                           "tcId": 76,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 77,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 78,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 79,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 80,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 81,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 82,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 83,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 84,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 85,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 86,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 87,
+                                           "testPassed": true
+                                   },
+                                   {
+
+
+
+Fussell                 Expires February 2, 2019               [Page 19]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                           "tcId": 88,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 89,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 90,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 91,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 92,
+                                           "testPassed": false
+                                   }
+                           ]
+                   }
+           ]
+   }
+
+
+4.  CMAC-TDES
+
+4.1.  CMAC-TDES Algorithm Capabilities Registration
+
+   Each algorithm capability advertised is a self-contained JSON object
+   using the following values.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 20]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +--------------+----------------+--------------+---------+----------+
+   | JSON Value   | Description    | JSON type    | Valid   | Optional |
+   |              |                |              | Values  |          |
+   +--------------+----------------+--------------+---------+----------+
+   | algorithm    | The MAC        | value        | CMAC    | No       |
+   |              | algorithm to   |              |         |          |
+   |              | be validated.  |              |         |          |
+   |              |                |              |         |          |
+   | mode         | The mode to be | value        | TDES    | No       |
+   |              | validated.     |              |         |          |
+   |              |                |              |         |          |
+   | prereqVals   | prerequistie   | array of     | See     | No       |
+   |              | algorithm      | prereqAlgVal | Section |          |
+   |              | validations,   | objects      | 2.1     |          |
+   |              | See Section    |              |         |          |
+   |              | 2.1 for        |              |         |          |
+   |              | examples       |              |         |          |
+   |              |                |              |         |          |
+   | capabilities | The CMAC-TDES  | array of     | See     | No       |
+   |              | capabilities   | capability   | Table   |          |
+   |              |                | objects      | 11      |          |
+   |              |                |              |         |          |
+   +--------------+----------------+--------------+---------+----------+
+
+          Table 10: CMAC-TDES Algorithm Capabilities JSON Values
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 21]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +--------------+---------------------+--------+----------+----------+
+   | JSON Value   | Description         | JSON   | Valid    | Optional |
+   |              |                     | type   | Values   |          |
+   +--------------+---------------------+--------+----------+----------+
+   | direction    | The MAC             | array  | gen, ver | No       |
+   |              | direction(s) to     |        |          |          |
+   |              | test.               |        |          |          |
+   |              |                     |        |          |          |
+   | keyingOption | The Keying Option   | value  | 1, 2     | No       |
+   |              | used in TDES.       |        |          |          |
+   |              | Keying option 1 (1) |        |          |          |
+   |              | is 3 distinct keys  |        |          |          |
+   |              | (K1, K2, K3).       |        |          |          |
+   |              | Keying Option 2 (2) |        |          |          |
+   |              | is 2 distinct only  |        |          |          |
+   |              | suitable for        |        |          |          |
+   |              | decrypt (K1, K2,    |        |          |          |
+   |              | K1). Keying option  |        |          |          |
+   |              | 3 (No longer valid  |        |          |          |
+   |              | for testing, save   |        |          |          |
+   |              | TDES KATs) is a     |        |          |          |
+   |              | single key, now     |        |          |          |
+   |              | deprecated (K1, K1, |        |          |          |
+   |              | K1).                |        |          |          |
+   |              |                     |        |          |          |
+   | msgLen       | The CMAC message    | Domain | 0-524288 | No       |
+   |              | lengths supported   |        |          |          |
+   |              | in bits.            |        |          |          |
+   |              | Min/max/increment   |        |          |          |
+   |              | and values must be  |        |          |          |
+   |              | mod 8.              |        |          |          |
+   |              |                     |        |          |          |
+   | macLen       | The supported mac   | Domain | 32-64    | No       |
+   |              | sizes.              |        |          |          |
+   |              |                     |        |          |          |
+   +--------------+---------------------+--------+----------+----------+
+
+               Table 11: CMAC-TDES Capabilities JSON Values
+
+   macLen for CMAC contains a Domain of values, the server may choose
+   values defined by these rules:
+
+   o  The smallest CMAC length supported
+
+   o  A second CMAC length supported
+
+   o  The largest CMAC length supported
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 22]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   msgLen for CMAC contains a Domain of values, the server may choose
+   values defined by these rules:
+
+   o  The smallest message length supported
+
+   o  Two message lengths divisible by block size
+
+   o  Two message lengths NOT divisible by block size
+
+   o  The largest message length supported
+
+4.1.1.  Example CMAC-TDES Capabilities JSON Object
+
+   The following is an example JSON object advertising support for CMAC-
+   TDES.
+
+
+   {
+     "algorithm": "CMAC",
+     "mode": "TDES",
+     "capabilities": [
+       {
+         "direction": "gen",
+         "keyingOption": 1,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 32,
+             "max": 64,
+             "increment": 8
+           }
+         ]
+       },
+       {
+         "direction": "ver",
+         "keyingOption": 1,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+
+
+
+Fussell                 Expires February 2, 2019               [Page 23]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+         ],
+         "macLen": [
+           {
+             "min": 32,
+             "max": 64,
+             "increment": 8
+           }
+         ]
+       },
+       {
+         "direction": "ver",
+         "keyLen": 0,
+         "msgLen": [
+           {
+             "min": 0,
+             "max": 65536,
+             "increment": 8
+           }
+         ],
+         "macLen": [
+           {
+             "min": 32,
+             "max": 64,
+             "increment": 8
+           }
+         ]
+       }
+     ]
+   }
+
+
+4.2.  CMAC-TDES Test Vectors
+
+   The ACVP server provides test vectors to the ACVP client, which are
+   then processed and returned to the ACVP server for validation.  A
+   typical ACVP validation session would require multiple test vector
+   sets to be downloaded and processed by the ACVP client.  Each test
+   vector set represents an individual crypto algorithm, such as HMAC-
+   SHA-1, HMAC-SHA2-224, CMAC-TDES, etc.  This section describes the
+   JSON schema for a test vector set used with HMAC and CMAC crypto
+   algorithms.
+
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
+   test vectors to be processed by the ACVP client.  The following table
+   describes the JSON elements at the top level of the hierarchy.
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 24]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | algorithm  | The algorithm used for the test vectors.    | value  |
+   |            |                                             |        |
+   | mode       | The mode used for the test vectors.         | value  |
+   |            |                                             |        |
+   | testGroups | Array of test group JSON objects, which are | array  |
+   |            | defined in Section 4.2.1                    |        |
+   +------------+---------------------------------------------+--------+
+
+                Table 12: CMAC-TDES Vector Set JSON Object
+
+4.2.1.  CMAC-TDES Test Groups JSON Schema
+
+   The testGroups element at the top level in the test vector JSON
+   object is an array of test groups.  Test vectors are grouped into
+   similar test cases to reduce the amount of data transmitted in the
+   vector set.  For instance, all test vectors that use the same key
+   size would be grouped together.  The Test Group JSON object contains
+   meta data that applies to all test vectors within the group.  The
+   following table describes the secure HMAC and CMAC JSON elements of
+   the Test Group JSON object.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 25]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +-----------+------------------------------------+-------+----------+
+   | JSON      | Description                        | JSON  | Optional |
+   | Value     |                                    | type  |          |
+   +-----------+------------------------------------+-------+----------+
+   | tgId      | Numeric identifier for the test    | value | No       |
+   |           | group, unique across the entire    |       |          |
+   |           | vector set.                        |       |          |
+   |           |                                    |       |          |
+   | testType  | Test category type (AFT)           | value | No       |
+   |           |                                    |       |          |
+   | direction | The direction of the tests - gen   | value | No       |
+   |           | or ver                             |       |          |
+   |           |                                    |       |          |
+   | keyLen    | Length of key in bits to use       | value | No       |
+   |           |                                    |       |          |
+   | msgLen    | Length of message/hash in bits     | value | No       |
+   |           |                                    |       |          |
+   | macLen    | Length of MAC in bits to           | value | No       |
+   |           | generate/verify                    |       |          |
+   |           |                                    |       |          |
+   | tests     | Array of individual test vector    | array | No       |
+   |           | JSON objects, which are defined in |       |          |
+   |           | Section 4.2.2                      |       |          |
+   +-----------+------------------------------------+-------+----------+
+
+                Table 13: CMAC-TDES Test Group JSON Object
+
+4.2.2.  CMAC-TDES Test Case JSON Schema
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each secure MAC test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 26]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +----------+-------------------------------------+-------+----------+
+   | JSON     | Description                         | JSON  | Optional |
+   | Value    |                                     | type  |          |
+   +----------+-------------------------------------+-------+----------+
+   | tcId     | Numeric identifier for the test     | value | No       |
+   |          | case, unique across the entire      |       |          |
+   |          | vector set.                         |       |          |
+   |          |                                     |       |          |
+   | key1,    | Encryption keys to use for TDES     | value | No       |
+   | key2,    |                                     |       |          |
+   | key3     |                                     |       |          |
+   |          |                                     |       |          |
+   | msg      | Value of the message                | value | No       |
+   |          |                                     |       |          |
+   | mac      | MAC value, for CMAC verify          | value | Yes      |
+   +----------+-------------------------------------+-------+----------+
+
+                 Table 14: CMAC-TDES Test Case JSON Object
+
+4.2.3.  Example CMAC-TDES Test Vector JSON Object
+
+   The following is an example JSON test vector object for CMAC-TDES.
+
+
+{
+        "vsId": 1,
+        "algorithm": "CMAC",
+        "mode": "TDES",
+        "testGroups": [{
+                        "tgId": 4,
+                        "testType": "AFT",
+                        "direction": "gen",
+                        "keyLen": 192,
+                        "msgLen": 752,
+                        "macLen": 32,
+                        "tests": [{
+                                        "tcId": 25,
+                                        "key": "7FFDB31A3A06BF0D5201FFE83CC5253EBBECA60F1D631BB8",
+                                        "message": "4D2D07AE0224289BE111E0D4522A8AC127FAD537D7D4240613A73EA23CA673F8DC554B4C8CC69699C1DCB638D06FCA54D858DF68F595B7987A937599BDEA77974AB1441D7E63190762CBCD8E6D9F9A8940FB8DB43EBDAA2172C9B0A5CDF9",
+                                        "key1": "7FFDB31A3A06BF0D",
+                                        "key2": "5201FFE83CC5253E",
+                                        "key3": "BBECA60F1D631BB8"
+                                },
+                                {
+                                        "tcId": 26,
+                                        "key": "82E572E29C84009E28390918155E4891A0D24C94C306FE56",
+                                        "message": "7A70F3CE17598AC3553FBADA0CC562018FD40C6D25B098EC0B905B1BC9F67DFCBD797494E4B05E2C6C3C0F655F9E95FFFE16782E1454A5EE04D87E7586F7FF65A51979A1C46118080320C1CB9E9CC48A05E113C95C2316361B39F5FCB861",
+                                        "key1": "82E572E29C84009E",
+
+
+
+Fussell                 Expires February 2, 2019               [Page 27]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "key2": "28390918155E4891",
+                                        "key3": "A0D24C94C306FE56"
+                                },
+                                {
+                                        "tcId": 27,
+                                        "key": "662A89E47D86F6A0CB9D612E199B4AD2AE3AEBA19FAB4340",
+                                        "message": "2DAF1E213A6AE9E88FEBC70458AACBFB9B668EB22F12662B281D29A57B568CA35146E073D6B4BECB3E10AD8D398CADF672464707207FB40D23F4D6F93528F83D79019106A03D41E26DAE32E3208920FE165FCD739305A4E24D81B118972C",
+                                        "key1": "662A89E47D86F6A0",
+                                        "key2": "CB9D612E199B4AD2",
+                                        "key3": "AE3AEBA19FAB4340"
+                                },
+                                {
+                                        "tcId": 28,
+                                        "key": "522729A011C73BE2079D67ECEBFCE42EF5F91F6ECD43F71E",
+                                        "message": "7F1170A442EEAFCAFD00925C8BD2DB22AB2458AAAB6F6C2B061EB56F005DAC0D11392ADAA0E07FF6074208E22D5E07F4C4B9A1C9DDFD2FAAEB1185C2E5B60D06E2BFBB92C6A0DC4CED36A8DB19583D8BE09A260E638FCCCDCBF17A7D2D6D",
+                                        "key1": "522729A011C73BE2",
+                                        "key2": "079D67ECEBFCE42E",
+                                        "key3": "F5F91F6ECD43F71E"
+                                },
+                                {
+                                        "tcId": 29,
+                                        "key": "B5FE32A150833A60A8C619C2A89BD8BCD8DFB2654AEB4923",
+                                        "message": "839733866DC749C9F2F3756E02FB1FEAAF0BC47814CD52159EE1AA1945F50D789483E4705437482712F26FE8505233638B9004A2938669670888BEB5EF5BBB62DBC6C0355FAB7BB4AE57FE7E345A9E5D9699750157E83F55B8431CD0ECF6",
+                                        "key1": "B5FE32A150833A60",
+                                        "key2": "A8C619C2A89BD8BC",
+                                        "key3": "D8DFB2654AEB4923"
+                                },
+                                {
+                                        "tcId": 30,
+                                        "key": "C2406CA7AA81A4A6FBB0D6A665B0D1410445F4CC132F46E6",
+                                        "message": "95FC92BAC8AE751818427F2090B3BCC76BD1A5A3CAE6C5B914AF59DA589BDED6A2CF0B7A17CB659B46C9FF3163AFEC505D3BBBAF42AD9FA077AA862E49BBE21773E3CF7C031A022681E85169873C639ADDA2953AB352B9724B0F941AF2E6",
+                                        "key1": "C2406CA7AA81A4A6",
+                                        "key2": "FBB0D6A665B0D141",
+                                        "key3": "0445F4CC132F46E6"
+                                },
+                                {
+                                        "tcId": 31,
+                                        "key": "AE90AF3424A99A304F0D54B1FDAAAA5B4D026169F067D997",
+                                        "message": "AECC231068148AE400B1F1922684C681FBEC9C836B1593BB0805C8A38340564C1CA39C341588913C3E425934B8D219FED6D58553BC3AE44B003999FA51C8265AE6AA653F839C56813F58BD4F6093F5A2FF196CAA9A3CF782E21FD06C0AD0",
+                                        "key1": "AE90AF3424A99A30",
+                                        "key2": "4F0D54B1FDAAAA5B",
+                                        "key3": "4D026169F067D997"
+                                },
+                                {
+                                        "tcId": 32,
+                                        "key": "B10CCB821E63EF98928D1BC20D797C5E9149B32BFC090140",
+                                        "message": "B19716D364D0680873D83F4991839465C169CADA64D5B57454ADDCDA64D1778219B204571593C5965E8F84C373CF0DBD10F4C8124D932FB6EF2B662966C698F79CB3199E40A45A8A7C186E948CA5A0BAD743A1FDC91336325145FC701D41",
+                                        "key1": "B10CCB821E63EF98",
+
+
+
+Fussell                 Expires February 2, 2019               [Page 28]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "key2": "928D1BC20D797C5E",
+                                        "key3": "9149B32BFC090140"
+                                }
+                        ],
+                        "keyingOption": 1
+                },
+                {
+                        "tgId": 10,
+                        "testType": "AFT",
+                        "direction": "ver",
+                        "keyLen": 192,
+                        "msgLen": 0,
+                        "macLen": 32,
+                        "tests": [{
+                                        "tcId": 73,
+                                        "key": "D127F902CFF69A82785D99EF117E5B5636D4CB2C34A3AF30",
+                                        "message": "",
+                                        "mac": "D78010B3",
+                                        "key1": "D127F902CFF69A82",
+                                        "key2": "785D99EF117E5B56",
+                                        "key3": "36D4CB2C34A3AF30"
+                                },
+                                {
+                                        "tcId": 74,
+                                        "key": "9D5DAC4D75E0A3496A55855C62D8C767CBD9FC7CCBDA8BE9",
+                                        "message": "",
+                                        "mac": "5313D9E8",
+                                        "key1": "9D5DAC4D75E0A349",
+                                        "key2": "6A55855C62D8C767",
+                                        "key3": "CBD9FC7CCBDA8BE9"
+                                },
+                                {
+                                        "tcId": 75,
+                                        "key": "B711BA268A1F3663AA83B2195E85BFC6AA1CFBC128AAE0FD",
+                                        "message": "",
+                                        "mac": "07B1926F",
+                                        "key1": "B711BA268A1F3663",
+                                        "key2": "AA83B2195E85BFC6",
+                                        "key3": "AA1CFBC128AAE0FD"
+                                },
+                                {
+                                        "tcId": 76,
+                                        "key": "4DB908F0A14A3959AC76D38D171114CA3651F7FF9C9B20B5",
+                                        "message": "",
+                                        "mac": "7C920795",
+                                        "key1": "4DB908F0A14A3959",
+                                        "key2": "AC76D38D171114CA",
+                                        "key3": "3651F7FF9C9B20B5"
+
+
+
+Fussell                 Expires February 2, 2019               [Page 29]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                },
+                                {
+                                        "tcId": 77,
+                                        "key": "670AB0529BCE3007BDC7706FED307419291C6BA004943806",
+                                        "message": "",
+                                        "mac": "7988C839",
+                                        "key1": "670AB0529BCE3007",
+                                        "key2": "BDC7706FED307419",
+                                        "key3": "291C6BA004943806"
+                                },
+                                {
+                                        "tcId": 78,
+                                        "key": "62AA8060A173FD6A19FB1E39C09914E8453D89A318FEAA0A",
+                                        "message": "",
+                                        "mac": "14B588F8",
+                                        "key1": "62AA8060A173FD6A",
+                                        "key2": "19FB1E39C09914E8",
+                                        "key3": "453D89A318FEAA0A"
+                                },
+                                {
+                                        "tcId": 79,
+                                        "key": "9B954C62C795DD599807683D5531A513E88406D75B04CDC9",
+                                        "message": "",
+                                        "mac": "9BDD8078",
+                                        "key1": "9B954C62C795DD59",
+                                        "key2": "9807683D5531A513",
+                                        "key3": "E88406D75B04CDC9"
+                                },
+                                {
+                                        "tcId": 80,
+                                        "key": "E085046DF6F97A3D9B00E3EA82482EBFA1DCA6EC94ACFD7E",
+                                        "message": "",
+                                        "mac": "D44BA0CD",
+                                        "key1": "E085046DF6F97A3D",
+                                        "key2": "9B00E3EA82482EBF",
+                                        "key3": "A1DCA6EC94ACFD7E"
+                                },
+                                {
+                                        "tcId": 81,
+                                        "key": "526DE285D64F65A20F2E9F52E789AD59E6AE85200F95501F",
+                                        "message": "",
+                                        "mac": "F068F177",
+                                        "key1": "526DE285D64F65A2",
+                                        "key2": "0F2E9F52E789AD59",
+                                        "key3": "E6AE85200F95501F"
+                                },
+                                {
+                                        "tcId": 82,
+
+
+
+Fussell                 Expires February 2, 2019               [Page 30]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
+                                        "message": "",
+                                        "mac": "317B4969",
+                                        "key1": "97FBEF5ADADC68CC",
+                                        "key2": "DD5BAFB50853589E",
+                                        "key3": "DF4918593D29F5C0"
+                                },
+                                {
+                                        "tcId": 83,
+                                        "key": "1D80CD109B749DCE6AF893051C0969B6705A264BFA49F2B2",
+                                        "message": "",
+                                        "mac": "FAFE8358",
+                                        "key1": "1D80CD109B749DCE",
+                                        "key2": "6AF893051C0969B6",
+                                        "key3": "705A264BFA49F2B2"
+                                },
+                                {
+                                        "tcId": 84,
+                                        "key": "B48C715C2B4EB7F5D0865F7ABC0BFD1F2CD83EA54C5136D7",
+                                        "message": "",
+                                        "mac": "F456798B",
+                                        "key1": "B48C715C2B4EB7F5",
+                                        "key2": "D0865F7ABC0BFD1F",
+                                        "key3": "2CD83EA54C5136D7"
+                                },
+                                {
+                                        "tcId": 85,
+                                        "key": "A8944ECE678BBFFD45C1557E59A6044352EF3B8808FD54DC",
+                                        "message": "",
+                                        "mac": "7CEEF54C",
+                                        "key1": "A8944ECE678BBFFD",
+                                        "key2": "45C1557E59A60443",
+                                        "key3": "52EF3B8808FD54DC"
+                                },
+                                {
+                                        "tcId": 86,
+                                        "key": "B6CA0DD41423786CD0E524E69C2D21DE81522CB976796269",
+                                        "message": "",
+                                        "mac": "02E9CDE5",
+                                        "key1": "B6CA0DD41423786C",
+                                        "key2": "D0E524E69C2D21DE",
+                                        "key3": "81522CB976796269"
+                                },
+                                {
+                                        "tcId": 87,
+                                        "key": "C2A4D041516F0B7535D37F2B55FB38CFB75F24285D7BEF39",
+                                        "message": "",
+                                        "mac": "4A099862",
+
+
+
+Fussell                 Expires February 2, 2019               [Page 31]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                        "key1": "C2A4D041516F0B75",
+                                        "key2": "35D37F2B55FB38CF",
+                                        "key3": "B75F24285D7BEF39"
+                                },
+                                {
+                                        "tcId": 88,
+                                        "key": "3F9879C2259E2C6E0E75799EC99FA126E9A59029ADCD6B7C",
+                                        "message": "",
+                                        "mac": "CB1FC90C",
+                                        "key1": "3F9879C2259E2C6E",
+                                        "key2": "0E75799EC99FA126",
+                                        "key3": "E9A59029ADCD6B7C"
+                                },
+                                {
+                                        "tcId": 89,
+                                        "key": "5059F4B1CA3C438F56FF7F3115E2B7ACC0970ADF892FBBA0",
+                                        "message": "",
+                                        "mac": "6F5CFAEC",
+                                        "key1": "5059F4B1CA3C438F",
+                                        "key2": "56FF7F3115E2B7AC",
+                                        "key3": "C0970ADF892FBBA0"
+                                },
+                                {
+                                        "tcId": 90,
+                                        "key": "DE8EB157BCE06D7A318ECE3D7E96B586FDDC6097E61C4F48",
+                                        "message": "",
+                                        "mac": "E67871E3",
+                                        "key1": "DE8EB157BCE06D7A",
+                                        "key2": "318ECE3D7E96B586",
+                                        "key3": "FDDC6097E61C4F48"
+                                },
+                                {
+                                        "tcId": 91,
+                                        "key": "840A1C616D0D776BFAF99C1444507BACD11881E87C8E0329",
+                                        "message": "",
+                                        "mac": "C2D06FE4",
+                                        "key1": "840A1C616D0D776B",
+                                        "key2": "FAF99C1444507BAC",
+                                        "key3": "D11881E87C8E0329"
+                                },
+                                {
+                                        "tcId": 92,
+                                        "key": "1A29B0ED9040FD2D6A7D20A4DF50E290AB1D497EC1D211AA",
+                                        "message": "",
+                                        "mac": "B5E61275",
+                                        "key1": "1A29B0ED9040FD2D",
+                                        "key2": "6A7D20A4DF50E290",
+                                        "key3": "AB1D497EC1D211AA"
+
+
+
+Fussell                 Expires February 2, 2019               [Page 32]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                }
+                        ],
+                        "keyingOption": 1
+                }
+        ]
+}
+
+
+4.3.  CMAC-TDES Test Vector Responses
+
+   After the ACVP client downloads and processes a vector set, it must
+   send the response vectors back to the ACVP server.  The following
+   table describes the JSON object that represents a vector set
+   response.
+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | testGroups | Array of JSON objects that represent each   | array  |
+   |            | test vector group. See Table 16             |        |
+   |            |                                             |        |
+   +------------+---------------------------------------------+--------+
+
+            Table 15: CMAC-TDES Vector Set Response JSON Object
+
+   The testGroups section is used to organize the ACVP client response
+   in a similar manner to how it receives vectors.  Several algorithms
+   SHALL require the client to send back group level properties in their
+   response.  This structure helps accommodate that.
+
+   +-----------+--------------------------------------------+----------+
+   | JSON      | Description                                | JSON     |
+   | Value     |                                            | type     |
+   +-----------+--------------------------------------------+----------+
+   | tgId      | The test group Id                          | value    |
+   |           |                                            |          |
+   | tests     | The tests associated to the group          | value    |
+   |           | specified in tgId                          |          |
+   |           |                                            |          |
+   +-----------+--------------------------------------------+----------+
+
+         Table 16: CMAC-TDES Vector Set Group Response JSON Object
+
+
+
+Fussell                 Expires February 2, 2019               [Page 33]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each DRBG test vector.
+
+   +------------+---------------------------------+---------+----------+
+   | JSON Value | Description                     | JSON    | Optional |
+   |            |                                 | type    |          |
+   +------------+---------------------------------+---------+----------+
+   | tcId       | Numeric identifier for the test | value   | No       |
+   |            | case, unique across the entire  |         |          |
+   |            | vector set.                     |         |          |
+   |            |                                 |         |          |
+   | mac        | value of the computed MAC       | value   | Yes      |
+   |            | output                          |         |          |
+   |            |                                 |         |          |
+   | testPassed | The result of CMAC verify       | boolean | Yes      |
+   |            |                                 |         |          |
+   +------------+---------------------------------+---------+----------+
+
+             Table 17: CMAC-TDES Test Case Results JSON Object
+
+4.3.1.  Example CMAC-TDES Test Vector Response JSON Object
+
+   The following is an example JSON test vector response object for
+   CMAC-TDES.
+
+
+   {
+       "vsId": 1,
+           "algorithm": "CMAC",
+           "mode": "TDES",
+           "testGroups": [{
+                           "tgId": 4,
+                           "tests": [{
+                                           "tcId": 25,
+                                           "mac": "6FA27FDC"
+                                   },
+                                   {
+                                           "tcId": 26,
+                                           "mac": "89CE2842"
+                                   },
+                                   {
+                                           "tcId": 27,
+                                           "mac": "5E03D980"
+                                   },
+                                   {
+                                           "tcId": 28,
+
+
+
+Fussell                 Expires February 2, 2019               [Page 34]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                           "mac": "EC68CA91"
+                                   },
+                                   {
+                                           "tcId": 29,
+                                           "mac": "ACAEF07C"
+                                   },
+                                   {
+                                           "tcId": 30,
+                                           "mac": "2207C5DF"
+                                   },
+                                   {
+                                           "tcId": 31,
+                                           "mac": "95248097"
+                                   },
+                                   {
+                                           "tcId": 32,
+                                           "mac": "33325023"
+                                   }
+                           ]
+                   },
+                   {
+                           "tgId": 10,
+                           "tests": [{
+                                           "tcId": 73,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 74,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 75,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 76,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 77,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 78,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 79,
+
+
+
+Fussell                 Expires February 2, 2019               [Page 35]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 80,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 81,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 82,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 83,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 84,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 85,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 86,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 87,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 88,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 89,
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 90,
+                                           "testPassed": false
+                                   },
+                                   {
+                                           "tcId": 91,
+
+
+
+Fussell                 Expires February 2, 2019               [Page 36]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                           "testPassed": true
+                                   },
+                                   {
+                                           "tcId": 92,
+                                           "testPassed": true
+                                   }
+                           ]
+                   }
+           ]
+   }
+
+
+5.  HMAC
+
+5.1.  HMAC Algorithm Capabilities Registration
+
+   Each algorithm capability advertised is a self-contained JSON object
+   using the following values.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 37]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+-----------------+--------------+----------+----------+
+   | JSON Value | Description     | JSON type    | Valid    | Optional |
+   |            |                 |              | Values   |          |
+   +------------+-----------------+--------------+----------+----------+
+   | algorithm  | The MAC         | value        | See      | No       |
+   |            | algorithm and   |              | Section  |          |
+   |            | mode to be      |              | 5.2      |          |
+   |            | validated.      |              |          |          |
+   |            |                 |              |          |          |
+   | prereqVals | prerequistie    | array of     | See      | No       |
+   |            | algorithm       | prereqAlgVal | Section  |          |
+   |            | validations,    | objects      | 2.1      |          |
+   |            | See Section 2.1 |              |          |          |
+   |            | for examples    |              |          |          |
+   |            |                 |              |          |          |
+   | keyLen     | The keyLen      | Domain       | 8-524288 | No       |
+   |            | Domain          |              |          |          |
+   |            | supported by    |              |          |          |
+   |            | the IUT in      |              |          |          |
+   |            | bits.           |              |          |          |
+   |            |                 |              |          |          |
+   | macLen     | The supported   | Domain       | 32-512   | No       |
+   |            | mac sizes.      |              |          |          |
+   |            | (range          |              |          |          |
+   |            | dependent on    |              |          |          |
+   |            | algorithm, see  |              |          |          |
+   |            | Section 5.2).   |              |          |          |
+   |            |                 |              |          |          |
+   +------------+-----------------+--------------+----------+----------+
+
+             Table 18: HMAC Algorithm Capabilities JSON Values
+
+   keyLen for HMAC contains a Domain of values, the server may choose
+   values defined by these rules:
+
+   o  2 values below the Hash's block length.  See Section 5.2
+
+   o  The Hash's block length.
+
+   o  2 values above the Hash's block length.
+
+   macLen for HMAC contains a Domain of values, the server may choose
+   values defined by these rules:
+
+   o  The smallest HMAC length supported
+
+   o  A second HMAC length supported
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 38]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   o  The largest HMAC length supported
+
+5.2.  Supported HMAC Algorithms
+
+   The following algorithms may be advertised by the ACVP compliant
+   crypto module:
+
+           +-------------------+--------------+----------------+
+           | Algorithm Value   | Block Length | Max MAC Length |
+           +-------------------+--------------+----------------+
+           | HMAC-SHA-1        | 512          | 160            |
+           |                   |              |                |
+           | HMAC-SHA2-224     | 512          | 224            |
+           |                   |              |                |
+           | HMAC-SHA2-256     | 512          | 256            |
+           |                   |              |                |
+           | HMAC-SHA2-384     | 1024         | 384            |
+           |                   |              |                |
+           | HMAC-SHA2-512     | 1024         | 512            |
+           |                   |              |                |
+           | HMAC-SHA2-512/224 | 1024         | 224            |
+           |                   |              |                |
+           | HMAC-SHA2-512/256 | 1024         | 256            |
+           |                   |              |                |
+           | HMAC-SHA3-224     | 1152         | 224            |
+           |                   |              |                |
+           | HMAC-SHA3-256     | 1088         | 256            |
+           |                   |              |                |
+           | HMAC-SHA3-384     | 832          | 384            |
+           |                   |              |                |
+           | HMAC-SHA3-512     | 576          | 512            |
+           |                   |              |                |
+           +-------------------+--------------+----------------+
+
+          Table 19: Algorithms w/ block size and max CMAC length.
+
+5.2.1.  Example HMAC Capabilities JSON Object
+
+   The following is an example JSON object advertising support for HMAC.
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 39]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   {
+     "algorithm": "HMAC-SHA-1",
+     "keyLen": [
+       {
+         "min": 8,
+         "max": 2048,
+         "increment": 8
+       }
+     ],
+     "macLen": [
+       {
+         "min": 80,
+         "max": 160,
+         "increment": 8
+       }
+     ]
+   }
+
+
+5.3.  HMAC Test Vectors
+
+   The ACVP server provides test vectors to the ACVP client, which are
+   then processed and returned to the ACVP server for validation.  A
+   typical ACVP validation session would require multiple test vector
+   sets to be downloaded and processed by the ACVP client.  Each test
+   vector set represents an individual crypto algorithm, such as HMAC-
+   SHA-1, HMAC-SHA2-224, CMAC-AES, etc.  This section describes the JSON
+   schema for a test vector set used with HMAC crypto algorithms.
+
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
+   test vectors to be processed by the ACVP client.  The following table
+   describes the JSON elements at the top level of the hierarchy.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 40]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+----------------------------------------------+-------+
+   | JSON Value | Description                                  | JSON  |
+   |            |                                              | type  |
+   +------------+----------------------------------------------+-------+
+   | acvVersion | Protocol version identifier                  | value |
+   |            |                                              |       |
+   | vsId       | Unique numeric identifier for the vector set | value |
+   |            |                                              |       |
+   | algorithm  | The algorithm and mode used for the test     | value |
+   |            | vectors. See Section 5.2 for possible        |       |
+   |            | values.                                      |       |
+   |            |                                              |       |
+   | testGroups | Array of test group JSON objects, which are  | array |
+   |            | defined in Section 5.3.1                     |       |
+   +------------+----------------------------------------------+-------+
+
+                   Table 20: HMAC Vector Set JSON Object
+
+5.3.1.  HMAC Test Groups JSON Schema
+
+   The testGroups element at the top level in the test vector JSON
+   object is an array of test groups.  Test vectors are grouped into
+   similar test cases to reduce the amount of data transmitted in the
+   vector set.  For instance, all test vectors that use the same key
+   size would be grouped together.  The Test Group JSON object contains
+   meta data that applies to all test vectors within the group.  The
+   following table describes the secure HMAC and CMAC JSON elements of
+   the Test Group JSON object.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 41]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +----------+-------------------------------------+-------+----------+
+   | JSON     | Description                         | JSON  | Optional |
+   | Value    |                                     | type  |          |
+   +----------+-------------------------------------+-------+----------+
+   | tgId     | Numeric identifier for the test     | value | No       |
+   |          | group, unique across the entire     |       |          |
+   |          | vector set.                         |       |          |
+   |          |                                     |       |          |
+   | testType | Test category type (AFT)            | value | No       |
+   |          |                                     |       |          |
+   | keyLen   | Length of key in bits to use        | value | No       |
+   |          |                                     |       |          |
+   | msgLen   | Length of message/hash in bits      | value | No       |
+   |          |                                     |       |          |
+   | macLen   | Length of MAC in bits to            | value | No       |
+   |          | generate/verify                     |       |          |
+   |          |                                     |       |          |
+   | tests    | Array of individual test vector     | array | No       |
+   |          | JSON objects, which are defined in  |       |          |
+   |          | Section 5.3.2                       |       |          |
+   +----------+-------------------------------------+-------+----------+
+
+                   Table 21: HMAC Test Group JSON Object
+
+5.3.2.  HMAC Test Case JSON Schema
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each secure MAC test vector.
+
+   +--------+---------------------------------------+-------+----------+
+   | JSON   | Description                           | JSON  | Optional |
+   | Value  |                                       | type  |          |
+   +--------+---------------------------------------+-------+----------+
+   | tcId   | Numeric identifier for the test case, | value | No       |
+   |        | unique across the entire vector set.  |       |          |
+   |        |                                       |       |          |
+   | key    | The value of the key                  | value | No       |
+   |        |                                       |       |          |
+   | msg    | Value of the message                  | value | No       |
+   |        |                                       |       |          |
+   +--------+---------------------------------------+-------+----------+
+
+                   Table 22: HMAC Test Case JSON Object
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 42]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+5.3.3.  Example HMAC Test Vector JSON Object
+
+   The following is an example JSON test vector object for HMAC.
+
+
+{
+    "vsId": 1,
+        "algorithm": "HMAC-SHA-1",
+        "testGroups": [{
+                "tgId": 1,
+                "testType": "AFT",
+                "keyLen": 56,
+                "msgLen": 128,
+                "macLen": 80,
+                "tests": [{
+                                "tcId": 1,
+                                "key": "0CBB3AA866E4D1",
+                                "msg": "28CD4091D45F28CD5709CC9B6F1E9D0D"
+                        },
+                        {
+                                "tcId": 2,
+                                "key": "7FB3F60ACB9FB7",
+                                "msg": "9F224BF653F9BE143FFA0518D12761F7"
+                        },
+                        {
+                                "tcId": 3,
+                                "key": "3834463234DA39",
+                                "msg": "F0FA740D261D5916B06F09AFBB04C94E"
+                        },
+                        {
+                                "tcId": 4,
+                                "key": "ED97154BE9D252",
+                                "msg": "4B491408D929C33980C13091FF95DCD7"
+                        },
+                        {
+                                "tcId": 5,
+                                "key": "24D8F9E20EA536",
+                                "msg": "DD0919DF2CDCB622E95D60E2E93E2B14"
+                        },
+                        {
+                                "tcId": 6,
+                                "key": "9AE463E4D85480",
+                                "msg": "DF4653D381B8FFF3B507A5B28708DCF2"
+                        },
+                        {
+                                "tcId": 7,
+                                "key": "E82C2306DADB20",
+                                "msg": "ABD9D90C4C912FC1F4208E8DC82C316A"
+
+
+
+Fussell                 Expires February 2, 2019               [Page 43]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                        },
+                        {
+                                "tcId": 8,
+                                "key": "98262DE8011B43",
+                                "msg": "79DD85559EF4C577DE8808B875398A36"
+                        },
+                        {
+                                "tcId": 9,
+                                "key": "064251F70AD327",
+                                "msg": "6719543EF69843BA4421EA9730470539"
+                        },
+                        {
+                                "tcId": 10,
+                                "key": "3B1887195138EC",
+                                "msg": "F1D7716FFF84F4472E2214DAA1662583"
+                        }
+                ]
+        }]
+}
+
+
+5.4.  HMAC Test Vector Responses
+
+   After the ACVP client downloads and processes a vector set, it must
+   send the response vectors back to the ACVP server.  The following
+   table describes the JSON object that represents a vector set
+   response.
+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | testGroups | Array of JSON objects that represent each   | array  |
+   |            | test vector group. See Table 24             |        |
+   |            |                                             |        |
+   +------------+---------------------------------------------+--------+
+
+              Table 23: HMAC Vector Set Response JSON Object
+
+   The testGroups section is used to organize the ACVP client response
+   in a similar manner to how it receives vectors.  Several algorithms
+   SHALL require the client to send back group level properties in their
+   response.  This structure helps accommodate that.
+
+
+
+Fussell                 Expires February 2, 2019               [Page 44]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +-----------+--------------------------------------------+----------+
+   | JSON      | Description                                | JSON     |
+   | Value     |                                            | type     |
+   +-----------+--------------------------------------------+----------+
+   | tgId      | The test group Id                          | value    |
+   |           |                                            |          |
+   | tests     | The tests associated to the group          | value    |
+   |           | specified in tgId                          |          |
+   |           |                                            |          |
+   +-----------+--------------------------------------------+----------+
+
+           Table 24: HMAC Vector Set Group Response JSON Object
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each DRBG test vector.
+
+   +--------+---------------------------------------+-------+----------+
+   | JSON   | Description                           | JSON  | Optional |
+   | Value  |                                       | type  |          |
+   +--------+---------------------------------------+-------+----------+
+   | tcId   | Numeric identifier for the test case, | value | No       |
+   |        | unique across the entire vector set.  |       |          |
+   |        |                                       |       |          |
+   | mac    | value of the computed MAC output      | value | No       |
+   |        |                                       |       |          |
+   +--------+---------------------------------------+-------+----------+
+
+               Table 25: HMAC Test Case Results JSON Object
+
+5.4.1.  Example HMAC Test Vector Response JSON Object
+
+   The following is an example JSON test vector response object for
+   HMAC.
+
+
+   {
+           "vsId": 1,
+           "algorithm": "HMAC-SHA-1",
+           "testGroups": [{
+                   "tgId": 1,
+                   "tests": [{
+                                   "tcId": 1,
+                                   "mac": "0970D053D6829C251070"
+                           },
+                           {
+                                   "tcId": 2,
+
+
+
+Fussell                 Expires February 2, 2019               [Page 45]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+                                   "mac": "3A476E0407D7ADF14792"
+                           },
+                           {
+                                   "tcId": 3,
+                                   "mac": "5B219B4C4862242DB175"
+                           },
+                           {
+                                   "tcId": 4,
+                                   "mac": "07A689738031C215C55C"
+                           },
+                           {
+                                   "tcId": 5,
+                                   "mac": "1A2633ADC7D119FBCD67"
+                           },
+                           {
+                                   "tcId": 6,
+                                   "mac": "4C41990B6E99AA39D03F"
+                           },
+                           {
+                                   "tcId": 7,
+                                   "mac": "9097773C9429DA776C16"
+                           },
+                           {
+                                   "tcId": 8,
+                                   "mac": "2F86E2DF1E5D65793373"
+                           },
+                           {
+                                   "tcId": 9,
+                                   "mac": "AE7222EA6DA826814612"
+                           },
+                           {
+                                   "tcId": 10,
+                                   "mac": "3CA58B0FA50E7EC66D0D"
+                           }
+                   ]
+           }]
+   }
+
+
+6.  Acknowledgements
 
    TBD...
 
-6.  IANA Considerations
+7.  IANA Considerations
 
    This memo includes no request to IANA.
 
@@ -612,28 +2573,27 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-Fussell                   Expires March 1, 2019                [Page 11]
+Fussell                 Expires February 2, 2019               [Page 46]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-7.  Security Considerations
+8.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
 
-8.  References
+9.  References
 
-8.1.  Normative References
+9.1.  Normative References
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997,
-              <https://www.rfc-editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
+              editor.org/info/rfc2119>.
 
-8.2.  Informative References
+9.2.  Informative References
 
    [CMACVS]   Sharon S. Keller, SSK., "The CMAC Validation System
               (CMACVS)", 2011.
@@ -646,402 +2606,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [SHAVS]    Lawrence E. Bassham III, LEB., "The Secure Hash Algorithm
               Validation System (SHAVS)", 2014.
-
-Appendix A.  Example MAC Capabilities JSON Object
-
-   The following is an example JSON object advertising support for HMAC-
-   SHA-1.
-
-
-
-            {
-                "algorithm": "HMAC-SHA2-256",
-                "prereqVals" : [{"algorithm" : "SHA", "valValue" : "123456"}],
-                "keyLen": [ { "min": 256, "max": 2048, "increment": 8 } ],
-                "macLen": [ 192 ]
-            }
-
-   The following is an example JSON object advertising support for CMAC-
-   AES.
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                [Page 12]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-            {
-                "algorithm": "CMAC-AES",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                                {"algorithm" : "TDES", "valValue" : "123456"}],
-                "direction" : [ "gen", "ver" ],
-                "keyLen" : [ 128, 192 ],
-                "macLen" : [ 64 ],
-                "msgLen" : [ 0 ]
-            }
-
-   The following is an example JSON object advertising support for CMAC-
-   TDES.
-
-
-
-            {
-                "algorithm": "CMAC-TDES",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-                                {"algorithm" : "TDES", "valValue" : "123456"}],
-                "direction" : [ "gen", "ver" ],
-                "keyingOption" : [ 1, 2 ],
-                "macLen" : [ 8, 64 ],
-                "msgLen" : [ 0, 256, 120, 248, 320 ]
-            }
-
-Appendix B.  Example Test Vectors JSON Object
-
-   The following is an example JSON object for HMAC test vectors sent
-   from the ACVP server to the crypto module.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                [Page 13]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-[{
-                "acvVersion": <acvp-version>
-        },
-        {
-                "vsId": 1565,
-                "algorithm": "HMAC-SHA-1",
-                "testGroups": [{
-                        "tgId": 1,
-                        "testType": "AFT",
-                        "keyLen": 256,
-                        "msgLen": 160,
-                        "macLen": 80,
-                        "tests": [{
-                                        "tcId": 2172,
-                                        "key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-                                        "msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-                                },
-                                {
-                                        "tcId": 2173,
-                                        "key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-                                        "msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-                                }
-                        ]
-                }]
-        }
-]
-
-   The following is an example JSON object for CMAC-AES test vectors
-   sent from the ACVP server to the crypto module.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                [Page 14]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-[{
-                "acvVersion": <acvp-version>
-        },
-        {
-                "vsId": 3500,
-                "algorithm": "CMAC-AES",
-                "testGroups": [{
-                        "tgId": 1,
-                        "testType": "AFT",
-                        "direction": "gen",
-                        "keyLen": 128,
-                        "msgLen": 0,
-                        "macLen": 64,
-                        "tests": [{
-                                        "tcId": 2750,
-                                        "key": "f28effca41cb11819a81eb3ebf3b7e83",
-                                        "msg": ""
-                                },
-                                {
-                                        "tcId": 2751,
-                                        "key": "ab566f4af532efc8bc56555fe07696fd",
-                                        "msg": ""
-                                }
-                        ]
-                }]
-        },
-        {
-                "tgId": 2,
-                "testType": "AFT",
-                "direction": "ver",
-                "keyLen": 128,
-                "msgLen": 0,
-                "macLen": 64,
-                "tests": [{
-                                "tcId": 2752,
-                                "key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-                                "msg": "",
-                                "mac": "2eef1e38fcc7c568"
-                        },
-                        {
-                                "tcId": 2753,
-                                "key": "eb87fb7a5fb60caecb9b23564befe513",
-                                "msg": "",
-                                "mac": "cafecafecafecafe"
-                        }
-                ]
-        }
-]
-
-
-
-Fussell                   Expires March 1, 2019                [Page 15]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-   The following is an example JSON object for CMAC-TDES test vectors
-   sent from the ACVP server to the crypto module.
-
-[{
-                "acvVersion": <acvp-version>
-        },
-        {
-                "vsId": 1566,
-                "algorithm": "CMAC-TDES",
-                "testGroups": [{
-                                "tgId": 1,
-                                "testType": "AFT",
-                                "direction": "gen",
-                                "keyingOption": 1,
-                                "msgLen": 0,
-                                "macLen": 40,
-                                "tests": [{
-                                                "tcId": 2175,
-                                                "key1": "c479f813ad1a45d5",
-                                                "key2": "dc43459da4c85e85",
-                                                "key3": "1cda518af886bf1f",
-                                                "msg": ""
-                                        },
-                                        {
-                                                "tcId": 2176,
-                                                "key1": "731331866754588f",
-                                                "key2": "d332ef51e0ce1925",
-                                                "key3": "d586cba70440f44f",
-                                                "msg": ""
-                                        }
-                                ]
-                        },
-                        {
-                                "tgId": 2,
-                                "testType": "AFT",
-                                "direction": "ver",
-                                "keyingOption": 1,
-                                "msgLen": 0,
-                                "macLen": 40,
-                                "tests": [{
-                                                "tcId": 2177,
-                                                "key1": "d586cba70440f44f",
-                                                "key2": "d332ef51e0ce1925",
-                                                "key3": "dc43459da4c85e85",
-                                                "msg": "",
-                                                "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                                        },
-                                        {
-
-
-
-Fussell                   Expires March 1, 2019                [Page 16]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-                                                "tcId": 2177,
-                                                "key1": "dc43459da4c85e85",
-                                                "key2": "c479f813ad1a45d5",
-                                                "key3": "1cda518af886bf1f",
-                                                "msg": "",
-                                                "mac": "cafecafecafecafecafecafecafecafecafecafe"
-                                        }
-                                ]
-                        }
-                ]
-        }
-]
-
-Appendix C.  Example Test Results JSON Object
-
-   The following is an example JSON object for HMAC test results sent
-   from the crypto module to the ACVP server.
-
-[{
-                "acvVersion": <acvp-version>
-        },
-        {
-                "vsId": 1565,
-                "testGroups": [{
-                        "tgId": 1,
-                        "tests": [{
-                                        "tcId": 2172,
-                                        "mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
-                                },
-                                {
-                                        "tcId": 2173,
-                                        "mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-                                }
-                        ]
-                }]
-        }
-]
-
-   The following is an example JSON object for CMAC-AES test results
-   sent from the crypto module to the ACVP server.
-
-
-
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                [Page 17]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-   [{
-                   "acvVersion": <acvp-version>
-           },
-           {
-                   "vsId": 3500,
-                   "testGroups": [{
-                           "tgId": 1,
-                           "tests": [{
-                                           "tcId": 2750,
-                                           "mac": "e77145f0d6c77ad5"
-                                   },
-                                   {
-                                           "tcId": 2751,
-                                           "mac": "6b078f7e53b6d183"
-                                   }
-                           ]
-                   }, {
-                           "tgId": 2,
-                           "tests": [{
-                                           "tcId": 2752,
-                                           "testPassed": true
-                                   },
-                                   {
-                                           "tcId": 2753,
-                                           "testPassed": false
-                                   }
-                           ]
-                   }]
-           }
-   ]
-
-   The following is an example JSON object for CMAC-TDES test results
-   sent from the crypto module to the ACVP server.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                [Page 18]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-   [{
-                   "acvVersion": <acvp-version>
-           },
-           {
-                   "vsId": 1566,
-                   "testGroups": [{
-                                   "tgId": 1,
-                                   "tests": [{
-                                                   "tcId": 2175,
-                                                   "mac": "fea01c84a7"
-                                           },
-                                           {
-                                                   "tcId": 2176,
-                                                   "mac": "164bdb8582"
-                                           }
-                                   ]
-                           },
-                           {
-                                   "tgId": 2,
-                                   "tests": [{
-                                                   "tcId": 2177,
-                                                   "testPassed": false
-                                           },
-                                           {
-                                                   "tcId": 2178,
-                                                   "testPassed": false
-                                           }
-                                   ]
-                           }
-                   ]
-           }
-   ]
 
 Author's Address
 
@@ -1061,4 +2625,8 @@ Author's Address
 
 
 
-Fussell                   Expires March 1, 2019                [Page 19]
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 47]

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -94,18 +94,18 @@ Table of Contents
        5.4.1.  Example HMAC Test Vector Response JSON Object . . . .  45
    6.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .  46
      6.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .  47
-       6.1.1.  CMAC-AES Requirements Covered . . . . . . . . . . . .  47
-       6.1.2.  CMAC-AES Requirements Not Covered . . . . . . . . . .  47
-       6.1.3.  CMAC-TDES Requirements Covered  . . . . . . . . . . .  47
-       6.1.4.  CMAC-TDES Requirements Not Covered  . . . . . . . . .  47
-       6.1.5.  HMAC Requirements Covered . . . . . . . . . . . . . .  47
-       6.1.6.  HMAC Requirements Not Covered . . . . . . . . . . . .  47
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  47
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  47
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  47
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  47
+       6.1.1.  CMAC Requirements Covered . . . . . . . . . . . . . .  47
+       6.1.2.  CMACRequirements Not Covered  . . . . . . . . . . . .  47
+       6.1.3.  HMAC Requirements Covered . . . . . . . . . . . . . .  47
+       6.1.4.  HMAC Requirements Not Covered . . . . . . . . . . . .  48
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  48
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  48
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  48
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  48
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  48
      10.2.  Informative References . . . . . . . . . . . . . . . . .  48
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  49
+
 
 
 
@@ -113,8 +113,6 @@ Fussell                 Expires February 2, 2019                [Page 2]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
-
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  48
 
 1.  Introduction
 
@@ -162,6 +160,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    underlying algorithm primitives must be validated, either separately
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
+
+
 
 
 
@@ -2578,13 +2578,13 @@ Fussell                 Expires February 2, 2019               [Page 46]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   subsections for CMACs).  the single test type, algorithm functional
+   subsections for CMACs). the single test type, algorithm functional
    test (AFT) can be described as follows:
 
       "AFT" - Algorithm Function Test.  The IUT processes all of HMAC
       and the "gen" direction of CMAC by running the randomly chosen key
       and message data (with constraints as per the IUT's capabilities
-      registration) through the MAC algorithm.  CMAC has an addition
+      registration) through the MAC algorithm.  CMAC has an additional
       "ver" direction present in its testing to ensure the IUT can
       successfully determine when a MAC does not match its originating
       message/key combination.
@@ -2594,17 +2594,58 @@ Internet-Draft                Sym Alg JSON                   August 2018
    The tests described in this document have the intention of ensuring
    an implementation is conformant to [SP-800-38B] and [FIPS-198-1].
 
-6.1.1.  CMAC-AES Requirements Covered
+6.1.1.  CMAC Requirements Covered
 
-6.1.2.  CMAC-AES Requirements Not Covered
+      SP 800-38b - 6.2 Mac Generation.  ACVP server creates random sets
+      of keys and messages for the IUT to process, then compares the
+      IUT's result to the ACVP result.
 
-6.1.3.  CMAC-TDES Requirements Covered
+      SP 800-38b - 6.3 Mac Verification.  ACVP server creates random
+      sets of keys, messages, and macs.  These test vectors are then
+      randomly altered to ensure the MAC will not match the given key
+      and message.  Using the provided test case, the IUT is expected to
+      validate the mac against the provided key and message.
 
-6.1.4.  CMAC-TDES Requirements Not Covered
+6.1.2.  CMACRequirements Not Covered
 
-6.1.5.  HMAC Requirements Covered
+      SP 800-38b - 5.4 Sub-keys.  While sub-keys are computed, as they
+      are intermediate values, are not validated via current testing.
 
-6.1.6.  HMAC Requirements Not Covered
+      SP 800-38b - 5.5 Input and Output Data.  The mlen is currently
+      provided and not inferred.
+
+      SP 800-38b - Appendix A.  Length of MAC.  The ACVP server will
+      generate vectors as per the IUT's specified criteria.  The IUT
+      should register its entire range of supported MAC lengths,
+      regardless of security strength.  The ACVP server will test a
+      random sampling of valid MAC lengths as per the IUT registration -
+      this generally includes the minimum and maximum mac length.
+
+6.1.3.  HMAC Requirements Covered
+
+      FIPS 198-1 - 3 Cryptographic Keys.  The ACVP server will test,
+      depending on the nature of the IUT capabilities registration, keys
+      that are below, at, or above the hashing algorithm block size.
+
+
+
+Fussell                 Expires February 2, 2019               [Page 47]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+      FIPS 198-1 - 4 HMAC Specification.  Mac Generation.  ACVP server
+      creates random sets of keys and messages for the IUT to process,
+      then compares the IUT's result to the ACVP result.
+
+      FIPS 198-1 - 5 Truncation.  The ACVP server is capable of
+      generating MACs as per the capability registration of the IUT.
+      Groups will be created containing a random sampling of valid MAC
+      lengths from the IUT registration.
+
+6.1.4.  HMAC Requirements Not Covered
+
+   N/A
 
 7.  Acknowledgements
 
@@ -2624,16 +2665,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
 
-
-
-
-
-
-Fussell                 Expires February 2, 2019               [Page 47]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
@@ -2651,6 +2682,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [HMACVS]   Lawrence E. Bassham III, LEB., "The Keyed-Hash Message
               Authentication Code Validation System (HMACVS)", 2016.
+
+
+
+Fussell                 Expires February 2, 2019               [Page 48]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    [SHA3VS]   Lawrence E. Bassham III, LEB., "The Secure Hash Algorithm
               3 Validation System (SHA3VS)", 2016.
@@ -2685,4 +2723,22 @@ Authors' Addresses
 
 
 
-Fussell                 Expires February 2, 2019               [Page 48]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 49]

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -4,8 +4,9 @@
 
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                               August 2018
-Expires: February 2, 2019
+Intended status: Informational                                  R. , Ed.
+Expires: February 2, 2019                                       G2, Inc.
+                                                             August 2018
 
 
         ACVP Message Authentication Algorithm JSON Specification
@@ -47,7 +48,6 @@ Copyright Notice
    include Simplified BSD License text as described in Section 4.e of
    the Trust Legal Provisions and are provided without warranty as
    described in the Simplified BSD License.
-
 
 
 
@@ -98,7 +98,7 @@ Table of Contents
    9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
      9.1.  Normative References  . . . . . . . . . . . . . . . . . .  47
      9.2.  Informative References  . . . . . . . . . . . . . . . . .  47
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  47
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  47
 
 1.  Introduction
 
@@ -2607,7 +2607,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    [SHAVS]    Lawrence E. Bassham III, LEB., "The Secure Hash Algorithm
               Validation System (SHAVS)", 2014.
 
-Author's Address
+Authors' Addresses
 
    Barry Fussell (editor)
    Cisco Systems, Inc.
@@ -2618,13 +2618,13 @@ Author's Address
    Email: bfussell@cisco.com
 
 
+   Russell Hammett (editor)
+   G2, Inc.
+   302 Sentinel Dr Suite 300
+   Annapolis Junction , MD  20701
+   USA
 
-
-
-
-
-
-
+   Email: russ.hammett@g2-inc.com
 
 
 

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -60,7 +60,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 Table of Contents
 
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
    2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
      2.1.  Required Prerequisite Algorithms for MAC Validations  . .   3
@@ -92,20 +92,20 @@ Table of Contents
        5.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  43
      5.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  44
        5.4.1.  Example HMAC Test Vector Response JSON Object . . . .  45
-   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  46
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  46
-   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  47
-   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
-     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  47
-     9.2.  Informative References  . . . . . . . . . . . . . . . . .  47
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  47
-
-1.  Introduction
-
-   The Automated Crypto Validation Protocol (ACVP) defines a mechanism
-   to automatically verify the cryptographic implementation of a
-   software or hardware crypto module.  The ACVP specification defines
-   how a crypto module communicates with an ACVP server, including
+   6.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .  46
+     6.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .  47
+       6.1.1.  CMAC-AES Requirements Covered . . . . . . . . . . . .  47
+       6.1.2.  CMAC-AES Requirements Not Covered . . . . . . . . . .  47
+       6.1.3.  CMAC-TDES Requirements Covered  . . . . . . . . . . .  47
+       6.1.4.  CMAC-TDES Requirements Not Covered  . . . . . . . . .  47
+       6.1.5.  HMAC Requirements Covered . . . . . . . . . . . . . .  47
+       6.1.6.  HMAC Requirements Not Covered . . . . . . . . . . . .  47
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  47
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  47
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  47
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  47
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  48
 
 
 
@@ -114,6 +114,14 @@ Fussell                 Expires February 2, 2019                [Page 2]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  48
+
+1.  Introduction
+
+   The Automated Crypto Validation Protocol (ACVP) defines a mechanism
+   to automatically verify the cryptographic implementation of a
+   software or hardware crypto module.  The ACVP specification defines
+   how a crypto module communicates with an ACVP server, including
    crypto capabilities negotiation, session management, authentication,
    vector processing and more.  The ACVP specification does not define
    algorithm specific JSON constructs for performing the crypto
@@ -154,14 +162,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    underlying algorithm primitives must be validated, either separately
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
-
-
-
-
-
-
-
-
 
 
 
@@ -2561,15 +2561,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-6.  Acknowledgements
+6.  Test Types and Test Coverage
 
-   TBD...
-
-7.  IANA Considerations
-
-   This memo includes no request to IANA.
-
-
+   The ACVP server performs a set of tests on the MAC algorithms in
+   order to assess the correctness and robustness of the implementation.
+   A typical ACVP validation session would require multiple tests to be
+   performed for every supported cryptographic algorithm, such as CMAC-
+   AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc.  This section
+   describes the design of the tests used to validate implementations of
+   MAC algorithms.  There is a single test type for MACs (broken into
 
 
 
@@ -2578,25 +2578,76 @@ Fussell                 Expires February 2, 2019               [Page 46]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-8.  Security Considerations
+   subsections for CMACs).  the single test type, algorithm functional
+   test (AFT) can be described as follows:
+
+      "AFT" - Algorithm Function Test.  The IUT processes all of HMAC
+      and the "gen" direction of CMAC by running the randomly chosen key
+      and message data (with constraints as per the IUT's capabilities
+      registration) through the MAC algorithm.  CMAC has an addition
+      "ver" direction present in its testing to ensure the IUT can
+      successfully determine when a MAC does not match its originating
+      message/key combination.
+
+6.1.  Test Coverage
+
+   The tests described in this document have the intention of ensuring
+   an implementation is conformant to [SP-800-38B] and [FIPS-198-1].
+
+6.1.1.  CMAC-AES Requirements Covered
+
+6.1.2.  CMAC-AES Requirements Not Covered
+
+6.1.3.  CMAC-TDES Requirements Covered
+
+6.1.4.  CMAC-TDES Requirements Not Covered
+
+6.1.5.  HMAC Requirements Covered
+
+6.1.6.  HMAC Requirements Not Covered
+
+7.  Acknowledgements
+
+   TBD...
+
+8.  IANA Considerations
+
+   This memo includes no request to IANA.
+
+9.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
 
-9.  References
+10.  References
 
-9.1.  Normative References
+10.1.  Normative References
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 47]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
               editor.org/info/rfc2119>.
 
-9.2.  Informative References
+10.2.  Informative References
 
    [CMACVS]   Sharon S. Keller, SSK., "The CMAC Validation System
               (CMACVS)", 2011.
+
+   [FIPS-198-1]
+              NIST, "The Keyed-Hash Message Authentication Code (HMAC)",
+              2008, <https://nvlpubs.nist.gov/nistpubs/FIPS/
+              NIST.FIPS.198-1.pdf>.
 
    [HMACVS]   Lawrence E. Bassham III, LEB., "The Keyed-Hash Message
               Authentication Code Validation System (HMACVS)", 2016.
@@ -2606,6 +2657,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [SHAVS]    Lawrence E. Bassham III, LEB., "The Secure Hash Algorithm
               Validation System (SHAVS)", 2014.
+
+   [SP-800-38B]
+              NIST, "Recommendation for Block Cipher Modes of Operation:
+              The CMAC Mode for Authentication", 2005,
+              <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/
+              NIST.SP.800-38b.pdf>.
 
 Authors' Addresses
 
@@ -2628,5 +2685,4 @@ Authors' Addresses
 
 
 
-
-Fussell                 Expires February 2, 2019               [Page 47]
+Fussell                 Expires February 2, 2019               [Page 48]

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -4,7 +4,7 @@
 
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                                  R. , Ed.
+Intended status: Informational                           R. Hammett, Ed.
 Expires: February 2, 2019                                       G2, Inc.
                                                              August 2018
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Fussell                 Expires February 2, 2019                [Page 1]
+Fussell & Hammett       Expires February 2, 2019                [Page 1]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -62,54 +62,54 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
-   2.  Capabilities Registration . . . . . . . . . . . . . . . . . .   3
-     2.1.  Required Prerequisite Algorithms for MAC Validations  . .   3
-   3.  CMAC-AES  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
-     3.1.  CMAC-AES Algorithm Capabilities Registration  . . . . . .   4
-       3.1.1.  Example CMAC-AES Capabilities JSON Object . . . . . .   6
-     3.2.  CMAC-AES Test Vectors . . . . . . . . . . . . . . . . . .   9
-       3.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .   9
-       3.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  10
-       3.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  11
-     3.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  15
-       3.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  16
-   4.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  19
-     4.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  19
-       4.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  22
-     4.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  23
-       4.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  24
-       4.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  25
-       4.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  26
-     4.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  32
-       4.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  33
-   5.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  36
-     5.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  36
-     5.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  38
-       5.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  38
-     5.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  39
-       5.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  40
-       5.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  41
-       5.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  42
-     5.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  43
-       5.4.1.  Example HMAC Test Vector Response JSON Object . . . .  44
-   6.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .  45
-     6.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .  46
-       6.1.1.  CMAC Requirements Covered . . . . . . . . . . . . . .  46
-       6.1.2.  CMACRequirements Not Covered  . . . . . . . . . . . .  46
-       6.1.3.  HMAC Requirements Covered . . . . . . . . . . . . . .  46
-       6.1.4.  HMAC Requirements Not Covered . . . . . . . . . . . .  47
+   2.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .   3
+     2.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .   3
+       2.1.1.  CMAC Requirements Covered . . . . . . . . . . . . . .   4
+       2.1.2.  CMACRequirements Not Covered  . . . . . . . . . . . .   4
+       2.1.3.  HMAC Requirements Covered . . . . . . . . . . . . . .   4
+       2.1.4.  HMAC Requirements Not Covered . . . . . . . . . . . .   4
+   3.  Capabilities Registration . . . . . . . . . . . . . . . . . .   5
+     3.1.  Required Prerequisite Algorithms for MAC Validations  . .   5
+   4.  CMAC-AES  . . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     4.1.  CMAC-AES Algorithm Capabilities Registration  . . . . . .   6
+       4.1.1.  Example CMAC-AES Capabilities JSON Object . . . . . .   7
+     4.2.  CMAC-AES Test Vectors . . . . . . . . . . . . . . . . . .  10
+       4.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .  11
+       4.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  12
+       4.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  13
+     4.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  17
+       4.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  18
+   5.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  21
+     5.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  21
+       5.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  24
+     5.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  25
+       5.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  26
+       5.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  27
+       5.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  28
+     5.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  34
+       5.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  35
+   6.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  38
+     6.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  38
+     6.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  40
+       6.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  40
+     6.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  41
+       6.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  42
+       6.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  43
+       6.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  44
+     6.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  45
+       6.4.1.  Example HMAC Test Vector Response JSON Object . . . .  46
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  47
    8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  47
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  47
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  47
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  47
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  48
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  48
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  48
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  48
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  48
 
 
 
 
-Fussell                 Expires February 2, 2019                [Page 2]
+Fussell & Hammett       Expires February 2, 2019                [Page 2]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -135,7 +135,98 @@ Internet-Draft                Sym Alg JSON                   August 2018
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted in RFC 2119 [RFC2119].
 
-2.  Capabilities Registration
+2.  Test Types and Test Coverage
+
+   The ACVP server performs a set of tests on the MAC algorithms in
+   order to assess the correctness and robustness of the implementation.
+   A typical ACVP validation session would require multiple tests to be
+   performed for every supported cryptographic algorithm, such as CMAC-
+   AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc.  This section
+   describes the design of the tests used to validate implementations of
+   MAC algorithms.  There is a single test type for MACs (broken into
+   subsections for CMACs). the single test type, algorithm functional
+   test (AFT) can be described as follows:
+
+      "AFT" - Algorithm Function Test.  The IUT processes all of HMAC
+      and the "gen" direction of CMAC by running the randomly chosen key
+      and message data (with constraints as per the IUT's capabilities
+      registration) through the MAC algorithm.  CMAC has an additional
+      "ver" direction present in its testing to ensure the IUT can
+      successfully determine when a MAC does not match its originating
+      message/key combination.
+
+2.1.  Test Coverage
+
+   The tests described in this document have the intention of ensuring
+   an implementation is conformant to [SP-800-38B] and [FIPS-198-1].
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 3]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+2.1.1.  CMAC Requirements Covered
+
+      SP 800-38b - 6.2 Mac Generation.  ACVP server creates random sets
+      of keys and messages for the IUT to process, then compares the
+      IUT's result to the ACVP result.
+
+      SP 800-38b - 6.3 Mac Verification.  ACVP server creates random
+      sets of keys, messages, and macs.  These test vectors are then
+      randomly altered to ensure the MAC will not match the given key
+      and message.  Using the provided test case, the IUT is expected to
+      validate the mac against the provided key and message.
+
+2.1.2.  CMACRequirements Not Covered
+
+      SP 800-38b - 5.4 Sub-keys.  While sub-keys are computed, as they
+      are intermediate values, are not validated via current testing.
+
+      SP 800-38b - 5.5 Input and Output Data.  The mlen is currently
+      provided and not inferred.
+
+      SP 800-38b - Appendix A.  Length of MAC.  The ACVP server will
+      generate vectors as per the IUT's specified criteria.  The IUT
+      should register its entire range of supported MAC lengths,
+      regardless of security strength.  The ACVP server will test a
+      random sampling of valid MAC lengths as per the IUT registration -
+      this generally includes the minimum and maximum mac length.
+
+2.1.3.  HMAC Requirements Covered
+
+      FIPS 198-1 - 3 Cryptographic Keys.  The ACVP server will test,
+      depending on the nature of the IUT capabilities registration, keys
+      that are below, at, or above the hashing algorithm block size.
+
+      FIPS 198-1 - 4 HMAC Specification.  Mac Generation.  ACVP server
+      creates random sets of keys and messages for the IUT to process,
+      then compares the IUT's result to the ACVP result.
+
+      FIPS 198-1 - 5 Truncation.  The ACVP server is capable of
+      generating MACs as per the capability registration of the IUT.
+      Groups will be created containing a random sampling of valid MAC
+      lengths from the IUT registration.
+
+2.1.4.  HMAC Requirements Not Covered
+
+   N/A
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 4]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+3.  Capabilities Registration
 
    ACVP requires crypto modules to register their capabilities.  This
    allows the crypto module to advertise support for specific
@@ -153,22 +244,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    registration message.  Each algorithm capability advertised is a
    self-contained JSON object.
 
-2.1.  Required Prerequisite Algorithms for MAC Validations
+3.1.  Required Prerequisite Algorithms for MAC Validations
 
    Each MAC implementation relies on other cryptographic primitives.
    For example, CMAC uses an underlying SHA algorithm.  Each of these
    underlying algorithm primitives must be validated, either separately
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
-
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 3]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
    +--------------+--------------+---------------+----------+----------+
    | JSON Value   | Description  | JSON type     | Valid    | Optional |
@@ -191,40 +273,21 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
          Table 1: Required MAC Prerequisite Algorithms JSON Values
 
-3.  CMAC-AES
-
-3.1.  CMAC-AES Algorithm Capabilities Registration
-
-   Each algorithm capability advertised is a self-contained JSON object
-   using the following values.
 
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 4]
+Fussell & Hammett       Expires February 2, 2019                [Page 5]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+4.  CMAC-AES
+
+4.1.  CMAC-AES Algorithm Capabilities Registration
+
+   Each algorithm capability advertised is a self-contained JSON object
+   using the following values.
 
    +--------------+---------------+--------------+----------+----------+
    | JSON Value   | Description   | JSON type    | Valid    | Optional |
@@ -236,9 +299,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              |               |              |          |          |
    | prereqVals   | prerequistie  | array of     | See      | No       |
    |              | algorithm     | prereqAlgVal | Section  |          |
-   |              | validations,  | objects      | 2.1      |          |
+   |              | validations,  | objects      | 3.1      |          |
    |              | See Section   |              |          |          |
-   |              | 2.1 for       |              |          |          |
+   |              | 3.1 for       |              |          |          |
    |              | examples      |              |          |          |
    |              |               |              |          |          |
    | capabilities | The CMAC-AES  | array of     | See      | No       |
@@ -251,6 +314,29 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    Each capability object describes a separate permutation of direction
    and key length.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 6]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    +-----------+------------------------+--------+----------+----------+
    | JSON      | Description            | JSON   | Valid    | Optional |
@@ -275,13 +361,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
                 Table 3: CMAC-AES Capabilities JSON Values
 
-
-
-Fussell                 Expires February 2, 2019                [Page 5]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    macLen for CMAC contains a Domain of values, the server may choose
    values defined by these rules:
 
@@ -302,10 +381,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  The largest message length supported
 
-3.1.1.  Example CMAC-AES Capabilities JSON Object
+4.1.1.  Example CMAC-AES Capabilities JSON Object
 
    The following is an example JSON object advertising support for CMAC-
    AES.
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 7]
+
+Internet-Draft                Sym Alg JSON                   August 2018
 
 
    {
@@ -330,14 +416,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
            }
          ]
        },
-
-
-
-Fussell                 Expires February 2, 2019                [Page 6]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
        {
          "direction": "ver",
          "keyLen": 128,
@@ -364,6 +442,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
          "msgLen": [
            {
              "min": 0,
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 8]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
              "max": 65536,
              "increment": 8
            }
@@ -386,14 +472,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "max": 65536,
              "increment": 8
            }
-
-
-
-Fussell                 Expires February 2, 2019                [Page 7]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
          ],
          "macLen": [
            {
@@ -420,6 +498,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "max": 128,
              "increment": 8
            }
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 9]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
          ]
        },
        {
@@ -442,18 +528,10 @@ Internet-Draft                Sym Alg JSON                   August 2018
          ]
        }
      ]
-
-
-
-Fussell                 Expires February 2, 2019                [Page 8]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    }
 
 
-3.2.  CMAC-AES Test Vectors
+4.2.  CMAC-AES Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -469,6 +547,21 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
 
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 10]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
    |            |                                             | type   |
@@ -481,12 +574,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | algorithm  | The algorithm used for the test vectors.    | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
-   |            | defined in Section 3.2.1                    |        |
+   |            | defined in Section 4.2.1                    |        |
    +------------+---------------------------------------------+--------+
 
                  Table 4: CMAC-AES Vector Set JSON Object
 
-3.2.1.  CMAC-AES Test Groups JSON Schema
+4.2.1.  CMAC-AES Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -501,7 +594,26 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019                [Page 9]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -528,12 +640,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |           |                                    |       |          |
    | tests     | Array of individual test vector    | array | No       |
    |           | JSON objects, which are defined in |       |          |
-   |           | Section 3.2.2                      |       |          |
+   |           | Section 4.2.2                      |       |          |
    +-----------+------------------------------------+-------+----------+
 
                  Table 5: CMAC-AES Test Group JSON Object
 
-3.2.2.  CMAC-AES Test Case JSON Schema
+4.2.2.  CMAC-AES Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -557,7 +669,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 10]
+Fussell & Hammett       Expires February 2, 2019               [Page 12]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -578,13 +690,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
                   Table 6: CMAC-AES Test Case JSON Object
 
-3.2.3.  Example CMAC-AES Test Vector JSON Object
+4.2.3.  Example CMAC-AES Test Vector JSON Object
 
    The following is an example JSON test vector object for CMAC-AES.
 
 
 {
-    "vsId": 1,
+        "vsId": 1,
         "algorithm": "CMAC-AES",
         "testGroups": [{
                         "tgId": 4,
@@ -613,7 +725,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 11]
+Fussell & Hammett       Expires February 2, 2019               [Page 13]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -669,7 +781,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 12]
+Fussell & Hammett       Expires February 2, 2019               [Page 14]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -725,7 +837,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 13]
+Fussell & Hammett       Expires February 2, 2019               [Page 15]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -781,7 +893,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 14]
+Fussell & Hammett       Expires February 2, 2019               [Page 16]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -800,7 +912,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 }
 
 
-3.3.  CMAC-AES Test Vector Responses
+4.3.  CMAC-AES Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
@@ -837,7 +949,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 15]
+Fussell & Hammett       Expires February 2, 2019               [Page 17]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -877,7 +989,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
               Table 9: CMAC-AES Test Case Results JSON Object
 
-3.3.1.  Example CMAC-AES Test Vector Response JSON Object
+4.3.1.  Example CMAC-AES Test Vector Response JSON Object
 
    The following is an example JSON test vector response object for
    CMAC-AES.
@@ -893,7 +1005,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 16]
+Fussell & Hammett       Expires February 2, 2019               [Page 18]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -949,7 +1061,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 17]
+Fussell & Hammett       Expires February 2, 2019               [Page 19]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1005,7 +1117,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 18]
+Fussell & Hammett       Expires February 2, 2019               [Page 20]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1034,9 +1146,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-4.  CMAC-TDES
+5.  CMAC-TDES
 
-4.1.  CMAC-TDES Algorithm Capabilities Registration
+5.1.  CMAC-TDES Algorithm Capabilities Registration
 
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
@@ -1061,7 +1173,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 19]
+Fussell & Hammett       Expires February 2, 2019               [Page 21]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1077,9 +1189,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              |              |              |           |          |
    | prereqVals   | prerequistie | array of     | See       | No       |
    |              | algorithm    | prereqAlgVal | Section   |          |
-   |              | validations, | objects      | 2.1       |          |
+   |              | validations, | objects      | 3.1       |          |
    |              | See Section  |              |           |          |
-   |              | 2.1 for      |              |           |          |
+   |              | 3.1 for      |              |           |          |
    |              | examples     |              |           |          |
    |              |              |              |           |          |
    | capabilities | The CMAC-    | array of     | See Table | No       |
@@ -1117,7 +1229,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 20]
+Fussell & Hammett       Expires February 2, 2019               [Page 22]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1173,7 +1285,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 21]
+Fussell & Hammett       Expires February 2, 2019               [Page 23]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1189,7 +1301,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  The largest message length supported
 
-4.1.1.  Example CMAC-TDES Capabilities JSON Object
+5.1.1.  Example CMAC-TDES Capabilities JSON Object
 
    The following is an example JSON object advertising support for CMAC-
    TDES.
@@ -1229,7 +1341,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 22]
+Fussell & Hammett       Expires February 2, 2019               [Page 24]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1264,7 +1376,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-4.2.  CMAC-TDES Test Vectors
+5.2.  CMAC-TDES Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -1285,7 +1397,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 23]
+Fussell & Hammett       Expires February 2, 2019               [Page 25]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1302,12 +1414,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | algorithm  | The algorithm used for the test vectors.    | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
-   |            | defined in Section 4.2.1                    |        |
+   |            | defined in Section 5.2.1                    |        |
    +------------+---------------------------------------------+--------+
 
                 Table 12: CMAC-TDES Vector Set JSON Object
 
-4.2.1.  CMAC-TDES Test Groups JSON Schema
+5.2.1.  CMAC-TDES Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -1341,7 +1453,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 24]
+Fussell & Hammett       Expires February 2, 2019               [Page 26]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1368,12 +1480,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |           |                                    |       |          |
    | tests     | Array of individual test vector    | array | No       |
    |           | JSON objects, which are defined in |       |          |
-   |           | Section 4.2.2                      |       |          |
+   |           | Section 5.2.2                      |       |          |
    +-----------+------------------------------------+-------+----------+
 
                 Table 13: CMAC-TDES Test Group JSON Object
 
-4.2.2.  CMAC-TDES Test Case JSON Schema
+5.2.2.  CMAC-TDES Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -1397,7 +1509,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 25]
+Fussell & Hammett       Expires February 2, 2019               [Page 27]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1421,7 +1533,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
                  Table 14: CMAC-TDES Test Case JSON Object
 
-4.2.3.  Example CMAC-TDES Test Vector JSON Object
+5.2.3.  Example CMAC-TDES Test Vector JSON Object
 
    The following is an example JSON test vector object for CMAC-TDES.
 
@@ -1453,7 +1565,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 26]
+Fussell & Hammett       Expires February 2, 2019               [Page 28]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1509,7 +1621,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 27]
+Fussell & Hammett       Expires February 2, 2019               [Page 29]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1565,7 +1677,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 28]
+Fussell & Hammett       Expires February 2, 2019               [Page 30]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1621,7 +1733,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 29]
+Fussell & Hammett       Expires February 2, 2019               [Page 31]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1677,7 +1789,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 30]
+Fussell & Hammett       Expires February 2, 2019               [Page 32]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1733,7 +1845,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 31]
+Fussell & Hammett       Expires February 2, 2019               [Page 33]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1745,7 +1857,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 }
 
 
-4.3.  CMAC-TDES Test Vector Responses
+5.3.  CMAC-TDES Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
@@ -1789,7 +1901,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 32]
+Fussell & Hammett       Expires February 2, 2019               [Page 34]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1816,7 +1928,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
              Table 17: CMAC-TDES Test Case Results JSON Object
 
-4.3.1.  Example CMAC-TDES Test Vector Response JSON Object
+5.3.1.  Example CMAC-TDES Test Vector Response JSON Object
 
    The following is an example JSON test vector response object for
    CMAC-TDES.
@@ -1845,7 +1957,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 33]
+Fussell & Hammett       Expires February 2, 2019               [Page 35]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1901,7 +2013,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 34]
+Fussell & Hammett       Expires February 2, 2019               [Page 36]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1957,7 +2069,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 35]
+Fussell & Hammett       Expires February 2, 2019               [Page 37]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1973,9 +2085,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-5.  HMAC
+6.  HMAC
 
-5.1.  HMAC Algorithm Capabilities Registration
+6.1.  HMAC Algorithm Capabilities Registration
 
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
@@ -2013,7 +2125,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 36]
+Fussell & Hammett       Expires February 2, 2019               [Page 38]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2024,13 +2136,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    +------------+-----------------+--------------+----------+----------+
    | algorithm  | The MAC         | value        | See      | No       |
    |            | algorithm and   |              | Section  |          |
-   |            | mode to be      |              | 5.2      |          |
+   |            | mode to be      |              | 6.2      |          |
    |            | validated.      |              |          |          |
    |            |                 |              |          |          |
    | prereqVals | prerequistie    | array of     | See      | No       |
    |            | algorithm       | prereqAlgVal | Section  |          |
-   |            | validations,    | objects      | 2.1      |          |
-   |            | See Section 2.1 |              |          |          |
+   |            | validations,    | objects      | 3.1      |          |
+   |            | See Section 3.1 |              |          |          |
    |            | for examples    |              |          |          |
    |            |                 |              |          |          |
    | keyLen     | The keyLen      | Domain       | 8-524288 | No       |
@@ -2044,7 +2156,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | (range          |              |          |          |
    |            | dependent on    |              |          |          |
    |            | algorithm, see  |              |          |          |
-   |            | Section 5.2).   |              |          |          |
+   |            | Section 6.2).   |              |          |          |
    |            |                 |              |          |          |
    +------------+-----------------+--------------+----------+----------+
 
@@ -2053,7 +2165,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    keyLen for HMAC contains a Domain of values, the server may choose
    values defined by these rules:
 
-   o  2 values below the Hash's block length.  See Section 5.2
+   o  2 values below the Hash's block length.  See Section 6.2
 
    o  The Hash's block length.
 
@@ -2069,14 +2181,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 37]
+Fussell & Hammett       Expires February 2, 2019               [Page 39]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
    o  The largest HMAC length supported
 
-5.2.  Supported HMAC Algorithms
+6.2.  Supported HMAC Algorithms
 
    The following algorithms may be advertised by the ACVP compliant
    crypto module:
@@ -2110,7 +2222,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
           Table 19: Algorithms w/ block size and max CMAC length.
 
-5.2.1.  Example HMAC Capabilities JSON Object
+6.2.1.  Example HMAC Capabilities JSON Object
 
    The following is an example JSON object advertising support for HMAC.
 
@@ -2125,7 +2237,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 38]
+Fussell & Hammett       Expires February 2, 2019               [Page 40]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2149,7 +2261,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-5.3.  HMAC Test Vectors
+6.3.  HMAC Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -2181,7 +2293,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 39]
+Fussell & Hammett       Expires February 2, 2019               [Page 41]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2195,16 +2307,16 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | vsId       | Unique numeric identifier for the vector set | value |
    |            |                                              |       |
    | algorithm  | The algorithm and mode used for the test     | value |
-   |            | vectors. See Section 5.2 for possible        |       |
+   |            | vectors. See Section 6.2 for possible        |       |
    |            | values.                                      |       |
    |            |                                              |       |
    | testGroups | Array of test group JSON objects, which are  | array |
-   |            | defined in Section 5.3.1                     |       |
+   |            | defined in Section 6.3.1                     |       |
    +------------+----------------------------------------------+-------+
 
                    Table 20: HMAC Vector Set JSON Object
 
-5.3.1.  HMAC Test Groups JSON Schema
+6.3.1.  HMAC Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -2237,7 +2349,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 40]
+Fussell & Hammett       Expires February 2, 2019               [Page 42]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2261,12 +2373,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |          |                                     |       |          |
    | tests    | Array of individual test vector     | array | No       |
    |          | JSON objects, which are defined in  |       |          |
-   |          | Section 5.3.2                       |       |          |
+   |          | Section 6.3.2                       |       |          |
    +----------+-------------------------------------+-------+----------+
 
                    Table 21: HMAC Test Group JSON Object
 
-5.3.2.  HMAC Test Case JSON Schema
+6.3.2.  HMAC Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -2293,12 +2405,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 41]
+Fussell & Hammett       Expires February 2, 2019               [Page 43]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-5.3.3.  Example HMAC Test Vector JSON Object
+6.3.3.  Example HMAC Test Vector JSON Object
 
    The following is an example JSON test vector object for HMAC.
 
@@ -2349,7 +2461,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 42]
+Fussell & Hammett       Expires February 2, 2019               [Page 44]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2375,7 +2487,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 }
 
 
-5.4.  HMAC Test Vector Responses
+6.4.  HMAC Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
@@ -2405,7 +2517,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 43]
+Fussell & Hammett       Expires February 2, 2019               [Page 45]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2441,7 +2553,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
                Table 25: HMAC Test Case Results JSON Object
 
-5.4.1.  Example HMAC Test Vector Response JSON Object
+6.4.1.  Example HMAC Test Vector Response JSON Object
 
    The following is an example JSON test vector response object for
    HMAC.
@@ -2461,7 +2573,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 44]
+Fussell & Hammett       Expires February 2, 2019               [Page 46]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2505,92 +2617,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-6.  Test Types and Test Coverage
-
-   The ACVP server performs a set of tests on the MAC algorithms in
-   order to assess the correctness and robustness of the implementation.
-   A typical ACVP validation session would require multiple tests to be
-   performed for every supported cryptographic algorithm, such as CMAC-
-   AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc.  This section
-   describes the design of the tests used to validate implementations of
-   MAC algorithms.  There is a single test type for MACs (broken into
-
-
-
-Fussell                 Expires February 2, 2019               [Page 45]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-   subsections for CMACs). the single test type, algorithm functional
-   test (AFT) can be described as follows:
-
-      "AFT" - Algorithm Function Test.  The IUT processes all of HMAC
-      and the "gen" direction of CMAC by running the randomly chosen key
-      and message data (with constraints as per the IUT's capabilities
-      registration) through the MAC algorithm.  CMAC has an additional
-      "ver" direction present in its testing to ensure the IUT can
-      successfully determine when a MAC does not match its originating
-      message/key combination.
-
-6.1.  Test Coverage
-
-   The tests described in this document have the intention of ensuring
-   an implementation is conformant to [SP-800-38B] and [FIPS-198-1].
-
-6.1.1.  CMAC Requirements Covered
-
-      SP 800-38b - 6.2 Mac Generation.  ACVP server creates random sets
-      of keys and messages for the IUT to process, then compares the
-      IUT's result to the ACVP result.
-
-      SP 800-38b - 6.3 Mac Verification.  ACVP server creates random
-      sets of keys, messages, and macs.  These test vectors are then
-      randomly altered to ensure the MAC will not match the given key
-      and message.  Using the provided test case, the IUT is expected to
-      validate the mac against the provided key and message.
-
-6.1.2.  CMACRequirements Not Covered
-
-      SP 800-38b - 5.4 Sub-keys.  While sub-keys are computed, as they
-      are intermediate values, are not validated via current testing.
-
-      SP 800-38b - 5.5 Input and Output Data.  The mlen is currently
-      provided and not inferred.
-
-      SP 800-38b - Appendix A.  Length of MAC.  The ACVP server will
-      generate vectors as per the IUT's specified criteria.  The IUT
-      should register its entire range of supported MAC lengths,
-      regardless of security strength.  The ACVP server will test a
-      random sampling of valid MAC lengths as per the IUT registration -
-      this generally includes the minimum and maximum mac length.
-
-6.1.3.  HMAC Requirements Covered
-
-      FIPS 198-1 - 3 Cryptographic Keys.  The ACVP server will test,
-      depending on the nature of the IUT capabilities registration, keys
-      that are below, at, or above the hashing algorithm block size.
-
-
-
-Fussell                 Expires February 2, 2019               [Page 46]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
-      FIPS 198-1 - 4 HMAC Specification.  Mac Generation.  ACVP server
-      creates random sets of keys and messages for the IUT to process,
-      then compares the IUT's result to the ACVP result.
-
-      FIPS 198-1 - 5 Truncation.  The ACVP server is capable of
-      generating MACs as per the capability registration of the IUT.
-      Groups will be created containing a random sampling of valid MAC
-      lengths from the IUT registration.
-
-6.1.4.  HMAC Requirements Not Covered
-
-   N/A
-
 7.  Acknowledgements
 
    TBD...
@@ -2598,6 +2624,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
 8.  IANA Considerations
 
    This memo includes no request to IANA.
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 47]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
 9.  Security Considerations
 
@@ -2627,13 +2662,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    [HMACVS]   Lawrence E. Bassham III, LEB., "The Keyed-Hash Message
               Authentication Code Validation System (HMACVS)", 2016.
 
-
-
-Fussell                 Expires February 2, 2019               [Page 47]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    [SHA3VS]   Lawrence E. Bassham III, LEB., "The Secure Hash Algorithm
               3 Validation System (SHA3VS)", 2016.
 
@@ -2647,6 +2675,20 @@ Internet-Draft                Sym Alg JSON                   August 2018
               NIST.SP.800-38b.pdf>.
 
 Authors' Addresses
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 48]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    Barry Fussell (editor)
    Cisco Systems, Inc.
@@ -2685,4 +2727,18 @@ Authors' Addresses
 
 
 
-Fussell                 Expires February 2, 2019               [Page 48]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 49]

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -68,43 +68,43 @@ Table of Contents
      3.1.  CMAC-AES Algorithm Capabilities Registration  . . . . . .   4
        3.1.1.  Example CMAC-AES Capabilities JSON Object . . . . . .   6
      3.2.  CMAC-AES Test Vectors . . . . . . . . . . . . . . . . . .   9
-       3.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .  10
-       3.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  11
-       3.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  12
-     3.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  16
-       3.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  17
-   4.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  20
-     4.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  20
-       4.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  23
-     4.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  24
-       4.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  25
-       4.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  26
-       4.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  27
-     4.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  33
-       4.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  34
-   5.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  37
-     5.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  37
-     5.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  39
-       5.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  39
-     5.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  40
-       5.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  41
-       5.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  42
-       5.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  43
-     5.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  44
-       5.4.1.  Example HMAC Test Vector Response JSON Object . . . .  45
-   6.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .  46
-     6.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .  47
-       6.1.1.  CMAC Requirements Covered . . . . . . . . . . . . . .  47
-       6.1.2.  CMACRequirements Not Covered  . . . . . . . . . . . .  47
-       6.1.3.  HMAC Requirements Covered . . . . . . . . . . . . . .  47
-       6.1.4.  HMAC Requirements Not Covered . . . . . . . . . . . .  48
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  48
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  48
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  48
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  48
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  48
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  48
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  49
+       3.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .   9
+       3.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  10
+       3.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  11
+     3.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  15
+       3.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  16
+   4.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  19
+     4.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  19
+       4.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  22
+     4.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  23
+       4.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  24
+       4.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  25
+       4.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  26
+     4.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  32
+       4.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  33
+   5.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  36
+     5.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  36
+     5.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  38
+       5.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  38
+     5.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  39
+       5.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  40
+       5.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  41
+       5.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  42
+     5.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  43
+       5.4.1.  Example HMAC Test Vector Response JSON Object . . . .  44
+   6.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .  45
+     6.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .  46
+       6.1.1.  CMAC Requirements Covered . . . . . . . . . . . . . .  46
+       6.1.2.  CMACRequirements Not Covered  . . . . . . . . . . . .  46
+       6.1.3.  HMAC Requirements Covered . . . . . . . . . . . . . .  46
+       6.1.4.  HMAC Requirements Not Covered . . . . . . . . . . . .  47
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  47
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  47
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  47
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  47
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  47
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  47
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  48
 
 
 
@@ -226,61 +226,31 @@ Fussell                 Expires February 2, 2019                [Page 4]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   +--------------+----------------+--------------+---------+----------+
-   | JSON Value   | Description    | JSON type    | Valid   | Optional |
-   |              |                |              | Values  |          |
-   +--------------+----------------+--------------+---------+----------+
-   | algorithm    | The MAC        | value        | CMAC    | No       |
-   |              | algorithm to   |              |         |          |
-   |              | be validated.  |              |         |          |
-   |              |                |              |         |          |
-   | mode         | The mode to be | value        | AES     | No       |
-   |              | validated.     |              |         |          |
-   |              |                |              |         |          |
-   | prereqVals   | prerequistie   | array of     | See     | No       |
-   |              | algorithm      | prereqAlgVal | Section |          |
-   |              | validations,   | objects      | 2.1     |          |
-   |              | See Section    |              |         |          |
-   |              | 2.1 for        |              |         |          |
-   |              | examples       |              |         |          |
-   |              |                |              |         |          |
-   | capabilities | The CMAC-AES   | array of     | See     | No       |
-   |              | capabilities   | capability   | Table 3 |          |
-   |              |                | objects      |         |          |
-   |              |                |              |         |          |
-   +--------------+----------------+--------------+---------+----------+
+   +--------------+---------------+--------------+----------+----------+
+   | JSON Value   | Description   | JSON type    | Valid    | Optional |
+   |              |               |              | Values   |          |
+   +--------------+---------------+--------------+----------+----------+
+   | algorithm    | The MAC       | value        | CMAC-AES | No       |
+   |              | algorithm to  |              |          |          |
+   |              | be validated. |              |          |          |
+   |              |               |              |          |          |
+   | prereqVals   | prerequistie  | array of     | See      | No       |
+   |              | algorithm     | prereqAlgVal | Section  |          |
+   |              | validations,  | objects      | 2.1      |          |
+   |              | See Section   |              |          |          |
+   |              | 2.1 for       |              |          |          |
+   |              | examples      |              |          |          |
+   |              |               |              |          |          |
+   | capabilities | The CMAC-AES  | array of     | See      | No       |
+   |              | capabilities  | capability   | Table 3  |          |
+   |              |               | objects      |          |          |
+   |              |               |              |          |          |
+   +--------------+---------------+--------------+----------+----------+
 
            Table 2: CMAC-AES Algorithm Capabilities JSON Values
 
    Each capability object describes a separate permutation of direction
    and key length.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 5]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
    +-----------+------------------------+--------+----------+----------+
    | JSON      | Description            | JSON   | Valid    | Optional |
@@ -304,6 +274,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    +-----------+------------------------+--------+----------+----------+
 
                 Table 3: CMAC-AES Capabilities JSON Values
+
+
+
+Fussell                 Expires February 2, 2019                [Page 5]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    macLen for CMAC contains a Domain of values, the server may choose
    values defined by these rules:
@@ -331,16 +308,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    AES.
 
 
-
-
-Fussell                 Expires February 2, 2019                [Page 6]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    {
-     "algorithm": "CMAC",
-     "mode": "AES",
+     "algorithm": "CMAC-AES",
      "capabilities": [
        {
          "direction": "gen",
@@ -361,6 +330,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
            }
          ]
        },
+
+
+
+Fussell                 Expires February 2, 2019                [Page 6]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
        {
          "direction": "ver",
          "keyLen": 128,
@@ -386,14 +363,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
          "keyingOption": 0,
          "msgLen": [
            {
-
-
-
-Fussell                 Expires February 2, 2019                [Page 7]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
              "min": 0,
              "max": 65536,
              "increment": 8
@@ -417,6 +386,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "max": 65536,
              "increment": 8
            }
+
+
+
+Fussell                 Expires February 2, 2019                [Page 7]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
          ],
          "macLen": [
            {
@@ -442,14 +419,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "min": 64,
              "max": 128,
              "increment": 8
-
-
-
-Fussell                 Expires February 2, 2019                [Page 8]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
            }
          ]
        },
@@ -473,6 +442,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
          ]
        }
      ]
+
+
+
+Fussell                 Expires February 2, 2019                [Page 8]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
    }
 
 
@@ -492,20 +469,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
 
-
-
-
-
-
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 9]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
    |            |                                             | type   |
@@ -516,8 +479,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | algorithm  | The algorithm used for the test vectors.    | value  |
-   |            |                                             |        |
-   | mode       | The mode used for the test vectors.         | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.2.1                    |        |
@@ -540,24 +501,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires February 2, 2019               [Page 10]
+Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -613,7 +557,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 11]
+Fussell                 Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -641,8 +585,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 {
     "vsId": 1,
-        "algorithm": "CMAC",
-        "mode": "AES",
+        "algorithm": "CMAC-AES",
         "testGroups": [{
                         "tgId": 4,
                         "testType": "AFT",
@@ -666,15 +609,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "message": "39A3DD0652483A26FB9D71F30A5E29D326627FE16E29E3A3BF8EDF68645B477B5DE88499EDB3CF9E036F3D0D316241EE7C569F74925AD0BD3DCBBA21E73D9638ABA2554C4CA62AC5D7113B3FE7216E79AFC7A6FB94F21EB234D0401879A6B03EAE242EA0DCF1B523513467B00C048E7DE333C8977C455DD943323D01C97CF93EC24843769E52AD785E2340F2CC61E571D2099472E47286F29BCDF28A69144692263312F176618777A6AD0A0338F8A636BCA6150F0E1F72D539BAD726C95425682678EA7297A118E819A2925747C0AD72F3BCDF8E7D6C0A11A6AA938E4AA119390451C4E56B99F29C34927C1830197FCD4921C7E38E29BAEA5E560C8A3D4D7B96BBC370C78EF794BA9F6DB737576867B334D1DCC537D4FD751952DDFF549109ECCAD38198CCB49F25E7FEB88B9FD33D3B56601B473946693C5C3D7B2D1C7BB857F9560B94A3BD145019150BA11159B39480F97B0DE90243D6"
                                 },
                                 {
+                                        "tcId": 28,
 
 
 
-Fussell                 Expires February 2, 2019               [Page 12]
+Fussell                 Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "tcId": 28,
                                         "key": "1E220113298DA3B30E14F1432C16FCE8",
                                         "message": "497E82B322B18B0295F3B4359AC0CFAF1D36B46F36C9E123B95B90985B06AC6AFAFB772E21CCA4665CEABFF9C1CE3D78F804BEBAC6F171C0ADA47FC718E7EC55EC7603D739C8B4DBF07B60A78A8EC83922A880485B99E0FED2B1F7D5A895E2BD9149888A085F21794C1953A6EF4471A47A285CFAA57E9F75000B375A4100F5432150ECFC3342627FA325C7FB0EE0090A0B39D69ED9030E7D46BBCC6ADFC49F14156187F94F7DDE50C736FEB3FCE530CC76171EE1150AA5A94A3B79119329B5A1D9C3E03EAC7F212A1AECA97EAD58B8BFCD5F94946578D8F5A0347970A7F93C70B4AB0BB5A4FE2B0AAC8459ED0045DDC3AC210ACF996A4DE478853CD88ACEAE73D9A9C48A1B64E0D82F2EFFB25C517BDD0C033E566C16197835271A85D65A38AB37B63E7B23E9C7EA7777E6B3E3820C930B1333C279E5291724E774E34F574F15E1E23568E486F03FC6B83B962E3E60A90A69DD26701A8D6C"
                                 },
@@ -722,15 +665,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 {
                                         "tcId": 75,
                                         "key": "5C185C01FBC57A40FC373F199374D1CC",
+                                        "message": "",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 13]
+Fussell                 Expires February 2, 2019               [Page 12]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "message": "",
                                         "mac": "9507F00153543DE6"
                                 },
                                 {
@@ -778,15 +721,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 {
                                         "tcId": 83,
                                         "key": "23E9BEA8C4F14330B2836FDD0B6E803F",
+                                        "message": "",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 14]
+Fussell                 Expires February 2, 2019               [Page 13]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "message": "",
                                         "mac": "F884E64E0CA4D34F"
                                 },
                                 {
@@ -834,15 +777,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 {
                                         "tcId": 91,
                                         "key": "E09B79F64B11F00B48081EEEA0482821",
+                                        "message": "",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 15]
+Fussell                 Expires February 2, 2019               [Page 14]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "message": "",
                                         "mac": "4D927CED15907953"
                                 },
                                 {
@@ -893,7 +836,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 16]
+
+Fussell                 Expires February 2, 2019               [Page 15]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -942,19 +886,18 @@ Internet-Draft                Sym Alg JSON                   August 2018
    {
            "vsId": 1,
        "algorithm": "CMAC",
-       "mode": "AES",
-           "testGroups": [{
+       "testGroups": [{
                            "tgId": 4,
                            "tests": [{
+                                           "tcId": 25,
 
 
 
-Fussell                 Expires February 2, 2019               [Page 17]
+Fussell                 Expires February 2, 2019               [Page 16]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                           "tcId": 25,
                                            "mac": "7AA2D56A0AE76620"
                                    },
                                    {
@@ -1002,15 +945,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                            "testPassed": true
                                    },
                                    {
+                                           "tcId": 76,
 
 
 
-Fussell                 Expires February 2, 2019               [Page 18]
+Fussell                 Expires February 2, 2019               [Page 17]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                           "tcId": 76,
                                            "testPassed": true
                                    },
                                    {
@@ -1058,15 +1001,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                            "testPassed": true
                                    },
                                    {
+                                           "tcId": 88,
 
 
 
-Fussell                 Expires February 2, 2019               [Page 19]
+Fussell                 Expires February 2, 2019               [Page 18]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                           "tcId": 88,
                                            "testPassed": false
                                    },
                                    {
@@ -1117,34 +1060,33 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 20]
+
+Fussell                 Expires February 2, 2019               [Page 19]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   +--------------+----------------+--------------+---------+----------+
-   | JSON Value   | Description    | JSON type    | Valid   | Optional |
-   |              |                |              | Values  |          |
-   +--------------+----------------+--------------+---------+----------+
-   | algorithm    | The MAC        | value        | CMAC    | No       |
-   |              | algorithm to   |              |         |          |
-   |              | be validated.  |              |         |          |
-   |              |                |              |         |          |
-   | mode         | The mode to be | value        | TDES    | No       |
-   |              | validated.     |              |         |          |
-   |              |                |              |         |          |
-   | prereqVals   | prerequistie   | array of     | See     | No       |
-   |              | algorithm      | prereqAlgVal | Section |          |
-   |              | validations,   | objects      | 2.1     |          |
-   |              | See Section    |              |         |          |
-   |              | 2.1 for        |              |         |          |
-   |              | examples       |              |         |          |
-   |              |                |              |         |          |
-   | capabilities | The CMAC-TDES  | array of     | See     | No       |
-   |              | capabilities   | capability   | Table   |          |
-   |              |                | objects      | 11      |          |
-   |              |                |              |         |          |
-   +--------------+----------------+--------------+---------+----------+
+   +--------------+--------------+--------------+-----------+----------+
+   | JSON Value   | Description  | JSON type    | Valid     | Optional |
+   |              |              |              | Values    |          |
+   +--------------+--------------+--------------+-----------+----------+
+   | algorithm    | The MAC      | value        | CMAC-TDES | No       |
+   |              | algorithm to |              |           |          |
+   |              | be           |              |           |          |
+   |              | validated.   |              |           |          |
+   |              |              |              |           |          |
+   | prereqVals   | prerequistie | array of     | See       | No       |
+   |              | algorithm    | prereqAlgVal | Section   |          |
+   |              | validations, | objects      | 2.1       |          |
+   |              | See Section  |              |           |          |
+   |              | 2.1 for      |              |           |          |
+   |              | examples     |              |           |          |
+   |              |              |              |           |          |
+   | capabilities | The CMAC-    | array of     | See Table | No       |
+   |              | TDES         | capability   | 11        |          |
+   |              | capabilities | objects      |           |          |
+   |              |              |              |           |          |
+   +--------------+--------------+--------------+-----------+----------+
 
           Table 10: CMAC-TDES Algorithm Capabilities JSON Values
 
@@ -1173,7 +1115,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 21]
+
+
+Fussell                 Expires February 2, 2019               [Page 20]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1229,7 +1173,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 22]
+Fussell                 Expires February 2, 2019               [Page 21]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1252,8 +1196,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
    {
-     "algorithm": "CMAC",
-     "mode": "TDES",
+     "algorithm": "CMAC-TDES",
      "capabilities": [
        {
          "direction": "gen",
@@ -1282,15 +1225,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "max": 65536,
              "increment": 8
            }
+         ],
 
 
 
-Fussell                 Expires February 2, 2019               [Page 23]
+Fussell                 Expires February 2, 2019               [Page 22]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-         ],
          "macLen": [
            {
              "min": 32,
@@ -1341,7 +1284,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 24]
+
+Fussell                 Expires February 2, 2019               [Page 23]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1356,8 +1300,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | algorithm  | The algorithm used for the test vectors.    | value  |
-   |            |                                             |        |
-   | mode       | The mode used for the test vectors.         | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 4.2.1                    |        |
@@ -1397,7 +1339,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 25]
+
+
+Fussell                 Expires February 2, 2019               [Page 24]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1453,7 +1397,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 26]
+Fussell                 Expires February 2, 2019               [Page 25]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1484,8 +1428,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 {
         "vsId": 1,
-        "algorithm": "CMAC",
-        "mode": "TDES",
+        "algorithm": "CMAC-TDES",
         "testGroups": [{
                         "tgId": 4,
                         "testType": "AFT",
@@ -1506,15 +1449,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key": "82E572E29C84009E28390918155E4891A0D24C94C306FE56",
                                         "message": "7A70F3CE17598AC3553FBADA0CC562018FD40C6D25B098EC0B905B1BC9F67DFCBD797494E4B05E2C6C3C0F655F9E95FFFE16782E1454A5EE04D87E7586F7FF65A51979A1C46118080320C1CB9E9CC48A05E113C95C2316361B39F5FCB861",
                                         "key1": "82E572E29C84009E",
+                                        "key2": "28390918155E4891",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 27]
+Fussell                 Expires February 2, 2019               [Page 26]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "key2": "28390918155E4891",
                                         "key3": "A0D24C94C306FE56"
                                 },
                                 {
@@ -1562,15 +1505,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key": "B10CCB821E63EF98928D1BC20D797C5E9149B32BFC090140",
                                         "message": "B19716D364D0680873D83F4991839465C169CADA64D5B57454ADDCDA64D1778219B204571593C5965E8F84C373CF0DBD10F4C8124D932FB6EF2B662966C698F79CB3199E40A45A8A7C186E948CA5A0BAD743A1FDC91336325145FC701D41",
                                         "key1": "B10CCB821E63EF98",
+                                        "key2": "928D1BC20D797C5E",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 28]
+Fussell                 Expires February 2, 2019               [Page 27]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "key2": "928D1BC20D797C5E",
                                         "key3": "9149B32BFC090140"
                                 }
                         ],
@@ -1618,15 +1561,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key1": "4DB908F0A14A3959",
                                         "key2": "AC76D38D171114CA",
                                         "key3": "3651F7FF9C9B20B5"
+                                },
 
 
 
-Fussell                 Expires February 2, 2019               [Page 29]
+Fussell                 Expires February 2, 2019               [Page 28]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                },
                                 {
                                         "tcId": 77,
                                         "key": "670AB0529BCE3007BDC7706FED307419291C6BA004943806",
@@ -1674,15 +1617,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 },
                                 {
                                         "tcId": 82,
+                                        "key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 30]
+Fussell                 Expires February 2, 2019               [Page 29]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
                                         "message": "",
                                         "mac": "317B4969",
                                         "key1": "97FBEF5ADADC68CC",
@@ -1730,15 +1673,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key": "C2A4D041516F0B7535D37F2B55FB38CFB75F24285D7BEF39",
                                         "message": "",
                                         "mac": "4A099862",
+                                        "key1": "C2A4D041516F0B75",
 
 
 
-Fussell                 Expires February 2, 2019               [Page 31]
+Fussell                 Expires February 2, 2019               [Page 30]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                        "key1": "C2A4D041516F0B75",
                                         "key2": "35D37F2B55FB38CF",
                                         "key3": "B75F24285D7BEF39"
                                 },
@@ -1786,15 +1729,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key1": "1A29B0ED9040FD2D",
                                         "key2": "6A7D20A4DF50E290",
                                         "key3": "AB1D497EC1D211AA"
+                                }
 
 
 
-Fussell                 Expires February 2, 2019               [Page 32]
+Fussell                 Expires February 2, 2019               [Page 31]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                }
                         ],
                         "keyingOption": 1
                 }
@@ -1845,7 +1788,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 33]
+
+Fussell                 Expires February 2, 2019               [Page 32]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1880,8 +1824,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    {
        "vsId": 1,
-           "algorithm": "CMAC",
-           "mode": "TDES",
+           "algorithm": "CMAC-TDES",
            "testGroups": [{
                            "tgId": 4,
                            "tests": [{
@@ -1898,15 +1841,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                    },
                                    {
                                            "tcId": 28,
+                                           "mac": "EC68CA91"
 
 
 
-Fussell                 Expires February 2, 2019               [Page 34]
+Fussell                 Expires February 2, 2019               [Page 33]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                           "mac": "EC68CA91"
                                    },
                                    {
                                            "tcId": 29,
@@ -1954,15 +1897,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                    },
                                    {
                                            "tcId": 79,
+                                           "testPassed": true
 
 
 
-Fussell                 Expires February 2, 2019               [Page 35]
+Fussell                 Expires February 2, 2019               [Page 34]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                           "testPassed": true
                                    },
                                    {
                                            "tcId": 80,
@@ -2010,15 +1953,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                    },
                                    {
                                            "tcId": 91,
+                                           "testPassed": true
 
 
 
-Fussell                 Expires February 2, 2019               [Page 36]
+Fussell                 Expires February 2, 2019               [Page 35]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                                           "testPassed": true
                                    },
                                    {
                                            "tcId": 92,
@@ -2069,7 +2012,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 37]
+
+Fussell                 Expires February 2, 2019               [Page 36]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2125,7 +2069,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 38]
+Fussell                 Expires February 2, 2019               [Page 37]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2181,7 +2125,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 39]
+Fussell                 Expires February 2, 2019               [Page 38]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2237,7 +2181,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 40]
+Fussell                 Expires February 2, 2019               [Page 39]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2293,7 +2237,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 41]
+Fussell                 Expires February 2, 2019               [Page 40]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2349,7 +2293,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 42]
+Fussell                 Expires February 2, 2019               [Page 41]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2405,7 +2349,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 43]
+Fussell                 Expires February 2, 2019               [Page 42]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2461,7 +2405,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 44]
+Fussell                 Expires February 2, 2019               [Page 43]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2517,7 +2461,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 45]
+Fussell                 Expires February 2, 2019               [Page 44]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2573,7 +2517,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 46]
+Fussell                 Expires February 2, 2019               [Page 45]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2629,7 +2573,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 47]
+Fussell                 Expires February 2, 2019               [Page 46]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2685,7 +2629,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019               [Page 48]
+Fussell                 Expires February 2, 2019               [Page 47]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2741,4 +2685,4 @@ Authors' Addresses
 
 
 
-Fussell                 Expires February 2, 2019               [Page 49]
+Fussell                 Expires February 2, 2019               [Page 48]

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -2405,6 +2405,45 @@
                 </section>
             </section>
         </section>
+        <section anchor="test_types" title="Test Types and Test Coverage">
+            <t>The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of 
+            the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported 
+            cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. 
+            This section describes the design of the tests used to validate implementations of MAC algorithms. 
+            There is a single test type for MACs (broken into subsections for CMACs).  the single test type, algorithm functional test (AFT)
+            can be described as follows:
+
+                <list style="testtype">
+                    <t>"AFT" - Algorithm Function Test.  The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen
+                    key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an addition "ver" direction
+                    present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</t>
+                </list>
+            
+            </t>
+
+            <section anchor="test_coverage" title="Test Coverage">
+                <t>The tests described in this document have the intention of ensuring an implementation is 
+                conformant to <xref target="SP-800-38B" /> and <xref target="FIPS-198-1" />.</t>
+
+                <section anchor="requirements_covered_cmac_aes" title="CMAC-AES Requirements Covered">
+                </section>
+                
+                <section anchor="requirements_not_covered_cmac_aes" title="CMAC-AES Requirements Not Covered">
+                </section>
+                
+                <section anchor="requirements_covered_cmac_tdes" title="CMAC-TDES Requirements Covered">
+                </section>
+                
+                <section anchor="requirements_not_covered_cmac_tdes" title="CMAC-TDES Requirements Not Covered">
+                </section>
+
+                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered">
+                </section>
+                
+                <section anchor="requirements_not_covered_hmac" title="HMAC Requirements Not Covered">
+                </section>
+            </section>
+        </section>
         <!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
         <section anchor="Acknowledgements" title="Acknowledgements">
             <t>TBD...</t>
@@ -2434,6 +2473,24 @@
             </reference>
         </references>
         <references title="Informative References">
+            <reference anchor="SP-800-38B" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf">
+                <front>
+                <title>Recommendation for Block Cipher Modes of Operation: The CMAC Mode for Authentication</title>
+                <author>
+                    <organization>NIST</organization>
+                </author>
+                <date year="2005"/>
+                </front>
+            </reference>
+            <reference anchor="FIPS-198-1" target="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.198-1.pdf">
+                <front>
+                <title>The Keyed-Hash Message Authentication Code (HMAC) </title>
+                <author>
+                    <organization>NIST</organization>
+                </author>
+                <date year="2008"/>
+                </front>
+            </reference>
             <reference anchor="SHAVS">
                 <!-- the following is the minimum to make xml2rfc happy -->
                 <front>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -56,7 +56,7 @@
                 <!-- uri and facsimile elements may also be added -->
             </address>
         </author>
-        <author fullname="Russell Hammett" initials="R.H." role="editor">
+        <author fullname="Russell Hammett" initials="R.H." role="editor" surname="Hammett">
             <organization>G2, Inc.</organization>
 
             <address>
@@ -120,6 +120,84 @@
                 <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
                     "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
                     interpreted in <xref target="RFC2119">RFC 2119</xref>. </t>
+            </section>
+        </section>
+        <section anchor="test_types" title="Test Types and Test Coverage">
+            <t>The ACVP server performs a set of tests on the MAC algorithms in order to assess the
+                correctness and robustness of the implementation. A typical ACVP validation session
+                would require multiple tests to be performed for every supported cryptographic
+                algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. This section
+                describes the design of the tests used to validate implementations of MAC
+                algorithms. There is a single test type for MACs (broken into subsections for
+                CMACs). the single test type, algorithm functional test (AFT) can be described as
+                follows: <list style="testtype">
+                    <t>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen"
+                        direction of CMAC by running the randomly chosen key and message data (with
+                        constraints as per the IUT's capabilities registration) through the MAC
+                        algorithm. CMAC has an additional "ver" direction present in its testing to
+                        ensure the IUT can successfully determine when a MAC does not match its
+                        originating message/key combination.</t>
+                </list>
+            </t>
+
+            <section anchor="test_coverage" title="Test Coverage">
+                <t>The tests described in this document have the intention of ensuring an
+                    implementation is conformant to <xref target="SP-800-38B"/> and <xref
+                        target="FIPS-198-1"/>.</t>
+
+                <section anchor="requirements_covered_cmac" title="CMAC Requirements Covered">
+                    <t>
+                    <list>
+                        <t> SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys
+                            and messages for the IUT to process, then compares the IUT's result to
+                            the ACVP result. </t>
+                        <t> SP 800-38b - 6.3 Mac Verification. ACVP server creates random sets of
+                            keys, messages, and macs. These test vectors are then randomly altered
+                            to ensure the MAC will not match the given key and message. Using the
+                            provided test case, the IUT is expected to validate the mac against the
+                            provided key and message. </t>
+                    </list>
+                    </t>
+                </section>
+
+                <section anchor="requirements_not_covered_cmac" title="CMACRequirements Not Covered">
+                    <t>
+                    <list>
+                        <t>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are
+                            intermediate values, are not validated via current testing.</t>
+                        <t>SP 800-38b - 5.5 Input and Output Data. The mlen is currently provided
+                            and not inferred.</t>
+                        <t> SP 800-38b - Appendix A. Length of MAC. The ACVP server will generate
+                            vectors as per the IUT's specified criteria. The IUT should register its
+                            entire range of supported MAC lengths, regardless of security strength.
+                            The ACVP server will test a random sampling of valid MAC lengths as per
+                            the IUT registration - this generally includes the minimum and maximum
+                            mac length. </t>
+                    </list>
+                    </t>
+                </section>
+
+                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered">
+                    <t>
+                    <list>
+                        <t>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending
+                            on the nature of the IUT capabilities registration, keys that are below,
+                            at, or above the hashing algorithm block size.</t>
+                        <t>FIPS 198-1 - 4 HMAC Specification. Mac Generation. ACVP server creates
+                            random sets of keys and messages for the IUT to process, then compares
+                            the IUT's result to the ACVP result.</t>
+                        <t>FIPS 198-1 - 5 Truncation. The ACVP server is capable of generating MACs
+                            as per the capability registration of the IUT. Groups will be created
+                            containing a random sampling of valid MAC lengths from the IUT
+                            registration.</t>
+                    </list>
+                    </t>
+                </section>
+
+                <section anchor="requirements_not_covered_hmac"
+                    title="HMAC Requirements Not Covered">
+                    <t>N/A</t>
+                </section>
             </section>
         </section>
         <section anchor="caps_reg" title="Capabilities Registration">
@@ -2364,84 +2442,6 @@
             ]]>
                         </artwork>
                     </figure>
-                </section>
-            </section>
-        </section>
-        <section anchor="test_types" title="Test Types and Test Coverage">
-            <t>The ACVP server performs a set of tests on the MAC algorithms in order to assess the
-                correctness and robustness of the implementation. A typical ACVP validation session
-                would require multiple tests to be performed for every supported cryptographic
-                algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. This section
-                describes the design of the tests used to validate implementations of MAC
-                algorithms. There is a single test type for MACs (broken into subsections for
-                CMACs). the single test type, algorithm functional test (AFT) can be described as
-                follows: <list style="testtype">
-                    <t>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen"
-                        direction of CMAC by running the randomly chosen key and message data (with
-                        constraints as per the IUT's capabilities registration) through the MAC
-                        algorithm. CMAC has an additional "ver" direction present in its testing to
-                        ensure the IUT can successfully determine when a MAC does not match its
-                        originating message/key combination.</t>
-                </list>
-            </t>
-
-            <section anchor="test_coverage" title="Test Coverage">
-                <t>The tests described in this document have the intention of ensuring an
-                    implementation is conformant to <xref target="SP-800-38B"/> and <xref
-                        target="FIPS-198-1"/>.</t>
-
-                <section anchor="requirements_covered_cmac" title="CMAC Requirements Covered">
-                    <t>
-                    <list>
-                        <t> SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys
-                            and messages for the IUT to process, then compares the IUT's result to
-                            the ACVP result. </t>
-                        <t> SP 800-38b - 6.3 Mac Verification. ACVP server creates random sets of
-                            keys, messages, and macs. These test vectors are then randomly altered
-                            to ensure the MAC will not match the given key and message. Using the
-                            provided test case, the IUT is expected to validate the mac against the
-                            provided key and message. </t>
-                    </list>
-                    </t>
-                </section>
-
-                <section anchor="requirements_not_covered_cmac" title="CMACRequirements Not Covered">
-                    <t>
-                    <list>
-                        <t>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are
-                            intermediate values, are not validated via current testing.</t>
-                        <t>SP 800-38b - 5.5 Input and Output Data. The mlen is currently provided
-                            and not inferred.</t>
-                        <t> SP 800-38b - Appendix A. Length of MAC. The ACVP server will generate
-                            vectors as per the IUT's specified criteria. The IUT should register its
-                            entire range of supported MAC lengths, regardless of security strength.
-                            The ACVP server will test a random sampling of valid MAC lengths as per
-                            the IUT registration - this generally includes the minimum and maximum
-                            mac length. </t>
-                    </list>
-                    </t>
-                </section>
-
-                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered">
-                    <t>
-                    <list>
-                        <t>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending
-                            on the nature of the IUT capabilities registration, keys that are below,
-                            at, or above the hashing algorithm block size.</t>
-                        <t>FIPS 198-1 - 4 HMAC Specification. Mac Generation. ACVP server creates
-                            random sets of keys and messages for the IUT to process, then compares
-                            the IUT's result to the ACVP result.</t>
-                        <t>FIPS 198-1 - 5 Truncation. The ACVP server is capable of generating MACs
-                            as per the capability registration of the IUT. Groups will be created
-                            containing a random sampling of valid MAC lengths from the IUT
-                            registration.</t>
-                    </list>
-                    </t>
-                </section>
-
-                <section anchor="requirements_not_covered_hmac"
-                    title="HMAC Requirements Not Covered">
-                    <t>N/A</t>
                 </section>
             </section>
         </section>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -185,7 +185,7 @@
                     <c/>
                     <c/>
                     <c>prereqVals</c>
-                    <c>prerequistie algorithm validations, See <xref target="app-reg-ex"/> for
+                    <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
                         examples </c>
                     <c>array of prereqAlgVal objects</c>
                     <c>See <xref target="prereq_algs"/>
@@ -576,7 +576,6 @@
     "vsId": 1,
 	"algorithm": "CMAC",
 	"mode": "AES",
-	"isSample": false,
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -859,6 +858,8 @@
                             <![CDATA[
 {
 	"vsId": 1,
+    "algorithm": "CMAC",
+    "mode": "AES",
 	"testGroups": [{
 			"tgId": 4,
 			"tests": [{
@@ -1020,7 +1021,7 @@
                     <c/>
                     <c/>
                     <c>prereqVals</c>
-                    <c>prerequistie algorithm validations, See <xref target="app-reg-ex"/> for
+                    <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
                         examples </c>
                     <c>array of prereqAlgVal objects</c>
                     <c>See <xref target="prereq_algs"/>
@@ -1875,7 +1876,7 @@
                     <c/>
                     <c/>
                     <c>prereqVals</c>
-                    <c>prerequistie algorithm validations, See <xref target="app-reg-ex"/> for
+                    <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
                         examples </c>
                     <c>array of prereqAlgVal objects</c>
                     <c>See <xref target="prereq_algs"/>
@@ -1887,10 +1888,10 @@
                     <c/>
                     <c/>
                     <c>keyLen</c>
-                    <c>The keyLen Domain supported by the IUT in bits. (HMAC only)</c>
+                    <c>The keyLen Domain supported by the IUT in bits.</c>
                     <c>Domain</c>
                     <c>8-524288</c>
-                    <c>Yes (required for HMAC)</c>
+                    <c>No</c>
                     <c/>
                     <c/>
                     <c/>
@@ -2004,6 +2005,32 @@
                     <c/>
                     <c/>
                 </texttable>
+                <section anchor="hmac_app-reg-ex" title="Example HMAC Capabilities JSON Object">
+                    <t>The following is an example JSON object advertising support for HMAC.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+  "algorithm": "HMAC-SHA-1",
+  "keyLen": [
+    {
+      "min": 8,
+      "max": 2048,
+      "increment": 8
+    }
+  ],
+  "macLen": [
+    {
+      "min": 80,
+      "max": 160,
+      "increment": 8
+    }
+  ]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
             </section>
             <section anchor="hmac_test_vectors" title="HMAC Test Vectors">
                 <t>The ACVP server provides test vectors to the ACVP client, which are then
@@ -2145,85 +2172,213 @@
                         <c/>
                     </texttable>
                 </section>
-                <section anchor="hmac_vector_responses" title="HMAC Test Vector Responses">
-                    <t>After the ACVP client downloads and processes a vector set, it must send the
-                        response vectors back to the ACVP server. The following table describes the
-                        JSON object that represents a vector set response.</t>
-                    <texttable anchor="hmac_vr_top_table"
-                        title="HMAC Vector Set Response JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <c>acvVersion</c>
-                        <c>Protocol version identifier</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>vsId</c>
-                        <c>Unique numeric identifier for the vector set</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>testGroups</c>
-                        <c>Array of JSON objects that represent each test vector group. See <xref
-                                target="hmac_vr_group_table"/>
-                        </c>
-                        <c>array</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
-                    <t>The testGroups section is used to organize the ACVP client response in a
-                        similar manner to how it receives vectors. Several algorithms SHALL require
-                        the client to send back group level properties in their response. This
-                        structure helps accommodate that.</t>
-                    <texttable anchor="hmac_vr_group_table"
-                        title="HMAC Vector Set Group Response JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <c>tgId</c>
-                        <c>The test group Id</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>tests</c>
-                        <c>The tests associated to the group specified in tgId</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
-                    <t>Each test group contains an array of one or more test cases. Each test case
-                        is a JSON object that represents a single test vector to be processed by the
-                        ACVP client. The following table describes the JSON elements for each DRBG
-                        test vector.</t>
-                    <texttable anchor="hmac_vs_tr_table" title="HMAC Test Case Results JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <ttcol align="left">Optional</ttcol>
-                        <c>tcId</c>
-                        <c>Numeric identifier for the test case, unique across the entire vector
-                            set.</c>
-                        <c>value</c>
-                        <c>No</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>mac</c>
-                        <c>value of the computed MAC output</c>
-                        <c>value</c>
-                        <c>No</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
+                <section anchor="hmac_test_vector_json" title="Example HMAC Test Vector JSON Object">
+                    <t>The following is an example JSON test vector object for HMAC.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+    "vsId": 1,
+	"algorithm": "HMAC-SHA-1",
+	"testGroups": [{
+		"tgId": 1,
+		"testType": "AFT",
+		"keyLen": 56,
+		"msgLen": 128,
+		"macLen": 80,
+		"tests": [{
+				"tcId": 1,
+				"key": "0CBB3AA866E4D1",
+				"msg": "28CD4091D45F28CD5709CC9B6F1E9D0D"
+			},
+			{
+				"tcId": 2,
+				"key": "7FB3F60ACB9FB7",
+				"msg": "9F224BF653F9BE143FFA0518D12761F7"
+			},
+			{
+				"tcId": 3,
+				"key": "3834463234DA39",
+				"msg": "F0FA740D261D5916B06F09AFBB04C94E"
+			},
+			{
+				"tcId": 4,
+				"key": "ED97154BE9D252",
+				"msg": "4B491408D929C33980C13091FF95DCD7"
+			},
+			{
+				"tcId": 5,
+				"key": "24D8F9E20EA536",
+				"msg": "DD0919DF2CDCB622E95D60E2E93E2B14"
+			},
+			{
+				"tcId": 6,
+				"key": "9AE463E4D85480",
+				"msg": "DF4653D381B8FFF3B507A5B28708DCF2"
+			},
+			{
+				"tcId": 7,
+				"key": "E82C2306DADB20",
+				"msg": "ABD9D90C4C912FC1F4208E8DC82C316A"
+			},
+			{
+				"tcId": 8,
+				"key": "98262DE8011B43",
+				"msg": "79DD85559EF4C577DE8808B875398A36"
+			},
+			{
+				"tcId": 9,
+				"key": "064251F70AD327",
+				"msg": "6719543EF69843BA4421EA9730470539"
+			},
+			{
+				"tcId": 10,
+				"key": "3B1887195138EC",
+				"msg": "F1D7716FFF84F4472E2214DAA1662583"
+			}
+		]
+	}]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+            </section>
+            <section anchor="hmac_vector_responses" title="HMAC Test Vector Responses">
+                <t>After the ACVP client downloads and processes a vector set, it must send the
+                    response vectors back to the ACVP server. The following table describes the JSON
+                    object that represents a vector set response.</t>
+                <texttable anchor="hmac_vr_top_table" title="HMAC Vector Set Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of JSON objects that represent each test vector group. See <xref
+                            target="hmac_vr_group_table"/>
+                    </c>
+                    <c>array</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>The testGroups section is used to organize the ACVP client response in a similar
+                    manner to how it receives vectors. Several algorithms SHALL require the client
+                    to send back group level properties in their response. This structure helps
+                    accommodate that.</t>
+                <texttable anchor="hmac_vr_group_table"
+                    title="HMAC Vector Set Group Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>tgId</c>
+                    <c>The test group Id</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>tests</c>
+                    <c>The tests associated to the group specified in tgId</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>Each test group contains an array of one or more test cases. Each test case is a
+                    JSON object that represents a single test vector to be processed by the ACVP
+                    client. The following table describes the JSON elements for each DRBG test
+                    vector.</t>
+                <texttable anchor="hmac_vs_tr_table" title="HMAC Test Case Results JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>tcId</c>
+                    <c>Numeric identifier for the test case, unique across the entire vector
+                        set.</c>
+                    <c>value</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mac</c>
+                    <c>value of the computed MAC output</c>
+                    <c>value</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <section anchor="hmac_test_vector_response_json"
+                    title="Example HMAC Test Vector Response JSON Object">
+                    <t>The following is an example JSON test vector response object for HMAC.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+	"vsId": 1,
+	"algorithm": "HMAC-SHA-1",
+	"testGroups": [{
+		"tgId": 1,
+		"tests": [{
+				"tcId": 1,
+				"mac": "0970D053D6829C251070"
+			},
+			{
+				"tcId": 2,
+				"mac": "3A476E0407D7ADF14792"
+			},
+			{
+				"tcId": 3,
+				"mac": "5B219B4C4862242DB175"
+			},
+			{
+				"tcId": 4,
+				"mac": "07A689738031C215C55C"
+			},
+			{
+				"tcId": 5,
+				"mac": "1A2633ADC7D119FBCD67"
+			},
+			{
+				"tcId": 6,
+				"mac": "4C41990B6E99AA39D03F"
+			},
+			{
+				"tcId": 7,
+				"mac": "9097773C9429DA776C16"
+			},
+			{
+				"tcId": 8,
+				"mac": "2F86E2DF1E5D65793373"
+			},
+			{
+				"tcId": 9,
+				"mac": "AE7222EA6DA826814612"
+			},
+			{
+				"tcId": 10,
+				"mac": "3CA58B0FA50E7EC66D0D"
+			}
+		]
+	}]
+}
+            ]]>
+                        </artwork>
+                    </figure>
                 </section>
             </section>
         </section>
@@ -2298,322 +2453,5 @@
                 </front>
             </reference>
         </references>
-        <section anchor="app-reg-ex" title="Example MAC Capabilities JSON Object">
-            <t>The following is an example JSON object advertising support for HMAC-SHA-1.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-
-
-            {
-                "algorithm": "HMAC-SHA2-256",
-                "prereqVals" : [{"algorithm" : "SHA", "valValue" : "123456"}],
-                "keyLen": [ { "min": 256, "max": 2048, "increment": 8 } ],
-                "macLen": [ 192 ]
-            }
-            ]]>
-                </artwork>
-            </figure>
-            <t>The following is an example JSON object advertising support for CMAC-AES.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-
-
-            {
-                "algorithm": "CMAC-AES",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-		                {"algorithm" : "TDES", "valValue" : "123456"}],
-                "direction" : [ "gen", "ver" ],
-                "keyLen" : [ 128, 192 ],
-                "macLen" : [ 64 ],
-                "msgLen" : [ 0 ]
-            }
-            ]]>
-                </artwork>
-            </figure>
-            <t>The following is an example JSON object advertising support for CMAC-TDES.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-
-
-            {
-                "algorithm": "CMAC-TDES",
-                "prereqVals" : [{"algorithm" : "AES", "valValue" : "123456"},
-		                {"algorithm" : "TDES", "valValue" : "123456"}],
-                "direction" : [ "gen", "ver" ],
-                "keyingOption" : [ 1, 2 ],
-                "macLen" : [ 8, 64 ],
-                "msgLen" : [ 0, 256, 120, 248, 320 ]
-            }
-            ]]>
-                </artwork>
-            </figure>
-        </section>
-        <section anchor="app-vs-ex" title="Example Test Vectors JSON Object">
-            <t>The following is an example JSON object for HMAC test vectors sent from the ACVP
-                server to the crypto module.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-[{
-		"acvVersion": <acvp-version>
-	},
-	{
-		"vsId": 1565,
-		"algorithm": "HMAC-SHA-1",
-		"testGroups": [{
-			"tgId": 1,
-			"testType": "AFT",
-			"keyLen": 256,
-			"msgLen": 160,
-			"macLen": 80,
-			"tests": [{
-					"tcId": 2172,
-					"key": "f8561d1477e58cb6061e709be60a40ab7468503eb6f3ff8234e3321c09b60212",
-					"msg": "5f4e900a8c223ad9fc834a4deefb33df8d6081bedafc6915e6eaa58c44c37f11be7b2bd8478559a0313e0b39a088a4433fb5423831a84ead4b3652d480d20a469c6abdff368ccdaadfcd8e20a06b542ba431d08f319b9c4bdd3b141cfe5b684362e4ef88407fbe7f6ff97a0ad6ec6a1f249cd0cbc11f7a7704c1946ba6a6c090"
-				},
-				{
-					"tcId": 2173,
-					"key": "c9ba74509181091ccf2159d9cada77e4be00384cca4f36ce097f1b0400181cd9",
-					"msg": "e249dbff751ef43598aab6fb642eb1b18731a33148729a5fc52059027f4dfdd219a1e0d15d4bbedf803d1689a799d323a9662c161788c97a7aef27e8db0e3d89898f607316456436a36204b15dea832b4867949f3cdf78562d0366bbafa92f6cb87c228da8f22d61887f461b8f0909f1eb9ba373be5dee1b66c4dd2501061ba0"
-				}
-			]
-		}]
-	}
-]
-            ]]>
-                </artwork>
-            </figure>
-            <t>The following is an example JSON object for CMAC-AES test vectors sent from the ACVP
-                server to the crypto module.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-[{
-		"acvVersion": <acvp-version>
-	},
-	{
-		"vsId": 3500,
-		"algorithm": "CMAC-AES",
-		"testGroups": [{
-			"tgId": 1,
-			"testType": "AFT",
-			"direction": "gen",
-			"keyLen": 128,
-			"msgLen": 0,
-			"macLen": 64,
-			"tests": [{
-					"tcId": 2750,
-					"key": "f28effca41cb11819a81eb3ebf3b7e83",
-					"msg": ""
-				},
-				{
-					"tcId": 2751,
-					"key": "ab566f4af532efc8bc56555fe07696fd",
-					"msg": ""
-				}
-			]
-		}]
-	},
-	{
-		"tgId": 2,
-		"testType": "AFT",
-		"direction": "ver",
-		"keyLen": 128,
-		"msgLen": 0,
-		"macLen": 64,
-		"tests": [{
-				"tcId": 2752,
-				"key": "ac7165b3778dd93f5e7e532ad2c1eb7b",
-				"msg": "",
-				"mac": "2eef1e38fcc7c568"
-			},
-			{
-				"tcId": 2753,
-				"key": "eb87fb7a5fb60caecb9b23564befe513",
-				"msg": "",
-				"mac": "cafecafecafecafe"
-			}
-		]
-	}
-]
-            ]]>
-                </artwork>
-            </figure>
-            <t>The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP
-                server to the crypto module.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-[{
-		"acvVersion": <acvp-version>
-	},
-	{
-		"vsId": 1566,
-		"algorithm": "CMAC-TDES",
-		"testGroups": [{
-				"tgId": 1,
-				"testType": "AFT",
-				"direction": "gen",
-				"keyingOption": 1,
-				"msgLen": 0,
-				"macLen": 40,
-				"tests": [{
-						"tcId": 2175,
-						"key1": "c479f813ad1a45d5",
-						"key2": "dc43459da4c85e85",
-						"key3": "1cda518af886bf1f",
-						"msg": ""
-					},
-					{
-						"tcId": 2176,
-						"key1": "731331866754588f",
-						"key2": "d332ef51e0ce1925",
-						"key3": "d586cba70440f44f",
-						"msg": ""
-					}
-				]
-			},
-			{
-				"tgId": 2,
-				"testType": "AFT",
-				"direction": "ver",
-				"keyingOption": 1,
-				"msgLen": 0,
-				"macLen": 40,
-				"tests": [{
-						"tcId": 2177,
-						"key1": "d586cba70440f44f",
-						"key2": "d332ef51e0ce1925",
-						"key3": "dc43459da4c85e85",
-						"msg": "",
-						"mac": "cafecafecafecafecafecafecafecafecafecafe"
-					},
-					{
-						"tcId": 2177,
-						"key1": "dc43459da4c85e85",
-						"key2": "c479f813ad1a45d5",
-						"key3": "1cda518af886bf1f",
-						"msg": "",
-						"mac": "cafecafecafecafecafecafecafecafecafecafe"
-					}
-				]
-			}
-		]
-	}
-]
-            ]]>
-                </artwork>
-            </figure>
-        </section>
-        <section anchor="app-results-ex" title="Example Test Results JSON Object">
-            <t>The following is an example JSON object for HMAC test results sent from the crypto
-                module to the ACVP server.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-[{
-		"acvVersion": <acvp-version>
-	},
-	{
-		"vsId": 1565,
-		"testGroups": [{
-			"tgId": 1,
-			"tests": [{
-					"tcId": 2172,
-					"mac": "eb0326e5edcf9465fc01c773262011a3059cfd97"
-				},
-				{
-					"tcId": 2173,
-					"mac": "feb3ff7b06eb7f62e9d19c331abbe2d183d2bc7a"
-				}
-			]
-		}]
-	}
-]
-            ]]>
-                </artwork>
-            </figure>
-            <t>The following is an example JSON object for CMAC-AES test results sent from the
-                crypto module to the ACVP server.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-[{
-		"acvVersion": <acvp-version>
-	},
-	{
-		"vsId": 3500,
-		"testGroups": [{
-			"tgId": 1,
-			"tests": [{
-					"tcId": 2750,
-					"mac": "e77145f0d6c77ad5"
-				},
-				{
-					"tcId": 2751,
-					"mac": "6b078f7e53b6d183"
-				}
-			]
-		}, {
-			"tgId": 2,
-			"tests": [{
-					"tcId": 2752,
-					"testPassed": true
-				},
-				{
-					"tcId": 2753,
-					"testPassed": false
-				}
-			]
-		}]
-	}
-]
-            ]]>
-                </artwork>
-            </figure>
-            <t>The following is an example JSON object for CMAC-TDES test results sent from the
-                crypto module to the ACVP server.</t>
-            <figure>
-                <artwork>
-                    <![CDATA[
-[{
-		"acvVersion": <acvp-version>
-	},
-	{
-		"vsId": 1566,
-		"testGroups": [{
-				"tgId": 1,
-				"tests": [{
-						"tcId": 2175,
-						"mac": "fea01c84a7"
-					},
-					{
-						"tcId": 2176,
-						"mac": "164bdb8582"
-					}
-				]
-			},
-			{
-				"tgId": 2,
-				"tests": [{
-						"tcId": 2177,
-						"testPassed": false
-					},
-					{
-						"tcId": 2178,
-						"testPassed": false
-					}
-				]
-			}
-		]
-	}
-]
-            ]]>
-                </artwork>
-            </figure>
-        </section>
     </back>
 </rfc>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -190,17 +190,7 @@
                     <c>algorithm</c>
                     <c>The MAC algorithm to be validated.</c>
                     <c>value</c>
-                    <c>CMAC</c>
-                    <c>No</c>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c>mode</c>
-                    <c>The mode to be validated.</c>
-                    <c>value</c>
-                    <c>AES</c>
+                    <c>CMAC-AES</c>
                     <c>No</c>
                     <c/>
                     <c/>
@@ -307,8 +297,7 @@
                         <artwork>
                             <![CDATA[
 {
-  "algorithm": "CMAC",
-  "mode": "AES",
+  "algorithm": "CMAC-AES",
   "capabilities": [
     {
       "direction": "gen",
@@ -466,12 +455,6 @@
                     <c/>
                     <c/>
                     <c/>
-                    <c>mode</c>
-                    <c>The mode used for the test vectors.</c>
-                    <c>value</c>
-                    <c/>
-                    <c/>
-                    <c/>
                     <c>testGroups</c>
                     <c>Array of test group JSON objects, which are defined in <xref
                             target="cmac_aes_tgjs"/>
@@ -596,9 +579,8 @@
                         <artwork>
                             <![CDATA[
 {
-    "vsId": 1,
-	"algorithm": "CMAC",
-	"mode": "AES",
+	"vsId": 1,
+	"algorithm": "CMAC-AES",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -882,8 +864,7 @@
 {
 	"vsId": 1,
     "algorithm": "CMAC",
-    "mode": "AES",
-	"testGroups": [{
+    "testGroups": [{
 			"tgId": 4,
 			"tests": [{
 					"tcId": 25,
@@ -1026,17 +1007,7 @@
                     <c>algorithm</c>
                     <c>The MAC algorithm to be validated.</c>
                     <c>value</c>
-                    <c>CMAC</c>
-                    <c>No</c>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c>mode</c>
-                    <c>The mode to be validated.</c>
-                    <c>value</c>
-                    <c>TDES</c>
+                    <c>CMAC-TDES</c>
                     <c>No</c>
                     <c/>
                     <c/>
@@ -1146,8 +1117,7 @@
                         <artwork>
                             <![CDATA[
 {
-  "algorithm": "CMAC",
-  "mode": "TDES",
+  "algorithm": "CMAC-TDES",
   "capabilities": [
     {
       "direction": "gen",
@@ -1240,12 +1210,6 @@
                     <c/>
                     <c>algorithm</c>
                     <c>The algorithm used for the test vectors.</c>
-                    <c>value</c>
-                    <c/>
-                    <c/>
-                    <c/>
-                    <c>mode</c>
-                    <c>The mode used for the test vectors.</c>
                     <c>value</c>
                     <c/>
                     <c/>
@@ -1377,8 +1341,7 @@
                             <![CDATA[
 {
 	"vsId": 1,
-	"algorithm": "CMAC",
-	"mode": "TDES",
+	"algorithm": "CMAC-TDES",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -1747,8 +1710,7 @@
                             <![CDATA[
 {
     "vsId": 1,
-	"algorithm": "CMAC",
-	"mode": "TDES",
+	"algorithm": "CMAC-TDES",
 	"testGroups": [{
 			"tgId": 4,
 			"tests": [{

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -56,6 +56,29 @@
                 <!-- uri and facsimile elements may also be added -->
             </address>
         </author>
+        <author fullname="Russell Hammett" initials="R.H." role="editor">
+			<organization>G2, Inc.</organization>
+
+			<address>
+				<postal>
+					<street>302 Sentinel Dr Suite 300</street>
+
+					<!-- Reorder these if your country does things differently -->
+
+					<city>Annapolis Junction </city>
+
+					<region>MD</region>
+
+					<code>20701</code>
+
+					<country>USA</country>
+				</postal>
+
+				<email>russ.hammett@g2-inc.com</email>
+
+				<!-- uri and facsimile elements may also be added -->
+			</address>
+		</author>
         <date month="August" year="2018"/>
         <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+
+
+
+
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 ]>
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -28,772 +32,1420 @@
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
 <rfc category="info" docName="draft-ietf-acvp-submac-0.5" ipr="trust200902">
-	<!-- category values: std, bcp, info, exp, and historic
+    <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"
      they will automatically be output with "(if approved)" -->
-
-	<!-- ***** FRONT MATTER ***** -->
-
-	<front>
-		<!-- The abbreviated title is used in the page header - it is only necessary if the
+    <!-- ***** FRONT MATTER ***** -->
+    <front>
+        <!-- The abbreviated title is used in the page header - it is only necessary if the
          full title is longer than 39 characters -->
-
-		<title abbrev="Sym Alg JSON">ACVP Message Authentication Algorithm JSON Specification</title>
-
-		<!-- add 'role="editor"' below for the editors if appropriate -->
-
-		<!-- Another author who claims to be an editor -->
-
-		<author fullname="Barry Fussell" initials="B.F." role="editor" surname="Fussell">
-			<organization>Cisco Systems, Inc.</organization>
-
-			<address>
-				<postal>
-					<street>170 West Tasman Dr.</street>
-
-					<!-- Reorder these if your country does things differently -->
-
-					<city>San Jose</city>
-
-					<region>CA</region>
-
-					<code>95134</code>
-
-					<country>USA</country>
-				</postal>
-
-				<email>bfussell@cisco.com</email>
-
-				<!-- uri and facsimile elements may also be added -->
-			</address>
-		</author>
-
-		<date month="August" year="2018" />
-
-		<!-- If the month and year are both specified and are the current ones, xml2rfc will fill
+        <title abbrev="Sym Alg JSON">ACVP Message Authentication Algorithm JSON
+			Specification</title>
+        <!-- add 'role="editor"' below for the editors if appropriate -->
+        <!-- Another author who claims to be an editor -->
+        <author fullname="Barry Fussell" initials="B.F." role="editor" surname="Fussell">
+            <organization>Cisco Systems, Inc.</organization>
+            <address>
+                <postal>
+                    <street>170 West Tasman Dr.</street>
+                    <!-- Reorder these if your country does things differently -->
+                    <city>San Jose</city>
+                    <region>CA</region>
+                    <code>95134</code>
+                    <country>USA</country>
+                </postal>
+                <email>bfussell@cisco.com</email>
+                <!-- uri and facsimile elements may also be added -->
+            </address>
+        </author>
+        <date month="August" year="2018"/>
+        <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
 	 in the current day and month for you. If the year is not the current one, it is
 	 necessary to specify at least a month (xml2rfc assumes day="1" if not specified for the
 	 purpose of calculating the expiry date).  With drafts it is normally sufficient to
 	 specify just the year. -->
-
-		<!-- Meta-data Declarations -->
-
-		<area>General</area>
-
-		<workgroup>TBD</workgroup>
-
-		<!-- WG name at the upperleft corner of the doc,
+        <!-- Meta-data Declarations -->
+        <area>General</area>
+        <workgroup>TBD</workgroup>
+        <!-- WG name at the upperleft corner of the doc,
          IETF is fine for individual submissions.
 	 If this element is not present, the default is "Network Working Group",
          which is used by the RFC Editor as a nod to the history of the IETF. -->
-
-		<keyword>acvp</keyword>
-		<keyword>crypto</keyword>
-
-		<!-- Keywords will be incorporated into HTML output
+        <keyword>acvp</keyword>
+        <keyword>crypto</keyword>
+        <!-- Keywords will be incorporated into HTML output
          files in a meta tag but they have no effect on text or nroff
          output. If you submit your draft to the RFC Editor, the
          keywords will be used for the search engine. -->
-
-		<abstract>
-			<t>This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification.</t>
-		</abstract>
-	</front>
-
-	<middle>
-		<section title="Introduction">
-			<t>The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically
-              verify the cryptographic implementation of a software or hardware crypto module.
-              The ACVP specification defines how a crypto module communicates with an ACVP
-              server, including crypto capabilities negotiation, session management, authentication,
-	      vector processing and more.  The ACVP specification does not define algorithm specific
-	      JSON constructs for performing the crypto validation.  A series of ACVP sub-specifications
-	      define the constructs for testing individual crypto algorithms.  Each sub-specification
-	      addresses a specific class of crypto algorithms.  This sub-specification defines the JSON
-	      constructs for testing HMAC and CMAC crypto algorithms using ACVP.</t>
-
-			<section title="Requirements Language">
-				<t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-        "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-	document are to be interpreted in
-					<xref target="RFC2119">RFC 2119</xref>.
-				</t>
-			</section>
-		</section>
-
-		<section anchor="caps_reg" title="Capabilities Registration">
-			<t>ACVP requires crypto modules to register their capabilities.  This allows the crypto
-	module to advertise support for specific algorithms, notifying the ACVP server which
-	algorithms need test vectors generated for the validation process.  This section
-    describes the constructs for advertising support of HMAC and CMAC algorithms to the ACVP server.</t>
-
-			<t>The algorithm capabilities are advertised as JSON objects within the 'algorithms'
-	value of the ACVP registration message.  The 'algorithms' value is an array, where each
-	array element is an individual JSON object defined in this section.  The 'algorithms'
-	value is part of the 'capability_exchange' element of the ACVP JSON registration message.
-	See the ACVP specification for details on the registration message.
-
-	Each algorithm capability advertised is a self-contained JSON object. </t>
-
-
-			<section anchor="prereq_algs" title="Required Prerequisite Algorithms for MAC Validations">
-				<t>Each MAC implementation relies on other cryptographic primitives.
-	    For example, CMAC uses an underlying SHA algorithm. Each of these underlying algorithm primitives 
-	    must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</t>
-				<texttable anchor="rereqs_table" title="Required MAC Prerequisite Algorithms JSON Values">
-					<ttcol align="left">JSON Value</ttcol>
-					<ttcol align="left">Description</ttcol>
-					<ttcol align="left">JSON type</ttcol>
-					<ttcol align="left">Valid Values</ttcol>
-					<ttcol align="left">Optional</ttcol>
-					<c>algorithm</c>
-					<c>a prerequisite algorithm</c>
-					<c>value</c>
-					<c>AES, SHA, TDES</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>valValue</c>
-					<c>algorithm validation number</c>
-					<c>value</c>
-					<c>actual number or "same"</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>prereqAlgVal</c>
-					<c>prerequistie algorithm validation</c>
-					<c>object with algorithm and valValue properties</c>
-					<c>see above</c>
-					<c>No</c>
-
-				</texttable>
-			</section>
-
-			<section anchor="mac_caps_reg" title="MAC Algorithm Capabilities Registration">
-				<t>Each algorithm capability advertised is a self-contained JSON object using the following values.</t>
-				<texttable anchor="caps_table2" title="MAC Algorithm Capabilities JSON Values">
-					<ttcol align="left">JSON Value</ttcol>
-					<ttcol align="left">Description</ttcol>
-					<ttcol align="left">JSON type</ttcol>
-					<ttcol align="left">Valid Values</ttcol>
-					<ttcol align="left">Optional</ttcol>
-
-					<c>algorithm</c>
-					<c>The MAC algorithm and mode to be validated.</c>
-					<c>value</c>
-					<c>See						<xref target="supported_algs" />
-					</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>prereqVals</c>
-					<c>prerequistie algorithm validations, See						<xref target="app-reg-ex" />
- for examples</c>
-					<c>array of prereqAlgVal objects</c>
-					<c>See						<xref target="prereq_algs" />
-					</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>direction</c>
-					<c>The MAC direction(s) to test. Only applies to CMAC.</c>
-					<c>array</c>
-					<c>gen, ver</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>keyLen</c>
-					<c>The keyLen Domain supported by the IUT in bits. (HMAC only)</c>
-					<c>Domain</c>
-					<c>8-524288</c>
-					<c>Yes (required for HMAC)</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>keyLen</c>
-					<c>The array of keyLens supported by the IUT in bits. (CMAC-AES only)</c>
-					<c>array</c>
-					<c>128, 192, 256</c>
-					<c>Yes (required for CMAC-AES)</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>keyingOption</c>
-					<c>The Keying Option used in TDES.   
-         
-          Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  
-          Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1).   
-          Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1).</c>
-					<c>array</c>
-					<c>1, 2</c>
-					<c>Yes (required for CMAC-TDES)</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>msgLen</c>
-					<c>The CMAC message lengths supported in bits.  Min/max/increment and values must be mod 8.</c>
-					<c>Domain</c>
-					<c>0-524288</c>
-					<c>Yes</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>macLen</c>
-					<c>The supported mac sizes. (range dependent on algorithm, see						<xref target="supported_algs" />
-).</c>
-					<c>Domain</c>
-					<c>32-512</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-				</texttable>
-
-
-				<t>Note: Some optional values are required depending on the algorithm. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</t>
-
-				<t>keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</t>
-				<t>
-					<list style="symbols">
-						<t>2 values below the Hash's block length. See							<xref target="supported_algs" />
-						</t>
-						<t>The Hash's block length.</t>
-						<t>2 values above the Hash's block length.</t>
-					</list>
-				</t>
-
-				<t>macLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</t>
-				<t>
-					<list style="symbols">
-						<t>The smallest CMAC length supported</t>
-						<t>A second CMAC length supported</t>
-						<t>The largest CMAC length supported</t>
-					</list>
-				</t>
-
-				<t>msgLen for CMAC contains a Domain of values, the server may choose values defined by these rules:</t>
-				<t>
-					<list style="symbols">
-						<t>The smallest message length supported</t>
-						<t>Two message lengths divisible by block size</t>
-						<t>Two message lengths NOT divisible by block size</t>
-						<t>The largest message length supported</t>
-					</list>
-				</t>
-
-			</section>
-
-			<section anchor="supported_algs" title="Supported MAC Algorithms">
-				<t>The following algorithms may be advertised by the ACVP compliant crypto module:</t>
-				<texttable anchor="table_algInfo" title="Algorithms w/ block size and max MAC length.">
-					<ttcol align="left">Algorithm Value</ttcol>
-					<ttcol align="left">Block Length</ttcol>
-					<ttcol align="left">Max MAC Length</ttcol>
-
-					<c>HMAC-SHA-1</c>
-					<c>512</c>
-					<c>160</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA2-224</c>
-					<c>512</c>
-					<c>224</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA2-256</c>
-					<c>512</c>
-					<c>256</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA2-384</c>
-					<c>1024</c>
-					<c>384</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA2-512</c>
-					<c>1024</c>
-					<c>512</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA2-512/224</c>
-					<c>1024</c>
-					<c>224</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA2-512/256</c>
-					<c>1024</c>
-					<c>256</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA3-224</c>
-					<c>1152</c>
-					<c>224</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA3-256</c>
-					<c>1088</c>
-					<c>256</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA3-384</c>
-					<c>832</c>
-					<c>384</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>HMAC-SHA3-512</c>
-					<c>576</c>
-					<c>512</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>CMAC-AES</c>
-					<c>128</c>
-					<c>128</c>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>CMAC-TDES</c>
-					<c>64</c>
-					<c>64</c>
-					<c/>
-					<c/>
-					<c/>
-
-				</texttable>
-			</section>
-		</section>
-
-		<section anchor="test_vectors" title="Test Vectors">
-			<t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to
-	    the ACVP server for validation.  A typical ACVP validation session would require multiple test vector
-	    sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual
-	    crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc.  This section
-	describes the JSON schema for a test vector set used with HMAC and CMAC crypto algorithms.</t>
-
-			<t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire
-	vector set as well as individual test vectors to be processed by the ACVP client.  The following table
-	describes the JSON elements at the top level of the hierarchy.
-			</t>
-			<texttable anchor="vs_top_table" title="Vector Set JSON Object">
-				<ttcol align="left">JSON Value</ttcol>
-				<ttcol align="left">Description</ttcol>
-				<ttcol align="left">JSON type</ttcol>
-
-				<c>acvVersion</c>
-				<c>Protocol version identifier</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>vsId</c>
-				<c>Unique numeric identifier for the vector set</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>algorithm</c>
-				<c>The algorithm and mode used for the test vectors.  See					<xref target="supported_algs" />
- for possible values.</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>testGroups</c>
-				<c>Array of test group JSON objects, which are defined in					<xref target="tgjs" />
-				</c>
-				<c>array</c>
-			</texttable>
-
-			<section title="Test Groups JSON Schema" anchor="tgjs">
-				<t>The testGroups element at the top level in the test vector JSON object is an array of test
-		groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted
-	        in the vector set.  For instance, all test vectors that use the same key size would be grouped
-	        together.  The Test Group JSON object contains meta data that applies to all test vectors within
-	        the group.  The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
-				<texttable anchor="vs_tg_table" title="Test Group JSON Object">
-					<ttcol align="left">JSON Value</ttcol>
-					<ttcol align="left">Description</ttcol>
-					<ttcol align="left">JSON type</ttcol>
-					<ttcol align="left">Optional</ttcol>
-
-					<c>tgId</c>
-					<c>Numeric identifier for the test group, unique across the entire vector set.</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>testType</c>
-					<c>Test category type (AFT)</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>direction</c>
-					<c>The direction of the tests - gen or ver - only applies to CMAC</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>keyLen</c>
-					<c>Length of key in bits to use</c>
-					<c>value</c>
-					<c>Yes</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>msgLen</c>
-					<c>Length of message/hash in bits</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>macLen</c>
-					<c>Length of MAC in bits to generate/verify</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>tests</c>
-					<c>Array of individual test vector JSON objects, which are defined in						<xref target="tvjs" />
-					</c>
-					<c>array</c>
-					<c>No</c>
-				</texttable>
-
-			</section>
-
-			<section title="Test Case JSON Schema" anchor="tvjs">
-				<t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
-		that represents a single test vector to be processed by the ACVP client.  The following table describes
-	    the JSON elements for each secure MAC test vector.</t>
-
-				<texttable anchor="vs_tc_table2" title="Test Case JSON Object">
-					<ttcol align="left">JSON Value</ttcol>
-					<ttcol align="left">Description</ttcol>
-					<ttcol align="left">JSON type</ttcol>
-					<ttcol align="left">Optional</ttcol>
-
-					<c>tcId</c>
-					<c>Numeric identifier for the test case, unique across the entire vector set.</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>key</c>
-					<c>Encryption key to use AES</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>key1, key2, key3</c>
-					<c>Encryption keys to use for TDES</c>
-					<c>value</c>
-					<c>Yes</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>msg</c>
-					<c>Value of the message</c>
-					<c>value</c>
-					<c>No</c>
-					<c/>
-					<c/>
-					<c/>
-					<c/>
-
-					<c>mac</c>
-					<c>MAC value, for CMAC verify</c>
-					<c>value</c>
-					<c>Yes</c>
-				</texttable>
-			</section>
-		</section>
-
-		<section anchor="vector_responses" title="Test Vector Responses">
-			<t>After the ACVP client downloads and processes a vector set, it must send the response vectors
-	back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</t>
-
-			<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">
-				<ttcol align="left">JSON Value</ttcol>
-				<ttcol align="left">Description</ttcol>
-				<ttcol align="left">JSON type</ttcol>
-
-				<c>acvVersion</c>
-				<c>Protocol version identifier</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>vsId</c>
-				<c>Unique numeric identifier for the vector set</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>testGroups</c>
-				<c>Array of JSON objects that represent each test vector group. See					<xref target="vr_group_table"/>
-				</c>
-				<c>array</c>
-				<c/>
-				<c/>
-				<c/>
-
-			</texttable>
-
-			<t>The testGroups section is used to organize the ACVP client response in a similar manner 
-      to how it receives vectors.  Several algorithms SHALL require the client to send back group 
-      level properties in their response.  This structure helps accommodate that.</t>
-
-			<texttable anchor="vr_group_table" title="Vector Set Group Response JSON Object">
-				<ttcol align="left">JSON Value</ttcol>
-				<ttcol align="left">Description</ttcol>
-				<ttcol align="left">JSON type</ttcol>
-
-				<c>tgId</c>
-				<c>The test group Id</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-				<c>tests</c>
-				<c>The tests associated to the group specified in tgId</c>
-				<c>value</c>
-				<c/>
-				<c/>
-				<c/>
-			</texttable>
-
-			<t>Each test group contains an array of one or more test cases.  Each test case is a JSON object
-		that represents a single test vector to be processed by the ACVP client.  The following table describes
-	    the JSON elements for each DRBG test vector.</t>
-			<texttable anchor="vs_tr_table" title="MAC Test Case Results JSON Object">
-				<ttcol align="left">JSON Value</ttcol>
-				<ttcol align="left">Description</ttcol>
-				<ttcol align="left">JSON type</ttcol>
-				<ttcol align="left">Optional</ttcol>
-
-				<c>tcId</c>
-				<c>Numeric identifier for the test case, unique across the entire vector set.</c>
-				<c>value</c>
-				<c>No</c>
-				<c/>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>mac</c>
-				<c>value of the computed MAC output</c>
-				<c>value</c>
-				<c>Yes</c>
-				<c/>
-				<c/>
-				<c/>
-				<c/>
-
-				<c>testPassed</c>
-				<c>The result of CMAC verify</c>
-				<c>boolean</c>
-				<c>Yes</c>
-				<c/>
-				<c/>
-				<c/>
-				<c/>
-
-			</texttable>
-		</section>
-
-		<!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
-
-		<section anchor="Acknowledgements" title="Acknowledgements">
-			<t>TBD...</t>
-		</section>
-
-		<!-- Possibly a 'Contributors' section ... -->
-
-		<section anchor="IANA" title="IANA Considerations">
-			<t>This memo includes no request to IANA.</t>
-		</section>
-
-		<section anchor="Security" title="Security Considerations">
-			<t>Security considerations are addressed by the ACVP specification.</t>
-		</section>
-	</middle>
-
-	<!--  *****BACK MATTER ***** -->
-
-	<back>
-		<references title="Normative References">
-			<!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?-->
-      &RFC2119;
-
-			<reference anchor="ACVP">
-				<!-- the following is the minimum to make xml2rfc happy -->
-
-				<front>
-					<title>ACVP Specification</title>
-
-					<author initials="authInitials" surname="authSurName">
-						<organization>NIST</organization>
-					</author>
-
-					<date year="2016" />
-				</front>
-			</reference>
-		</references>
-
-		<references title="Informative References">
-			<reference anchor="SHAVS">
-				<!-- the following is the minimum to make xml2rfc happy -->
-
-				<front>
-					<title>The Secure Hash Algorithm Validation System (SHAVS)</title>
-
-					<author initials="LEB" surname="Lawrence E. Bassham III">
-						<organization>NIST</organization>
-					</author>
-
-					<date year="2014" />
-				</front>
-			</reference>
-
-			<reference anchor="SHA3VS">
-				<!-- the following is the minimum to make xml2rfc happy -->
-
-				<front>
-					<title>The Secure Hash Algorithm 3 Validation System (SHA3VS)</title>
-
-					<author initials="LEB" surname="Lawrence E. Bassham III">
-						<organization>NIST</organization>
-					</author>
-
-					<date year="2016" />
-				</front>
-			</reference>
-
-			<reference anchor="HMACVS">
-				<!-- the following is the minimum to make xml2rfc happy -->
-
-				<front>
-					<title>The Keyed-Hash Message Authentication Code Validation System (HMACVS)</title>
-
-					<author initials="LEB" surname="Lawrence E. Bassham III">
-						<organization>NIST</organization>
-					</author>
-
-					<date year="2016" />
-				</front>
-			</reference>
-
-			<reference anchor="CMACVS">
-				<!-- the following is the minimum to make xml2rfc happy -->
-
-				<front>
-					<title>The CMAC Validation System (CMACVS)</title>
-
-					<author initials="SSK" surname="Sharon S. Keller">
-						<organization>NIST</organization>
-					</author>
-
-					<date year="2011" />
-				</front>
-			</reference>
-
-		</references>
-
-
-		<section anchor="app-reg-ex" title="Example MAC Capabilities JSON Object">
-			<t>The following is an example JSON object advertising support for HMAC-SHA-1.</t>
-			<figure>
-				<artwork><![CDATA[
+        <abstract>
+            <t>This document defines the JSON schema for using HMAC and CMAC algorithms with the
+				ACVP specification.</t>
+        </abstract>
+    </front>
+    <middle>
+        <section title="Introduction">
+            <t>The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically
+				verify the cryptographic implementation of a software or hardware crypto module. The
+				ACVP specification defines how a crypto module communicates with an ACVP server,
+				including crypto capabilities negotiation, session management, authentication,
+				vector processing and more. The ACVP specification does not define algorithm
+				specific JSON constructs for performing the crypto validation. A series of ACVP
+				sub-specifications define the constructs for testing individual crypto algorithms.
+				Each sub-specification addresses a specific class of crypto algorithms. This
+				sub-specification defines the JSON constructs for testing HMAC and CMAC crypto
+				algorithms using ACVP.</t>
+            <section title="Requirements Language">
+                <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+					"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+					interpreted in 
+                    
+                    
+                    <xref target="RFC2119">RFC 2119</xref>. 
+                
+                
+                </t>
+            </section>
+        </section>
+        <section anchor="caps_reg" title="Capabilities Registration">
+            <t>ACVP requires crypto modules to register their capabilities. This allows the crypto
+				module to advertise support for specific algorithms, notifying the ACVP server which
+				algorithms need test vectors generated for the validation process. This section
+				describes the constructs for advertising support of HMAC and CMAC algorithms to the
+				ACVP server.</t>
+            <t>The algorithm capabilities are advertised as JSON objects within the 'algorithms'
+				value of the ACVP registration message. The 'algorithms' value is an array, where
+				each array element is an individual JSON object defined in this section. The
+				'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON
+				registration message. See the ACVP specification for details on the registration
+				message. Each algorithm capability advertised is a self-contained JSON object. </t>
+            <section anchor="prereq_algs"
+				title="Required Prerequisite Algorithms for MAC Validations">
+                <t>Each MAC implementation relies on other cryptographic primitives. For example,
+					CMAC uses an underlying SHA algorithm. Each of these underlying algorithm
+					primitives must be validated, either separately or as part of the same
+					submission. ACVP provides a mechanism for specifying the required
+					prerequisites:</t>
+                <texttable anchor="rereqs_table"
+					title="Required MAC Prerequisite Algorithms JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>algorithm</c>
+                    <c>a prerequisite algorithm</c>
+                    <c>value</c>
+                    <c>AES, SHA, TDES</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>valValue</c>
+                    <c>algorithm validation number</c>
+                    <c>value</c>
+                    <c>actual number or "same"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>prereqAlgVal</c>
+                    <c>prerequistie algorithm validation</c>
+                    <c>object with algorithm and valValue properties</c>
+                    <c>see above</c>
+                    <c>No</c>
+                </texttable>
+            </section>
+        </section>
+        <section anchor="cmac_aes_root" title="CMAC-AES">
+            <section anchor="cmac_aes_caps_reg" title="CMAC-AES Algorithm Capabilities Registration">
+                <t>Each algorithm capability advertised is a self-contained JSON object using
+							the following values.</t>
+                <texttable anchor="cmac_aes_caps_table"
+							title="CMAC-AES Algorithm Capabilities JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>algorithm</c>
+                    <c>The MAC algorithm to be validated.</c>
+                    <c>value</c>
+                    <c>CMAC</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mode</c>
+                    <c>The mode to be validated.</c>
+                    <c>value</c>
+                    <c>AES</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>prereqVals</c>
+                    <c>prerequistie algorithm validations, See 
+								
+                            
+                        <xref target="app-reg-ex"/> for
+								examples 
+							
+                        
+                    </c>
+                    <c>array of prereqAlgVal objects</c>
+                    <c>See 
+								
+                            
+                        <xref target="prereq_algs"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>capabilities</c>
+                    <c>The CMAC-AES capabilities
+							</c>
+                    <c>array of capability objects</c>
+                    <c>See 
+								
+                            
+                        <xref target="cmac_aes_capabilities"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+
+				<t>Each capability object describes a separate permutation of direction and key length.</t>
+
+                <texttable anchor="cmac_aes_capabilities"
+							title="CMAC-AES Capabilities JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>direction</c>
+                    <c>The MAC direction(s) to test.</c>
+                    <c>array</c>
+                    <c>gen, ver</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>keyLen</c>
+                    <c>The keyLen supported</c>
+                    <c>value</c>
+                    <c>128, 192, 256</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>msgLen</c>
+                    <c>The CMAC message lengths supported in bits. Min/max/increment and values
+								must be mod 8.</c>
+                    <c>Domain</c>
+                    <c>0-524288</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>macLen</c>
+                    <c>The supported mac sizes.</c>
+                    <c>Domain</c>
+                    <c>32-128</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>macLen for CMAC contains a Domain of values, the server may choose values
+							defined by these rules:</t>
+                <t>
+                    <list style="symbols">
+                        <t>The smallest CMAC length supported</t>
+                        <t>A second CMAC length supported</t>
+                        <t>The largest CMAC length supported</t>
+                    </list>
+                </t>
+                <t>msgLen for CMAC contains a Domain of values, the server may choose values
+							defined by these rules:</t>
+                <t>
+                    <list style="symbols">
+                        <t>The smallest message length supported</t>
+                        <t>Two message lengths divisible by block size</t>
+                        <t>Two message lengths NOT divisible by block size</t>
+                        <t>The largest message length supported</t>
+                    </list>
+                </t>
+            </section>
+            <section anchor="cmac_aes_test_vectors" title="CMAC-AES Test Vectors">
+                <t>The ACVP server provides test vectors to the ACVP client, which are then
+							processed and returned to the ACVP server for validation. A typical ACVP
+							validation session would require multiple test vector sets to be downloaded
+							and processed by the ACVP client. Each test vector set represents an
+							individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES,
+							etc. This section describes the JSON schema for a test vector set used with
+							HMAC and CMAC crypto algorithms.</t>
+                <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
+							data for the entire vector set as well as individual test vectors to be
+							processed by the ACVP client. The following table describes the JSON
+							elements at the top level of the hierarchy. </t>
+                <texttable anchor="cmac_aes_vs_top_table" title="CMAC-AES Vector Set JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>algorithm</c>
+                    <c>The algorithm used for the test vectors.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mode</c>
+                    <c>The mode used for the test vectors.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of test group JSON objects, which are defined in 
+								
+                            
+                        <xref
+									target="cmac_aes_tgjs"/>
+                    </c>
+                    <c>array</c>
+                </texttable>
+                <section title="CMAC-AES Test Groups JSON Schema" anchor="cmac_aes_tgjs">
+                    <t>The testGroups element at the top level in the test vector JSON object is
+								an array of test groups. Test vectors are grouped into similar test
+								cases to reduce the amount of data transmitted in the vector set. For
+								instance, all test vectors that use the same key size would be grouped
+								together. The Test Group JSON object contains meta data that applies to
+								all test vectors within the group. The following table describes the
+								secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
+                    <texttable anchor="cmac_aes_vs_tg_table" title="CMAC-AES Test Group JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tgId</c>
+                        <c>Numeric identifier for the test group, unique across the entire
+									vector set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testType</c>
+                        <c>Test category type (AFT)</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>direction</c>
+                        <c>The direction of the tests - gen or ver</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>keyLen</c>
+                        <c>Length of key in bits to use</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>msgLen</c>
+                        <c>Length of message/hash in bits</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>macLen</c>
+                        <c>Length of MAC in bits to generate/verify</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>Array of individual test vector JSON objects, which are defined in
+										
+									
+                                
+                            <xref target="cmac_aes_tvjs"/>
+                        </c>
+                        <c>array</c>
+                        <c>No</c>
+                    </texttable>
+                </section>
+                <section title="CMAC-AES Test Case JSON Schema" anchor="cmac_aes_tvjs">
+                    <t>Each test group contains an array of one or more test cases. Each test
+								case is a JSON object that represents a single test vector to be
+								processed by the ACVP client. The following table describes the JSON
+								elements for each secure MAC test vector.</t>
+                    <texttable anchor="cmac_aes_vs_tc_table2" title="CMAC-AES Test Case JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+									set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>key</c>
+                        <c>Encryption key to use AES</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>msg</c>
+                        <c>Value of the message</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>mac</c>
+                        <c>MAC value, for CMAC verify</c>
+                        <c>value</c>
+                        <c>Yes</c>
+                    </texttable>
+                </section>
+                <section anchor="cmac_aes_vector_responses" title="CMAC-AES Test Vector Responses">
+                    <t>After the ACVP client downloads and processes a vector set, it must send
+								the response vectors back to the ACVP server. The following table
+								describes the JSON object that represents a vector set response.</t>
+                    <texttable anchor="cmac_aes_vr_top_table"
+								title="CMAC-AES Vector Set Response JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <c>acvVersion</c>
+                        <c>Protocol version identifier</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>vsId</c>
+                        <c>Unique numeric identifier for the vector set</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testGroups</c>
+                        <c>Array of JSON objects that represent each test vector group. See
+										
+									
+                                
+                            <xref target="cmac_aes_vr_group_table"/>
+                        </c>
+                        <c>array</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                    <t>The testGroups section is used to organize the ACVP client response in a
+								similar manner to how it receives vectors. Several algorithms SHALL
+								require the client to send back group level properties in their
+								response. This structure helps accommodate that.</t>
+                    <texttable anchor="cmac_aes_vr_group_table"
+								title="CMAC-AES Vector Set Group Response JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <c>tgId</c>
+                        <c>The test group Id</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>The tests associated to the group specified in tgId</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                    <t>Each test group contains an array of one or more test cases. Each test
+								case is a JSON object that represents a single test vector to be
+								processed by the ACVP client. The following table describes the JSON
+								elements for each DRBG test vector.</t>
+                    <texttable anchor="cmac_aes_vs_tr_table"
+								title="CMAC-AES Test Case Results JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+									set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>mac</c>
+                        <c>value of the computed MAC output</c>
+                        <c>value</c>
+                        <c>Yes</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testPassed</c>
+                        <c>The result of CMAC verify</c>
+                        <c>boolean</c>
+                        <c>Yes</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                </section>
+            </section>
+        </section>
+        <section anchor="cmac_tdes_root" title="CMAC-TDES">
+            <section anchor="cmac_tdes_caps_reg" title="CMAC-TDES Algorithm Capabilities Registration">
+                <t>Each algorithm capability advertised is a self-contained JSON object using
+							the following values.</t>
+                <texttable anchor="cmac_tdes_caps_table"
+							title="CMAC-TDES Algorithm Capabilities JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>algorithm</c>
+                    <c>The MAC algorithm to be validated.</c>
+                    <c>value</c>
+                    <c>CMAC</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mode</c>
+                    <c>The mode to be validated.</c>
+                    <c>value</c>
+                    <c>TDES</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>prereqVals</c>
+                    <c>prerequistie algorithm validations, See 
+								
+                            
+                        <xref target="app-reg-ex"/> for
+								examples 
+							
+                        
+                    </c>
+                    <c>array of prereqAlgVal objects</c>
+                    <c>See 
+								
+                            
+                        <xref target="prereq_algs"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>capabilities</c>
+                    <c>The CMAC-TDES capabilities
+							</c>
+                    <c>array of capability objects</c>
+                    <c>See 
+								
+                            
+                        <xref target="cmac_tdes_capabilities"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <texttable anchor="cmac_tdes_capabilities"
+							title="CMAC-TDES Capabilities JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>direction</c>
+                    <c>The MAC direction(s) to test.</c>
+                    <c>array</c>
+                    <c>gen, ver</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>keyingOption</c>
+                    <c>The Keying Option used in TDES. Keying option 1 (1) is 3 distinct keys
+								(K1, K2, K3). Keying Option 2 (2) is 2 distinct only suitable for
+								decrypt (K1, K2, K1). Keying option 3 (No longer valid for testing, save
+								TDES KATs) is a single key, now deprecated (K1, K1, K1).</c>
+                    <c>value</c>
+                    <c>1, 2</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>msgLen</c>
+                    <c>The CMAC message lengths supported in bits. Min/max/increment and values
+								must be mod 8.</c>
+                    <c>Domain</c>
+                    <c>0-524288</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>macLen</c>
+                    <c>The supported mac sizes.</c>
+                    <c>Domain</c>
+                    <c>32-64</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>macLen for CMAC contains a Domain of values, the server may choose values
+							defined by these rules:</t>
+                <t>
+                    <list style="symbols">
+                        <t>The smallest CMAC length supported</t>
+                        <t>A second CMAC length supported</t>
+                        <t>The largest CMAC length supported</t>
+                    </list>
+                </t>
+                <t>msgLen for CMAC contains a Domain of values, the server may choose values
+							defined by these rules:</t>
+                <t>
+                    <list style="symbols">
+                        <t>The smallest message length supported</t>
+                        <t>Two message lengths divisible by block size</t>
+                        <t>Two message lengths NOT divisible by block size</t>
+                        <t>The largest message length supported</t>
+                    </list>
+                </t>
+            </section>
+            <section anchor="cmac_tdes_test_vectors" title="CMAC-TDES Test Vectors">
+                <t>The ACVP server provides test vectors to the ACVP client, which are then
+							processed and returned to the ACVP server for validation. A typical ACVP
+							validation session would require multiple test vector sets to be downloaded
+							and processed by the ACVP client. Each test vector set represents an
+							individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-TDES,
+							etc. This section describes the JSON schema for a test vector set used with
+							HMAC and CMAC crypto algorithms.</t>
+                <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
+							data for the entire vector set as well as individual test vectors to be
+							processed by the ACVP client. The following table describes the JSON
+							elements at the top level of the hierarchy. </t>
+                <texttable anchor="cmac_tdes_vs_top_table" title="CMAC-TDES Vector Set JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>algorithm</c>
+                    <c>The algorithm used for the test vectors.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mode</c>
+                    <c>The mode used for the test vectors.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of test group JSON objects, which are defined in 
+								
+                            
+                        <xref
+									target="cmac_tdes_tgjs"/>
+                    </c>
+                    <c>array</c>
+                </texttable>
+                <section title="CMAC-TDES Test Groups JSON Schema" anchor="cmac_tdes_tgjs">
+                    <t>The testGroups element at the top level in the test vector JSON object is
+								an array of test groups. Test vectors are grouped into similar test
+								cases to reduce the amount of data transmitted in the vector set. For
+								instance, all test vectors that use the same key size would be grouped
+								together. The Test Group JSON object contains meta data that applies to
+								all test vectors within the group. The following table describes the
+								secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
+                    <texttable anchor="cmac_tdes_vs_tg_table" title="CMAC-TDES Test Group JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tgId</c>
+                        <c>Numeric identifier for the test group, unique across the entire
+									vector set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testType</c>
+                        <c>Test category type (AFT)</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>direction</c>
+                        <c>The direction of the tests - gen or ver</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>keyLen</c>
+                        <c>Length of key in bits to use</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>msgLen</c>
+                        <c>Length of message/hash in bits</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>macLen</c>
+                        <c>Length of MAC in bits to generate/verify</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>Array of individual test vector JSON objects, which are defined in
+										
+									
+                                
+                            <xref target="cmac_tdes_tvjs"/>
+                        </c>
+                        <c>array</c>
+                        <c>No</c>
+                    </texttable>
+                </section>
+                <section title="CMAC-TDES Test Case JSON Schema" anchor="cmac_tdes_tvjs">
+                    <t>Each test group contains an array of one or more test cases. Each test
+								case is a JSON object that represents a single test vector to be
+								processed by the ACVP client. The following table describes the JSON
+								elements for each secure MAC test vector.</t>
+                    <texttable anchor="cmac_tdes_vs_tc_table2" title="CMAC-TDES Test Case JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+									set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>key1, key2, key3</c>
+                        <c>Encryption keys to use for TDES</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>msg</c>
+                        <c>Value of the message</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>mac</c>
+                        <c>MAC value, for CMAC verify</c>
+                        <c>value</c>
+                        <c>Yes</c>
+                    </texttable>
+                </section>
+                <section anchor="cmac_tdes_vector_responses" title="CMAC-TDES Test Vector Responses">
+                    <t>After the ACVP client downloads and processes a vector set, it must send
+								the response vectors back to the ACVP server. The following table
+								describes the JSON object that represents a vector set response.</t>
+                    <texttable anchor="cmac_tdes_vr_top_table"
+								title="CMAC-TDES Vector Set Response JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <c>acvVersion</c>
+                        <c>Protocol version identifier</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>vsId</c>
+                        <c>Unique numeric identifier for the vector set</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testGroups</c>
+                        <c>Array of JSON objects that represent each test vector group. See
+										
+									
+                                
+                            <xref target="cmac_tdes_vr_group_table"/>
+                        </c>
+                        <c>array</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                    <t>The testGroups section is used to organize the ACVP client response in a
+								similar manner to how it receives vectors. Several algorithms SHALL
+								require the client to send back group level properties in their
+								response. This structure helps accommodate that.</t>
+                    <texttable anchor="cmac_tdes_vr_group_table"
+								title="CMAC-TDES Vector Set Group Response JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <c>tgId</c>
+                        <c>The test group Id</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>The tests associated to the group specified in tgId</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                    <t>Each test group contains an array of one or more test cases. Each test
+								case is a JSON object that represents a single test vector to be
+								processed by the ACVP client. The following table describes the JSON
+								elements for each DRBG test vector.</t>
+                    <texttable anchor="cmac_tdes_vs_tr_table"
+								title="CMAC-TDES Test Case Results JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+									set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>mac</c>
+                        <c>value of the computed MAC output</c>
+                        <c>value</c>
+                        <c>Yes</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testPassed</c>
+                        <c>The result of CMAC verify</c>
+                        <c>boolean</c>
+                        <c>Yes</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                </section>
+            </section>
+        </section>
+        <section anchor="hmac_root" title="CMAC">
+            <section anchor="hmac_caps_reg" title="HMAC Algorithm Capabilities Registration">
+                <t>Each algorithm capability advertised is a self-contained JSON object using
+						the following values.</t>
+                <texttable anchor="hmac_caps_table2"
+						title="HMAC Algorithm Capabilities JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>algorithm</c>
+                    <c>The MAC algorithm and mode to be validated.</c>
+                    <c>value</c>
+                    <c>See 
+                            
+                        
+                        <xref target="hmac_supported_algs"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>prereqVals</c>
+                    <c>prerequistie algorithm validations, See 
+                            
+                        
+                        <xref target="app-reg-ex"/> for
+							examples 
+                        
+                    
+                    </c>
+                    <c>array of prereqAlgVal objects</c>
+                    <c>See 
+                            
+                        
+                        <xref target="prereq_algs"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>keyLen</c>
+                    <c>The keyLen Domain supported by the IUT in bits. (HMAC only)</c>
+                    <c>Domain</c>
+                    <c>8-524288</c>
+                    <c>Yes (required for HMAC)</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>macLen</c>
+                    <c>The supported mac sizes. (range dependent on algorithm, see 
+                            
+                        
+                        <xref
+								target="hmac_supported_algs"/>). 
+                        
+                    
+                    </c>
+                    <c>Domain</c>
+                    <c>32-512</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>keyLen for HMAC contains a Domain of values, the server may choose values
+						defined by these rules:</t>
+                <t>
+                    <list style="symbols">
+                        <t>2 values below the Hash's block length. See 
+                                
+                            
+                            <xref
+									target="hmac_supported_algs"/>
+                        </t>
+                        <t>The Hash's block length.</t>
+                        <t>2 values above the Hash's block length.</t>
+                    </list>
+                </t>
+                <t>macLen for HMAC contains a Domain of values, the server may choose values
+						defined by these rules:</t>
+                <t>
+                    <list style="symbols">
+                        <t>The smallest HMAC length supported</t>
+                        <t>A second HMAC length supported</t>
+                        <t>The largest HMAC length supported</t>
+                    </list>
+                </t>
+            </section>
+            <section anchor="hmac_supported_algs" title="Supported HMAC Algorithms">
+                <t>The following algorithms may be advertised by the ACVP compliant crypto
+						module:</t>
+                <texttable anchor="hmac_table_algInfo"
+						title="Algorithms w/ block size and max CMAC length.">
+                    <ttcol align="left">Algorithm Value</ttcol>
+                    <ttcol align="left">Block Length</ttcol>
+                    <ttcol align="left">Max MAC Length</ttcol>
+                    <c>HMAC-SHA-1</c>
+                    <c>512</c>
+                    <c>160</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA2-224</c>
+                    <c>512</c>
+                    <c>224</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA2-256</c>
+                    <c>512</c>
+                    <c>256</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA2-384</c>
+                    <c>1024</c>
+                    <c>384</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA2-512</c>
+                    <c>1024</c>
+                    <c>512</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA2-512/224</c>
+                    <c>1024</c>
+                    <c>224</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA2-512/256</c>
+                    <c>1024</c>
+                    <c>256</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA3-224</c>
+                    <c>1152</c>
+                    <c>224</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA3-256</c>
+                    <c>1088</c>
+                    <c>256</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA3-384</c>
+                    <c>832</c>
+                    <c>384</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>HMAC-SHA3-512</c>
+                    <c>576</c>
+                    <c>512</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+            </section>
+            <section anchor="hmac_test_vectors" title="HMAC Test Vectors">
+                <t>The ACVP server provides test vectors to the ACVP client, which are then
+						processed and returned to the ACVP server for validation. A typical ACVP
+						validation session would require multiple test vector sets to be downloaded
+						and processed by the ACVP client. Each test vector set represents an
+						individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES,
+						etc. This section describes the JSON schema for a test vector set used with
+						HMAC crypto algorithms.</t>
+                <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
+						data for the entire vector set as well as individual test vectors to be
+						processed by the ACVP client. The following table describes the JSON
+						elements at the top level of the hierarchy. </t>
+                <texttable anchor="hmac_vs_top_table" title="HMAC Vector Set JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>algorithm</c>
+                    <c>The algorithm and mode used for the test vectors. See 
+                            
+                        
+                        <xref
+								target="hmac_supported_algs"/> for possible values. 
+                        
+                    
+                    </c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of test group JSON objects, which are defined in 
+                            
+                        
+                        <xref
+								target="hmac_tgjs"/>
+                    </c>
+                    <c>array</c>
+                </texttable>
+                <section title="HMAC Test Groups JSON Schema" anchor="hmac_tgjs">
+                    <t>The testGroups element at the top level in the test vector JSON object is
+							an array of test groups. Test vectors are grouped into similar test
+							cases to reduce the amount of data transmitted in the vector set. For
+							instance, all test vectors that use the same key size would be grouped
+							together. The Test Group JSON object contains meta data that applies to
+							all test vectors within the group. The following table describes the
+							secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
+                    <texttable anchor="hmac_vs_tg_table" title="HMAC Test Group JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tgId</c>
+                        <c>Numeric identifier for the test group, unique across the entire
+								vector set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testType</c>
+                        <c>Test category type (AFT)</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>keyLen</c>
+                        <c>Length of key in bits to use</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>msgLen</c>
+                        <c>Length of message/hash in bits</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>macLen</c>
+                        <c>Length of MAC in bits to generate/verify</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>Array of individual test vector JSON objects, which are defined in
+									
+                                
+                            
+                            <xref target="hmac_tvjs"/>
+                        </c>
+                        <c>array</c>
+                        <c>No</c>
+                    </texttable>
+                </section>
+                <section title="HMAC Test Case JSON Schema" anchor="hmac_tvjs">
+                    <t>Each test group contains an array of one or more test cases. Each test
+							case is a JSON object that represents a single test vector to be
+							processed by the ACVP client. The following table describes the JSON
+							elements for each secure MAC test vector.</t>
+                    <texttable anchor="hmac_vs_tc_table2" title="HMAC Test Case JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+								set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>key</c>
+                        <c>The value of the key</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>msg</c>
+                        <c>Value of the message</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                </section>
+                <section anchor="hmac_vector_responses" title="HMAC Test Vector Responses">
+                    <t>After the ACVP client downloads and processes a vector set, it must send
+							the response vectors back to the ACVP server. The following table
+							describes the JSON object that represents a vector set response.</t>
+                    <texttable anchor="hmac_vr_top_table"
+							title="HMAC Vector Set Response JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <c>acvVersion</c>
+                        <c>Protocol version identifier</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>vsId</c>
+                        <c>Unique numeric identifier for the vector set</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testGroups</c>
+                        <c>Array of JSON objects that represent each test vector group. See
+									
+                                
+                            
+                            <xref target="hmac_vr_group_table"/>
+                        </c>
+                        <c>array</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                    <t>The testGroups section is used to organize the ACVP client response in a
+							similar manner to how it receives vectors. Several algorithms SHALL
+							require the client to send back group level properties in their
+							response. This structure helps accommodate that.</t>
+                    <texttable anchor="hmac_vr_group_table"
+							title="HMAC Vector Set Group Response JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <c>tgId</c>
+                        <c>The test group Id</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>The tests associated to the group specified in tgId</c>
+                        <c>value</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                    <t>Each test group contains an array of one or more test cases. Each test
+							case is a JSON object that represents a single test vector to be
+							processed by the ACVP client. The following table describes the JSON
+							elements for each DRBG test vector.</t>
+                    <texttable anchor="hmac_vs_tr_table"
+							title="HMAC Test Case Results JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+								set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>mac</c>
+                        <c>value of the computed MAC output</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                    </texttable>
+                </section>
+            </section>
+        </section>
+        <!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
+        <section anchor="Acknowledgements" title="Acknowledgements">
+            <t>TBD...</t>
+        </section>
+        <!-- Possibly a 'Contributors' section ... -->
+        <section anchor="IANA" title="IANA Considerations">
+            <t>This memo includes no request to IANA.</t>
+        </section>
+        <section anchor="Security" title="Security Considerations">
+            <t>Security considerations are addressed by the ACVP specification.</t>
+        </section>
+    </middle>
+    <!--  *****BACK MATTER ***** -->
+    <back>
+        <references title="Normative References">
+            <!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?-->
+			&RFC2119; 
+            
+            
+            <reference anchor="ACVP">
+                <!-- the following is the minimum to make xml2rfc happy -->
+                <front>
+                    <title>ACVP Specification</title>
+                    <author initials="authInitials" surname="authSurName">
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2016"/>
+                </front>
+            </reference>
+        </references>
+        <references title="Informative References">
+            <reference anchor="SHAVS">
+                <!-- the following is the minimum to make xml2rfc happy -->
+                <front>
+                    <title>The Secure Hash Algorithm Validation System (SHAVS)</title>
+                    <author initials="LEB" surname="Lawrence E. Bassham III">
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2014"/>
+                </front>
+            </reference>
+            <reference anchor="SHA3VS">
+                <!-- the following is the minimum to make xml2rfc happy -->
+                <front>
+                    <title>The Secure Hash Algorithm 3 Validation System (SHA3VS)</title>
+                    <author initials="LEB" surname="Lawrence E. Bassham III">
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2016"/>
+                </front>
+            </reference>
+            <reference anchor="HMACVS">
+                <!-- the following is the minimum to make xml2rfc happy -->
+                <front>
+                    <title>The Keyed-Hash Message Authentication Code Validation System
+						(HMACVS)</title>
+                    <author initials="LEB" surname="Lawrence E. Bassham III">
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2016"/>
+                </front>
+            </reference>
+            <reference anchor="CMACVS">
+                <!-- the following is the minimum to make xml2rfc happy -->
+                <front>
+                    <title>The CMAC Validation System (CMACVS)</title>
+                    <author initials="SSK" surname="Sharon S. Keller">
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2011"/>
+                </front>
+            </reference>
+        </references>
+        <section anchor="app-reg-ex" title="Example MAC Capabilities JSON Object">
+            <t>The following is an example JSON object advertising support for HMAC-SHA-1.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 
 
             {
@@ -802,11 +1454,13 @@
                 "keyLen": [ { "min": 256, "max": 2048, "increment": 8 } ],
                 "macLen": [ 192 ]
             }
-            ]]>				</artwork>
-			</figure>
-			<t>The following is an example JSON object advertising support for CMAC-AES.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+            <t>The following is an example JSON object advertising support for CMAC-AES.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 
 
             {
@@ -818,11 +1472,13 @@
                 "macLen" : [ 64 ],
                 "msgLen" : [ 0 ]
             }
-            ]]>				</artwork>
-			</figure>
-			<t>The following is an example JSON object advertising support for CMAC-TDES.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+            <t>The following is an example JSON object advertising support for CMAC-TDES.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 
 
             {
@@ -834,13 +1490,16 @@
                 "macLen" : [ 8, 64 ],
                 "msgLen" : [ 0, 256, 120, 248, 320 ]
             }
-            ]]>				</artwork>
-			</figure>
-		</section>
-		<section anchor="app-vs-ex" title="Example Test Vectors JSON Object">
-			<t>The following is an example JSON object for HMAC test vectors sent from the ACVP server to the crypto module.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+        </section>
+        <section anchor="app-vs-ex" title="Example Test Vectors JSON Object">
+            <t>The following is an example JSON object for HMAC test vectors sent from the ACVP
+				server to the crypto module.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 [{
 		"acvVersion": <acvp-version>
 	},
@@ -867,11 +1526,14 @@
 		}]
 	}
 ]
-            ]]>				</artwork>
-			</figure>
-			<t>The following is an example JSON object for CMAC-AES test vectors sent from the ACVP server to the crypto module.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+            <t>The following is an example JSON object for CMAC-AES test vectors sent from the ACVP
+				server to the crypto module.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 [{
 		"acvVersion": <acvp-version>
 	},
@@ -920,11 +1582,14 @@
 		]
 	}
 ]
-            ]]>				</artwork>
-			</figure>
-			<t>The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP server to the crypto module.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+            <t>The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP
+				server to the crypto module.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 [{
 		"acvVersion": <acvp-version>
 	},
@@ -982,13 +1647,16 @@
 		]
 	}
 ]
-            ]]>				</artwork>
-			</figure>
-		</section>
-		<section anchor="app-results-ex" title="Example Test Results JSON Object">
-			<t>The following is an example JSON object for HMAC test results sent from the crypto module to the ACVP server.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+        </section>
+        <section anchor="app-results-ex" title="Example Test Results JSON Object">
+            <t>The following is an example JSON object for HMAC test results sent from the crypto
+				module to the ACVP server.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 [{
 		"acvVersion": <acvp-version>
 	},
@@ -1008,11 +1676,14 @@
 		}]
 	}
 ]
-            ]]>				</artwork>
-			</figure>
-			<t>The following is an example JSON object for CMAC-AES test results sent from the crypto module to the ACVP server.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+            <t>The following is an example JSON object for CMAC-AES test results sent from the
+				crypto module to the ACVP server.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 [{
 		"acvVersion": <acvp-version>
 	},
@@ -1043,11 +1714,14 @@
 		}]
 	}
 ]
-            ]]>				</artwork>
-			</figure>
-			<t>The following is an example JSON object for CMAC-TDES test results sent from the crypto module to the ACVP server.</t>
-			<figure>
-				<artwork><![CDATA[
+            ]]>
+                </artwork>
+            </figure>
+            <t>The following is an example JSON object for CMAC-TDES test results sent from the
+				crypto module to the ACVP server.</t>
+            <figure>
+                <artwork>
+                    <![CDATA[
 [{
 		"acvVersion": <acvp-version>
 	},
@@ -1080,8 +1754,9 @@
 		]
 	}
 ]
-            ]]>				</artwork>
-			</figure>
-		</section>
-	</back>
+            ]]>
+                </artwork>
+            </figure>
+        </section>
+    </back>
 </rfc>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -2456,10 +2456,25 @@
                     </list>
                 </section>
 
-                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered"> </section>
+                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered">
+                    <list>
+                        <t>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending
+                            on the nature of the IUT capabilities registration, keys that are below,
+                            at, or above the hashing algorithm block size.</t>
+                        <t>FIPS 198-1 - 4 HMAC Specification. Mac Generation. ACVP server creates
+                            random sets of keys and messages for the IUT to process, then compares
+                            the IUT's result to the ACVP result.</t>
+                        <t>FIPS 198-1 - 5 Truncation. The ACVP server is capable of generating MACs
+                            as per the capability registration of the IUT. Groups will be created
+                            containing a random sampling of valid MAC lengths from the IUT
+                            registration.</t>
+                    </list>
+                </section>
 
                 <section anchor="requirements_not_covered_hmac"
-                    title="HMAC Requirements Not Covered"> </section>
+                    title="HMAC Requirements Not Covered">
+                    <t>N/A</t>
+                </section>
             </section>
         </section>
         <!-- This PI places the pagebreak correctly (before the section title) in the text output. -->

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -57,9 +57,9 @@
             </address>
         </author>
         <author fullname="Russell Hammett" initials="R.H." role="editor">
-			<organization>G2, Inc.</organization>
+            <organization>G2, Inc.</organization>
 
-			<address>
+            <address>
 				<postal>
 					<street>302 Sentinel Dr Suite 300</street>
 
@@ -78,7 +78,7 @@
 
 				<!-- uri and facsimile elements may also be added -->
 			</address>
-		</author>
+        </author>
         <date month="August" year="2018"/>
         <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
@@ -2406,42 +2406,60 @@
             </section>
         </section>
         <section anchor="test_types" title="Test Types and Test Coverage">
-            <t>The ACVP server performs a set of tests on the MAC algorithms in order to assess the correctness and robustness of 
-            the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported 
-            cryptographic algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. 
-            This section describes the design of the tests used to validate implementations of MAC algorithms. 
-            There is a single test type for MACs (broken into subsections for CMACs).  the single test type, algorithm functional test (AFT)
-            can be described as follows:
-
-                <list style="testtype">
-                    <t>"AFT" - Algorithm Function Test.  The IUT processes all of HMAC and the "gen" direction of CMAC by running the randomly chosen
-                    key and message data (with constraints as per the IUT's capabilities registration) through the MAC algorithm. CMAC has an addition "ver" direction
-                    present in its testing to ensure the IUT can successfully determine when a MAC does not match its originating message/key combination.</t>
+            <t>The ACVP server performs a set of tests on the MAC algorithms in order to assess the
+                correctness and robustness of the implementation. A typical ACVP validation session
+                would require multiple tests to be performed for every supported cryptographic
+                algorithm, such as CMAC-AES, CMAC-TDES, HMAC-SHA-1, HMAC-SHA2-256, etc. This section
+                describes the design of the tests used to validate implementations of MAC
+                algorithms. There is a single test type for MACs (broken into subsections for
+                CMACs). the single test type, algorithm functional test (AFT) can be described as
+                follows: <list style="testtype">
+                    <t>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen"
+                        direction of CMAC by running the randomly chosen key and message data (with
+                        constraints as per the IUT's capabilities registration) through the MAC
+                        algorithm. CMAC has an addition "ver" direction present in its testing to
+                        ensure the IUT can successfully determine when a MAC does not match its
+                        originating message/key combination.</t>
                 </list>
-            
             </t>
 
             <section anchor="test_coverage" title="Test Coverage">
-                <t>The tests described in this document have the intention of ensuring an implementation is 
-                conformant to <xref target="SP-800-38B" /> and <xref target="FIPS-198-1" />.</t>
+                <t>The tests described in this document have the intention of ensuring an
+                    implementation is conformant to <xref target="SP-800-38B"/> and <xref
+                        target="FIPS-198-1"/>.</t>
 
-                <section anchor="requirements_covered_cmac_aes" title="CMAC-AES Requirements Covered">
-                </section>
-                
-                <section anchor="requirements_not_covered_cmac_aes" title="CMAC-AES Requirements Not Covered">
-                </section>
-                
-                <section anchor="requirements_covered_cmac_tdes" title="CMAC-TDES Requirements Covered">
-                </section>
-                
-                <section anchor="requirements_not_covered_cmac_tdes" title="CMAC-TDES Requirements Not Covered">
+                <section anchor="requirements_covered_cmac" title="CMAC Requirements Covered">
+                    <list>
+                        <t> SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys
+                            and messages for the IUT to process, then compares the IUT's result to
+                            the ACVP result. </t>
+                        <t> SP 800-38b - 6.3 Mac Verification. ACVP server creates random sets of
+                            keys, messages, and macs. These test vectors are then randomly altered
+                            to ensure the MAC will not match the given key and message. Using the
+                            provided test case, the IUT is expected to validate the mac against the
+                            provided key and message. </t>
+                    </list>
                 </section>
 
-                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered">
+                <section anchor="requirements_not_covered_cmac" title="CMACRequirements Not Covered">
+                    <list>
+                        <t>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are
+                            intermediate values, are not validated via current testing.</t>
+                        <t>SP 800-38b - 5.5 Input and Output Data. The mlen is currently provided
+                            and not inferred.</t>
+                        <t> SP 800-38b - Appendix A. Length of MAC. The ACVP server will generate
+                            vectors as per the IUT's specified criteria. The IUT should register its
+                            entire range of supported MAC lengths, regardless of security strength.
+                            The ACVP server will test a random sampling of valid MAC lengths as per
+                            the IUT registration - this generally includes the minimum and maximum
+                            mac length. </t>
+                    </list>
                 </section>
-                
-                <section anchor="requirements_not_covered_hmac" title="HMAC Requirements Not Covered">
-                </section>
+
+                <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered"> </section>
+
+                <section anchor="requirements_not_covered_hmac"
+                    title="HMAC Requirements Not Covered"> </section>
             </section>
         </section>
         <!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
@@ -2473,22 +2491,25 @@
             </reference>
         </references>
         <references title="Informative References">
-            <reference anchor="SP-800-38B" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf">
+            <reference anchor="SP-800-38B"
+                target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf">
                 <front>
-                <title>Recommendation for Block Cipher Modes of Operation: The CMAC Mode for Authentication</title>
-                <author>
-                    <organization>NIST</organization>
-                </author>
-                <date year="2005"/>
+                    <title>Recommendation for Block Cipher Modes of Operation: The CMAC Mode for
+                        Authentication</title>
+                    <author>
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2005"/>
                 </front>
             </reference>
-            <reference anchor="FIPS-198-1" target="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.198-1.pdf">
+            <reference anchor="FIPS-198-1"
+                target="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.198-1.pdf">
                 <front>
-                <title>The Keyed-Hash Message Authentication Code (HMAC) </title>
-                <author>
-                    <organization>NIST</organization>
-                </author>
-                <date year="2008"/>
+                    <title>The Keyed-Hash Message Authentication Code (HMAC) </title>
+                    <author>
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2008"/>
                 </front>
             </reference>
             <reference anchor="SHAVS">

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -286,8 +286,6 @@
 {
   "algorithm": "CMAC",
   "mode": "AES",
-  "isSample": false,
-  "conformances": [],
   "capabilities": [
     {
       "direction": "gen",
@@ -1116,6 +1114,77 @@
                         <t>The largest message length supported</t>
                     </list>
                 </t>
+                <section anchor="cmac_tdes_app-reg-ex"
+                    title="Example CMAC-TDES Capabilities JSON Object">
+                    <t>The following is an example JSON object advertising support for
+                        CMAC-TDES.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+  "algorithm": "CMAC",
+  "mode": "TDES",
+  "capabilities": [
+    {
+      "direction": "gen",
+      "keyingOption": 1,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 32,
+          "max": 64,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyingOption": 1,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 32,
+          "max": 64,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 32,
+          "max": 64,
+          "increment": 8
+        }
+      ]
+    }
+  ]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
             </section>
             <section anchor="cmac_tdes_test_vectors" title="CMAC-TDES Test Vectors">
                 <t>The ACVP server provides test vectors to the ACVP client, which are then
@@ -1276,94 +1345,511 @@
                         <c>Yes</c>
                     </texttable>
                 </section>
-                <section anchor="cmac_tdes_vector_responses" title="CMAC-TDES Test Vector Responses">
-                    <t>After the ACVP client downloads and processes a vector set, it must send the
-                        response vectors back to the ACVP server. The following table describes the
-                        JSON object that represents a vector set response.</t>
-                    <texttable anchor="cmac_tdes_vr_top_table"
-                        title="CMAC-TDES Vector Set Response JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <c>acvVersion</c>
-                        <c>Protocol version identifier</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>vsId</c>
-                        <c>Unique numeric identifier for the vector set</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>testGroups</c>
-                        <c>Array of JSON objects that represent each test vector group. See <xref
-                                target="cmac_tdes_vr_group_table"/>
-                        </c>
-                        <c>array</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
-                    <t>The testGroups section is used to organize the ACVP client response in a
-                        similar manner to how it receives vectors. Several algorithms SHALL require
-                        the client to send back group level properties in their response. This
-                        structure helps accommodate that.</t>
-                    <texttable anchor="cmac_tdes_vr_group_table"
-                        title="CMAC-TDES Vector Set Group Response JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <c>tgId</c>
-                        <c>The test group Id</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>tests</c>
-                        <c>The tests associated to the group specified in tgId</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
-                    <t>Each test group contains an array of one or more test cases. Each test case
-                        is a JSON object that represents a single test vector to be processed by the
-                        ACVP client. The following table describes the JSON elements for each DRBG
-                        test vector.</t>
-                    <texttable anchor="cmac_tdes_vs_tr_table"
-                        title="CMAC-TDES Test Case Results JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <ttcol align="left">Optional</ttcol>
-                        <c>tcId</c>
-                        <c>Numeric identifier for the test case, unique across the entire vector
-                            set.</c>
-                        <c>value</c>
-                        <c>No</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>mac</c>
-                        <c>value of the computed MAC output</c>
-                        <c>value</c>
-                        <c>Yes</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>testPassed</c>
-                        <c>The result of CMAC verify</c>
-                        <c>boolean</c>
-                        <c>Yes</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
+                <section anchor="cmac_tdes_test_vector_json"
+                    title="Example CMAC-TDES Test Vector JSON Object">
+                    <t>The following is an example JSON test vector object for CMAC-TDES.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+	"vsId": 1,
+	"algorithm": "CMAC",
+	"mode": "TDES",
+	"testGroups": [{
+			"tgId": 4,
+			"testType": "AFT",
+			"direction": "gen",
+			"keyLen": 192,
+			"msgLen": 752,
+			"macLen": 32,
+			"tests": [{
+					"tcId": 25,
+					"key": "7FFDB31A3A06BF0D5201FFE83CC5253EBBECA60F1D631BB8",
+					"message": "4D2D07AE0224289BE111E0D4522A8AC127FAD537D7D4240613A73EA23CA673F8DC554B4C8CC69699C1DCB638D06FCA54D858DF68F595B7987A937599BDEA77974AB1441D7E63190762CBCD8E6D9F9A8940FB8DB43EBDAA2172C9B0A5CDF9",
+					"key1": "7FFDB31A3A06BF0D",
+					"key2": "5201FFE83CC5253E",
+					"key3": "BBECA60F1D631BB8"
+				},
+				{
+					"tcId": 26,
+					"key": "82E572E29C84009E28390918155E4891A0D24C94C306FE56",
+					"message": "7A70F3CE17598AC3553FBADA0CC562018FD40C6D25B098EC0B905B1BC9F67DFCBD797494E4B05E2C6C3C0F655F9E95FFFE16782E1454A5EE04D87E7586F7FF65A51979A1C46118080320C1CB9E9CC48A05E113C95C2316361B39F5FCB861",
+					"key1": "82E572E29C84009E",
+					"key2": "28390918155E4891",
+					"key3": "A0D24C94C306FE56"
+				},
+				{
+					"tcId": 27,
+					"key": "662A89E47D86F6A0CB9D612E199B4AD2AE3AEBA19FAB4340",
+					"message": "2DAF1E213A6AE9E88FEBC70458AACBFB9B668EB22F12662B281D29A57B568CA35146E073D6B4BECB3E10AD8D398CADF672464707207FB40D23F4D6F93528F83D79019106A03D41E26DAE32E3208920FE165FCD739305A4E24D81B118972C",
+					"key1": "662A89E47D86F6A0",
+					"key2": "CB9D612E199B4AD2",
+					"key3": "AE3AEBA19FAB4340"
+				},
+				{
+					"tcId": 28,
+					"key": "522729A011C73BE2079D67ECEBFCE42EF5F91F6ECD43F71E",
+					"message": "7F1170A442EEAFCAFD00925C8BD2DB22AB2458AAAB6F6C2B061EB56F005DAC0D11392ADAA0E07FF6074208E22D5E07F4C4B9A1C9DDFD2FAAEB1185C2E5B60D06E2BFBB92C6A0DC4CED36A8DB19583D8BE09A260E638FCCCDCBF17A7D2D6D",
+					"key1": "522729A011C73BE2",
+					"key2": "079D67ECEBFCE42E",
+					"key3": "F5F91F6ECD43F71E"
+				},
+				{
+					"tcId": 29,
+					"key": "B5FE32A150833A60A8C619C2A89BD8BCD8DFB2654AEB4923",
+					"message": "839733866DC749C9F2F3756E02FB1FEAAF0BC47814CD52159EE1AA1945F50D789483E4705437482712F26FE8505233638B9004A2938669670888BEB5EF5BBB62DBC6C0355FAB7BB4AE57FE7E345A9E5D9699750157E83F55B8431CD0ECF6",
+					"key1": "B5FE32A150833A60",
+					"key2": "A8C619C2A89BD8BC",
+					"key3": "D8DFB2654AEB4923"
+				},
+				{
+					"tcId": 30,
+					"key": "C2406CA7AA81A4A6FBB0D6A665B0D1410445F4CC132F46E6",
+					"message": "95FC92BAC8AE751818427F2090B3BCC76BD1A5A3CAE6C5B914AF59DA589BDED6A2CF0B7A17CB659B46C9FF3163AFEC505D3BBBAF42AD9FA077AA862E49BBE21773E3CF7C031A022681E85169873C639ADDA2953AB352B9724B0F941AF2E6",
+					"key1": "C2406CA7AA81A4A6",
+					"key2": "FBB0D6A665B0D141",
+					"key3": "0445F4CC132F46E6"
+				},
+				{
+					"tcId": 31,
+					"key": "AE90AF3424A99A304F0D54B1FDAAAA5B4D026169F067D997",
+					"message": "AECC231068148AE400B1F1922684C681FBEC9C836B1593BB0805C8A38340564C1CA39C341588913C3E425934B8D219FED6D58553BC3AE44B003999FA51C8265AE6AA653F839C56813F58BD4F6093F5A2FF196CAA9A3CF782E21FD06C0AD0",
+					"key1": "AE90AF3424A99A30",
+					"key2": "4F0D54B1FDAAAA5B",
+					"key3": "4D026169F067D997"
+				},
+				{
+					"tcId": 32,
+					"key": "B10CCB821E63EF98928D1BC20D797C5E9149B32BFC090140",
+					"message": "B19716D364D0680873D83F4991839465C169CADA64D5B57454ADDCDA64D1778219B204571593C5965E8F84C373CF0DBD10F4C8124D932FB6EF2B662966C698F79CB3199E40A45A8A7C186E948CA5A0BAD743A1FDC91336325145FC701D41",
+					"key1": "B10CCB821E63EF98",
+					"key2": "928D1BC20D797C5E",
+					"key3": "9149B32BFC090140"
+				}
+			],
+			"keyingOption": 1
+		},
+		{
+			"tgId": 10,
+			"testType": "AFT",
+			"direction": "ver",
+			"keyLen": 192,
+			"msgLen": 0,
+			"macLen": 32,
+			"tests": [{
+					"tcId": 73,
+					"key": "D127F902CFF69A82785D99EF117E5B5636D4CB2C34A3AF30",
+					"message": "",
+					"mac": "D78010B3",
+					"key1": "D127F902CFF69A82",
+					"key2": "785D99EF117E5B56",
+					"key3": "36D4CB2C34A3AF30"
+				},
+				{
+					"tcId": 74,
+					"key": "9D5DAC4D75E0A3496A55855C62D8C767CBD9FC7CCBDA8BE9",
+					"message": "",
+					"mac": "5313D9E8",
+					"key1": "9D5DAC4D75E0A349",
+					"key2": "6A55855C62D8C767",
+					"key3": "CBD9FC7CCBDA8BE9"
+				},
+				{
+					"tcId": 75,
+					"key": "B711BA268A1F3663AA83B2195E85BFC6AA1CFBC128AAE0FD",
+					"message": "",
+					"mac": "07B1926F",
+					"key1": "B711BA268A1F3663",
+					"key2": "AA83B2195E85BFC6",
+					"key3": "AA1CFBC128AAE0FD"
+				},
+				{
+					"tcId": 76,
+					"key": "4DB908F0A14A3959AC76D38D171114CA3651F7FF9C9B20B5",
+					"message": "",
+					"mac": "7C920795",
+					"key1": "4DB908F0A14A3959",
+					"key2": "AC76D38D171114CA",
+					"key3": "3651F7FF9C9B20B5"
+				},
+				{
+					"tcId": 77,
+					"key": "670AB0529BCE3007BDC7706FED307419291C6BA004943806",
+					"message": "",
+					"mac": "7988C839",
+					"key1": "670AB0529BCE3007",
+					"key2": "BDC7706FED307419",
+					"key3": "291C6BA004943806"
+				},
+				{
+					"tcId": 78,
+					"key": "62AA8060A173FD6A19FB1E39C09914E8453D89A318FEAA0A",
+					"message": "",
+					"mac": "14B588F8",
+					"key1": "62AA8060A173FD6A",
+					"key2": "19FB1E39C09914E8",
+					"key3": "453D89A318FEAA0A"
+				},
+				{
+					"tcId": 79,
+					"key": "9B954C62C795DD599807683D5531A513E88406D75B04CDC9",
+					"message": "",
+					"mac": "9BDD8078",
+					"key1": "9B954C62C795DD59",
+					"key2": "9807683D5531A513",
+					"key3": "E88406D75B04CDC9"
+				},
+				{
+					"tcId": 80,
+					"key": "E085046DF6F97A3D9B00E3EA82482EBFA1DCA6EC94ACFD7E",
+					"message": "",
+					"mac": "D44BA0CD",
+					"key1": "E085046DF6F97A3D",
+					"key2": "9B00E3EA82482EBF",
+					"key3": "A1DCA6EC94ACFD7E"
+				},
+				{
+					"tcId": 81,
+					"key": "526DE285D64F65A20F2E9F52E789AD59E6AE85200F95501F",
+					"message": "",
+					"mac": "F068F177",
+					"key1": "526DE285D64F65A2",
+					"key2": "0F2E9F52E789AD59",
+					"key3": "E6AE85200F95501F"
+				},
+				{
+					"tcId": 82,
+					"key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
+					"message": "",
+					"mac": "317B4969",
+					"key1": "97FBEF5ADADC68CC",
+					"key2": "DD5BAFB50853589E",
+					"key3": "DF4918593D29F5C0"
+				},
+				{
+					"tcId": 83,
+					"key": "1D80CD109B749DCE6AF893051C0969B6705A264BFA49F2B2",
+					"message": "",
+					"mac": "FAFE8358",
+					"key1": "1D80CD109B749DCE",
+					"key2": "6AF893051C0969B6",
+					"key3": "705A264BFA49F2B2"
+				},
+				{
+					"tcId": 84,
+					"key": "B48C715C2B4EB7F5D0865F7ABC0BFD1F2CD83EA54C5136D7",
+					"message": "",
+					"mac": "F456798B",
+					"key1": "B48C715C2B4EB7F5",
+					"key2": "D0865F7ABC0BFD1F",
+					"key3": "2CD83EA54C5136D7"
+				},
+				{
+					"tcId": 85,
+					"key": "A8944ECE678BBFFD45C1557E59A6044352EF3B8808FD54DC",
+					"message": "",
+					"mac": "7CEEF54C",
+					"key1": "A8944ECE678BBFFD",
+					"key2": "45C1557E59A60443",
+					"key3": "52EF3B8808FD54DC"
+				},
+				{
+					"tcId": 86,
+					"key": "B6CA0DD41423786CD0E524E69C2D21DE81522CB976796269",
+					"message": "",
+					"mac": "02E9CDE5",
+					"key1": "B6CA0DD41423786C",
+					"key2": "D0E524E69C2D21DE",
+					"key3": "81522CB976796269"
+				},
+				{
+					"tcId": 87,
+					"key": "C2A4D041516F0B7535D37F2B55FB38CFB75F24285D7BEF39",
+					"message": "",
+					"mac": "4A099862",
+					"key1": "C2A4D041516F0B75",
+					"key2": "35D37F2B55FB38CF",
+					"key3": "B75F24285D7BEF39"
+				},
+				{
+					"tcId": 88,
+					"key": "3F9879C2259E2C6E0E75799EC99FA126E9A59029ADCD6B7C",
+					"message": "",
+					"mac": "CB1FC90C",
+					"key1": "3F9879C2259E2C6E",
+					"key2": "0E75799EC99FA126",
+					"key3": "E9A59029ADCD6B7C"
+				},
+				{
+					"tcId": 89,
+					"key": "5059F4B1CA3C438F56FF7F3115E2B7ACC0970ADF892FBBA0",
+					"message": "",
+					"mac": "6F5CFAEC",
+					"key1": "5059F4B1CA3C438F",
+					"key2": "56FF7F3115E2B7AC",
+					"key3": "C0970ADF892FBBA0"
+				},
+				{
+					"tcId": 90,
+					"key": "DE8EB157BCE06D7A318ECE3D7E96B586FDDC6097E61C4F48",
+					"message": "",
+					"mac": "E67871E3",
+					"key1": "DE8EB157BCE06D7A",
+					"key2": "318ECE3D7E96B586",
+					"key3": "FDDC6097E61C4F48"
+				},
+				{
+					"tcId": 91,
+					"key": "840A1C616D0D776BFAF99C1444507BACD11881E87C8E0329",
+					"message": "",
+					"mac": "C2D06FE4",
+					"key1": "840A1C616D0D776B",
+					"key2": "FAF99C1444507BAC",
+					"key3": "D11881E87C8E0329"
+				},
+				{
+					"tcId": 92,
+					"key": "1A29B0ED9040FD2D6A7D20A4DF50E290AB1D497EC1D211AA",
+					"message": "",
+					"mac": "B5E61275",
+					"key1": "1A29B0ED9040FD2D",
+					"key2": "6A7D20A4DF50E290",
+					"key3": "AB1D497EC1D211AA"
+				}
+			],
+			"keyingOption": 1
+		}
+	]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+            </section>
+            <section anchor="cmac_tdes_vector_responses" title="CMAC-TDES Test Vector Responses">
+                <t>After the ACVP client downloads and processes a vector set, it must send the
+                    response vectors back to the ACVP server. The following table describes the JSON
+                    object that represents a vector set response.</t>
+                <texttable anchor="cmac_tdes_vr_top_table"
+                    title="CMAC-TDES Vector Set Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of JSON objects that represent each test vector group. See <xref
+                            target="cmac_tdes_vr_group_table"/>
+                    </c>
+                    <c>array</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>The testGroups section is used to organize the ACVP client response in a similar
+                    manner to how it receives vectors. Several algorithms SHALL require the client
+                    to send back group level properties in their response. This structure helps
+                    accommodate that.</t>
+                <texttable anchor="cmac_tdes_vr_group_table"
+                    title="CMAC-TDES Vector Set Group Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>tgId</c>
+                    <c>The test group Id</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>tests</c>
+                    <c>The tests associated to the group specified in tgId</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>Each test group contains an array of one or more test cases. Each test case is a
+                    JSON object that represents a single test vector to be processed by the ACVP
+                    client. The following table describes the JSON elements for each DRBG test
+                    vector.</t>
+                <texttable anchor="cmac_tdes_vs_tr_table"
+                    title="CMAC-TDES Test Case Results JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>tcId</c>
+                    <c>Numeric identifier for the test case, unique across the entire vector
+                        set.</c>
+                    <c>value</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mac</c>
+                    <c>value of the computed MAC output</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testPassed</c>
+                    <c>The result of CMAC verify</c>
+                    <c>boolean</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <section anchor="cmac_tdes_test_vector_response_json"
+                    title="Example CMAC-TDES Test Vector Response JSON Object">
+                    <t>The following is an example JSON test vector response object for
+                        CMAC-TDES.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+    "vsId": 1,
+	"algorithm": "CMAC",
+	"mode": "TDES",
+	"testGroups": [{
+			"tgId": 4,
+			"tests": [{
+					"tcId": 25,
+					"mac": "6FA27FDC"
+				},
+				{
+					"tcId": 26,
+					"mac": "89CE2842"
+				},
+				{
+					"tcId": 27,
+					"mac": "5E03D980"
+				},
+				{
+					"tcId": 28,
+					"mac": "EC68CA91"
+				},
+				{
+					"tcId": 29,
+					"mac": "ACAEF07C"
+				},
+				{
+					"tcId": 30,
+					"mac": "2207C5DF"
+				},
+				{
+					"tcId": 31,
+					"mac": "95248097"
+				},
+				{
+					"tcId": 32,
+					"mac": "33325023"
+				}
+			]
+		},
+		{
+			"tgId": 10,
+			"tests": [{
+					"tcId": 73,
+					"testPassed": true
+				},
+				{
+					"tcId": 74,
+					"testPassed": true
+				},
+				{
+					"tcId": 75,
+					"testPassed": true
+				},
+				{
+					"tcId": 76,
+					"testPassed": true
+				},
+				{
+					"tcId": 77,
+					"testPassed": false
+				},
+				{
+					"tcId": 78,
+					"testPassed": true
+				},
+				{
+					"tcId": 79,
+					"testPassed": true
+				},
+				{
+					"tcId": 80,
+					"testPassed": true
+				},
+				{
+					"tcId": 81,
+					"testPassed": false
+				},
+				{
+					"tcId": 82,
+					"testPassed": true
+				},
+				{
+					"tcId": 83,
+					"testPassed": true
+				},
+				{
+					"tcId": 84,
+					"testPassed": true
+				},
+				{
+					"tcId": 85,
+					"testPassed": true
+				},
+				{
+					"tcId": 86,
+					"testPassed": true
+				},
+				{
+					"tcId": 87,
+					"testPassed": true
+				},
+				{
+					"tcId": 88,
+					"testPassed": false
+				},
+				{
+					"tcId": 89,
+					"testPassed": true
+				},
+				{
+					"tcId": 90,
+					"testPassed": false
+				},
+				{
+					"tcId": 91,
+					"testPassed": true
+				},
+				{
+					"tcId": 92,
+					"testPassed": true
+				}
+			]
+		}
+	]
+}
+            ]]>
+                        </artwork>
+                    </figure>
                 </section>
             </section>
         </section>

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -2417,7 +2417,7 @@
                     <t>"AFT" - Algorithm Function Test. The IUT processes all of HMAC and the "gen"
                         direction of CMAC by running the randomly chosen key and message data (with
                         constraints as per the IUT's capabilities registration) through the MAC
-                        algorithm. CMAC has an addition "ver" direction present in its testing to
+                        algorithm. CMAC has an additional "ver" direction present in its testing to
                         ensure the IUT can successfully determine when a MAC does not match its
                         originating message/key combination.</t>
                 </list>
@@ -2429,6 +2429,7 @@
                         target="FIPS-198-1"/>.</t>
 
                 <section anchor="requirements_covered_cmac" title="CMAC Requirements Covered">
+                    <t>
                     <list>
                         <t> SP 800-38b - 6.2 Mac Generation. ACVP server creates random sets of keys
                             and messages for the IUT to process, then compares the IUT's result to
@@ -2439,9 +2440,11 @@
                             provided test case, the IUT is expected to validate the mac against the
                             provided key and message. </t>
                     </list>
+                    </t>
                 </section>
 
                 <section anchor="requirements_not_covered_cmac" title="CMACRequirements Not Covered">
+                    <t>
                     <list>
                         <t>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are
                             intermediate values, are not validated via current testing.</t>
@@ -2454,9 +2457,11 @@
                             the IUT registration - this generally includes the minimum and maximum
                             mac length. </t>
                     </list>
+                    </t>
                 </section>
 
                 <section anchor="requirements_covered_hmac" title="HMAC Requirements Covered">
+                    <t>
                     <list>
                         <t>FIPS 198-1 - 3 Cryptographic Keys. The ACVP server will test, depending
                             on the nature of the IUT capabilities registration, keys that are below,
@@ -2469,6 +2474,7 @@
                             containing a random sampling of valid MAC lengths from the IUT
                             registration.</t>
                     </list>
+                    </t>
                 </section>
 
                 <section anchor="requirements_not_covered_hmac"

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 
-
-
-
 <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 ]>
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -41,7 +38,7 @@
         <!-- The abbreviated title is used in the page header - it is only necessary if the
          full title is longer than 39 characters -->
         <title abbrev="Sym Alg JSON">ACVP Message Authentication Algorithm JSON
-			Specification</title>
+            Specification</title>
         <!-- add 'role="editor"' below for the editors if appropriate -->
         <!-- Another author who claims to be an editor -->
         <author fullname="Barry Fussell" initials="B.F." role="editor" surname="Fussell">
@@ -81,54 +78,48 @@
          keywords will be used for the search engine. -->
         <abstract>
             <t>This document defines the JSON schema for using HMAC and CMAC algorithms with the
-				ACVP specification.</t>
+                ACVP specification.</t>
         </abstract>
     </front>
     <middle>
         <section title="Introduction">
             <t>The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically
-				verify the cryptographic implementation of a software or hardware crypto module. The
-				ACVP specification defines how a crypto module communicates with an ACVP server,
-				including crypto capabilities negotiation, session management, authentication,
-				vector processing and more. The ACVP specification does not define algorithm
-				specific JSON constructs for performing the crypto validation. A series of ACVP
-				sub-specifications define the constructs for testing individual crypto algorithms.
-				Each sub-specification addresses a specific class of crypto algorithms. This
-				sub-specification defines the JSON constructs for testing HMAC and CMAC crypto
-				algorithms using ACVP.</t>
+                verify the cryptographic implementation of a software or hardware crypto module. The
+                ACVP specification defines how a crypto module communicates with an ACVP server,
+                including crypto capabilities negotiation, session management, authentication,
+                vector processing and more. The ACVP specification does not define algorithm
+                specific JSON constructs for performing the crypto validation. A series of ACVP
+                sub-specifications define the constructs for testing individual crypto algorithms.
+                Each sub-specification addresses a specific class of crypto algorithms. This
+                sub-specification defines the JSON constructs for testing HMAC and CMAC crypto
+                algorithms using ACVP.</t>
             <section title="Requirements Language">
                 <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-					"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-					interpreted in 
-                    
-                    
-                    <xref target="RFC2119">RFC 2119</xref>. 
-                
-                
-                </t>
+                    "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+                    interpreted in <xref target="RFC2119">RFC 2119</xref>. </t>
             </section>
         </section>
         <section anchor="caps_reg" title="Capabilities Registration">
             <t>ACVP requires crypto modules to register their capabilities. This allows the crypto
-				module to advertise support for specific algorithms, notifying the ACVP server which
-				algorithms need test vectors generated for the validation process. This section
-				describes the constructs for advertising support of HMAC and CMAC algorithms to the
-				ACVP server.</t>
+                module to advertise support for specific algorithms, notifying the ACVP server which
+                algorithms need test vectors generated for the validation process. This section
+                describes the constructs for advertising support of HMAC and CMAC algorithms to the
+                ACVP server.</t>
             <t>The algorithm capabilities are advertised as JSON objects within the 'algorithms'
-				value of the ACVP registration message. The 'algorithms' value is an array, where
-				each array element is an individual JSON object defined in this section. The
-				'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON
-				registration message. See the ACVP specification for details on the registration
-				message. Each algorithm capability advertised is a self-contained JSON object. </t>
+                value of the ACVP registration message. The 'algorithms' value is an array, where
+                each array element is an individual JSON object defined in this section. The
+                'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON
+                registration message. See the ACVP specification for details on the registration
+                message. Each algorithm capability advertised is a self-contained JSON object. </t>
             <section anchor="prereq_algs"
-				title="Required Prerequisite Algorithms for MAC Validations">
+                title="Required Prerequisite Algorithms for MAC Validations">
                 <t>Each MAC implementation relies on other cryptographic primitives. For example,
-					CMAC uses an underlying SHA algorithm. Each of these underlying algorithm
-					primitives must be validated, either separately or as part of the same
-					submission. ACVP provides a mechanism for specifying the required
-					prerequisites:</t>
+                    CMAC uses an underlying SHA algorithm. Each of these underlying algorithm
+                    primitives must be validated, either separately or as part of the same
+                    submission. ACVP provides a mechanism for specifying the required
+                    prerequisites:</t>
                 <texttable anchor="rereqs_table"
-					title="Required MAC Prerequisite Algorithms JSON Values">
+                    title="Required MAC Prerequisite Algorithms JSON Values">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
                     <ttcol align="left">JSON type</ttcol>
@@ -164,10 +155,10 @@
         </section>
         <section anchor="cmac_aes_root" title="CMAC-AES">
             <section anchor="cmac_aes_caps_reg" title="CMAC-AES Algorithm Capabilities Registration">
-                <t>Each algorithm capability advertised is a self-contained JSON object using
-							the following values.</t>
+                <t>Each algorithm capability advertised is a self-contained JSON object using the
+                    following values.</t>
                 <texttable anchor="cmac_aes_caps_table"
-							title="CMAC-AES Algorithm Capabilities JSON Values">
+                    title="CMAC-AES Algorithm Capabilities JSON Values">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
                     <ttcol align="left">JSON type</ttcol>
@@ -194,19 +185,10 @@
                     <c/>
                     <c/>
                     <c>prereqVals</c>
-                    <c>prerequistie algorithm validations, See 
-								
-                            
-                        <xref target="app-reg-ex"/> for
-								examples 
-							
-                        
-                    </c>
+                    <c>prerequistie algorithm validations, See <xref target="app-reg-ex"/> for
+                        examples </c>
                     <c>array of prereqAlgVal objects</c>
-                    <c>See 
-								
-                            
-                        <xref target="prereq_algs"/>
+                    <c>See <xref target="prereq_algs"/>
                     </c>
                     <c>No</c>
                     <c/>
@@ -215,13 +197,9 @@
                     <c/>
                     <c/>
                     <c>capabilities</c>
-                    <c>The CMAC-AES capabilities
-							</c>
+                    <c>The CMAC-AES capabilities </c>
                     <c>array of capability objects</c>
-                    <c>See 
-								
-                            
-                        <xref target="cmac_aes_capabilities"/>
+                    <c>See <xref target="cmac_aes_capabilities"/>
                     </c>
                     <c>No</c>
                     <c/>
@@ -230,11 +208,9 @@
                     <c/>
                     <c/>
                 </texttable>
-
-				<t>Each capability object describes a separate permutation of direction and key length.</t>
-
-                <texttable anchor="cmac_aes_capabilities"
-							title="CMAC-AES Capabilities JSON Values">
+                <t>Each capability object describes a separate permutation of direction and key
+                    length.</t>
+                <texttable anchor="cmac_aes_capabilities" title="CMAC-AES Capabilities JSON Values">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
                     <ttcol align="left">JSON type</ttcol>
@@ -261,8 +237,8 @@
                     <c/>
                     <c/>
                     <c>msgLen</c>
-                    <c>The CMAC message lengths supported in bits. Min/max/increment and values
-								must be mod 8.</c>
+                    <c>The CMAC message lengths supported in bits. Min/max/increment and values must
+                        be mod 8.</c>
                     <c>Domain</c>
                     <c>0-524288</c>
                     <c>No</c>
@@ -282,8 +258,8 @@
                     <c/>
                     <c/>
                 </texttable>
-                <t>macLen for CMAC contains a Domain of values, the server may choose values
-							defined by these rules:</t>
+                <t>macLen for CMAC contains a Domain of values, the server may choose values defined
+                    by these rules:</t>
                 <t>
                     <list style="symbols">
                         <t>The smallest CMAC length supported</t>
@@ -291,8 +267,8 @@
                         <t>The largest CMAC length supported</t>
                     </list>
                 </t>
-                <t>msgLen for CMAC contains a Domain of values, the server may choose values
-							defined by these rules:</t>
+                <t>msgLen for CMAC contains a Domain of values, the server may choose values defined
+                    by these rules:</t>
                 <t>
                     <list style="symbols">
                         <t>The smallest message length supported</t>
@@ -301,19 +277,152 @@
                         <t>The largest message length supported</t>
                     </list>
                 </t>
+                <section anchor="cmac_aes_app-reg-ex"
+                    title="Example CMAC-AES Capabilities JSON Object">
+                    <t>The following is an example JSON object advertising support for CMAC-AES.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+  "algorithm": "CMAC",
+  "mode": "AES",
+  "isSample": false,
+  "conformances": [],
+  "capabilities": [
+    {
+      "direction": "gen",
+      "keyLen": 128,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 128,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "gen",
+      "keyLen": 192,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 192,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "gen",
+      "keyLen": 256,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    },
+    {
+      "direction": "ver",
+      "keyLen": 256,
+      "keyingOption": 0,
+      "msgLen": [
+        {
+          "min": 0,
+          "max": 65536,
+          "increment": 8
+        }
+      ],
+      "macLen": [
+        {
+          "min": 64,
+          "max": 128,
+          "increment": 8
+        }
+      ]
+    }
+  ]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+
             </section>
             <section anchor="cmac_aes_test_vectors" title="CMAC-AES Test Vectors">
                 <t>The ACVP server provides test vectors to the ACVP client, which are then
-							processed and returned to the ACVP server for validation. A typical ACVP
-							validation session would require multiple test vector sets to be downloaded
-							and processed by the ACVP client. Each test vector set represents an
-							individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES,
-							etc. This section describes the JSON schema for a test vector set used with
-							HMAC and CMAC crypto algorithms.</t>
+                    processed and returned to the ACVP server for validation. A typical ACVP
+                    validation session would require multiple test vector sets to be downloaded and
+                    processed by the ACVP client. Each test vector set represents an individual
+                    crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section
+                    describes the JSON schema for a test vector set used with HMAC and CMAC crypto
+                    algorithms.</t>
                 <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
-							data for the entire vector set as well as individual test vectors to be
-							processed by the ACVP client. The following table describes the JSON
-							elements at the top level of the hierarchy. </t>
+                    data for the entire vector set as well as individual test vectors to be
+                    processed by the ACVP client. The following table describes the JSON elements at
+                    the top level of the hierarchy. </t>
                 <texttable anchor="cmac_aes_vs_top_table" title="CMAC-AES Vector Set JSON Object">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
@@ -343,30 +452,27 @@
                     <c/>
                     <c/>
                     <c>testGroups</c>
-                    <c>Array of test group JSON objects, which are defined in 
-								
-                            
-                        <xref
-									target="cmac_aes_tgjs"/>
+                    <c>Array of test group JSON objects, which are defined in <xref
+                            target="cmac_aes_tgjs"/>
                     </c>
                     <c>array</c>
                 </texttable>
                 <section title="CMAC-AES Test Groups JSON Schema" anchor="cmac_aes_tgjs">
-                    <t>The testGroups element at the top level in the test vector JSON object is
-								an array of test groups. Test vectors are grouped into similar test
-								cases to reduce the amount of data transmitted in the vector set. For
-								instance, all test vectors that use the same key size would be grouped
-								together. The Test Group JSON object contains meta data that applies to
-								all test vectors within the group. The following table describes the
-								secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
+                    <t>The testGroups element at the top level in the test vector JSON object is an
+                        array of test groups. Test vectors are grouped into similar test cases to
+                        reduce the amount of data transmitted in the vector set. For instance, all
+                        test vectors that use the same key size would be grouped together. The Test
+                        Group JSON object contains meta data that applies to all test vectors within
+                        the group. The following table describes the secure HMAC and CMAC JSON
+                        elements of the Test Group JSON object.</t>
                     <texttable anchor="cmac_aes_vs_tg_table" title="CMAC-AES Test Group JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
                         <ttcol align="left">Optional</ttcol>
                         <c>tgId</c>
-                        <c>Numeric identifier for the test group, unique across the entire
-									vector set.</c>
+                        <c>Numeric identifier for the test group, unique across the entire vector
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -414,21 +520,18 @@
                         <c/>
                         <c/>
                         <c>tests</c>
-                        <c>Array of individual test vector JSON objects, which are defined in
-										
-									
-                                
-                            <xref target="cmac_aes_tvjs"/>
+                        <c>Array of individual test vector JSON objects, which are defined in <xref
+                                target="cmac_aes_tvjs"/>
                         </c>
                         <c>array</c>
                         <c>No</c>
                     </texttable>
                 </section>
                 <section title="CMAC-AES Test Case JSON Schema" anchor="cmac_aes_tvjs">
-                    <t>Each test group contains an array of one or more test cases. Each test
-								case is a JSON object that represents a single test vector to be
-								processed by the ACVP client. The following table describes the JSON
-								elements for each secure MAC test vector.</t>
+                    <t>Each test group contains an array of one or more test cases. Each test case
+                        is a JSON object that represents a single test vector to be processed by the
+                        ACVP client. The following table describes the JSON elements for each secure
+                        MAC test vector.</t>
                     <texttable anchor="cmac_aes_vs_tc_table2" title="CMAC-AES Test Case JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
@@ -436,7 +539,7 @@
                         <ttcol align="left">Optional</ttcol>
                         <c>tcId</c>
                         <c>Numeric identifier for the test case, unique across the entire vector
-									set.</c>
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -465,106 +568,434 @@
                         <c>Yes</c>
                     </texttable>
                 </section>
-                <section anchor="cmac_aes_vector_responses" title="CMAC-AES Test Vector Responses">
-                    <t>After the ACVP client downloads and processes a vector set, it must send
-								the response vectors back to the ACVP server. The following table
-								describes the JSON object that represents a vector set response.</t>
-                    <texttable anchor="cmac_aes_vr_top_table"
-								title="CMAC-AES Vector Set Response JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <c>acvVersion</c>
-                        <c>Protocol version identifier</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>vsId</c>
-                        <c>Unique numeric identifier for the vector set</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>testGroups</c>
-                        <c>Array of JSON objects that represent each test vector group. See
-										
-									
-                                
-                            <xref target="cmac_aes_vr_group_table"/>
-                        </c>
-                        <c>array</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
-                    <t>The testGroups section is used to organize the ACVP client response in a
-								similar manner to how it receives vectors. Several algorithms SHALL
-								require the client to send back group level properties in their
-								response. This structure helps accommodate that.</t>
-                    <texttable anchor="cmac_aes_vr_group_table"
-								title="CMAC-AES Vector Set Group Response JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <c>tgId</c>
-                        <c>The test group Id</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>tests</c>
-                        <c>The tests associated to the group specified in tgId</c>
-                        <c>value</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
-                    <t>Each test group contains an array of one or more test cases. Each test
-								case is a JSON object that represents a single test vector to be
-								processed by the ACVP client. The following table describes the JSON
-								elements for each DRBG test vector.</t>
-                    <texttable anchor="cmac_aes_vs_tr_table"
-								title="CMAC-AES Test Case Results JSON Object">
-                        <ttcol align="left">JSON Value</ttcol>
-                        <ttcol align="left">Description</ttcol>
-                        <ttcol align="left">JSON type</ttcol>
-                        <ttcol align="left">Optional</ttcol>
-                        <c>tcId</c>
-                        <c>Numeric identifier for the test case, unique across the entire vector
-									set.</c>
-                        <c>value</c>
-                        <c>No</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>mac</c>
-                        <c>value of the computed MAC output</c>
-                        <c>value</c>
-                        <c>Yes</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c>testPassed</c>
-                        <c>The result of CMAC verify</c>
-                        <c>boolean</c>
-                        <c>Yes</c>
-                        <c/>
-                        <c/>
-                        <c/>
-                        <c/>
-                    </texttable>
+                <section anchor="cmac_aes_test_vector_json"
+                    title="Example CMAC-AES Test Vector JSON Object">
+                    <t>The following is an example JSON test vector object for CMAC-AES.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+    "vsId": 1,
+	"algorithm": "CMAC",
+	"mode": "AES",
+	"isSample": false,
+	"testGroups": [{
+			"tgId": 4,
+			"testType": "AFT",
+			"direction": "gen",
+			"keyLen": 128,
+			"msgLen": 2752,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 25,
+					"key": "E2547E38B28B2C24892C133FF4770688",
+					"message": "89DE09D747FB4B2669B59759A15BAAF068CAF31FD938DFCFFB38ECED53BA91DD659FD91E6CCCFEC5F972B1AD66BF78FE7FE319E58F514362FC75A346C144981B63FD18195A2AD482AF83711C9ADC449F7EAD32EBD5F4DB7EB93348404EAD496B8F4C89AB5FF7ACB2CFEFD96BD0FC9645B6F1F30AB02767ECA8771106DCA47188EE42183121FB9172B8E2133DE084F6CA3924E4BF3638ADA77DAAA6F06A6494E32CBAEFC6C6D0699BB12A425DCFE5974F687B6A71879D42DE08DF018A96429CFA40E32378D35E46A4956C5D7916B6877F353D33075FD4C64F32C3250D74FF070EA358135664CD8C9B82C9454EED75A12EEC758A9E514053533A884560FAC96DDBBA4AEEB8E473F4BFDB8447B22800D7782320D6E2DAC2599111F8CA598D6720CA7C6E4FC5EDC54FC3576460AAD1644B04E1D2C81B93EA49090FDB7E33374C243B2F19177405B94BEC3C69CC24CC686D8F2B01A6B2A350E394"
+				},
+				{
+					"tcId": 26,
+					"key": "D1D99979CD96C3401291905F53B2ECA4",
+					"message": "6D054A7D1CD161B21F80E6586E5821DDA97451D98F815663932872720BD2156752EA650AE0EC4AB9FEE5635B1CCF1B123CF0247D2487BCD3102B6A668B5F9882DB03278A6B5DCECDF176604B55668FFD8EFED2A454F16A7A75D168AFBA3C305E31B8C1ABCCAA110E94796F8F0231A479DA25A2BCBECA3A9DAFF4357C6C63476106627DF9DF692231BA906E8F8E196FAA4DD412019D36C1AEB2A015EFDCCB9E0308FDA871DBF14DED263FF28079ED3DC4E411470A664F5EAED458EB2D564971AD10E77DCCDE53BB95DF7951FCE595079ECD6C394D78AFEB85CA87C596872D66783BD816808B0B311E5EC0BA52D5283699EE725ABDC2AD85266808D80F72195599CB27241B2FF6112829FCFBFDD5548EA29637B0DCC731A060F345769D335B1B5ABE90A664CBCCD19F4F21EE630E786BDFA60C6A8D731329718CEFE80095604918600976413334AE01C524F0F0A22D50DB460CFE7D737B6334"
+				},
+				{
+					"tcId": 27,
+					"key": "672556E105B83BF39FC9E45268BD35D1",
+					"message": "39A3DD0652483A26FB9D71F30A5E29D326627FE16E29E3A3BF8EDF68645B477B5DE88499EDB3CF9E036F3D0D316241EE7C569F74925AD0BD3DCBBA21E73D9638ABA2554C4CA62AC5D7113B3FE7216E79AFC7A6FB94F21EB234D0401879A6B03EAE242EA0DCF1B523513467B00C048E7DE333C8977C455DD943323D01C97CF93EC24843769E52AD785E2340F2CC61E571D2099472E47286F29BCDF28A69144692263312F176618777A6AD0A0338F8A636BCA6150F0E1F72D539BAD726C95425682678EA7297A118E819A2925747C0AD72F3BCDF8E7D6C0A11A6AA938E4AA119390451C4E56B99F29C34927C1830197FCD4921C7E38E29BAEA5E560C8A3D4D7B96BBC370C78EF794BA9F6DB737576867B334D1DCC537D4FD751952DDFF549109ECCAD38198CCB49F25E7FEB88B9FD33D3B56601B473946693C5C3D7B2D1C7BB857F9560B94A3BD145019150BA11159B39480F97B0DE90243D6"
+				},
+				{
+					"tcId": 28,
+					"key": "1E220113298DA3B30E14F1432C16FCE8",
+					"message": "497E82B322B18B0295F3B4359AC0CFAF1D36B46F36C9E123B95B90985B06AC6AFAFB772E21CCA4665CEABFF9C1CE3D78F804BEBAC6F171C0ADA47FC718E7EC55EC7603D739C8B4DBF07B60A78A8EC83922A880485B99E0FED2B1F7D5A895E2BD9149888A085F21794C1953A6EF4471A47A285CFAA57E9F75000B375A4100F5432150ECFC3342627FA325C7FB0EE0090A0B39D69ED9030E7D46BBCC6ADFC49F14156187F94F7DDE50C736FEB3FCE530CC76171EE1150AA5A94A3B79119329B5A1D9C3E03EAC7F212A1AECA97EAD58B8BFCD5F94946578D8F5A0347970A7F93C70B4AB0BB5A4FE2B0AAC8459ED0045DDC3AC210ACF996A4DE478853CD88ACEAE73D9A9C48A1B64E0D82F2EFFB25C517BDD0C033E566C16197835271A85D65A38AB37B63E7B23E9C7EA7777E6B3E3820C930B1333C279E5291724E774E34F574F15E1E23568E486F03FC6B83B962E3E60A90A69DD26701A8D6C"
+				},
+				{
+					"tcId": 29,
+					"key": "B2EDB3F5189E14E1E860A8B70D5CF676",
+					"message": "EAF87567D104DF3DA93312EEB0B695409E927F6D2EF287AC12130AC82082D600DDCFDD0074DF3CFB41CE347FAC8BEADAA522D7CE33E539C7F8E9470E00210CDDB3BF799B913B627561B35368BA80955A210AE92C5F89C0566A6E3BD6559DAE9537EE0042E60BE58E4F3757F43CA43634C09CABAEB644CCB30260A776C9B2ACB8A7900DF0B556F7CDB9A0712C3CC2B711E505880156552645DFB598DDD99E2FC06394B6F3B51C3A499E0204DD89AB699A3E8015F9720F4D5D84C30CEF9F95CFBE7DFAD7A55DF591FBFFFB10A3B3AA08EBA53873A95CADBA3A3913E947173945AFA6B88791970ED2B12972A62D4A86716D0A2429E4447676058C6EB42FA6BB6DA5295B2A2518130FCF1CB81FD3B247A9EE438F0284DF6E0AD0DEA0A4A7DDEF6A48465974F375B5FD0DA809534F4654A53116921F1004B3FF9E4E9FDA1520B8D86F0766285878BF8062A00638DE0C5970B9B6C560B65F71AF6E"
+				},
+				{
+					"tcId": 30,
+					"key": "7BD39F41F80079D7D0DC0154F833086A",
+					"message": "AB1311F60133E446CEF81973E4FC67DB365441AD367BA0E38AFD564F137AE8AC7ED0C64551EBC7A5A5F49765835C67A33F38BA1A3EFDA4725962E2C9D9893A665D9CD04BA0A613F06F7FAADBEDF9466CC62FD84DE146494E1C67EB65DC362450CF855FC9C92DD217869B60874CC0D944C7BEFFFDDA09ECBC66997873BE9A8BD007F79CC73E0E2BC52DB257CD02B0E794DAAAFF68062C476B4C9DD7F4F3FFCADE6863383455B3EEC727062A2175395A3E8D6C738878F4333F2BF27A2DD653CC57D4CC065DEE75014D32785D3A6B725DC7CBAE47BF579EAB6FC126A95701214084409594D20025ECD52CCA272364F466D4497C4F16D80CED689F0783DB4B2D185A9CC12FD247A6431AC51FCC44074B774402F584197BDD466F68DC794440B1F5F80F2F6FDB3968CACE95CBF41E7C5544194CC38D412627890B9D683A1175D9E6B93E499A4C64C4088F36AA4105E8E3D8A2EEEE1E266A3441A9"
+				},
+				{
+					"tcId": 31,
+					"key": "64F8BD1CC49FD16A4DF0253F31917ED4",
+					"message": "340104D85093FDB0740B597207D25496D5670CAF006507470783EFE2071E2026CE2C333D86F5E7BBDA91F2440C4589366BE8C337CA0B59683E8ACD384FD842675066B79008BF7F989FD7BB5ACE46D2D5BB3EBB4985708D85BD3CFC058D869295ECC18ADF1A4475263249A7579117A53B905BBFE26E2E29DA46D1D57DE6B1E2462E4C71738262307A212978AE4BD35792BAE2B770CDC1E25D350C424BBF9650ABF8F22BE9A95F1E47CC8CA4518C5EE7881C9414365DDB3959361AD3A0A9FC07C57B050D335B7426CE19144B061B197809ADEC47C75BCBB00525865ED02E375C1793BF6A05679574645B6F020EE15EE094EB02D706149B85E50A74C8CFD9823E1B222C65FCAD630B84F25C62E0B1BB7AED5637526C537F44F9BC1869721966C1BE50B3C95B4C37CC3D6E2A85589441FE73E7E2369A418ECFEB88B2337AA179AF77B5F622B02E62CF8CD294FB226ACCABF0920AECC9DD76B572"
+				},
+				{
+					"tcId": 32,
+					"key": "AF2B918C3CC53D064688E1A517A33D2C",
+					"message": "8FC205EB22775C0570A1867E3FB6E2FCF2A743171107190B89CE8A2A04C1B46A0D45781207AAB25BEC6C55F35E21F662F660C68BED54DD08D40C95D4D24872C595E49F3519D85DB933306BEF10EE181FA25C727787494FAD7A91EA6563E58B575C65E2774098BF69D74DD53D015899BF71F9B95EA0CE2A775BE0CED8423507086E6C48A9AE89195CBB1345B1C0AB8D496A2D9A6AEEFAC4A40F900159F47A7C1DFF96E88EA104EC0C64A858657239085C3AC353BE53069E57FBE9AE9B967D041478B8EBC908C70CBEEBEE718D51C08EBD2C97D7F98EF4D6EA5FF156ADC2D8FAD535AA2501F734F411BCE2B329F0FE485297707490523ABE9DB9E2FEFCD8C8A09E18628B9912262DA0282A334D9290CC5DED2F7662771237C144382724D51C3BF02F45BABD5B35810ED3EBA38AFC03D6E107D31814B8D0E4D21FE7CF9434018BCCB42F506971D33106432F325BE456A914CD5C2561E8F01F80"
+				}
+			]
+		},
+		{
+			"tgId": 10,
+			"testType": "AFT",
+			"direction": "ver",
+			"keyLen": 128,
+			"msgLen": 0,
+			"macLen": 64,
+			"tests": [{
+					"tcId": 73,
+					"key": "D5E09A89B2A4627BF987517B66A51564",
+					"message": "",
+					"mac": "CBBC968859633C24"
+				},
+				{
+					"tcId": 74,
+					"key": "646A150116ABAA37662FE9D8BB278693",
+					"message": "",
+					"mac": "21D069331196E579"
+				},
+				{
+					"tcId": 75,
+					"key": "5C185C01FBC57A40FC373F199374D1CC",
+					"message": "",
+					"mac": "9507F00153543DE6"
+				},
+				{
+					"tcId": 76,
+					"key": "4E3A4C7AE2DCA644FF752B8B74CACEF8",
+					"message": "",
+					"mac": "6D58E6464497A9B4"
+				},
+				{
+					"tcId": 77,
+					"key": "BA924D356A696E97BEF0477A9D600FCE",
+					"message": "",
+					"mac": "93FEA54132999B1D"
+				},
+				{
+					"tcId": 78,
+					"key": "DA877E0EFC098E1EAD8B2DC61A5B98D5",
+					"message": "",
+					"mac": "24E6ED4D00D7122C"
+				},
+				{
+					"tcId": 79,
+					"key": "61698DB0B49E2F252849590E940CBCF3",
+					"message": "",
+					"mac": "2C531F92D23D6B2B"
+				},
+				{
+					"tcId": 80,
+					"key": "BE149E46BE89BF16BDDE41D1A494AEA4",
+					"message": "",
+					"mac": "7A858023143F6B98"
+				},
+				{
+					"tcId": 81,
+					"key": "9A9F006EF8EDFDA0F1113FC6FEF2E84D",
+					"message": "",
+					"mac": "C0750CD586472C8A"
+				},
+				{
+					"tcId": 82,
+					"key": "F68A91DE6AC099F7D72D7B211245D8D9",
+					"message": "",
+					"mac": "C91C3DCC36F2BC21"
+				},
+				{
+					"tcId": 83,
+					"key": "23E9BEA8C4F14330B2836FDD0B6E803F",
+					"message": "",
+					"mac": "F884E64E0CA4D34F"
+				},
+				{
+					"tcId": 84,
+					"key": "02636CC18751A5CF27C56D2C69793BC4",
+					"message": "",
+					"mac": "1D5F5531BA263CC2"
+				},
+				{
+					"tcId": 85,
+					"key": "46D7DA4F123C37F05FC269FCF92B1FC1",
+					"message": "",
+					"mac": "06D743483812AAB4"
+				},
+				{
+					"tcId": 86,
+					"key": "C28DD76F2A31C90EE4A91313CB7D4ECC",
+					"message": "",
+					"mac": "09B6D2C848F8C9FD"
+				},
+				{
+					"tcId": 87,
+					"key": "810BAE6E85149F244179CA7F1488353B",
+					"message": "",
+					"mac": "68D7AFF612EAEDB4"
+				},
+				{
+					"tcId": 88,
+					"key": "C67C04544E0DDDE14FAE608135909FED",
+					"message": "",
+					"mac": "E9B7FE8ECF21DDD7"
+				},
+				{
+					"tcId": 89,
+					"key": "D9D5B9D32533DB3276BE4FFF3D79374A",
+					"message": "",
+					"mac": "081BAFA11BFDF238"
+				},
+				{
+					"tcId": 90,
+					"key": "D8A05E45602DD6ACBE989BD0F26CED9E",
+					"message": "",
+					"mac": "D84F8EE112352837"
+				},
+				{
+					"tcId": 91,
+					"key": "E09B79F64B11F00B48081EEEA0482821",
+					"message": "",
+					"mac": "4D927CED15907953"
+				},
+				{
+					"tcId": 92,
+					"key": "24B7BE1D4F72AE1A1C5FBDB2A3AC8287",
+					"message": "",
+					"mac": "548CBD558D8F6E3A"
+				}
+			]
+		}
+	]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+            </section>
+            <section anchor="cmac_aes_vector_responses" title="CMAC-AES Test Vector Responses">
+                <t>After the ACVP client downloads and processes a vector set, it must send the
+                    response vectors back to the ACVP server. The following table describes the JSON
+                    object that represents a vector set response.</t>
+                <texttable anchor="cmac_aes_vr_top_table"
+                    title="CMAC-AES Vector Set Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of JSON objects that represent each test vector group. See <xref
+                            target="cmac_aes_vr_group_table"/>
+                    </c>
+                    <c>array</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>The testGroups section is used to organize the ACVP client response in a similar
+                    manner to how it receives vectors. Several algorithms SHALL require the client
+                    to send back group level properties in their response. This structure helps
+                    accommodate that.</t>
+                <texttable anchor="cmac_aes_vr_group_table"
+                    title="CMAC-AES Vector Set Group Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>tgId</c>
+                    <c>The test group Id</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>tests</c>
+                    <c>The tests associated to the group specified in tgId</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>Each test group contains an array of one or more test cases. Each test case is a
+                    JSON object that represents a single test vector to be processed by the ACVP
+                    client. The following table describes the JSON elements for each DRBG test
+                    vector.</t>
+                <texttable anchor="cmac_aes_vs_tr_table"
+                    title="CMAC-AES Test Case Results JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>tcId</c>
+                    <c>Numeric identifier for the test case, unique across the entire vector
+                        set.</c>
+                    <c>value</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>mac</c>
+                    <c>value of the computed MAC output</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testPassed</c>
+                    <c>The result of CMAC verify</c>
+                    <c>boolean</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <section anchor="cmac_aes_test_vector_response_json"
+                    title="Example CMAC-AES Test Vector Response JSON Object">
+                    <t>The following is an example JSON test vector response object for
+                        CMAC-AES.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+	"vsId": 1,
+	"testGroups": [{
+			"tgId": 4,
+			"tests": [{
+					"tcId": 25,
+					"mac": "7AA2D56A0AE76620"
+				},
+				{
+					"tcId": 26,
+					"mac": "9E23524D3CD18C93"
+				},
+				{
+					"tcId": 27,
+					"mac": "4D51872CBFAA102A"
+				},
+				{
+					"tcId": 28,
+					"mac": "027BCA655EC9ACEB"
+				},
+				{
+					"tcId": 29,
+					"mac": "A86D99B6121507A6"
+				},
+				{
+					"tcId": 30,
+					"mac": "25E5F000F2B1E071"
+				},
+				{
+					"tcId": 31,
+					"mac": "F2DBA25F9A903C80"
+				},
+				{
+					"tcId": 32,
+					"mac": "1D35816BD32CA4DB"
+				}
+			]
+		},
+		{
+			"tgId": 10,
+			"tests": [{
+					"tcId": 73,
+					"testPassed": true
+				},
+				{
+					"tcId": 74,
+					"testPassed": true
+				},
+				{
+					"tcId": 75,
+					"testPassed": true
+				},
+				{
+					"tcId": 76,
+					"testPassed": true
+				},
+				{
+					"tcId": 77,
+					"testPassed": false
+				},
+				{
+					"tcId": 78,
+					"testPassed": true
+				},
+				{
+					"tcId": 79,
+					"testPassed": true
+				},
+				{
+					"tcId": 80,
+					"testPassed": true
+				},
+				{
+					"tcId": 81,
+					"testPassed": true
+				},
+				{
+					"tcId": 82,
+					"testPassed": true
+				},
+				{
+					"tcId": 83,
+					"testPassed": true
+				},
+				{
+					"tcId": 84,
+					"testPassed": true
+				},
+				{
+					"tcId": 85,
+					"testPassed": true
+				},
+				{
+					"tcId": 86,
+					"testPassed": false
+				},
+				{
+					"tcId": 87,
+					"testPassed": true
+				},
+				{
+					"tcId": 88,
+					"testPassed": false
+				},
+				{
+					"tcId": 89,
+					"testPassed": true
+				},
+				{
+					"tcId": 90,
+					"testPassed": false
+				},
+				{
+					"tcId": 91,
+					"testPassed": false
+				},
+				{
+					"tcId": 92,
+					"testPassed": false
+				}
+			]
+		}
+	]
+}
+            ]]>
+                        </artwork>
+                    </figure>
                 </section>
             </section>
         </section>
         <section anchor="cmac_tdes_root" title="CMAC-TDES">
-            <section anchor="cmac_tdes_caps_reg" title="CMAC-TDES Algorithm Capabilities Registration">
-                <t>Each algorithm capability advertised is a self-contained JSON object using
-							the following values.</t>
+            <section anchor="cmac_tdes_caps_reg"
+                title="CMAC-TDES Algorithm Capabilities Registration">
+                <t>Each algorithm capability advertised is a self-contained JSON object using the
+                    following values.</t>
                 <texttable anchor="cmac_tdes_caps_table"
-							title="CMAC-TDES Algorithm Capabilities JSON Values">
+                    title="CMAC-TDES Algorithm Capabilities JSON Values">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
                     <ttcol align="left">JSON type</ttcol>
@@ -591,19 +1022,10 @@
                     <c/>
                     <c/>
                     <c>prereqVals</c>
-                    <c>prerequistie algorithm validations, See 
-								
-                            
-                        <xref target="app-reg-ex"/> for
-								examples 
-							
-                        
-                    </c>
+                    <c>prerequistie algorithm validations, See <xref target="app-reg-ex"/> for
+                        examples </c>
                     <c>array of prereqAlgVal objects</c>
-                    <c>See 
-								
-                            
-                        <xref target="prereq_algs"/>
+                    <c>See <xref target="prereq_algs"/>
                     </c>
                     <c>No</c>
                     <c/>
@@ -612,13 +1034,9 @@
                     <c/>
                     <c/>
                     <c>capabilities</c>
-                    <c>The CMAC-TDES capabilities
-							</c>
+                    <c>The CMAC-TDES capabilities </c>
                     <c>array of capability objects</c>
-                    <c>See 
-								
-                            
-                        <xref target="cmac_tdes_capabilities"/>
+                    <c>See <xref target="cmac_tdes_capabilities"/>
                     </c>
                     <c>No</c>
                     <c/>
@@ -628,7 +1046,7 @@
                     <c/>
                 </texttable>
                 <texttable anchor="cmac_tdes_capabilities"
-							title="CMAC-TDES Capabilities JSON Values">
+                    title="CMAC-TDES Capabilities JSON Values">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
                     <ttcol align="left">JSON type</ttcol>
@@ -645,10 +1063,10 @@
                     <c/>
                     <c/>
                     <c>keyingOption</c>
-                    <c>The Keying Option used in TDES. Keying option 1 (1) is 3 distinct keys
-								(K1, K2, K3). Keying Option 2 (2) is 2 distinct only suitable for
-								decrypt (K1, K2, K1). Keying option 3 (No longer valid for testing, save
-								TDES KATs) is a single key, now deprecated (K1, K1, K1).</c>
+                    <c>The Keying Option used in TDES. Keying option 1 (1) is 3 distinct keys (K1,
+                        K2, K3). Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1,
+                        K2, K1). Keying option 3 (No longer valid for testing, save TDES KATs) is a
+                        single key, now deprecated (K1, K1, K1).</c>
                     <c>value</c>
                     <c>1, 2</c>
                     <c>No</c>
@@ -658,8 +1076,8 @@
                     <c/>
                     <c/>
                     <c>msgLen</c>
-                    <c>The CMAC message lengths supported in bits. Min/max/increment and values
-								must be mod 8.</c>
+                    <c>The CMAC message lengths supported in bits. Min/max/increment and values must
+                        be mod 8.</c>
                     <c>Domain</c>
                     <c>0-524288</c>
                     <c>No</c>
@@ -679,8 +1097,8 @@
                     <c/>
                     <c/>
                 </texttable>
-                <t>macLen for CMAC contains a Domain of values, the server may choose values
-							defined by these rules:</t>
+                <t>macLen for CMAC contains a Domain of values, the server may choose values defined
+                    by these rules:</t>
                 <t>
                     <list style="symbols">
                         <t>The smallest CMAC length supported</t>
@@ -688,8 +1106,8 @@
                         <t>The largest CMAC length supported</t>
                     </list>
                 </t>
-                <t>msgLen for CMAC contains a Domain of values, the server may choose values
-							defined by these rules:</t>
+                <t>msgLen for CMAC contains a Domain of values, the server may choose values defined
+                    by these rules:</t>
                 <t>
                     <list style="symbols">
                         <t>The smallest message length supported</t>
@@ -701,16 +1119,16 @@
             </section>
             <section anchor="cmac_tdes_test_vectors" title="CMAC-TDES Test Vectors">
                 <t>The ACVP server provides test vectors to the ACVP client, which are then
-							processed and returned to the ACVP server for validation. A typical ACVP
-							validation session would require multiple test vector sets to be downloaded
-							and processed by the ACVP client. Each test vector set represents an
-							individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-TDES,
-							etc. This section describes the JSON schema for a test vector set used with
-							HMAC and CMAC crypto algorithms.</t>
+                    processed and returned to the ACVP server for validation. A typical ACVP
+                    validation session would require multiple test vector sets to be downloaded and
+                    processed by the ACVP client. Each test vector set represents an individual
+                    crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-TDES, etc. This
+                    section describes the JSON schema for a test vector set used with HMAC and CMAC
+                    crypto algorithms.</t>
                 <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
-							data for the entire vector set as well as individual test vectors to be
-							processed by the ACVP client. The following table describes the JSON
-							elements at the top level of the hierarchy. </t>
+                    data for the entire vector set as well as individual test vectors to be
+                    processed by the ACVP client. The following table describes the JSON elements at
+                    the top level of the hierarchy. </t>
                 <texttable anchor="cmac_tdes_vs_top_table" title="CMAC-TDES Vector Set JSON Object">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
@@ -740,30 +1158,28 @@
                     <c/>
                     <c/>
                     <c>testGroups</c>
-                    <c>Array of test group JSON objects, which are defined in 
-								
-                            
-                        <xref
-									target="cmac_tdes_tgjs"/>
+                    <c>Array of test group JSON objects, which are defined in <xref
+                            target="cmac_tdes_tgjs"/>
                     </c>
                     <c>array</c>
                 </texttable>
                 <section title="CMAC-TDES Test Groups JSON Schema" anchor="cmac_tdes_tgjs">
-                    <t>The testGroups element at the top level in the test vector JSON object is
-								an array of test groups. Test vectors are grouped into similar test
-								cases to reduce the amount of data transmitted in the vector set. For
-								instance, all test vectors that use the same key size would be grouped
-								together. The Test Group JSON object contains meta data that applies to
-								all test vectors within the group. The following table describes the
-								secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
-                    <texttable anchor="cmac_tdes_vs_tg_table" title="CMAC-TDES Test Group JSON Object">
+                    <t>The testGroups element at the top level in the test vector JSON object is an
+                        array of test groups. Test vectors are grouped into similar test cases to
+                        reduce the amount of data transmitted in the vector set. For instance, all
+                        test vectors that use the same key size would be grouped together. The Test
+                        Group JSON object contains meta data that applies to all test vectors within
+                        the group. The following table describes the secure HMAC and CMAC JSON
+                        elements of the Test Group JSON object.</t>
+                    <texttable anchor="cmac_tdes_vs_tg_table"
+                        title="CMAC-TDES Test Group JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
                         <ttcol align="left">Optional</ttcol>
                         <c>tgId</c>
-                        <c>Numeric identifier for the test group, unique across the entire
-									vector set.</c>
+                        <c>Numeric identifier for the test group, unique across the entire vector
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -811,29 +1227,27 @@
                         <c/>
                         <c/>
                         <c>tests</c>
-                        <c>Array of individual test vector JSON objects, which are defined in
-										
-									
-                                
-                            <xref target="cmac_tdes_tvjs"/>
+                        <c>Array of individual test vector JSON objects, which are defined in <xref
+                                target="cmac_tdes_tvjs"/>
                         </c>
                         <c>array</c>
                         <c>No</c>
                     </texttable>
                 </section>
                 <section title="CMAC-TDES Test Case JSON Schema" anchor="cmac_tdes_tvjs">
-                    <t>Each test group contains an array of one or more test cases. Each test
-								case is a JSON object that represents a single test vector to be
-								processed by the ACVP client. The following table describes the JSON
-								elements for each secure MAC test vector.</t>
-                    <texttable anchor="cmac_tdes_vs_tc_table2" title="CMAC-TDES Test Case JSON Object">
+                    <t>Each test group contains an array of one or more test cases. Each test case
+                        is a JSON object that represents a single test vector to be processed by the
+                        ACVP client. The following table describes the JSON elements for each secure
+                        MAC test vector.</t>
+                    <texttable anchor="cmac_tdes_vs_tc_table2"
+                        title="CMAC-TDES Test Case JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
                         <ttcol align="left">Optional</ttcol>
                         <c>tcId</c>
                         <c>Numeric identifier for the test case, unique across the entire vector
-									set.</c>
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -863,11 +1277,11 @@
                     </texttable>
                 </section>
                 <section anchor="cmac_tdes_vector_responses" title="CMAC-TDES Test Vector Responses">
-                    <t>After the ACVP client downloads and processes a vector set, it must send
-								the response vectors back to the ACVP server. The following table
-								describes the JSON object that represents a vector set response.</t>
+                    <t>After the ACVP client downloads and processes a vector set, it must send the
+                        response vectors back to the ACVP server. The following table describes the
+                        JSON object that represents a vector set response.</t>
                     <texttable anchor="cmac_tdes_vr_top_table"
-								title="CMAC-TDES Vector Set Response JSON Object">
+                        title="CMAC-TDES Vector Set Response JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
@@ -884,11 +1298,8 @@
                         <c/>
                         <c/>
                         <c>testGroups</c>
-                        <c>Array of JSON objects that represent each test vector group. See
-										
-									
-                                
-                            <xref target="cmac_tdes_vr_group_table"/>
+                        <c>Array of JSON objects that represent each test vector group. See <xref
+                                target="cmac_tdes_vr_group_table"/>
                         </c>
                         <c>array</c>
                         <c/>
@@ -896,11 +1307,11 @@
                         <c/>
                     </texttable>
                     <t>The testGroups section is used to organize the ACVP client response in a
-								similar manner to how it receives vectors. Several algorithms SHALL
-								require the client to send back group level properties in their
-								response. This structure helps accommodate that.</t>
+                        similar manner to how it receives vectors. Several algorithms SHALL require
+                        the client to send back group level properties in their response. This
+                        structure helps accommodate that.</t>
                     <texttable anchor="cmac_tdes_vr_group_table"
-								title="CMAC-TDES Vector Set Group Response JSON Object">
+                        title="CMAC-TDES Vector Set Group Response JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
@@ -917,19 +1328,19 @@
                         <c/>
                         <c/>
                     </texttable>
-                    <t>Each test group contains an array of one or more test cases. Each test
-								case is a JSON object that represents a single test vector to be
-								processed by the ACVP client. The following table describes the JSON
-								elements for each DRBG test vector.</t>
+                    <t>Each test group contains an array of one or more test cases. Each test case
+                        is a JSON object that represents a single test vector to be processed by the
+                        ACVP client. The following table describes the JSON elements for each DRBG
+                        test vector.</t>
                     <texttable anchor="cmac_tdes_vs_tr_table"
-								title="CMAC-TDES Test Case Results JSON Object">
+                        title="CMAC-TDES Test Case Results JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
                         <ttcol align="left">Optional</ttcol>
                         <c>tcId</c>
                         <c>Numeric identifier for the test case, unique across the entire vector
-									set.</c>
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -956,12 +1367,11 @@
                 </section>
             </section>
         </section>
-        <section anchor="hmac_root" title="CMAC">
+        <section anchor="hmac_root" title="HMAC">
             <section anchor="hmac_caps_reg" title="HMAC Algorithm Capabilities Registration">
-                <t>Each algorithm capability advertised is a self-contained JSON object using
-						the following values.</t>
-                <texttable anchor="hmac_caps_table2"
-						title="HMAC Algorithm Capabilities JSON Values">
+                <t>Each algorithm capability advertised is a self-contained JSON object using the
+                    following values.</t>
+                <texttable anchor="hmac_caps_table2" title="HMAC Algorithm Capabilities JSON Values">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
                     <ttcol align="left">JSON type</ttcol>
@@ -970,10 +1380,7 @@
                     <c>algorithm</c>
                     <c>The MAC algorithm and mode to be validated.</c>
                     <c>value</c>
-                    <c>See 
-                            
-                        
-                        <xref target="hmac_supported_algs"/>
+                    <c>See <xref target="hmac_supported_algs"/>
                     </c>
                     <c>No</c>
                     <c/>
@@ -982,19 +1389,10 @@
                     <c/>
                     <c/>
                     <c>prereqVals</c>
-                    <c>prerequistie algorithm validations, See 
-                            
-                        
-                        <xref target="app-reg-ex"/> for
-							examples 
-                        
-                    
-                    </c>
+                    <c>prerequistie algorithm validations, See <xref target="app-reg-ex"/> for
+                        examples </c>
                     <c>array of prereqAlgVal objects</c>
-                    <c>See 
-                            
-                        
-                        <xref target="prereq_algs"/>
+                    <c>See <xref target="prereq_algs"/>
                     </c>
                     <c>No</c>
                     <c/>
@@ -1013,14 +1411,8 @@
                     <c/>
                     <c/>
                     <c>macLen</c>
-                    <c>The supported mac sizes. (range dependent on algorithm, see 
-                            
-                        
-                        <xref
-								target="hmac_supported_algs"/>). 
-                        
-                    
-                    </c>
+                    <c>The supported mac sizes. (range dependent on algorithm, see <xref
+                            target="hmac_supported_algs"/>). </c>
                     <c>Domain</c>
                     <c>32-512</c>
                     <c>No</c>
@@ -1030,22 +1422,19 @@
                     <c/>
                     <c/>
                 </texttable>
-                <t>keyLen for HMAC contains a Domain of values, the server may choose values
-						defined by these rules:</t>
+                <t>keyLen for HMAC contains a Domain of values, the server may choose values defined
+                    by these rules:</t>
                 <t>
                     <list style="symbols">
-                        <t>2 values below the Hash's block length. See 
-                                
-                            
-                            <xref
-									target="hmac_supported_algs"/>
+                        <t>2 values below the Hash's block length. See <xref
+                                target="hmac_supported_algs"/>
                         </t>
                         <t>The Hash's block length.</t>
                         <t>2 values above the Hash's block length.</t>
                     </list>
                 </t>
-                <t>macLen for HMAC contains a Domain of values, the server may choose values
-						defined by these rules:</t>
+                <t>macLen for HMAC contains a Domain of values, the server may choose values defined
+                    by these rules:</t>
                 <t>
                     <list style="symbols">
                         <t>The smallest HMAC length supported</t>
@@ -1056,9 +1445,9 @@
             </section>
             <section anchor="hmac_supported_algs" title="Supported HMAC Algorithms">
                 <t>The following algorithms may be advertised by the ACVP compliant crypto
-						module:</t>
+                    module:</t>
                 <texttable anchor="hmac_table_algInfo"
-						title="Algorithms w/ block size and max CMAC length.">
+                    title="Algorithms w/ block size and max CMAC length.">
                     <ttcol align="left">Algorithm Value</ttcol>
                     <ttcol align="left">Block Length</ttcol>
                     <ttcol align="left">Max MAC Length</ttcol>
@@ -1132,16 +1521,16 @@
             </section>
             <section anchor="hmac_test_vectors" title="HMAC Test Vectors">
                 <t>The ACVP server provides test vectors to the ACVP client, which are then
-						processed and returned to the ACVP server for validation. A typical ACVP
-						validation session would require multiple test vector sets to be downloaded
-						and processed by the ACVP client. Each test vector set represents an
-						individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES,
-						etc. This section describes the JSON schema for a test vector set used with
-						HMAC crypto algorithms.</t>
+                    processed and returned to the ACVP server for validation. A typical ACVP
+                    validation session would require multiple test vector sets to be downloaded and
+                    processed by the ACVP client. Each test vector set represents an individual
+                    crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section
+                    describes the JSON schema for a test vector set used with HMAC crypto
+                    algorithms.</t>
                 <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
-						data for the entire vector set as well as individual test vectors to be
-						processed by the ACVP client. The following table describes the JSON
-						elements at the top level of the hierarchy. </t>
+                    data for the entire vector set as well as individual test vectors to be
+                    processed by the ACVP client. The following table describes the JSON elements at
+                    the top level of the hierarchy. </t>
                 <texttable anchor="hmac_vs_top_table" title="HMAC Vector Set JSON Object">
                     <ttcol align="left">JSON Value</ttcol>
                     <ttcol align="left">Description</ttcol>
@@ -1159,43 +1548,34 @@
                     <c/>
                     <c/>
                     <c>algorithm</c>
-                    <c>The algorithm and mode used for the test vectors. See 
-                            
-                        
-                        <xref
-								target="hmac_supported_algs"/> for possible values. 
-                        
-                    
-                    </c>
+                    <c>The algorithm and mode used for the test vectors. See <xref
+                            target="hmac_supported_algs"/> for possible values. </c>
                     <c>value</c>
                     <c/>
                     <c/>
                     <c/>
                     <c>testGroups</c>
-                    <c>Array of test group JSON objects, which are defined in 
-                            
-                        
-                        <xref
-								target="hmac_tgjs"/>
+                    <c>Array of test group JSON objects, which are defined in <xref
+                            target="hmac_tgjs"/>
                     </c>
                     <c>array</c>
                 </texttable>
                 <section title="HMAC Test Groups JSON Schema" anchor="hmac_tgjs">
-                    <t>The testGroups element at the top level in the test vector JSON object is
-							an array of test groups. Test vectors are grouped into similar test
-							cases to reduce the amount of data transmitted in the vector set. For
-							instance, all test vectors that use the same key size would be grouped
-							together. The Test Group JSON object contains meta data that applies to
-							all test vectors within the group. The following table describes the
-							secure HMAC and CMAC JSON elements of the Test Group JSON object.</t>
+                    <t>The testGroups element at the top level in the test vector JSON object is an
+                        array of test groups. Test vectors are grouped into similar test cases to
+                        reduce the amount of data transmitted in the vector set. For instance, all
+                        test vectors that use the same key size would be grouped together. The Test
+                        Group JSON object contains meta data that applies to all test vectors within
+                        the group. The following table describes the secure HMAC and CMAC JSON
+                        elements of the Test Group JSON object.</t>
                     <texttable anchor="hmac_vs_tg_table" title="HMAC Test Group JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
                         <ttcol align="left">Optional</ttcol>
                         <c>tgId</c>
-                        <c>Numeric identifier for the test group, unique across the entire
-								vector set.</c>
+                        <c>Numeric identifier for the test group, unique across the entire vector
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -1235,21 +1615,18 @@
                         <c/>
                         <c/>
                         <c>tests</c>
-                        <c>Array of individual test vector JSON objects, which are defined in
-									
-                                
-                            
-                            <xref target="hmac_tvjs"/>
+                        <c>Array of individual test vector JSON objects, which are defined in <xref
+                                target="hmac_tvjs"/>
                         </c>
                         <c>array</c>
                         <c>No</c>
                     </texttable>
                 </section>
                 <section title="HMAC Test Case JSON Schema" anchor="hmac_tvjs">
-                    <t>Each test group contains an array of one or more test cases. Each test
-							case is a JSON object that represents a single test vector to be
-							processed by the ACVP client. The following table describes the JSON
-							elements for each secure MAC test vector.</t>
+                    <t>Each test group contains an array of one or more test cases. Each test case
+                        is a JSON object that represents a single test vector to be processed by the
+                        ACVP client. The following table describes the JSON elements for each secure
+                        MAC test vector.</t>
                     <texttable anchor="hmac_vs_tc_table2" title="HMAC Test Case JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
@@ -1257,7 +1634,7 @@
                         <ttcol align="left">Optional</ttcol>
                         <c>tcId</c>
                         <c>Numeric identifier for the test case, unique across the entire vector
-								set.</c>
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -1283,11 +1660,11 @@
                     </texttable>
                 </section>
                 <section anchor="hmac_vector_responses" title="HMAC Test Vector Responses">
-                    <t>After the ACVP client downloads and processes a vector set, it must send
-							the response vectors back to the ACVP server. The following table
-							describes the JSON object that represents a vector set response.</t>
+                    <t>After the ACVP client downloads and processes a vector set, it must send the
+                        response vectors back to the ACVP server. The following table describes the
+                        JSON object that represents a vector set response.</t>
                     <texttable anchor="hmac_vr_top_table"
-							title="HMAC Vector Set Response JSON Object">
+                        title="HMAC Vector Set Response JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
@@ -1304,11 +1681,8 @@
                         <c/>
                         <c/>
                         <c>testGroups</c>
-                        <c>Array of JSON objects that represent each test vector group. See
-									
-                                
-                            
-                            <xref target="hmac_vr_group_table"/>
+                        <c>Array of JSON objects that represent each test vector group. See <xref
+                                target="hmac_vr_group_table"/>
                         </c>
                         <c>array</c>
                         <c/>
@@ -1316,11 +1690,11 @@
                         <c/>
                     </texttable>
                     <t>The testGroups section is used to organize the ACVP client response in a
-							similar manner to how it receives vectors. Several algorithms SHALL
-							require the client to send back group level properties in their
-							response. This structure helps accommodate that.</t>
+                        similar manner to how it receives vectors. Several algorithms SHALL require
+                        the client to send back group level properties in their response. This
+                        structure helps accommodate that.</t>
                     <texttable anchor="hmac_vr_group_table"
-							title="HMAC Vector Set Group Response JSON Object">
+                        title="HMAC Vector Set Group Response JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
@@ -1337,19 +1711,18 @@
                         <c/>
                         <c/>
                     </texttable>
-                    <t>Each test group contains an array of one or more test cases. Each test
-							case is a JSON object that represents a single test vector to be
-							processed by the ACVP client. The following table describes the JSON
-							elements for each DRBG test vector.</t>
-                    <texttable anchor="hmac_vs_tr_table"
-							title="HMAC Test Case Results JSON Object">
+                    <t>Each test group contains an array of one or more test cases. Each test case
+                        is a JSON object that represents a single test vector to be processed by the
+                        ACVP client. The following table describes the JSON elements for each DRBG
+                        test vector.</t>
+                    <texttable anchor="hmac_vs_tr_table" title="HMAC Test Case Results JSON Object">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
                         <ttcol align="left">JSON type</ttcol>
                         <ttcol align="left">Optional</ttcol>
                         <c>tcId</c>
                         <c>Numeric identifier for the test case, unique across the entire vector
-								set.</c>
+                            set.</c>
                         <c>value</c>
                         <c>No</c>
                         <c/>
@@ -1379,15 +1752,13 @@
         <section anchor="Security" title="Security Considerations">
             <t>Security considerations are addressed by the ACVP specification.</t>
         </section>
+
     </middle>
     <!--  *****BACK MATTER ***** -->
     <back>
         <references title="Normative References">
             <!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?-->
-			&RFC2119; 
-            
-            
-            <reference anchor="ACVP">
+            &RFC2119; <reference anchor="ACVP">
                 <!-- the following is the minimum to make xml2rfc happy -->
                 <front>
                     <title>ACVP Specification</title>
@@ -1423,7 +1794,7 @@
                 <!-- the following is the minimum to make xml2rfc happy -->
                 <front>
                     <title>The Keyed-Hash Message Authentication Code Validation System
-						(HMACVS)</title>
+                        (HMACVS)</title>
                     <author initials="LEB" surname="Lawrence E. Bassham III">
                         <organization>NIST</organization>
                     </author>
@@ -1496,7 +1867,7 @@
         </section>
         <section anchor="app-vs-ex" title="Example Test Vectors JSON Object">
             <t>The following is an example JSON object for HMAC test vectors sent from the ACVP
-				server to the crypto module.</t>
+                server to the crypto module.</t>
             <figure>
                 <artwork>
                     <![CDATA[
@@ -1530,7 +1901,7 @@
                 </artwork>
             </figure>
             <t>The following is an example JSON object for CMAC-AES test vectors sent from the ACVP
-				server to the crypto module.</t>
+                server to the crypto module.</t>
             <figure>
                 <artwork>
                     <![CDATA[
@@ -1586,7 +1957,7 @@
                 </artwork>
             </figure>
             <t>The following is an example JSON object for CMAC-TDES test vectors sent from the ACVP
-				server to the crypto module.</t>
+                server to the crypto module.</t>
             <figure>
                 <artwork>
                     <![CDATA[
@@ -1653,7 +2024,7 @@
         </section>
         <section anchor="app-results-ex" title="Example Test Results JSON Object">
             <t>The following is an example JSON object for HMAC test results sent from the crypto
-				module to the ACVP server.</t>
+                module to the ACVP server.</t>
             <figure>
                 <artwork>
                     <![CDATA[
@@ -1680,7 +2051,7 @@
                 </artwork>
             </figure>
             <t>The following is an example JSON object for CMAC-AES test results sent from the
-				crypto module to the ACVP server.</t>
+                crypto module to the ACVP server.</t>
             <figure>
                 <artwork>
                     <![CDATA[
@@ -1718,7 +2089,7 @@
                 </artwork>
             </figure>
             <t>The following is an example JSON object for CMAC-TDES test results sent from the
-				crypto module to the ACVP server.</t>
+                crypto module to the ACVP server.</t>
             <figure>
                 <artwork>
                     <![CDATA[


### PR DESCRIPTION
* CMAC (AES and TDES) has had its capability registration slightly restructured to fit more in line with how validations are issued.
* Reorganized document to keep JSON samples along with descriptions of the algorithm
  * Removed appendix sections, as the JSON samples are now located along with the descriptions
* Broke out CMAC-AES, CMAC-TDES, and HMAC into their own sections, to (hopefully) very clearly show the differences in server/iut back and forth between the different algorithms.