### PR TITLE
Kas updates mirror symmetric spec

### DIFF
--- a/artifacts/acvp_sub_kas_ecc.html
+++ b/artifacts/acvp_sub_kas_ecc.html
@@ -432,7 +432,7 @@
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasecc-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-9" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11-7" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification." />
 
@@ -456,12 +456,12 @@
 <td class="right">R. Hammett, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: March 5, 2019</td>
+<td class="left">Expires: May 11, 2019</td>
 <td class="right">G2, Inc.</td>
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">September 2018</td>
+<td class="right">November 7, 2018</td>
 </tr>
 
     	
@@ -477,7 +477,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on March 5, 2019.</p>
+<p>This Internet-Draft will expire on May 11, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -602,11 +602,11 @@
 <h1 id="rfc.section.2">
 <a href="#rfc.section.2">2.</a> <a href="#test_types" id="test_types">Test Types and Test Coverage</a>
 </h1>
-<p id="rfc.section.2.p.1">The ACVP server performs a set of tests on the KAS protocol in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported permutation of KAS capabilities. This section describes the design of the tests used to validate implementations of KAS algorithms. There are two test types for KAS testing: </p>
+<p id="rfc.section.2.p.1">The ACVP server performs a set of tests on the KAS protocol in order to assess the correctness and robustness of the implementation. A typical ACVP validation session SHALL require multiple tests to be performed for every supported permutation of KAS capabilities. This section describes the design of the tests used to validate implementations of KAS algorithms. There are two test types for KAS testing: </p>
 
 <ul class="empty">
-<li>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT is expected to act as a party in the Key Agreement with the ACVP server. The server will generate and provide all necessary information for the IUT to perform a successful key agreement; both the server and IUT can act as party U/V, as well as recipient/provider to key confirmation.</li>
-<li>"VAL" - Validation test. In the VAL test mode, The ACVP server generates a complete (from both party U and party V's perspectives) key agreement, and expects the IUT to be able to determine if that agreement is valid. Various types of errors are introduced in varying portions of the key agreement process (like bad DKM, bad key, bad hash, etc), that the IUT should be able to detect and report on.</li>
+<li>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT SHALL act as a party in the Key Agreement with the ACVP server. The server SHALL generate and provide all necessary information for the IUT to perform a successful key agreement; both the server and IUT MAY act as party U/V, as well as recipient/provider to key confirmation.</li>
+<li>"VAL" - Validation test. In the VAL test mode, The ACVP server MUST generate a complete (from both party U and party V's perspectives) key agreement, and expects the IUT to be able to determine if that agreement is valid. Various types of errors MSUT be introduced in varying portions of the key agreement process (changed DKM, changed key, changed hash digest, etc), that the IUT MUST be able to detect and report on.</li>
 </ul>
 
 <p> </p>
@@ -622,14 +622,14 @@
 <ul class="empty">
 <li>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.</li>
 <li>SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.</li>
-<li>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS make use of a hash function. The hash function may be used for confirmation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).</li>
-<li>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is required only for kdfKc, though is utilized for both kdfNoKc and kdfKc.</li>
-<li>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT are expected to be able to generate nonces.</li>
-<li>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation is performed solely from the ACVP server, with constraints from the IUTs capabilities registration. It is expected that the same set of domain parameters will generate all keypairs (party U/V, static/ephemeral) for a single test case.</li>
-<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, shall inject bad keypairs that the IUT should be able detect. These random tests are only present in groups given appropriate assurance functions see: <a href="#supported_functions" class="xref">Section 3.3</a> </li>
-<li>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV is used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.</li>
-<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  All schemes/modes save noKdfNoKc (component) make use of a KDF. KDF construction utilizes <a href="#oiPatternConstruction" class="xref">Section 3.10.1</a> for its pattern. </li>
-<li>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT can be Providers or Recipients of said confirmation. Additionally, key confirmation can be performed on one or both parties (depending on scheme).</li>
+<li>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS SHALL make use of a hash function. The hash function MAY be used for confirmation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).</li>
+<li>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is REQUIRED only for kdfKc, though is utilized for both kdfNoKc and kdfKc.</li>
+<li>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT SHALL be expected to generate nonces.</li>
+<li>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation SHALL be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters SHALL generate all keypairs (party U/V, static/ephemeral) for a single test case.</li>
+<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, MAY inject bad keypairs that the IUT MUST be able detect. These random tests are only present in groups given appropriate assurance functions see: <a href="#supported_functions" class="xref">Section 3.3</a> </li>
+<li>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV SHALL be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.</li>
+<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  All schemes/modes save noKdfNoKc (component) MUST make use of a KDF. KDF construction SHALL utilize <a href="#oiPatternConstruction" class="xref">Section 3.10.1</a> for its pattern. </li>
+<li>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT MAY be Providers or Recipients of said confirmation. Additionally, key confirmation MAY be performed on one or both parties (depending on scheme).</li>
 <li>SP 800-56a - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.</li>
 </ul>
 
@@ -640,23 +640,23 @@
 <p></p>
 
 <ul class="empty">
-<li>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server does not make a distinction between IUT generated keys via a trusted third party and the IUT itself.</li>
-<li>SP 800-56a - 5.3 Random Number Generation. It is expected the IUT performs all random number generation with a validated random number generator. A DRBG is expected as a prerequisite to KAS, but is out of the scope of testing assurances. </li>
-<li>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.5 are expected to be used, however their generation is out of scope of KAS testing assurances</li>
-<li>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server generates all domain parameters, IUT validation of such parameters is out of scope for KAS testing.</li>
-<li>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter Management is out of scope for KAS testing.</li>
-<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation, assurances, and management of said key-pairs is out of scope for KAS testing.</li>
-<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  Two-step Key-Derivation (Extraction-then-Expansion) is not utilized in KAS testing.</li>
-<li>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as being a valid MAC function; it however is not (currently) supported in KAS testing.</li>
-<li>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective is out of scope.</li>
-<li>SP 800-56a - 8 Key Recovery. Key Recovery is not in scope of KAS testing.</li>
+<li>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server SHALL NOT make a distinction between IUT generated keys via a trusted third party and the IUT itself.</li>
+<li>SP 800-56a - 5.3 Random Number Generation. The IUT MUST perform all random number generation with a validated random number generator. A DRBG is REQUIRED as a prerequisite to KAS, but SHALL NOT be in the scope testing assurances. </li>
+<li>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.5 MUST be used, however their generation SHALL NOT be in scope of KAS testing assurances</li>
+<li>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server SHALL generate all domain parameters, IUT validation of such parameters is SHALL NOT be in scope for KAS testing.</li>
+<li>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter Management SHALL NOT be in scope for KAS testing.</li>
+<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs MUST be used in each KAS scheme, the generation, assurances, and management of said key-pairs SHALL NOT be in scope of KAS testing.</li>
+<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  Two-step Key-Derivation (Extraction-then-Expansion) SHALL NOT be utilized in KAS testing.</li>
+<li>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as being a valid MAC function; it however SHALL NOT (currently) be supported in KAS testing.</li>
+<li>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective SHALL NOT be in scope.</li>
+<li>SP 800-56a - 8 Key Recovery. Key Recovery SHALL NOT be in scope of KAS testing.</li>
 </ul>
 
 <p> </p>
 <h1 id="rfc.section.3">
 <a href="#rfc.section.3">3.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
 </h1>
-<p id="rfc.section.3.p.1">ACVP requires crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of KAS ECC algorithms to the ACVP server.</p>
+<p id="rfc.section.3.p.1">ACVP REQUIRES crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of KAS ECC algorithms to the ACVP server.</p>
 <p id="rfc.section.3.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message. Each KDF algorithm capability advertised is a self-contained JSON object.</p>
 <h1 id="rfc.section.3.1">
 <a href="#rfc.section.3.1">3.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for KAS ECC Validations</a>
@@ -730,7 +730,7 @@
 <tbody>
 <tr>
 <td class="left">DRBG</td>
-<td class="left">Always required</td>
+<td class="left">Always REQUIRED</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -738,7 +738,7 @@
 </tr>
 <tr>
 <td class="left">SHA</td>
-<td class="left">Always required</td>
+<td class="left">Always REQUIRED</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -746,7 +746,7 @@
 </tr>
 <tr>
 <td class="left">ECDSA</td>
-<td class="left">ECDSA.PKV validation required when IUT using assurance functions of "fullVal", "keyPairGen", or "keyRegen". ECDSA.KeyPair validation required when IUT using assurances functions of "keyPairGen", or "keyRegen". </td>
+<td class="left">ECDSA.PKV validation REQUIRED when IUT using assurance functions of "fullVal", "keyPairGen", or "keyRegen". ECDSA.KeyPair validation REQUIRED when IUT using assurances functions of "keyPairGen", or "keyRegen". </td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -754,7 +754,7 @@
 </tr>
 <tr>
 <td class="left">AES-CCM</td>
-<td class="left">AES-CCM validation required when IUT is performing KeyConfirmation (KC) and utilizing AES-CCM.</td>
+<td class="left">AES-CCM validation REQUIRED when IUT is performing KeyConfirmation (KC) and utilizing AES-CCM.</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -762,7 +762,7 @@
 </tr>
 <tr>
 <td class="left">CMAC</td>
-<td class="left">CMAC validation required when IUT is performing KeyConfirmation (KC) and utilizing CMAC.</td>
+<td class="left">CMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and utilizing CMAC.</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -770,7 +770,7 @@
 </tr>
 <tr>
 <td class="left">HMAC</td>
-<td class="left">HMAC validation required when IUT is performing KeyConfirmation (KC) and utilizing HMAC.</td>
+<td class="left">HMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and utilizing HMAC.</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -870,7 +870,7 @@
 <h1 id="rfc.section.3.3">
 <a href="#rfc.section.3.3">3.3.</a> <a href="#supported_functions" id="supported_functions">Supported KAS ECC Functions</a>
 </h1>
-<p id="rfc.section.3.3.p.1">The following function types may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.3.p.1">The following function types MAY be advertised by the ACVP compliant crypto module:</p>
 <p></p>
 
 <ul>
@@ -889,7 +889,7 @@
 <h1 id="rfc.section.3.4.1">
 <a href="#rfc.section.3.4.1">3.4.1.</a> <a href="#supported_schemes" id="supported_schemes">KAS ECC Scheme Capabilities JSON Values</a>
 </h1>
-<p id="rfc.section.3.4.1.p.1">All other scheme capability advertised is a self-contained JSON object using the following values. Note that at least one of "noKdfNoKc", "kdfNoKc", or "kdfKc" must be supplied with the registration. See <a href="#supported_scheme_values" class="xref">Section 3.4.2</a> for allowed ECC scheme types. </p>
+<p id="rfc.section.3.4.1.p.1">All other scheme capabilities are advertised as a self-contained JSON object using the following values. Note that at least one of "noKdfNoKc", "kdfNoKc", or "kdfKc" MUST be supplied with the registration. See <a href="#supported_scheme_values" class="xref">Section 3.4.2</a> for allowed ECC scheme types. </p>
 <div id="rfc.table.4"></div>
 <div id="scheme_caps_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -918,7 +918,7 @@
 </tr>
 <tr>
 <td class="left">noKdfNoKc</td>
-<td class="left">Indicates no KDF, no KC tests are to be generated. Note this is a COMPONENT mode only test. This property can only be used with "KAS-ECC" / "Component"</td>
+<td class="left">Indicates no KDF, no KC tests are to be generated. Note this is a COMPONENT mode only test. This property MUST only be used with "KAS-ECC" / "Component"</td>
 <td class="left">object</td>
 <td class="left">
 <a href="#noKdfNoKc" class="xref">Section 3.5.1</a> </td>
@@ -933,7 +933,7 @@
 </tr>
 <tr>
 <td class="left">kdfNoKc</td>
-<td class="left">Indicates KDF, no KC tests are to be generated. Note this is a KAS-ECC only test. This mode is only valid for registrations with "KAS-ECC" (no mode)</td>
+<td class="left">Indicates KDF, no KC tests are to be generated. Note this is a KAS-ECC only test. This mode MAY only be used for registrations with "KAS-ECC" (no mode)</td>
 <td class="left">object</td>
 <td class="left">
 <a href="#kdfNoKc" class="xref">Section 3.5.2</a> </td>
@@ -948,7 +948,7 @@
 </tr>
 <tr>
 <td class="left">kdfKc</td>
-<td class="left">Indicates KDF, KC tests are to be generated. Note this is a KAS-ECC only test. This mode is only valid for registrations with "KAS-ECC" (no mode)</td>
+<td class="left">Indicates KDF, KC tests are to be generated. Note this is a KAS-ECC only test. This mode MAY only be used for registrations with "KAS-ECC" (no mode)</td>
 <td class="left">object</td>
 <td class="left">
 <a href="#kdfKc" class="xref">Section 3.5.3</a> </td>
@@ -966,7 +966,7 @@
 <h1 id="rfc.section.3.4.2">
 <a href="#rfc.section.3.4.2">3.4.2.</a> <a href="#supported_scheme_values" id="supported_scheme_values">Supported KAS ECC Schemes</a>
 </h1>
-<p id="rfc.section.3.4.2.p.1">The following schemes may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.4.2.p.1">The following schemes MAY be advertised by the ACVP compliant crypto module:</p>
 <p></p>
 
 <ul>
@@ -986,7 +986,7 @@
 <h1 id="rfc.section.3.5.1">
 <a href="#rfc.section.3.5.1">3.5.1.</a> <a href="#noKdfNoKc" id="noKdfNoKc">KAS ECC noKdfNoKc</a>
 </h1>
-<p id="rfc.section.3.5.1.p.1">Contains properties required for "noKdfNoKc" registration. </p>
+<p id="rfc.section.3.5.1.p.1">Contains properties REQUIRED for "noKdfNoKc" registration. </p>
 <div id="rfc.table.5"></div>
 <div id="noKdfNoKc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1019,7 +1019,7 @@
 <h1 id="rfc.section.3.5.2">
 <a href="#rfc.section.3.5.2">3.5.2.</a> <a href="#kdfNoKc" id="kdfNoKc">KAS ECC kdfNoKc</a>
 </h1>
-<p id="rfc.section.3.5.2.p.1">Contains properties required for "kdfNoKc" registration. </p>
+<p id="rfc.section.3.5.2.p.1">Contains properties REQUIRED for "kdfNoKc" registration. </p>
 <div id="rfc.table.6"></div>
 <div id="kdfNoKc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1067,7 +1067,7 @@
 <h1 id="rfc.section.3.5.3">
 <a href="#rfc.section.3.5.3">3.5.3.</a> <a href="#kdfKc" id="kdfKc">KAS ECC kdfKc</a>
 </h1>
-<p id="rfc.section.3.5.3.p.1">Contains properties required for "kdfKc" registration. </p>
+<p id="rfc.section.3.5.3.p.1">Contains properties REQUIRED for "kdfKc" registration. </p>
 <div id="rfc.table.7"></div>
 <div id="kdfKc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1133,7 +1133,7 @@
 <h1 id="rfc.section.3.6.1">
 <a href="#rfc.section.3.6.1">3.6.1.</a> <a href="#parameter_set" id="parameter_set">KAS ECC Parameter Set</a>
 </h1>
-<p id="rfc.section.3.6.1.p.1">Each parameter set advertised is a self-contained JSON object using the following values. Note that at least one parameter set ("eb", "ec", "ed", "ee") is required.</p>
+<p id="rfc.section.3.6.1.p.1">Each parameter set advertised is a self-contained JSON object using the following values. Note that at least one parameter set ("eb", "ec", "ed", "ee") is REQUIRED.</p>
 <div id="rfc.table.8"></div>
 <div id="parameter_set_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1211,9 +1211,9 @@
 <p id="rfc.section.3.6.2.p.2">ec: Len n - 256-283, min Len h - 128, min hash len - 256, min keySize - 128, min macSize - 64</p>
 <p id="rfc.section.3.6.2.p.3">ed: Len n - 384-511, min Len h - 192, min hash len - 384, min keySize - 192, min macSize - 64</p>
 <p id="rfc.section.3.6.2.p.4">ee: Len n - 512+, min Len h - 256, min hash len - 512, min keySize - 256, min macSize - 64</p>
-<p id="rfc.section.3.6.2.p.5">"noKdfNoKc" requires "hashAlg"</p>
-<p id="rfc.section.3.6.2.p.6">"kdfNoKc" requires "hashAlg" and at least one valid MAC registration</p>
-<p id="rfc.section.3.6.2.p.7">"kdfKc" requires "hashAlg" and at least one valid MAC registration</p>
+<p id="rfc.section.3.6.2.p.5">"noKdfNoKc" REQUIRES "hashAlg"</p>
+<p id="rfc.section.3.6.2.p.6">"kdfNoKc" REQUIRES "hashAlg" and at least one valid MAC registration</p>
+<p id="rfc.section.3.6.2.p.7">"kdfKc" REQUIRES "hashAlg" and at least one valid MAC registration</p>
 <div id="rfc.table.9"></div>
 <div id="parameter_set_details_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1273,7 +1273,7 @@
 <h1 id="rfc.section.3.7">
 <a href="#rfc.section.3.7">3.7.</a> <a href="#supported_curves" id="supported_curves">Supported ECC Curves</a>
 </h1>
-<p id="rfc.section.3.7.p.1">The following ECC Curves may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.7.p.1">The following ECC Curves MAY be advertised by the ACVP compliant crypto module:</p>
 <div id="rfc.table.10"></div>
 <div id="curves"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1338,7 +1338,7 @@
 <h1 id="rfc.section.3.8">
 <a href="#rfc.section.3.8">3.8.</a> <a href="#supported_hashAlg" id="supported_hashAlg">Supported Hash Algorithm Methods</a>
 </h1>
-<p id="rfc.section.3.8.p.1">The following SHA methods may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.8.p.1">The following SHA methods MAY be advertised by the ACVP compliant crypto module:</p>
 <p></p>
 
 <ul>
@@ -1352,7 +1352,7 @@
 <h1 id="rfc.section.3.9">
 <a href="#rfc.section.3.9">3.9.</a> <a href="#supported_macOption" id="supported_macOption">Supported KAS ECC MAC Options</a>
 </h1>
-<p id="rfc.section.3.9.p.1">The following MAC options are available for registration under a "kdfNoKc" and "kdfKc" kasMode:</p>
+<p id="rfc.section.3.9.p.1">The following MAC options MAY be advertised for registration under a "kdfNoKc" and "kdfKc" kasMode:</p>
 <p></p>
 
 <ul>
@@ -1381,7 +1381,7 @@
 <td class="left">keyLen</td>
 <td class="left">The supported keyLens for the selected MAC.</td>
 <td class="left">Domain</td>
-<td class="left">AES based MACs limited to 128, 192, 256. HashAlg based MACs mod 8. All keySizes minimum must conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
+<td class="left">AES based MACs limited to 128, 192, 256. HashAlg based MACs mod 8. All keySizes minimum MUST conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -1395,7 +1395,7 @@
 <td class="left">nonceLen</td>
 <td class="left">The nonce len for use with AES-CCM mac</td>
 <td class="left">value</td>
-<td class="left">Input as bits, 56-104, odd byte values only (7-13). Additionally minimum must conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
+<td class="left">Input as bits, 56-104, odd byte values only (7-13). Additionally minimum MUST conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
 <td class="left">Yes (required for AES-CCM)</td>
 </tr>
 <tr>
@@ -1409,7 +1409,7 @@
 <td class="left">macLen</td>
 <td class="left">The mac len for use with mac</td>
 <td class="left">value</td>
-<td class="left">Input as bits, mod 8, minimum must conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> , maximum may not exceed block size.. </td>
+<td class="left">Input as bits, mod 8, minimum MUST conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> , maximum SHALL NOT exceed block size.. </td>
 <td class="left">Yes (required for AES-CCM)</td>
 </tr>
 <tr>
@@ -1464,7 +1464,7 @@
 <h1 id="rfc.section.3.10.1">
 <a href="#rfc.section.3.10.1">3.10.1.</a> <a href="#oiPatternConstruction" id="oiPatternConstruction">Other Information Construction</a>
 </h1>
-<p id="rfc.section.3.10.1.p.1">Some IUTs require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength must be 240 for FFC, and 376 for ECC. The OI will be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement </p>
+<p id="rfc.section.3.10.1.p.1">Some IUTs MAY require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength MUST be 240 for FFC, and 376 for ECC. The OI SHALL be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement </p>
 <p id="rfc.section.3.10.1.p.2">Pattern candidates:</p>
 <p></p>
 
@@ -3403,7 +3403,7 @@
 </tr>
 <tr>
 <td class="left">macType</td>
-<td class="left">The MAC being used. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The MAC being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.9</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3415,7 +3415,7 @@
 </tr>
 <tr>
 <td class="left">keyLen</td>
-<td class="left">The key length of the MAC. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The key length of the MAC. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.9</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3427,7 +3427,7 @@
 </tr>
 <tr>
 <td class="left">nonceAesCcmLen</td>
-<td class="left">The nonce length of the MAC (applies only to AES-CCM). Required for "kdfNoKc" and "kdfKc" modes using a AES-CCM MAC.</td>
+<td class="left">The nonce length of the MAC (applies only to AES-CCM). REQUIRED for "kdfNoKc" and "kdfKc" modes using a AES-CCM MAC.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.9</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3439,7 +3439,7 @@
 </tr>
 <tr>
 <td class="left">macLen</td>
-<td class="left">The mac length. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The mac length. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.9</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3451,7 +3451,7 @@
 </tr>
 <tr>
 <td class="left">kdfType</td>
-<td class="left">The KDF being used. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The KDF being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">concatenation, asn1</td>
 <td class="left">Yes</td>
 </tr>
@@ -3463,7 +3463,7 @@
 </tr>
 <tr>
 <td class="left">idServerLen</td>
-<td class="left">The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3475,7 +3475,7 @@
 </tr>
 <tr>
 <td class="left">idServer</td>
-<td class="left">The server ID. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3487,7 +3487,7 @@
 </tr>
 <tr>
 <td class="left">idIutLen</td>
-<td class="left">The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.  Provided in response by IUT for AFT tests.</td>
+<td class="left">The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.  Provided in response by IUT for AFT tests.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3499,7 +3499,7 @@
 </tr>
 <tr>
 <td class="left">idIut</td>
-<td class="left">The server ID. Required for "kdfNoKc" and "kdfKc" modes. Provided in response by IUT for AFT tests.</td>
+<td class="left">The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes. Provided in response by IUT for AFT tests.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3511,7 +3511,7 @@
 </tr>
 <tr>
 <td class="left">oiPattern</td>
-<td class="left">The oiPattern used in the KDF. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The oiPattern used in the KDF. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#oiPatternConstruction" class="xref">Section 3.10.1</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3523,7 +3523,7 @@
 </tr>
 <tr>
 <td class="left">kcRole</td>
-<td class="left">Key confirmation roles supported. Required for "kdfKc" modes.</td>
+<td class="left">Key confirmation roles supported. REQUIRED for "kdfKc" modes.</td>
 <td class="left">provider, recipient</td>
 <td class="left">Yes</td>
 </tr>
@@ -3535,7 +3535,7 @@
 </tr>
 <tr>
 <td class="left">kcType</td>
-<td class="left">Key confirmation types supported. Required for "kdfKc" modes.</td>
+<td class="left">Key confirmation types supported. REQUIRED for "kdfKc" modes.</td>
 <td class="left">unilateral and/or bilateral</td>
 <td class="left">Yes</td>
 </tr>
@@ -4207,41 +4207,6 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.p.3">Note. the following bullet lists outline which JSON keywords must be provided for the respective KAS ECC test types in the shared secret generation test vector response.</p>
-<p id="rfc.section.6.p.4">ephemeralUnified:</p>
-<p></p>
-
-<ul>
-<li>ephemeralPublicIutX</li>
-<li>ephemeralPublicIutY</li>
-<li>hashZIut</li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.6.p.6">fullMqv: TBD</p>
-<p id="rfc.section.6.p.7">fullUnified: TBD</p>
-<p id="rfc.section.6.p.8">onePassDh</p>
-<p></p>
-
-<ul>
-<li>ephemeralPublicIutX</li>
-<li>ephemeralPublicIutY</li>
-<li>hashZIut</li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.6.p.10">onePassMqv: TBD</p>
-<p id="rfc.section.6.p.11">onePassUnified: TBD</p>
-<p id="rfc.section.6.p.12">staticUnified</p>
-<p></p>
-
-<ul>
-<li>staticPublicIutX</li>
-<li>staticPublicIutY</li>
-<li>hashZIut</li>
-</ul>
-
-<p> </p>
 <h1 id="rfc.section.6.1">
 <a href="#rfc.section.6.1">6.1.</a> <a href="#app-results-ex" id="app-results-ex">Example Test Results JSON Object</a>
 </h1>

--- a/artifacts/acvp_sub_kas_ecc.txt
+++ b/artifacts/acvp_sub_kas_ecc.txt
@@ -5,8 +5,8 @@
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
 Intended status: Informational                           R. Hammett, Ed.
-Expires: March 5, 2019                                          G2, Inc.
-                                                          September 2018
+Expires: May 11, 2019                                           G2, Inc.
+                                                        November 7, 2018
 
 
                     ACVP KAS ECC JSON Specification
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 5, 2019.
+   This Internet-Draft will expire on May 11, 2019.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 1]
+Fussell & Hammett         Expires May 11, 2019                  [Page 1]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 Table of Contents
@@ -95,7 +95,7 @@ Table of Contents
      5.3.  Example Test Vectors JSON Object  . . . . . . . . . . . .  37
      5.4.  Example Test Vectors Component JSON Object  . . . . . . .  40
    6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  42
-     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  43
+     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  42
      6.2.  Example Test Results Component JSON Object  . . . . . . .  44
    7.  ECC CDH Component Test  . . . . . . . . . . . . . . . . . . .  45
      7.1.  ECC CDH Component Capabilities JSON Values  . . . . . . .  46
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 2]
+Fussell & Hammett         Expires May 11, 2019                  [Page 2]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
      7.3.  KAS CDH-Component Test Vector Responses . . . . . . . . .  50
@@ -147,34 +147,34 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    The ACVP server performs a set of tests on the KAS protocol in order
    to assess the correctness and robustness of the implementation.  A
-   typical ACVP validation session would require multiple tests to be
+   typical ACVP validation session SHALL require multiple tests to be
    performed for every supported permutation of KAS capabilities.  This
    section describes the design of the tests used to validate
    implementations of KAS algorithms.  There are two test types for KAS
    testing:
 
-      "AFT" - Algorithm Function Test.  In the AFT test mode, the IUT is
-      expected to act as a party in the Key Agreement with the ACVP
-      server.  The server will generate and provide all necessary
-      information for the IUT to perform a successful key agreement;
-      both the server and IUT can act as party U/V, as well as
-      recipient/provider to key confirmation.
+      "AFT" - Algorithm Function Test.  In the AFT test mode, the IUT
+      SHALL act as a party in the Key Agreement with the ACVP server.
+      The server SHALL generate and provide all necessary information
+      for the IUT to perform a successful key agreement; both the server
+      and IUT MAY act as party U/V, as well as recipient/provider to key
+      confirmation.
 
       "VAL" - Validation test.  In the VAL test mode, The ACVP server
-      generates a complete (from both party U and party V's
+      MUST generate a complete (from both party U and party V's
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 3]
+Fussell & Hammett         Expires May 11, 2019                  [Page 3]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
       perspectives) key agreement, and expects the IUT to be able to
-      determine if that agreement is valid.  Various types of errors are
-      introduced in varying portions of the key agreement process (like
-      bad DKM, bad key, bad hash, etc), that the IUT should be able to
-      detect and report on.
+      determine if that agreement is valid.  Various types of errors
+      MSUT be introduced in varying portions of the key agreement
+      process (changed DKM, changed key, changed hash digest, etc), that
+      the IUT MUST be able to detect and report on.
 
 2.1.  Test Coverage
 
@@ -193,56 +193,57 @@ Internet-Draft                Sym Alg JSON                September 2018
       of steps depicted in "Figure 2: Key Agreement process" can vary.
 
       SP 800-56a - 5.1 Cryptographic Hash Functions.  All modes of
-      performing KAS make use of a hash function.  The hash function may
-      be used for confirmation of a successfully generated shared secret
-      Z (noKdfNoKc), or as a primitive within the KDF being tested
-      (kdfNoKc and kdfKc).
+      performing KAS SHALL make use of a hash function.  The hash
+      function MAY be used for confirmation of a successfully generated
+      shared secret Z (noKdfNoKc), or as a primitive within the KDF
+      being tested (kdfNoKc and kdfKc).
 
       SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm.  A
       MAC is utilized for confirmation of success for kdfNoKc and kdfKc
-      modes of KAS.  Note - a MAC prerequisite is required only for
+      modes of KAS.  Note - a MAC prerequisite is REQUIRED only for
       kdfKc, though is utilized for both kdfNoKc and kdfKc.
 
       SP 800-56a - 5.4 Nonce.  Nonces are made use of in various KAS
-      schemes - both the ACVP server and IUT are expected to be able to
+      schemes - both the ACVP server and IUT SHALL be expected to
       generate nonces.
 
       SP 800-56a - 5.6 Domain Parameters.  Domain Parameter Generation
-      is performed solely from the ACVP server, with constraints from
-      the IUTs capabilities registration.  It is expected that the same
-      set of domain parameters will generate all keypairs (party U/V,
-      static/ephemeral) for a single test case.
+      SHALL be performed solely from the ACVP server, with constraints
+      from the IUTs capabilities registration.  The same set of domain
+      parameters SHALL generate all keypairs (party U/V, static/
+      ephemeral) for a single test case.
 
       SP 800-56a - 5.6 Key-Pair Generation.  While Key-Pairs are used in
       each KAS scheme, the generation of said key-pairs is out of scope
-      for KAS testing.  Random tests from the VAL groups, shall inject
-      bad keypairs that the IUT should be able detect.  These random
+      for KAS testing.  Random tests from the VAL groups, MAY inject bad
+      keypairs that the IUT MUST be able detect.  These random tests are
 
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 4]
+Fussell & Hammett         Expires May 11, 2019                  [Page 4]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
-      tests are only present in groups given appropriate assurance
-      functions see: Section 3.3
+      only present in groups given appropriate assurance functions see:
+      Section 3.3
 
       SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC
       Primitives.  Depending on the scheme used, either Diffie Hellman
-      or MQV is used to negotiate a shared secret of z.  Testing and
-      validation of such key exchanges is covered under their respective
-      schemes.
+      or MQV SHALL be used to negotiate a shared secret of z.  Testing
+      and validation of such key exchanges is covered under their
+      respective schemes.
 
       SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-      All schemes/modes save noKdfNoKc (component) make use of a KDF.
-      KDF construction utilizes Section 3.10.1 for its pattern.
+      All schemes/modes save noKdfNoKc (component) MUST make use of a
+      KDF.  KDF construction SHALL utilize Section 3.10.1 for its
+      pattern.
 
       SP 800-56a - 5.9 Key Confirmation.  Most KAS schemes allow for a
-      Key Confirmation process, the ACVP server and IUT can be Providers
+      Key Confirmation process, the ACVP server and IUT MAY be Providers
       or Recipients of said confirmation.  Additionally, key
-      confirmation can be performed on one or both parties (depending on
+      confirmation MAY be performed on one or both parties (depending on
       scheme).
 
       SP 800-56a - 6 Key Agreement Schemes.  All schemes specified in
@@ -252,59 +253,58 @@ Internet-Draft                Sym Alg JSON                September 2018
 2.1.2.  KAS-ECC Requirements Not Covered
 
       SP 800-56a - 4.1 Key Establishment Preparations.  The ACVP server
-      does not make a distinction between IUT generated keys via a
+      SHALL NOT make a distinction between IUT generated keys via a
       trusted third party and the IUT itself.
 
-      SP 800-56a - 5.3 Random Number Generation.  It is expected the IUT
-      performs all random number generation with a validated random
-      number generator.  A DRBG is expected as a prerequisite to KAS,
-      but is out of the scope of testing assurances.
+      SP 800-56a - 5.3 Random Number Generation.  The IUT MUST perform
+      all random number generation with a validated random number
+      generator.  A DRBG is REQUIRED as a prerequisite to KAS, but SHALL
+      NOT be in the scope testing assurances.
 
       SP 800-56a - 5.4 Nonce.  Nonce generation is utilized for several
       schemes.  The various methods of generating a nonce described in
-      section 5.5 are expected to be used, however their generation is
-      out of scope of KAS testing assurances
+      section 5.5 MUST be used, however their generation SHALL NOT be in
+      scope of KAS testing assurances
 
       SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity.  The
-      ACVP server generates all domain parameters, IUT validation of
-      such parameters is out of scope for KAS testing.
+      ACVP server SHALL generate all domain parameters, IUT validation
+      of such parameters is SHALL NOT be in scope for KAS testing.
 
       SP 800-56a - 5.5.3 Domain Parameter Management.  Domain Parameter
-      Management is out of scope for KAS testing.
+      Management SHALL NOT be in scope for KAS testing.
 
 
 
 
 
-
-Fussell & Hammett         Expires March 5, 2019                 [Page 5]
+Fussell & Hammett         Expires May 11, 2019                  [Page 5]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
-      SP 800-56a - 5.6 Key-Pair Generation.  While Key-Pairs are used in
-      each KAS scheme, the generation, assurances, and management of
-      said key-pairs is out of scope for KAS testing.
+      SP 800-56a - 5.6 Key-Pair Generation.  While Key-Pairs MUST be
+      used in each KAS scheme, the generation, assurances, and
+      management of said key-pairs SHALL NOT be in scope of KAS testing.
 
       SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-      Two-step Key-Derivation (Extraction-then-Expansion) is not
+      Two-step Key-Derivation (Extraction-then-Expansion) SHALL NOT be
       utilized in KAS testing.
 
       SP 800-56a - 5.9 Key Confirmation.  KMAC is referenced in 800-56a
-      as being a valid MAC function; it however is not (currently)
+      as being a valid MAC function; it however SHALL NOT (currently) be
       supported in KAS testing.
 
       SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme.  It is
       expected that the IUT registers all schemes it supports in its
       capabilities registration.  Selecting specific schemes from a KAS
-      testing perspective is out of scope.
+      testing perspective SHALL NOT be in scope.
 
-      SP 800-56a - 8 Key Recovery.  Key Recovery is not in scope of KAS
-      testing.
+      SP 800-56a - 8 Key Recovery.  Key Recovery SHALL NOT be in scope
+      of KAS testing.
 
 3.  Capabilities Registration
 
-   ACVP requires crypto modules to register their capabilities.  This
+   ACVP REQUIRES crypto modules to register their capabilities.  This
    allows the crypto module to advertise support for specific
    algorithms, notifying the ACVP server which algorithms need test
    vectors generated for the validation process.  This section describes
@@ -333,9 +333,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 6]
+Fussell & Hammett         Expires May 11, 2019                  [Page 6]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +--------------+--------------+--------------+-----------+----------+
@@ -389,32 +389,32 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 7]
+Fussell & Hammett         Expires May 11, 2019                  [Page 7]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +--------------+----------------------------------------------------+
    | Prerequisite | Condition                                          |
    | Algorithm    |                                                    |
    +--------------+----------------------------------------------------+
-   | DRBG         | Always required                                    |
+   | DRBG         | Always REQUIRED                                    |
    |              |                                                    |
-   | SHA          | Always required                                    |
+   | SHA          | Always REQUIRED                                    |
    |              |                                                    |
-   | ECDSA        | ECDSA.PKV validation required when IUT using       |
+   | ECDSA        | ECDSA.PKV validation REQUIRED when IUT using       |
    |              | assurance functions of "fullVal", "keyPairGen", or |
-   |              | "keyRegen". ECDSA.KeyPair validation required when |
+   |              | "keyRegen". ECDSA.KeyPair validation REQUIRED when |
    |              | IUT using assurances functions of "keyPairGen", or |
    |              | "keyRegen".                                        |
    |              |                                                    |
-   | AES-CCM      | AES-CCM validation required when IUT is performing |
+   | AES-CCM      | AES-CCM validation REQUIRED when IUT is performing |
    |              | KeyConfirmation (KC) and utilizing AES-CCM.        |
    |              |                                                    |
-   | CMAC         | CMAC validation required when IUT is performing    |
+   | CMAC         | CMAC validation REQUIRED when IUT is performing    |
    |              | KeyConfirmation (KC) and utilizing CMAC.           |
    |              |                                                    |
-   | HMAC         | HMAC validation required when IUT is performing    |
+   | HMAC         | HMAC validation REQUIRED when IUT is performing    |
    |              | KeyConfirmation (KC) and utilizing HMAC.           |
    |              |                                                    |
    +--------------+----------------------------------------------------+
@@ -445,9 +445,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 8]
+Fussell & Hammett         Expires May 11, 2019                  [Page 8]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +------------+----------------+--------------+-----------+----------+
@@ -486,7 +486,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.3.  Supported KAS ECC Functions
 
-   The following function types may be advertised by the ACVP compliant
+   The following function types MAY be advertised by the ACVP compliant
    crypto module:
 
    o  dpGen - IUT can perform domain parameter generation (FFC only)
@@ -501,9 +501,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                 [Page 9]
+Fussell & Hammett         Expires May 11, 2019                  [Page 9]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    o  partialVal - IUT can perform partial public key validation (
@@ -516,9 +516,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.4.1.  KAS ECC Scheme Capabilities JSON Values
 
-   All other scheme capability advertised is a self-contained JSON
+   All other scheme capabilities are advertised as a self-contained JSON
    object using the following values.  Note that at least one of
-   "noKdfNoKc", "kdfNoKc", or "kdfKc" must be supplied with the
+   "noKdfNoKc", "kdfNoKc", or "kdfKc" MUST be supplied with the
    registration.  See Section 3.4.2 for allowed ECC scheme types.
 
 
@@ -557,9 +557,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 10]
+Fussell & Hammett         Expires May 11, 2019                 [Page 10]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +-----------+-----------------------+--------+-----------+----------+
@@ -575,7 +575,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | generated. Note this  |        |           |          |
    |           | is a COMPONENT mode   |        |           |          |
    |           | only test. This       |        |           |          |
-   |           | property can only be  |        |           |          |
+   |           | property MUST only be |        |           |          |
    |           | used with "KAS-ECC" / |        |           |          |
    |           | "Component"           |        |           |          |
    |           |                       |        |           |          |
@@ -583,8 +583,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | tests are to be       |        | 3.5.2     |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-ECC only     |        |           |          |
-   |           | test. This mode is    |        |           |          |
-   |           | only valid for        |        |           |          |
+   |           | test. This mode MAY   |        |           |          |
+   |           | only be used for      |        |           |          |
    |           | registrations with    |        |           |          |
    |           | "KAS-ECC" (no mode)   |        |           |          |
    |           |                       |        |           |          |
@@ -592,8 +592,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | tests are to be       |        | 3.5.3     |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-ECC only     |        |           |          |
-   |           | test. This mode is    |        |           |          |
-   |           | only valid for        |        |           |          |
+   |           | test. This mode MAY   |        |           |          |
+   |           | only be used for      |        |           |          |
    |           | registrations with    |        |           |          |
    |           | "KAS-ECC" (no mode)   |        |           |          |
    |           |                       |        |           |          |
@@ -603,7 +603,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.4.2.  Supported KAS ECC Schemes
 
-   The following schemes may be advertised by the ACVP compliant crypto
+   The following schemes MAY be advertised by the ACVP compliant crypto
    module:
 
    o  ephemeralUnified - keyConfirmation not supported
@@ -613,9 +613,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 11]
+Fussell & Hammett         Expires May 11, 2019                 [Page 11]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    o  fullUnified
@@ -633,7 +633,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.5.1.  KAS ECC noKdfNoKc
 
-   Contains properties required for "noKdfNoKc" registration.
+   Contains properties REQUIRED for "noKdfNoKc" registration.
 
    +--------------+---------------------+--------+----------+----------+
    | JSON Value   | Description         | JSON   | Valid    | Optional |
@@ -649,7 +649,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.5.2.  KAS ECC kdfNoKc
 
-   Contains properties required for "kdfNoKc" registration.
+   Contains properties REQUIRED for "kdfNoKc" registration.
 
    +--------------+---------------------+--------+----------+----------+
    | JSON Value   | Description         | JSON   | Valid    | Optional |
@@ -669,14 +669,14 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 12]
+Fussell & Hammett         Expires May 11, 2019                 [Page 12]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 3.5.3.  KAS ECC kdfKc
 
-   Contains properties required for "kdfKc" registration.
+   Contains properties REQUIRED for "kdfKc" registration.
 
    +--------------+---------------------+--------+----------+----------+
    | JSON Value   | Description         | JSON   | Valid    | Optional |
@@ -702,7 +702,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    Each parameter set advertised is a self-contained JSON object using
    the following values.  Note that at least one parameter set ("eb",
-   "ec", "ed", "ee") is required.
+   "ec", "ed", "ee") is REQUIRED.
 
 
 
@@ -725,9 +725,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 13]
+Fussell & Hammett         Expires May 11, 2019                 [Page 13]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +----------+------------------+----------+---------------+----------+
@@ -764,13 +764,11 @@ Internet-Draft                Sym Alg JSON                September 2018
    ee: Len n - 512+, min Len h - 256, min hash len - 512, min keySize -
    256, min macSize - 64
 
-   "noKdfNoKc" requires "hashAlg"
+   "noKdfNoKc" REQUIRES "hashAlg"
 
-   "kdfNoKc" requires "hashAlg" and at least one valid MAC registration
+   "kdfNoKc" REQUIRES "hashAlg" and at least one valid MAC registration
 
-   "kdfKc" requires "hashAlg" and at least one valid MAC registration
-
-
+   "kdfKc" REQUIRES "hashAlg" and at least one valid MAC registration
 
 
 
@@ -781,9 +779,11 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 14]
+
+
+Fussell & Hammett         Expires May 11, 2019                 [Page 14]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +-----------+-----------------------+--------+-----------+----------+
@@ -808,7 +808,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.7.  Supported ECC Curves
 
-   The following ECC Curves may be advertised by the ACVP compliant
+   The following ECC Curves MAY be advertised by the ACVP compliant
    crypto module:
 
                +---------------+-------+---------+--------+
@@ -828,7 +828,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.8.  Supported Hash Algorithm Methods
 
-   The following SHA methods may be advertised by the ACVP compliant
+   The following SHA methods MAY be advertised by the ACVP compliant
    crypto module:
 
    o  SHA2-224
@@ -837,9 +837,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 15]
+Fussell & Hammett         Expires May 11, 2019                 [Page 15]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    o  SHA2-384
@@ -848,7 +848,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.9.  Supported KAS ECC MAC Options
 
-   The following MAC options are available for registration under a
+   The following MAC options MAY be advertised for registration under a
    "kdfNoKc" and "kdfKc" kasMode:
 
    o  AES-CCM
@@ -893,9 +893,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 16]
+Fussell & Hammett         Expires May 11, 2019                 [Page 16]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +----------+-------------+--------+---------------------+-----------+
@@ -907,7 +907,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    |          | keyLens for |        | 192, 256. HashAlg   |           |
    |          | the         |        | based MACs mod 8.   |           |
    |          | selected    |        | All keySizes        |           |
-   |          | MAC.        |        | minimum must        |           |
+   |          | MAC.        |        | minimum MUST        |           |
    |          |             |        | conform to          |           |
    |          |             |        | parameter set       |           |
    |          |             |        | requirements See    |           |
@@ -917,19 +917,19 @@ Internet-Draft                Sym Alg JSON                September 2018
    |          | len for use |        | 56-104, odd byte    | (required |
    |          | with AES-   |        | values only (7-13). | for AES-  |
    |          | CCM mac     |        | Additionally        | CCM)      |
-   |          |             |        | minimum must        |           |
+   |          |             |        | minimum MUST        |           |
    |          |             |        | conform to          |           |
    |          |             |        | parameter set       |           |
    |          |             |        | requirements See    |           |
    |          |             |        | Section 3.6.2 .     |           |
    |          |             |        |                     |           |
    | macLen   | The mac len | value  | Input as bits, mod  | Yes       |
-   |          | for use     |        | 8, minimum must     | (required |
+   |          | for use     |        | 8, minimum MUST     | (required |
    |          | with mac    |        | conform to          | for AES-  |
    |          |             |        | parameter set       | CCM)      |
    |          |             |        | requirements See    |           |
    |          |             |        | Section 3.6.2 ,     |           |
-   |          |             |        | maximum may not     |           |
+   |          |             |        | maximum SHALL NOT   |           |
    |          |             |        | exceed block size.. |           |
    |          |             |        |                     |           |
    +----------+-------------+--------+---------------------+-----------+
@@ -949,9 +949,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 17]
+Fussell & Hammett         Expires May 11, 2019                 [Page 17]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +-----------+-----------------------+-------+------------+----------+
@@ -968,13 +968,13 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.10.1.  Other Information Construction
 
-   Some IUTs require a specific pattern for the OtherInfo portion of the
-   KDFs for KAS.  An "oiPattern" is specified in the KDF registration to
-   accommodate such requirements.  Regardless of the oiPattern
-   specified, the OI bitlength must be 240 for FFC, and 376 for ECC.
-   The OI will be padded with random bits (or the most significant bits
-   utilized) when the specified OI pattern does not meet the bitlength
-   requirement
+   Some IUTs MAY require a specific pattern for the OtherInfo portion of
+   the KDFs for KAS.  An "oiPattern" is specified in the KDF
+   registration to accommodate such requirements.  Regardless of the
+   oiPattern specified, the OI bitlength MUST be 240 for FFC, and 376
+   for ECC.  The OI SHALL be padded with random bits (or the most
+   significant bits utilized) when the specified OI pattern does not
+   meet the bitlength requirement
 
    Pattern candidates:
 
@@ -1005,9 +1005,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 18]
+Fussell & Hammett         Expires May 11, 2019                 [Page 18]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    Evaluated as:
@@ -1061,9 +1061,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 19]
+Fussell & Hammett         Expires May 11, 2019                 [Page 19]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
                 },
@@ -1117,9 +1117,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 20]
+Fussell & Hammett         Expires May 11, 2019                 [Page 20]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 3.13.  Example KAS ECC Component Capabilities JSON Object
@@ -1173,9 +1173,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 21]
+Fussell & Hammett         Expires May 11, 2019                 [Page 21]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 {
@@ -1229,9 +1229,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 22]
+Fussell & Hammett         Expires May 11, 2019                 [Page 22]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 4.  Generation requirements per party per scheme
@@ -1285,9 +1285,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 23]
+Fussell & Hammett         Expires May 11, 2019                 [Page 23]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    | brid | Kc  | iato | ient  | al      |       |       |       | se  |
@@ -1341,9 +1341,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 24]
+Fussell & Hammett         Expires May 11, 2019                 [Page 24]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |      |     |      |       |         |       |       |       |     |
@@ -1397,9 +1397,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 25]
+Fussell & Hammett         Expires May 11, 2019                 [Page 25]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |      | c   | rPar |       |         |       |       |       |     |
@@ -1453,9 +1453,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 26]
+Fussell & Hammett         Expires May 11, 2019                 [Page 26]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    | DhHy | Kdf | Resp | Provi | Unilate | True  | False | False | Fal |
@@ -1509,9 +1509,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 27]
+Fussell & Hammett         Expires May 11, 2019                 [Page 27]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |      |     | tyU  |       |         |       |       |       |     |
@@ -1565,9 +1565,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 28]
+Fussell & Hammett         Expires May 11, 2019                 [Page 28]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    | eFlo | NoK | onde |       |         |       |       |       | se  |
@@ -1621,9 +1621,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 29]
+Fussell & Hammett         Expires May 11, 2019                 [Page 29]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |      |     |      |       |         |       |       |       |     |
@@ -1677,9 +1677,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 30]
+Fussell & Hammett         Expires May 11, 2019                 [Page 30]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +------------+---------------------------------------------+--------+
@@ -1733,9 +1733,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 31]
+Fussell & Hammett         Expires May 11, 2019                 [Page 31]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |                | AFT (Functional)     |                |          |
@@ -1772,53 +1772,53 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | used                 | 3.8            |          |
    |                |                      |                |          |
    | macType        | The MAC being used.  | See Section    | Yes      |
-   |                | Required for         | 3.9            |          |
+   |                | REQUIRED for         | 3.9            |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | keyLen         | The key length of    | See Section    | Yes      |
-   |                | the MAC. Required    | 3.9            |          |
+   |                | the MAC. REQUIRED    | 3.9            |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | nonceAesCcmLen | The nonce length of  | See Section    | Yes      |
    |                | the MAC (applies     | 3.9            |          |
    |                | only to AES-CCM).    |                |          |
-   |                | Required for         |                |          |
+   |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 32]
+Fussell & Hammett         Expires May 11, 2019                 [Page 32]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |                | "kdfKc" modes using  |                |          |
    |                | a AES-CCM MAC.       |                |          |
    |                |                      |                |          |
    | macLen         | The mac length.      | See Section    | Yes      |
-   |                | Required for         | 3.9            |          |
+   |                | REQUIRED for         | 3.9            |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | kdfType        | The KDF being used.  | concatenation, | Yes      |
-   |                | Required for         | asn1           |          |
+   |                | REQUIRED for         | asn1           |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | idServerLen    | The length of the    | value          | Yes      |
-   |                | server ID. Required  |                |          |
+   |                | server ID. REQUIRED  |                |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | idServer       | The server ID.       | value          | Yes      |
-   |                | Required for         |                |          |
+   |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | idIutLen       | The length of the    | value          | Yes      |
-   |                | server ID. Required  |                |          |
+   |                | server ID. REQUIRED  |                |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                | Provided in response |                |          |
@@ -1826,7 +1826,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | tests.               |                |          |
    |                |                      |                |          |
    | idIut          | The server ID.       | value          | Yes      |
-   |                | Required for         |                |          |
+   |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                | Provided in response |                |          |
@@ -1834,26 +1834,26 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | tests.               |                |          |
    |                |                      |                |          |
    | oiPattern      | The oiPattern used   | See Section    | Yes      |
-   |                | in the KDF. Required | 3.10.1         |          |
+   |                | in the KDF. REQUIRED | 3.10.1         |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | kcRole         | Key confirmation     | provider,      | Yes      |
    |                | roles supported.     | recipient      |          |
-   |                | Required for "kdfKc" |                |          |
+   |                | REQUIRED for "kdfKc" |                |          |
    |                | modes.               |                |          |
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 33]
+Fussell & Hammett         Expires May 11, 2019                 [Page 33]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |                |                      |                |          |
    | kcType         | Key confirmation     | unilateral     | Yes      |
    |                | types supported.     | and/or         |          |
-   |                | Required for "kdfKc" | bilateral      |          |
+   |                | REQUIRED for "kdfKc" | bilateral      |          |
    |                | modes.               |                |          |
    |                |                      |                |          |
    | curve          | The curve useds for  | value          | No       |
@@ -1901,9 +1901,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 34]
+Fussell & Hammett         Expires May 11, 2019                 [Page 34]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |                       | coordinate           |         |          |
@@ -1957,9 +1957,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 35]
+Fussell & Hammett         Expires May 11, 2019                 [Page 35]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    | oi                    | OtherInfo field      | value   | Yes      |
@@ -2013,9 +2013,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 36]
+Fussell & Hammett         Expires May 11, 2019                 [Page 36]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    |                       | the Tag.             |         |          |
@@ -2069,9 +2069,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 37]
+Fussell & Hammett         Expires May 11, 2019                 [Page 37]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
                                 "testType": "AFT",
@@ -2125,9 +2125,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 38]
+Fussell & Hammett         Expires May 11, 2019                 [Page 38]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
                                 "kasMode": "kdfNoKc",
@@ -2181,9 +2181,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 39]
+Fussell & Hammett         Expires May 11, 2019                 [Page 39]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
                                         "ephemeralPublicIutY": "216EA3B35E630A1EA4A91C430E5B63306A83624F0FFD8ADFF63A380E",
@@ -2237,9 +2237,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 40]
+Fussell & Hammett         Expires May 11, 2019                 [Page 40]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
                                 "tests": [{
@@ -2293,9 +2293,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 41]
+Fussell & Hammett         Expires May 11, 2019                 [Page 41]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 6.  Test Vector Responses
@@ -2338,50 +2338,6 @@ Internet-Draft                Sym Alg JSON                September 2018
 
               Table 19: Vector Set Group Response JSON Object
 
-   Note. the following bullet lists outline which JSON keywords must be
-   provided for the respective KAS ECC test types in the shared secret
-   generation test vector response.
-
-   ephemeralUnified:
-
-   o  ephemeralPublicIutX
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 42]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
-   o  ephemeralPublicIutY
-
-   o  hashZIut
-
-   fullMqv: TBD
-
-   fullUnified: TBD
-
-   onePassDh
-
-   o  ephemeralPublicIutX
-
-   o  ephemeralPublicIutY
-
-   o  hashZIut
-
-   onePassMqv: TBD
-
-   onePassUnified: TBD
-
-   staticUnified
-
-   o  staticPublicIutX
-
-   o  staticPublicIutY
-
-   o  hashZIut
-
 6.1.  Example Test Results JSON Object
 
    The following is a example JSON object for KAS ECC test results sent
@@ -2390,6 +2346,14 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 [{
                 "acvVersion": <acvp-version>
+
+
+
+Fussell & Hammett         Expires May 11, 2019                 [Page 42]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
         },
         {
                 "vsId": 1564,
@@ -2402,14 +2366,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "ephemeralPublicIutY": "1D746A8F960AE8425C63DE17618362F7040365D9168F21A0762526ECCC556084",
                                         "idIutLen": 40,
                                         "idIut": "A1B2C3D4E5",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 43]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "oiLen": 376,
                                         "oi": "A1B2C3D4E5434156536964CAFECAFEA0988C0EB862E29CBFBD0B087D3223B9052811800B2D1ADF1D42AE73BAAD162A",
                                         "nonceAesCcm": "FF5B0FD5F295257B",
@@ -2446,6 +2402,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                         }
                 ]
         }
+
+
+
+Fussell & Hammett         Expires May 11, 2019                 [Page 43]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
 ]
 
 
@@ -2461,9 +2425,45 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 44]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett         Expires May 11, 2019                 [Page 44]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 [{
@@ -2517,9 +2517,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 45]
+Fussell & Hammett         Expires May 11, 2019                 [Page 45]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 7.1.  ECC CDH Component Capabilities JSON Values
@@ -2573,9 +2573,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 46]
+Fussell & Hammett         Expires May 11, 2019                 [Page 46]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 7.2.  ECC CDH Component TestVectors JSON Values
@@ -2629,9 +2629,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 47]
+Fussell & Hammett         Expires May 11, 2019                 [Page 47]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +----------+------------------+-------+------------------+----------+
@@ -2685,9 +2685,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 48]
+Fussell & Hammett         Expires May 11, 2019                 [Page 48]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +---------------+-------------------------------+--------+----------+
@@ -2741,9 +2741,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 49]
+Fussell & Hammett         Expires May 11, 2019                 [Page 49]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 [{
@@ -2797,9 +2797,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 50]
+Fussell & Hammett         Expires May 11, 2019                 [Page 50]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +------------+---------------------------------------------+--------+
@@ -2853,9 +2853,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 51]
+Fussell & Hammett         Expires May 11, 2019                 [Page 51]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    +------------+-----------------------------------+-------+----------+
@@ -2909,9 +2909,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 52]
+Fussell & Hammett         Expires May 11, 2019                 [Page 52]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 [{
@@ -2965,9 +2965,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 53]
+Fussell & Hammett         Expires May 11, 2019                 [Page 53]
 
-Internet-Draft                Sym Alg JSON                September 2018
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 10.  Security Considerations
@@ -3021,4 +3021,4 @@ Authors' Addresses
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 54]
+Fussell & Hammett         Expires May 11, 2019                 [Page 54]

--- a/artifacts/acvp_sub_kas_ffc.html
+++ b/artifacts/acvp_sub_kas_ffc.html
@@ -378,8 +378,8 @@
 <link href="#rfc.section.1.1" rel="Chapter" title="1.1 Requirements Language">
 <link href="#rfc.section.2" rel="Chapter" title="2 Test Types and Test Coverage">
 <link href="#rfc.section.2.1" rel="Chapter" title="2.1 Test Coverage">
-<link href="#rfc.section.2.1.1" rel="Chapter" title="2.1.1 KAS-FFC Requirements Covered">
-<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 KAS-FFC Requirements Not Covered">
+<link href="#rfc.section.2.1.1" rel="Chapter" title="2.1.1 KAS-ECC Requirements Covered">
+<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 KAS-ECC Requirements Not Covered">
 <link href="#rfc.section.3" rel="Chapter" title="3 Capabilities Registration">
 <link href="#rfc.section.3.1" rel="Chapter" title="3.1 Required Prerequisite Algorithms for KAS FFC Validations">
 <link href="#rfc.section.3.2" rel="Chapter" title="3.2 KAS FFC Algorithm Capabilities JSON Values">
@@ -485,9 +485,9 @@
 </li>
 <ul><li>2.1.   <a href="#rfc.section.2.1">Test Coverage</a>
 </li>
-<ul><li>2.1.1.   <a href="#rfc.section.2.1.1">KAS-FFC Requirements Covered</a>
+<ul><li>2.1.1.   <a href="#rfc.section.2.1.1">KAS-ECC Requirements Covered</a>
 </li>
-<li>2.1.2.   <a href="#rfc.section.2.1.2">KAS-FFC Requirements Not Covered</a>
+<li>2.1.2.   <a href="#rfc.section.2.1.2">KAS-ECC Requirements Not Covered</a>
 </li>
 </ul></ul><li>3.   <a href="#rfc.section.3">Capabilities Registration</a>
 </li>
@@ -575,8 +575,8 @@
 <p id="rfc.section.2.p.1">The ACVP server performs a set of tests on the KAS protocol in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported permutation of KAS capabilities. This section describes the design of the tests used to validate implementations of KAS algorithms. There are two test types for KAS testing: </p>
 
 <ul class="empty">
-<li>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT is expected to act as a party in the Key Agreement with the ACVP server. The server will generate and provide all necessary information for the IUT to perform a successful key agreement; both the server and IUT can act as party U/V, as well as recipient/provider to key confirmation.</li>
-<li>"VAL" - Validation test. In the VAL test mode, The ACVP server generates a complete (from both party U and party V's perspectives) key agreement, and expects the IUT to be able to determine if that agreement is valid. Various types of errors are introduced in varying portions of the key agreement process (like bad DKM, bad key, bad hash, etc), that the IUT should be able to detect and report on.</li>
+<li>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT MUST act as a party in the Key Agreement with the ACVP server. The server SHALL generate and provide all necessary information for the IUT to perform a successful key agreement; both the server and IUT MAY act as party U/V, as well as recipient/provider to key confirmation.</li>
+<li>"VAL" - Validation test. In the VAL test mode, The ACVP server generates a complete (from both party U and party V's perspectives) key agreement, and REQUIRES the IUT to determine if that agreement is valid. Various types of errors SHALL be introduced in varying portions of the key agreement process (changed DKM, changed key, changed hash, etc), that the IUT MUST be able to detect and report on.</li>
 </ul>
 
 <p> </p>
@@ -585,48 +585,48 @@
 </h1>
 <p id="rfc.section.2.1.p.1">The tests described in this document have the intention of ensuring an implementation is conformant to <a href="#SP800-56a" class="xref">[SP800-56a]</a>. </p>
 <h1 id="rfc.section.2.1.1">
-<a href="#rfc.section.2.1.1">2.1.1.</a> <a href="#requirements_covered_kas_ffc" id="requirements_covered_kas_ffc">KAS-FFC Requirements Covered</a>
+<a href="#rfc.section.2.1.1">2.1.1.</a> <a href="#requirements_covered_kas_ecc" id="requirements_covered_kas_ecc">KAS-ECC Requirements Covered</a>
 </h1>
 <p></p>
 
 <ul class="empty">
 <li>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.</li>
 <li>SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.</li>
-<li>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS make use of a hash function. The hash function may be used for confirmation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).</li>
-<li>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is required only for kdfKc, though is utilized for both kdfNoKc and kdfKc.</li>
-<li>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT are expected to be able to generate nonces.</li>
-<li>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation is performed solely from the ACVP server, with constraints from the IUTs capabilities registration. It is expected that the same set of domain parameters will generate all keypairs (party U/V, static/ephemeral) for a single test case.</li>
-<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, shall inject bad keypairs that the IUT should be able detect. These random tests are only present in groups given appropriate assurance functions see: <a href="#supported_functions" class="xref">Section 3.3</a> </li>
-<li>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV is used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.</li>
-<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  All schemes/modes save noKdfNoKc (component) make use of a KDF. KDF construction utilizes <a href="#oiPatternConstruction" class="xref">Section 3.9.1</a> for its pattern. </li>
-<li>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT can be Providers or Recipients of said confirmation. Additionally, key confirmation can be performed on one or both parties (depending on scheme).</li>
+<li>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS SHALL make use of a hash function. The hash function MAY be used for confirmation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).</li>
+<li>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is REQUIRED only for kdfKc, though is utilized for both kdfNoKc and kdfKc.</li>
+<li>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT SHALL be expected to generate nonces.</li>
+<li>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation SHALL be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters SHALL generate all keypairs (party U/V, static/ephemeral) for a single test case.</li>
+<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, MAY inject bad keypairs that the IUT MUST be able detect. These random tests are only present in groups given appropriate assurance functions see: <a href="#supported_functions" class="xref">Section 3.3</a> </li>
+<li>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV SHALL be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.</li>
+<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  All schemes/modes save noKdfNoKc (component) MUST make use of a KDF. KDF construction SHALL utilize <a href="#oiPatternConstruction" class="xref">Section 3.9.1</a> for its pattern. </li>
+<li>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT MAY be Providers or Recipients of said confirmation. Additionally, key confirmation MAY be performed on one or both parties (depending on scheme).</li>
 <li>SP 800-56a - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.</li>
 </ul>
 
 <p> </p>
 <h1 id="rfc.section.2.1.2">
-<a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#requirements_not_covered_kas_ffc" id="requirements_not_covered_kas_ffc">KAS-FFC Requirements Not Covered</a>
+<a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#requirements_not_covered_kas_ecc" id="requirements_not_covered_kas_ecc">KAS-ECC Requirements Not Covered</a>
 </h1>
 <p></p>
 
 <ul class="empty">
-<li>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server does not make a distinction between IUT generated keys via a trusted third party and the IUT itself.</li>
-<li>SP 800-56a - 5.3 Random Number Generation. It is expected the IUT performs all random number generation with a validated random number generator. A DRBG is expected as a prerequisite to KAS, but is out of the scope of testing assurances. </li>
-<li>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.5 are expected to be used, however their generation is out of scope of KAS testing assurances</li>
-<li>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server generates all domain parameters, IUT validation of such parameters is out of scope for KAS testing.</li>
-<li>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter Management is out of scope for KAS testing.</li>
-<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation, assurances, and management of said key-pairs is out of scope for KAS testing.</li>
-<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  Two-step Key-Derivation (Extraction-then-Expansion) is not utilized in KAS testing.</li>
-<li>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as being a valid MAC function; it however is not (currently) supported in KAS testing.</li>
-<li>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective is out of scope.</li>
-<li>SP 800-56a - 8 Key Recovery. Key Recovery is not in scope of KAS testing.</li>
+<li>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server SHALL NOT make a distinction between IUT generated keys via a trusted third party and the IUT itself.</li>
+<li>SP 800-56a - 5.3 Random Number Generation. The IUT MUST perform all random number generation with a validated random number generator. A DRBG is REQUIRED as a prerequisite to KAS, but SHALL NOT be in the scope testing assurances. </li>
+<li>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.5 MUST be used, however their generation SHALL NOT be in scope of KAS testing assurances</li>
+<li>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server SHALL generate all domain parameters, IUT validation of such parameters is SHALL NOT be in scope for KAS testing.</li>
+<li>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter Management SHALL NOT be in scope for KAS testing.</li>
+<li>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs MUST be used in each KAS scheme, the generation, assurances, and management of said key-pairs SHALL NOT be in scope of KAS testing.</li>
+<li>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.  Two-step Key-Derivation (Extraction-then-Expansion) SHALL NOT be utilized in KAS testing.</li>
+<li>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as being a valid MAC function; it however SHALL NOT (currently) be supported in KAS testing.</li>
+<li>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective SHALL NOT be in scope.</li>
+<li>SP 800-56a - 8 Key Recovery. Key Recovery SHALL NOT be in scope of KAS testing.</li>
 </ul>
 
 <p> </p>
 <h1 id="rfc.section.3">
 <a href="#rfc.section.3">3.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
 </h1>
-<p id="rfc.section.3.p.1">ACVP requires crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of KAS FFC algorithms to the ACVP server.</p>
+<p id="rfc.section.3.p.1">ACVP REQUIRES crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process. This section describes the constructs for advertising support of KAS FFC algorithms to the ACVP server.</p>
 <p id="rfc.section.3.p.2">The algorithm capabilities are advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification for details on the registration message. Each KDF algorithm capability advertised is a self-contained JSON object.</p>
 <h1 id="rfc.section.3.1">
 <a href="#rfc.section.3.1">3.1.</a> <a href="#prereq_algs" id="prereq_algs">Required Prerequisite Algorithms for KAS FFC Validations</a>
@@ -700,7 +700,7 @@
 <tbody>
 <tr>
 <td class="left">DRBG</td>
-<td class="left">Always required</td>
+<td class="left">Always REQUIRED</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -708,7 +708,7 @@
 </tr>
 <tr>
 <td class="left">SHA</td>
-<td class="left">Always required</td>
+<td class="left">Always REQUIRED</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -716,7 +716,7 @@
 </tr>
 <tr>
 <td class="left">DSA</td>
-<td class="left">DSA.PQGGen validation required when IUT using assurance function of "dpGen".  DSA.PQGVer validation required when IUT using assurance function of "dpVal".  DSA.KeyPairGen validation required when IUT using assurances functions of "keyPairGen", or "keyRegen". </td>
+<td class="left">DSA.PQGGen validation REQUIRED when IUT using assurance function of "dpGen".  DSA.PQGVer validation REQUIRED when IUT using assurance function of "dpVal".  DSA.KeyPairGen validation REQUIRED when IUT using assurances functions of "keyPairGen", or "keyRegen". </td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -724,7 +724,7 @@
 </tr>
 <tr>
 <td class="left">AES-CCM</td>
-<td class="left">AES-CCM validation required when IUT is performing KeyConfirmation (KC) and utilizing AES-CCM.</td>
+<td class="left">AES-CCM validation REQUIRED when IUT is performing KeyConfirmation (KC) and utilizing AES-CCM.</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -732,7 +732,7 @@
 </tr>
 <tr>
 <td class="left">CMAC</td>
-<td class="left">CMAC validation required when IUT is performing KeyConfirmation (KC) and utilizing CMAC.</td>
+<td class="left">CMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and utilizing CMAC.</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -740,7 +740,7 @@
 </tr>
 <tr>
 <td class="left">HMAC</td>
-<td class="left">HMAC validation required when IUT is performing KeyConfirmation (KC) and utilizing HMAC.</td>
+<td class="left">HMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and utilizing HMAC.</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -836,11 +836,11 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.3.2.p.2">Note: Some optional values are required depending on the algorithm. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</p>
+<p id="rfc.section.3.2.p.2">Note: Some optional values are REQUIRED depending on the algorithm. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</p>
 <h1 id="rfc.section.3.3">
 <a href="#rfc.section.3.3">3.3.</a> <a href="#supported_functions" id="supported_functions">Supported KAS FFC Functions</a>
 </h1>
-<p id="rfc.section.3.3.p.1">The following function types may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.3.p.1">The following function types MAY be advertised by the ACVP compliant crypto module:</p>
 <p></p>
 
 <ul>
@@ -859,7 +859,7 @@
 <h1 id="rfc.section.3.4.1">
 <a href="#rfc.section.3.4.1">3.4.1.</a> <a href="#supported_schemes" id="supported_schemes">KAS FFC Scheme Capabilities JSON Values</a>
 </h1>
-<p id="rfc.section.3.4.1.p.1">All other scheme capability advertised is a self-contained JSON object using the following values. Note that at least one of "noKdfNoKc", "kdfNoKc", or "kdfKc" must be supplied with the registration. See <a href="#supported_scheme_values" class="xref">Section 3.4.2</a> for allowed FFC scheme types. </p>
+<p id="rfc.section.3.4.1.p.1">All other scheme capabilities are advertised is a self-contained JSON object using the following values. Note that at least one of "noKdfNoKc", "kdfNoKc", or "kdfKc" MUST be supplied with the registration. See <a href="#supported_scheme_values" class="xref">Section 3.4.2</a> for allowed FFC scheme types. </p>
 <div id="rfc.table.4"></div>
 <div id="scheme_caps_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -888,7 +888,7 @@
 </tr>
 <tr>
 <td class="left">noKdfNoKc</td>
-<td class="left">Indicates no KDF, no KC tests are to be generated. Note this is a COMPONENT mode only test. This property can only be used with "KAS-FFC" / "Component"</td>
+<td class="left">Indicates no KDF, no KC tests are to be generated. Note this is a COMPONENT mode only test. This property MUST only be used with "KAS-FFC" / "Component"</td>
 <td class="left">object</td>
 <td class="left">
 <a href="#noKdfNoKc" class="xref">Section 3.5.1</a> </td>
@@ -903,7 +903,7 @@
 </tr>
 <tr>
 <td class="left">kdfNoKc</td>
-<td class="left">Indicates KDF, no KC tests are to be generated. Note this is a KAS-FFC only test. This mode is only valid for registrations with "KAS-FFC" (no mode)</td>
+<td class="left">Indicates KDF, no KC tests are to be generated. Note this is a KAS-FFC only test. This mode MUST only be used for registrations with "KAS-FFC" (no mode)</td>
 <td class="left">object</td>
 <td class="left">
 <a href="#kdfNoKc" class="xref">Section 3.5.2</a> </td>
@@ -918,7 +918,7 @@
 </tr>
 <tr>
 <td class="left">kdfKc</td>
-<td class="left">Indicates KDF, KC tests are to be generated.</td>
+<td class="left">Indicates KDF, KC tests are to be generated. Note this is a KAS-FFC only test. This mode MAY only be used for registrations with "KAS-FFC" (no mode)</td>
 <td class="left">object</td>
 <td class="left">
 <a href="#kdfKc" class="xref">Section 3.5.3</a> </td>
@@ -936,7 +936,7 @@
 <h1 id="rfc.section.3.4.2">
 <a href="#rfc.section.3.4.2">3.4.2.</a> <a href="#supported_scheme_values" id="supported_scheme_values">Supported KAS FFC Schemes</a>
 </h1>
-<p id="rfc.section.3.4.2.p.1">The following schemes may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.4.2.p.1">The following schemes MAY be advertised by the ACVP compliant crypto module:</p>
 <p></p>
 
 <ul>
@@ -956,7 +956,7 @@
 <h1 id="rfc.section.3.5.1">
 <a href="#rfc.section.3.5.1">3.5.1.</a> <a href="#noKdfNoKc" id="noKdfNoKc">KAS FFC noKdfNoKc</a>
 </h1>
-<p id="rfc.section.3.5.1.p.1">Contains properties required for "noKdfNoKc" registration. </p>
+<p id="rfc.section.3.5.1.p.1">Contains properties REQUIRED for "noKdfNoKc" registration. </p>
 <div id="rfc.table.5"></div>
 <div id="noKdfNoKc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -989,7 +989,7 @@
 <h1 id="rfc.section.3.5.2">
 <a href="#rfc.section.3.5.2">3.5.2.</a> <a href="#kdfNoKc" id="kdfNoKc">KAS FFC kdfNoKc</a>
 </h1>
-<p id="rfc.section.3.5.2.p.1">Contains properties required for "kdfNoKc" registration. </p>
+<p id="rfc.section.3.5.2.p.1">Contains properties REQUIRED for "kdfNoKc" registration. </p>
 <div id="rfc.table.6"></div>
 <div id="kdfNoKc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1037,7 +1037,7 @@
 <h1 id="rfc.section.3.5.3">
 <a href="#rfc.section.3.5.3">3.5.3.</a> <a href="#kdfKc" id="kdfKc">KAS FFC kdfKc</a>
 </h1>
-<p id="rfc.section.3.5.3.p.1">Contains properties required for "kdfKc" registration. </p>
+<p id="rfc.section.3.5.3.p.1">Contains properties REQUIRED for "kdfKc" registration. </p>
 <div id="rfc.table.7"></div>
 <div id="kdfKc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1103,7 +1103,7 @@
 <h1 id="rfc.section.3.6.1">
 <a href="#rfc.section.3.6.1">3.6.1.</a> <a href="#parameter_set" id="parameter_set">KAS FFC Parameter Set</a>
 </h1>
-<p id="rfc.section.3.6.1.p.1">Each parameter set advertised is a self-contained JSON object using the following values. Note that at least one parameter set ("fb", "fc") is required.</p>
+<p id="rfc.section.3.6.1.p.1">Each parameter set advertised is a self-contained JSON object using the following values. Note that at least one parameter set ("fb", "fc") MUST be provided.</p>
 <div id="rfc.table.8"></div>
 <div id="parameter_set_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1152,9 +1152,9 @@
 <p id="rfc.section.3.6.2.p.1">fb/fc changes minimum allowed values on options.</p>
 <p id="rfc.section.3.6.2.p.2">fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112, min macSize - 64</p>
 <p id="rfc.section.3.6.2.p.3">fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min macSize - 64</p>
-<p id="rfc.section.3.6.2.p.4">"noKdfNoKc" requires "hashAlg"</p>
-<p id="rfc.section.3.6.2.p.5">"kdfNoKc" requires "hashAlg" and at least one valid MAC registration</p>
-<p id="rfc.section.3.6.2.p.6">"kdfKc" requires "hashAlg" and at least one valid MAC registration</p>
+<p id="rfc.section.3.6.2.p.4">"noKdfNoKc" REQUIRES "hashAlg"</p>
+<p id="rfc.section.3.6.2.p.5">"kdfNoKc" REQUIRES "hashAlg" and at least one valid MAC registration</p>
+<p id="rfc.section.3.6.2.p.6">"kdfKc" REQUIRES "hashAlg" and at least one valid MAC registration</p>
 <div id="rfc.table.9"></div>
 <div id="parameter_set_details_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1200,7 +1200,7 @@
 <h1 id="rfc.section.3.7">
 <a href="#rfc.section.3.7">3.7.</a> <a href="#supported_hashAlg" id="supported_hashAlg">Supported Hash Algorithm Methods</a>
 </h1>
-<p id="rfc.section.3.7.p.1">The following SHA methods may be advertised by the ACVP compliant crypto module:</p>
+<p id="rfc.section.3.7.p.1">The following SHA methods MAY be advertised by the ACVP compliant crypto module:</p>
 <p></p>
 
 <ul>
@@ -1214,7 +1214,7 @@
 <h1 id="rfc.section.3.8">
 <a href="#rfc.section.3.8">3.8.</a> <a href="#supported_macOption" id="supported_macOption">Supported KAS FFC MAC Options</a>
 </h1>
-<p id="rfc.section.3.8.p.1">The following MAC options are available for registration under a "kdfNoKc" and "kdfKc" kasMode:</p>
+<p id="rfc.section.3.8.p.1">The following MAC options MAY be advertised for registration under a "kdfNoKc" and "kdfKc" kasMode:</p>
 <p></p>
 
 <ul>
@@ -1243,7 +1243,7 @@
 <td class="left">keyLen</td>
 <td class="left">The supported keyLens for the selected MAC.</td>
 <td class="left">Domain</td>
-<td class="left">AES based MACs limited to 128, 192, 256. HashAlg based MACs mod 8. All keySizes minimum must conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
+<td class="left">AES based MACs limited to 128, 192, 256. HashAlg based MACs mod 8. All keySizes minimum MUST conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -1257,8 +1257,8 @@
 <td class="left">nonceLen</td>
 <td class="left">The nonce len for use with AES-CCM mac</td>
 <td class="left">value</td>
-<td class="left">Input as bits, 56-104, odd byte values only (7-13). Additionally minimum must conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
-<td class="left">Yes (required for AES-CCM)</td>
+<td class="left">Input as bits, 56-104, odd byte values only (7-13). Additionally minimum MUST conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> . </td>
+<td class="left">Yes (REQUIRED for AES-CCM)</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1271,8 +1271,8 @@
 <td class="left">macLen</td>
 <td class="left">The mac len for use with mac</td>
 <td class="left">value</td>
-<td class="left">Input as bits, mod 8, minimum must conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> , maximum may not exceed block size.. </td>
-<td class="left">Yes (required for AES-CCM)</td>
+<td class="left">Input as bits, mod 8, minimum MUST conform to parameter set requirements See <a href="#parameter_set_details" class="xref">Section 3.6.2</a> , maximum MAY NOT exceed block size.. </td>
+<td class="left">Yes (REQUIRED for AES-CCM)</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1326,7 +1326,7 @@
 <h1 id="rfc.section.3.9.1">
 <a href="#rfc.section.3.9.1">3.9.1.</a> <a href="#oiPatternConstruction" id="oiPatternConstruction">Other Information Construction</a>
 </h1>
-<p id="rfc.section.3.9.1.p.1">Some IUTs require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength must be 240 for FFC, and 376 for ECC. The OI will be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement </p>
+<p id="rfc.section.3.9.1.p.1">Some IUTs MAY require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength MUST be 240 for FFC, and 376 for ECC. The OI will be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement </p>
 <p id="rfc.section.3.9.1.p.2">Pattern candidates:</p>
 <p></p>
 
@@ -3236,7 +3236,7 @@
 <h1 id="rfc.section.5.1">
 <a href="#rfc.section.5.1">5.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.5.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.5.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size MAY be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
 <p id="rfc.section.5.1.p.2">The test group for KAS FFC is as follows:</p>
 <div id="rfc.table.15"></div>
 <div id="vs_tg_table5"></div>
@@ -3335,7 +3335,7 @@
 </tr>
 <tr>
 <td class="left">macType</td>
-<td class="left">The MAC being used. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The MAC being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.8</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3347,7 +3347,7 @@
 </tr>
 <tr>
 <td class="left">keyLen</td>
-<td class="left">The key length of the MAC. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The key length of the MAC. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.8</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3359,7 +3359,7 @@
 </tr>
 <tr>
 <td class="left">nonceAesCcmLen</td>
-<td class="left">The nonce length of the MAC (applies only to AES-CCM). Required for "kdfNoKc" and "kdfKc" modes using a AES-CCM MAC.</td>
+<td class="left">The nonce length of the MAC (applies only to AES-CCM). REQUIRED for "kdfNoKc" and "kdfKc" modes using a AES-CCM MAC.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.8</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3371,7 +3371,7 @@
 </tr>
 <tr>
 <td class="left">macLen</td>
-<td class="left">The mac length. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The mac length. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#supported_macOption" class="xref">Section 3.8</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3383,7 +3383,7 @@
 </tr>
 <tr>
 <td class="left">kdfType</td>
-<td class="left">The KDF being used. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The KDF being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">concatenation, asn1</td>
 <td class="left">Yes</td>
 </tr>
@@ -3395,7 +3395,7 @@
 </tr>
 <tr>
 <td class="left">idServerLen</td>
-<td class="left">The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3407,7 +3407,7 @@
 </tr>
 <tr>
 <td class="left">idServer</td>
-<td class="left">The server ID. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3419,7 +3419,7 @@
 </tr>
 <tr>
 <td class="left">idIutLen</td>
-<td class="left">The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.  Provided in response by IUT for AFT tests.</td>
+<td class="left">The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.  Provided in response by IUT for AFT tests.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3431,7 +3431,7 @@
 </tr>
 <tr>
 <td class="left">idIut</td>
-<td class="left">The server ID. Required for "kdfNoKc" and "kdfKc" modes. Provided in response by IUT for AFT tests.</td>
+<td class="left">The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes. Provided in response by IUT for AFT tests.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -3443,7 +3443,7 @@
 </tr>
 <tr>
 <td class="left">oiPattern</td>
-<td class="left">The oiPattern used in the KDF. Required for "kdfNoKc" and "kdfKc" modes.</td>
+<td class="left">The oiPattern used in the KDF. For "kdfNoKc" and "kdfKc" modes.</td>
 <td class="left">See <a href="#oiPatternConstruction" class="xref">Section 3.9.1</a> </td>
 <td class="left">Yes</td>
 </tr>
@@ -3455,7 +3455,7 @@
 </tr>
 <tr>
 <td class="left">kcRole</td>
-<td class="left">Key confirmation roles supported. Required for "kdfKc" modes.</td>
+<td class="left">Key confirmation roles supported. REQUIRED for "kdfKc" modes.</td>
 <td class="left">provider, recipient</td>
 <td class="left">Yes</td>
 </tr>
@@ -3467,7 +3467,7 @@
 </tr>
 <tr>
 <td class="left">kcType</td>
-<td class="left">Key confirmation types supported. Required for "kdfKc" modes.</td>
+<td class="left">Key confirmation types supported. REQUIRED for "kdfKc" modes.</td>
 <td class="left">unilateral and/or bilateral</td>
 <td class="left">Yes</td>
 </tr>
@@ -3586,7 +3586,7 @@
 </tr>
 <tr>
 <td class="left">nonceNoKc</td>
-<td class="left">The 16 byte nonce concatenated to the "Standard Test Message". Used for No Key Confirmation tests only.</td>
+<td class="left">The 16 byte nonce concatenated to the "Standard Test Message". REQUIRED for No Key Confirmation tests only.</td>
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
@@ -4632,7 +4632,7 @@
 <h1 id="rfc.section.6">
 <a href="#rfc.section.6">6.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
 </h1>
-<p id="rfc.section.6.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<p id="rfc.section.6.p.1">After the ACVP client downloads and processes a vector set, it SHALL send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
 <div id="rfc.table.17"></div>
 <div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">

--- a/artifacts/acvp_sub_kas_ffc.txt
+++ b/artifacts/acvp_sub_kas_ffc.txt
@@ -64,8 +64,8 @@ Table of Contents
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
    2.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .   3
      2.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .   4
-       2.1.1.  KAS-FFC Requirements Covered  . . . . . . . . . . . .   4
-       2.1.2.  KAS-FFC Requirements Not Covered  . . . . . . . . . .   5
+       2.1.1.  KAS-ECC Requirements Covered  . . . . . . . . . . . .   4
+       2.1.2.  KAS-ECC Requirements Not Covered  . . . . . . . . . .   5
    3.  Capabilities Registration . . . . . . . . . . . . . . . . . .   6
      3.1.  Required Prerequisite Algorithms for KAS FFC Validations    6
      3.2.  KAS FFC Algorithm Capabilities JSON Values  . . . . . . .   8
@@ -73,34 +73,34 @@ Table of Contents
      3.4.  KAS FFC Schemes . . . . . . . . . . . . . . . . . . . . .  10
        3.4.1.  KAS FFC Scheme Capabilities JSON Values . . . . . . .  10
        3.4.2.  Supported KAS FFC Schemes . . . . . . . . . . . . . .  11
-     3.5.  KAS FFC Modes . . . . . . . . . . . . . . . . . . . . . .  11
-       3.5.1.  KAS FFC noKdfNoKc . . . . . . . . . . . . . . . . . .  11
-       3.5.2.  KAS FFC kdfNoKc . . . . . . . . . . . . . . . . . . .  11
-       3.5.3.  KAS FFC kdfKc . . . . . . . . . . . . . . . . . . . .  12
-     3.6.  Parameter Sets  . . . . . . . . . . . . . . . . . . . . .  12
-       3.6.1.  KAS FFC Parameter Set . . . . . . . . . . . . . . . .  12
-       3.6.2.  KAS FFC Parameter Set Details . . . . . . . . . . . .  13
+     3.5.  KAS FFC Modes . . . . . . . . . . . . . . . . . . . . . .  12
+       3.5.1.  KAS FFC noKdfNoKc . . . . . . . . . . . . . . . . . .  12
+       3.5.2.  KAS FFC kdfNoKc . . . . . . . . . . . . . . . . . . .  12
+       3.5.3.  KAS FFC kdfKc . . . . . . . . . . . . . . . . . . . .  13
+     3.6.  Parameter Sets  . . . . . . . . . . . . . . . . . . . . .  13
+       3.6.1.  KAS FFC Parameter Set . . . . . . . . . . . . . . . .  13
+       3.6.2.  KAS FFC Parameter Set Details . . . . . . . . . . . .  14
      3.7.  Supported Hash Algorithm Methods  . . . . . . . . . . . .  14
-     3.8.  Supported KAS FFC MAC Options . . . . . . . . . . . . . .  14
-     3.9.  Supported KAS FFC KDF Options . . . . . . . . . . . . . .  15
-       3.9.1.  Other Information Construction  . . . . . . . . . . .  16
-     3.10. Supported KAS FFC KC Options  . . . . . . . . . . . . . .  17
-     3.11. Example KAS FFC Capabilities JSON Object  . . . . . . . .  17
-     3.12. Example KAS FFC Component Capabilities JSON Object  . . .  20
-   4.  Generation requirements per party per scheme  . . . . . . . .  21
-   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  29
-     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  30
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  33
-     5.3.  Example Test Vectors JSON Object  . . . . . . . . . . . .  36
-     5.4.  Example Test Vectors Component JSON Object  . . . . . . .  50
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  52
-     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  53
-     6.2.  Example Test Results Component JSON Object  . . . . . . .  58
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  59
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  59
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  59
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  59
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  60
+     3.8.  Supported KAS FFC MAC Options . . . . . . . . . . . . . .  15
+     3.9.  Supported KAS FFC KDF Options . . . . . . . . . . . . . .  16
+       3.9.1.  Other Information Construction  . . . . . . . . . . .  17
+     3.10. Supported KAS FFC KC Options  . . . . . . . . . . . . . .  18
+     3.11. Example KAS FFC Capabilities JSON Object  . . . . . . . .  18
+     3.12. Example KAS FFC Component Capabilities JSON Object  . . .  21
+   4.  Generation requirements per party per scheme  . . . . . . . .  22
+   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  30
+     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  31
+     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  34
+     5.3.  Example Test Vectors JSON Object  . . . . . . . . . . . .  37
+     5.4.  Example Test Vectors Component JSON Object  . . . . . . .  51
+   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  53
+     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  54
+     6.2.  Example Test Results Component JSON Object  . . . . . . .  59
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  60
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  60
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  60
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  60
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  61
 
 
 
@@ -145,20 +145,20 @@ Internet-Draft                Sym Alg JSON                September 2018
    implementations of KAS algorithms.  There are two test types for KAS
    testing:
 
-      "AFT" - Algorithm Function Test.  In the AFT test mode, the IUT is
-      expected to act as a party in the Key Agreement with the ACVP
-      server.  The server will generate and provide all necessary
-      information for the IUT to perform a successful key agreement;
-      both the server and IUT can act as party U/V, as well as
-      recipient/provider to key confirmation.
+      "AFT" - Algorithm Function Test.  In the AFT test mode, the IUT
+      MUST act as a party in the Key Agreement with the ACVP server.
+      The server SHALL generate and provide all necessary information
+      for the IUT to perform a successful key agreement; both the server
+      and IUT MAY act as party U/V, as well as recipient/provider to key
+      confirmation.
 
       "VAL" - Validation test.  In the VAL test mode, The ACVP server
       generates a complete (from both party U and party V's
-      perspectives) key agreement, and expects the IUT to be able to
-      determine if that agreement is valid.  Various types of errors are
-      introduced in varying portions of the key agreement process (like
-      bad DKM, bad key, bad hash, etc), that the IUT should be able to
-      detect and report on.
+      perspectives) key agreement, and REQUIRES the IUT to determine if
+      that agreement is valid.  Various types of errors SHALL be
+      introduced in varying portions of the key agreement process
+      (changed DKM, changed key, changed hash, etc), that the IUT MUST
+      be able to detect and report on.
 
 
 
@@ -175,7 +175,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    The tests described in this document have the intention of ensuring
    an implementation is conformant to [SP800-56a].
 
-2.1.1.  KAS-FFC Requirements Covered
+2.1.1.  KAS-ECC Requirements Covered
 
       SP 800-56a - 4.1 Key Establishment Preparations.  The ACVP server
       is responsible for generating domain parameters as per the IUT's
@@ -187,36 +187,36 @@ Internet-Draft                Sym Alg JSON                September 2018
       of steps depicted in "Figure 2: Key Agreement process" can vary.
 
       SP 800-56a - 5.1 Cryptographic Hash Functions.  All modes of
-      performing KAS make use of a hash function.  The hash function may
-      be used for confirmation of a successfully generated shared secret
-      Z (noKdfNoKc), or as a primitive within the KDF being tested
-      (kdfNoKc and kdfKc).
+      performing KAS SHALL make use of a hash function.  The hash
+      function MAY be used for confirmation of a successfully generated
+      shared secret Z (noKdfNoKc), or as a primitive within the KDF
+      being tested (kdfNoKc and kdfKc).
 
       SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm.  A
       MAC is utilized for confirmation of success for kdfNoKc and kdfKc
-      modes of KAS.  Note - a MAC prerequisite is required only for
+      modes of KAS.  Note - a MAC prerequisite is REQUIRED only for
       kdfKc, though is utilized for both kdfNoKc and kdfKc.
 
       SP 800-56a - 5.4 Nonce.  Nonces are made use of in various KAS
-      schemes - both the ACVP server and IUT are expected to be able to
+      schemes - both the ACVP server and IUT SHALL be expected to
       generate nonces.
 
       SP 800-56a - 5.6 Domain Parameters.  Domain Parameter Generation
-      is performed solely from the ACVP server, with constraints from
-      the IUTs capabilities registration.  It is expected that the same
-      set of domain parameters will generate all keypairs (party U/V,
-      static/ephemeral) for a single test case.
+      SHALL be performed solely from the ACVP server, with constraints
+      from the IUTs capabilities registration.  The same set of domain
+      parameters SHALL generate all keypairs (party U/V, static/
+      ephemeral) for a single test case.
 
       SP 800-56a - 5.6 Key-Pair Generation.  While Key-Pairs are used in
       each KAS scheme, the generation of said key-pairs is out of scope
-      for KAS testing.  Random tests from the VAL groups, shall inject
-      bad keypairs that the IUT should be able detect.  These random
-      tests are only present in groups given appropriate assurance
-      functions see: Section 3.3
+      for KAS testing.  Random tests from the VAL groups, MAY inject bad
+      keypairs that the IUT MUST be able detect.  These random tests are
+      only present in groups given appropriate assurance functions see:
+      Section 3.3
 
       SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC
       Primitives.  Depending on the scheme used, either Diffie Hellman
-      or MQV is used to negotiate a shared secret of z.  Testing and
+      or MQV SHALL be used to negotiate a shared secret of z.  Testing
 
 
 
@@ -226,54 +226,54 @@ Fussell & Hammett         Expires March 5, 2019                 [Page 4]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
-      validation of such key exchanges is covered under their respective
-      schemes.
+      and validation of such key exchanges is covered under their
+      respective schemes.
 
       SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-      All schemes/modes save noKdfNoKc (component) make use of a KDF.
-      KDF construction utilizes Section 3.9.1 for its pattern.
+      All schemes/modes save noKdfNoKc (component) MUST make use of a
+      KDF.  KDF construction SHALL utilize Section 3.9.1 for its
+      pattern.
 
       SP 800-56a - 5.9 Key Confirmation.  Most KAS schemes allow for a
-      Key Confirmation process, the ACVP server and IUT can be Providers
+      Key Confirmation process, the ACVP server and IUT MAY be Providers
       or Recipients of said confirmation.  Additionally, key
-      confirmation can be performed on one or both parties (depending on
+      confirmation MAY be performed on one or both parties (depending on
       scheme).
 
       SP 800-56a - 6 Key Agreement Schemes.  All schemes specified in
       referenced document are supported for validation with the ACVP
       server.
 
-2.1.2.  KAS-FFC Requirements Not Covered
+2.1.2.  KAS-ECC Requirements Not Covered
 
       SP 800-56a - 4.1 Key Establishment Preparations.  The ACVP server
-      does not make a distinction between IUT generated keys via a
+      SHALL NOT make a distinction between IUT generated keys via a
       trusted third party and the IUT itself.
 
-      SP 800-56a - 5.3 Random Number Generation.  It is expected the IUT
-      performs all random number generation with a validated random
-      number generator.  A DRBG is expected as a prerequisite to KAS,
-      but is out of the scope of testing assurances.
+      SP 800-56a - 5.3 Random Number Generation.  The IUT MUST perform
+      all random number generation with a validated random number
+      generator.  A DRBG is REQUIRED as a prerequisite to KAS, but SHALL
+      NOT be in the scope testing assurances.
 
       SP 800-56a - 5.4 Nonce.  Nonce generation is utilized for several
       schemes.  The various methods of generating a nonce described in
-      section 5.5 are expected to be used, however their generation is
-      out of scope of KAS testing assurances
+      section 5.5 MUST be used, however their generation SHALL NOT be in
+      scope of KAS testing assurances
 
       SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity.  The
-      ACVP server generates all domain parameters, IUT validation of
-      such parameters is out of scope for KAS testing.
+      ACVP server SHALL generate all domain parameters, IUT validation
+      of such parameters is SHALL NOT be in scope for KAS testing.
 
       SP 800-56a - 5.5.3 Domain Parameter Management.  Domain Parameter
-      Management is out of scope for KAS testing.
+      Management SHALL NOT be in scope for KAS testing.
 
-      SP 800-56a - 5.6 Key-Pair Generation.  While Key-Pairs are used in
-      each KAS scheme, the generation, assurances, and management of
-      said key-pairs is out of scope for KAS testing.
+      SP 800-56a - 5.6 Key-Pair Generation.  While Key-Pairs MUST be
+      used in each KAS scheme, the generation, assurances, and
+      management of said key-pairs SHALL NOT be in scope of KAS testing.
 
       SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-      Two-step Key-Derivation (Extraction-then-Expansion) is not
+      Two-step Key-Derivation (Extraction-then-Expansion) SHALL NOT be
       utilized in KAS testing.
-
 
 
 
@@ -283,20 +283,20 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
       SP 800-56a - 5.9 Key Confirmation.  KMAC is referenced in 800-56a
-      as being a valid MAC function; it however is not (currently)
+      as being a valid MAC function; it however SHALL NOT (currently) be
       supported in KAS testing.
 
       SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme.  It is
       expected that the IUT registers all schemes it supports in its
       capabilities registration.  Selecting specific schemes from a KAS
-      testing perspective is out of scope.
+      testing perspective SHALL NOT be in scope.
 
-      SP 800-56a - 8 Key Recovery.  Key Recovery is not in scope of KAS
-      testing.
+      SP 800-56a - 8 Key Recovery.  Key Recovery SHALL NOT be in scope
+      of KAS testing.
 
 3.  Capabilities Registration
 
-   ACVP requires crypto modules to register their capabilities.  This
+   ACVP REQUIRES crypto modules to register their capabilities.  This
    allows the crypto module to advertise support for specific
    algorithms, notifying the ACVP server which algorithms need test
    vectors generated for the validation process.  This section describes
@@ -398,24 +398,24 @@ Internet-Draft                Sym Alg JSON                September 2018
    | Prerequisite | Condition                                          |
    | Algorithm    |                                                    |
    +--------------+----------------------------------------------------+
-   | DRBG         | Always required                                    |
+   | DRBG         | Always REQUIRED                                    |
    |              |                                                    |
-   | SHA          | Always required                                    |
+   | SHA          | Always REQUIRED                                    |
    |              |                                                    |
-   | DSA          | DSA.PQGGen validation required when IUT using      |
+   | DSA          | DSA.PQGGen validation REQUIRED when IUT using      |
    |              | assurance function of "dpGen".  DSA.PQGVer         |
-   |              | validation required when IUT using assurance       |
+   |              | validation REQUIRED when IUT using assurance       |
    |              | function of "dpVal".  DSA.KeyPairGen validation    |
-   |              | required when IUT using assurances functions of    |
+   |              | REQUIRED when IUT using assurances functions of    |
    |              | "keyPairGen", or "keyRegen".                       |
    |              |                                                    |
-   | AES-CCM      | AES-CCM validation required when IUT is performing |
+   | AES-CCM      | AES-CCM validation REQUIRED when IUT is performing |
    |              | KeyConfirmation (KC) and utilizing AES-CCM.        |
    |              |                                                    |
-   | CMAC         | CMAC validation required when IUT is performing    |
+   | CMAC         | CMAC validation REQUIRED when IUT is performing    |
    |              | KeyConfirmation (KC) and utilizing CMAC.           |
    |              |                                                    |
-   | HMAC         | HMAC validation required when IUT is performing    |
+   | HMAC         | HMAC validation REQUIRED when IUT is performing    |
    |              | KeyConfirmation (KC) and utilizing HMAC.           |
    |              |                                                    |
    +--------------+----------------------------------------------------+
@@ -480,13 +480,13 @@ Internet-Draft                Sym Alg JSON                September 2018
 
                  Table 3: KAS FFC Capabilities JSON Values
 
-   Note: Some optional values are required depending on the algorithm.
+   Note: Some optional values are REQUIRED depending on the algorithm.
    Failure to provide these values will result in the ACVP server
    returning an error to the ACVP client during registration.
 
 3.3.  Supported KAS FFC Functions
 
-   The following function types may be advertised by the ACVP compliant
+   The following function types MAY be advertised by the ACVP compliant
    crypto module:
 
    o  dpGen - IUT can perform domain parameter generation (FFC only)
@@ -516,10 +516,51 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.4.1.  KAS FFC Scheme Capabilities JSON Values
 
-   All other scheme capability advertised is a self-contained JSON
+   All other scheme capabilities are advertised is a self-contained JSON
    object using the following values.  Note that at least one of
-   "noKdfNoKc", "kdfNoKc", or "kdfKc" must be supplied with the
+   "noKdfNoKc", "kdfNoKc", or "kdfKc" MUST be supplied with the
    registration.  See Section 3.4.2 for allowed FFC scheme types.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 10]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
 
    +-----------+-----------------------+--------+-----------+----------+
    | JSON      | Description           | JSON   | Valid     | Optional |
@@ -534,7 +575,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | generated. Note this  |        |           |          |
    |           | is a COMPONENT mode   |        |           |          |
    |           | only test. This       |        |           |          |
-   |           | property can only be  |        |           |          |
+   |           | property MUST only be |        |           |          |
    |           | used with "KAS-FFC" / |        |           |          |
    |           | "Component"           |        |           |          |
    |           |                       |        |           |          |
@@ -542,34 +583,40 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | tests are to be       |        | 3.5.2     |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-FFC only     |        |           |          |
-   |           | test. This mode is    |        |           |          |
-   |           | only valid for        |        |           |          |
+   |           | test. This mode MUST  |        |           |          |
+   |           | only be used for      |        |           |          |
    |           | registrations with    |        |           |          |
    |           | "KAS-FFC" (no mode)   |        |           |          |
    |           |                       |        |           |          |
    | kdfKc     | Indicates KDF, KC     | object | Section   | Yes      |
    |           | tests are to be       |        | 3.5.3     |          |
-   |           | generated.            |        |           |          |
+   |           | generated. Note this  |        |           |          |
+   |           | is a KAS-FFC only     |        |           |          |
+   |           | test. This mode MAY   |        |           |          |
+   |           | only be used for      |        |           |          |
+   |           | registrations with    |        |           |          |
+   |           | "KAS-FFC" (no mode)   |        |           |          |
    |           |                       |        |           |          |
    +-----------+-----------------------+--------+-----------+----------+
 
                  Table 4: KAS FFC Capabilities JSON Values
 
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 10]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
 3.4.2.  Supported KAS FFC Schemes
 
-   The following schemes may be advertised by the ACVP compliant crypto
+   The following schemes MAY be advertised by the ACVP compliant crypto
    module:
 
    o  dhHybrid1
 
    o  MQV2
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 11]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
 
    o  dhEphem - KeyConfirmation not supported.
 
@@ -586,7 +633,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.5.1.  KAS FFC noKdfNoKc
 
-   Contains properties required for "noKdfNoKc" registration.
+   Contains properties REQUIRED for "noKdfNoKc" registration.
 
    +--------------+---------------------+--------+----------+----------+
    | JSON Value   | Description         | JSON   | Valid    | Optional |
@@ -602,21 +649,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.5.2.  KAS FFC kdfNoKc
 
-   Contains properties required for "kdfNoKc" registration.
-
-
-
-
-
-
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 11]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
+   Contains properties REQUIRED for "kdfNoKc" registration.
 
    +--------------+---------------------+--------+----------+----------+
    | JSON Value   | Description         | JSON   | Valid    | Optional |
@@ -633,9 +666,17 @@ Internet-Draft                Sym Alg JSON                September 2018
 
                        Table 6: kdfNoKc Capabilities
 
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 12]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
 3.5.3.  KAS FFC kdfKc
 
-   Contains properties required for "kdfKc" registration.
+   Contains properties REQUIRED for "kdfKc" registration.
 
    +--------------+---------------------+--------+----------+----------+
    | JSON Value   | Description         | JSON   | Valid    | Optional |
@@ -661,18 +702,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    Each parameter set advertised is a self-contained JSON object using
    the following values.  Note that at least one parameter set ("fb",
-   "fc") is required.
-
-
-
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 12]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
+   "fc") MUST be provided.
 
    +----------+------------------+----------+---------------+----------+
    | JSON     | Description      | JSON     | Valid Values  | Optional |
@@ -688,6 +718,18 @@ Internet-Draft                Sym Alg JSON                September 2018
 
           Table 8: KAS FFC Parameter Set Capabilities JSON Values
 
+
+
+
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 13]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
 3.6.2.  KAS FFC Parameter Set Details
 
    fb/fc changes minimum allowed values on options.
@@ -698,11 +740,11 @@ Internet-Draft                Sym Alg JSON                September 2018
    fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128,
    min macSize - 64
 
-   "noKdfNoKc" requires "hashAlg"
+   "noKdfNoKc" REQUIRES "hashAlg"
 
-   "kdfNoKc" requires "hashAlg" and at least one valid MAC registration
+   "kdfNoKc" REQUIRES "hashAlg" and at least one valid MAC registration
 
-   "kdfKc" requires "hashAlg" and at least one valid MAC registration
+   "kdfKc" REQUIRES "hashAlg" and at least one valid MAC registration
 
    +-----------+-----------------------+--------+-----------+----------+
    | JSON      | Description           | JSON   | Valid     | Optional |
@@ -720,19 +762,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
       Table 9: KAS FFC Parameter Set Details Capabilities JSON Values
 
-
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 13]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
 3.7.  Supported Hash Algorithm Methods
 
-   The following SHA methods may be advertised by the ACVP compliant
+   The following SHA methods MAY be advertised by the ACVP compliant
    crypto module:
 
    o  SHA2-224
@@ -743,9 +775,20 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    o  SHA2-512
 
+
+
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 14]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
 3.8.  Supported KAS FFC MAC Options
 
-   The following MAC options are available for registration under a
+   The following MAC options MAY be advertised for registration under a
    "kdfNoKc" and "kdfKc" kasMode:
 
    o  AES-CCM
@@ -781,7 +824,20 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 14]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 15]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -795,29 +851,29 @@ Internet-Draft                Sym Alg JSON                September 2018
    |          | keyLens for |        | 192, 256. HashAlg   |           |
    |          | the         |        | based MACs mod 8.   |           |
    |          | selected    |        | All keySizes        |           |
-   |          | MAC.        |        | minimum must        |           |
+   |          | MAC.        |        | minimum MUST        |           |
    |          |             |        | conform to          |           |
    |          |             |        | parameter set       |           |
    |          |             |        | requirements See    |           |
    |          |             |        | Section 3.6.2 .     |           |
    |          |             |        |                     |           |
    | nonceLen | The nonce   | value  | Input as bits,      | Yes       |
-   |          | len for use |        | 56-104, odd byte    | (required |
+   |          | len for use |        | 56-104, odd byte    | (REQUIRED |
    |          | with AES-   |        | values only (7-13). | for AES-  |
    |          | CCM mac     |        | Additionally        | CCM)      |
-   |          |             |        | minimum must        |           |
+   |          |             |        | minimum MUST        |           |
    |          |             |        | conform to          |           |
    |          |             |        | parameter set       |           |
    |          |             |        | requirements See    |           |
    |          |             |        | Section 3.6.2 .     |           |
    |          |             |        |                     |           |
    | macLen   | The mac len | value  | Input as bits, mod  | Yes       |
-   |          | for use     |        | 8, minimum must     | (required |
+   |          | for use     |        | 8, minimum MUST     | (REQUIRED |
    |          | with mac    |        | conform to          | for AES-  |
    |          |             |        | parameter set       | CCM)      |
    |          |             |        | requirements See    |           |
    |          |             |        | Section 3.6.2 ,     |           |
-   |          |             |        | maximum may not     |           |
+   |          |             |        | maximum MAY NOT     |           |
    |          |             |        | exceed block size.. |           |
    |          |             |        |                     |           |
    +----------+-------------+--------+---------------------+-----------+
@@ -837,7 +893,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 15]
+Fussell & Hammett         Expires March 5, 2019                [Page 16]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -856,13 +912,13 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 3.9.1.  Other Information Construction
 
-   Some IUTs require a specific pattern for the OtherInfo portion of the
-   KDFs for KAS.  An "oiPattern" is specified in the KDF registration to
-   accommodate such requirements.  Regardless of the oiPattern
-   specified, the OI bitlength must be 240 for FFC, and 376 for ECC.
-   The OI will be padded with random bits (or the most significant bits
-   utilized) when the specified OI pattern does not meet the bitlength
-   requirement
+   Some IUTs MAY require a specific pattern for the OtherInfo portion of
+   the KDFs for KAS.  An "oiPattern" is specified in the KDF
+   registration to accommodate such requirements.  Regardless of the
+   oiPattern specified, the OI bitlength MUST be 240 for FFC, and 376
+   for ECC.  The OI will be padded with random bits (or the most
+   significant bits utilized) when the specified OI pattern does not
+   meet the bitlength requirement
 
    Pattern candidates:
 
@@ -893,7 +949,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 16]
+Fussell & Hammett         Expires March 5, 2019                [Page 17]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -949,7 +1005,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 17]
+Fussell & Hammett         Expires March 5, 2019                [Page 18]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1005,7 +1061,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 18]
+Fussell & Hammett         Expires March 5, 2019                [Page 19]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1061,7 +1117,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 19]
+Fussell & Hammett         Expires March 5, 2019                [Page 20]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1117,7 +1173,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 20]
+Fussell & Hammett         Expires March 5, 2019                [Page 21]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1173,7 +1229,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 21]
+Fussell & Hammett         Expires March 5, 2019                [Page 22]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1229,7 +1285,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 22]
+Fussell & Hammett         Expires March 5, 2019                [Page 23]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1285,7 +1341,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 23]
+Fussell & Hammett         Expires March 5, 2019                [Page 24]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1341,7 +1397,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 24]
+Fussell & Hammett         Expires March 5, 2019                [Page 25]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1397,7 +1453,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 25]
+Fussell & Hammett         Expires March 5, 2019                [Page 26]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1453,7 +1509,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 26]
+Fussell & Hammett         Expires March 5, 2019                [Page 27]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1509,7 +1565,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 27]
+Fussell & Hammett         Expires March 5, 2019                [Page 28]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1565,7 +1621,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 28]
+Fussell & Hammett         Expires March 5, 2019                [Page 29]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1621,7 +1677,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 29]
+Fussell & Hammett         Expires March 5, 2019                [Page 30]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1632,7 +1688,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    object is an array of test groups.  Test vectors are grouped into
    similar test cases to reduce the amount of data transmitted in the
    vector set.  For instance, all test vectors that use the same key
-   size would be grouped together.  The Test Group JSON object contains
+   size MAY be grouped together.  The Test Group JSON object contains
    meta data that applies to all test vectors within the group.  The
    following table describes the secure hash JSON elements of the Test
    Group JSON object.
@@ -1677,7 +1733,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 30]
+Fussell & Hammett         Expires March 5, 2019                [Page 31]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1697,35 +1753,35 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | used                 | 3.7            |          |
    |                |                      |                |          |
    | macType        | The MAC being used.  | See Section    | Yes      |
-   |                | Required for         | 3.8            |          |
+   |                | REQUIRED for         | 3.8            |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | keyLen         | The key length of    | See Section    | Yes      |
-   |                | the MAC. Required    | 3.8            |          |
+   |                | the MAC. REQUIRED    | 3.8            |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | nonceAesCcmLen | The nonce length of  | See Section    | Yes      |
    |                | the MAC (applies     | 3.8            |          |
    |                | only to AES-CCM).    |                |          |
-   |                | Required for         |                |          |
+   |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes using  |                |          |
    |                | a AES-CCM MAC.       |                |          |
    |                |                      |                |          |
    | macLen         | The mac length.      | See Section    | Yes      |
-   |                | Required for         | 3.8            |          |
+   |                | REQUIRED for         | 3.8            |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | kdfType        | The KDF being used.  | concatenation, | Yes      |
-   |                | Required for         | asn1           |          |
+   |                | REQUIRED for         | asn1           |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | idServerLen    | The length of the    | value          | Yes      |
-   |                | server ID. Required  |                |          |
+   |                | server ID. REQUIRED  |                |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
@@ -1733,17 +1789,17 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 31]
+Fussell & Hammett         Expires March 5, 2019                [Page 32]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
 
-   |                | Required for         |                |          |
+   |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | idIutLen       | The length of the    | value          | Yes      |
-   |                | server ID. Required  |                |          |
+   |                | server ID. REQUIRED  |                |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                | Provided in response |                |          |
@@ -1751,7 +1807,7 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | tests.               |                |          |
    |                |                      |                |          |
    | idIut          | The server ID.       | value          | Yes      |
-   |                | Required for         |                |          |
+   |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                | Provided in response |                |          |
@@ -1759,18 +1815,18 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | tests.               |                |          |
    |                |                      |                |          |
    | oiPattern      | The oiPattern used   | See Section    | Yes      |
-   |                | in the KDF. Required | 3.9.1          |          |
-   |                | for "kdfNoKc" and    |                |          |
+   |                | in the KDF. For      | 3.9.1          |          |
+   |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | kcRole         | Key confirmation     | provider,      | Yes      |
    |                | roles supported.     | recipient      |          |
-   |                | Required for "kdfKc" |                |          |
+   |                | REQUIRED for "kdfKc" |                |          |
    |                | modes.               |                |          |
    |                |                      |                |          |
    | kcType         | Key confirmation     | unilateral     | Yes      |
    |                | types supported.     | and/or         |          |
-   |                | Required for "kdfKc" | bilateral      |          |
+   |                | REQUIRED for "kdfKc" | bilateral      |          |
    |                | modes.               |                |          |
    |                |                      |                |          |
    | p              | Domain parameter for | value          | No       |
@@ -1789,7 +1845,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 32]
+Fussell & Hammett         Expires March 5, 2019                [Page 33]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -1831,9 +1887,10 @@ Internet-Draft                Sym Alg JSON                September 2018
    | nonceNoKc             | The 16 byte nonce    | value   | Yes      |
    |                       | concatenated to the  |         |          |
    |                       | "Standard Test       |         |          |
-   |                       | Message". Used for   |         |          |
-   |                       | No Key Confirmation  |         |          |
-   |                       | tests only.          |         |          |
+   |                       | Message". REQUIRED   |         |          |
+   |                       | for No Key           |         |          |
+   |                       | Confirmation tests   |         |          |
+   |                       | only.                |         |          |
    |                       |                      |         |          |
    | nonceDkm              | The nonce supplied   | value   | Yes      |
    |                       | by the initiator to  |         |          |
@@ -1841,15 +1898,15 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                       | field in the         |         |          |
    |                       | PartyUInfo field.    |         |          |
    |                       |                      |         |          |
-   | staticPrivateIut      | The IUT DSA static   | value   | Yes      |
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 33]
+Fussell & Hammett         Expires March 5, 2019                [Page 34]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   | staticPrivateIut      | The IUT DSA static   | value   | Yes      |
    |                       | private key          |         |          |
    |                       |                      |         |          |
    | staticPublicIut       | The IUT DSA static   | value   | Yes      |
@@ -1897,15 +1954,15 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                       | supplied by the      |         |          |
    |                       | initiator to be used |         |          |
    |                       | in the OI field in   |         |          |
-   |                       | the PartyUInfo       |         |          |
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 34]
+Fussell & Hammett         Expires March 5, 2019                [Page 35]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   |                       | the PartyUInfo       |         |          |
    |                       | field.               |         |          |
    |                       |                      |         |          |
    | nonceEphemeralDkm     | ONLY USED BY C(1,2)  | value   | Yes      |
@@ -1956,8 +2013,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-
-Fussell & Hammett         Expires March 5, 2019                [Page 35]
+Fussell & Hammett         Expires March 5, 2019                [Page 36]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2013,7 +2069,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 36]
+Fussell & Hammett         Expires March 5, 2019                [Page 37]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2069,7 +2125,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 37]
+Fussell & Hammett         Expires March 5, 2019                [Page 38]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2125,7 +2181,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 38]
+Fussell & Hammett         Expires March 5, 2019                [Page 39]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2181,7 +2237,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 39]
+Fussell & Hammett         Expires March 5, 2019                [Page 40]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2237,7 +2293,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 40]
+Fussell & Hammett         Expires March 5, 2019                [Page 41]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2293,7 +2349,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 41]
+Fussell & Hammett         Expires March 5, 2019                [Page 42]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2349,7 +2405,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 42]
+Fussell & Hammett         Expires March 5, 2019                [Page 43]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2405,7 +2461,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 43]
+Fussell & Hammett         Expires March 5, 2019                [Page 44]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2461,7 +2517,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 44]
+Fussell & Hammett         Expires March 5, 2019                [Page 45]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2517,7 +2573,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 45]
+Fussell & Hammett         Expires March 5, 2019                [Page 46]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2573,7 +2629,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 46]
+Fussell & Hammett         Expires March 5, 2019                [Page 47]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2629,7 +2685,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 47]
+Fussell & Hammett         Expires March 5, 2019                [Page 48]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2685,7 +2741,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 48]
+Fussell & Hammett         Expires March 5, 2019                [Page 49]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2741,7 +2797,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 49]
+Fussell & Hammett         Expires March 5, 2019                [Page 50]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2797,7 +2853,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 50]
+Fussell & Hammett         Expires March 5, 2019                [Page 51]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2853,7 +2909,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 51]
+Fussell & Hammett         Expires March 5, 2019                [Page 52]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2890,7 +2946,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 6.  Test Vector Responses
 
-   After the ACVP client downloads and processes a vector set, it must
+   After the ACVP client downloads and processes a vector set, it SHALL
    send the response vectors back to the ACVP server.  The following
    table describes the JSON object that represents a vector set
    response.
@@ -2909,7 +2965,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 52]
+Fussell & Hammett         Expires March 5, 2019                [Page 53]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -2965,7 +3021,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 53]
+Fussell & Hammett         Expires March 5, 2019                [Page 54]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3021,7 +3077,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 54]
+Fussell & Hammett         Expires March 5, 2019                [Page 55]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3077,7 +3133,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 55]
+Fussell & Hammett         Expires March 5, 2019                [Page 56]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3133,7 +3189,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 56]
+Fussell & Hammett         Expires March 5, 2019                [Page 57]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3189,7 +3245,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 57]
+Fussell & Hammett         Expires March 5, 2019                [Page 58]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3245,7 +3301,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 58]
+Fussell & Hammett         Expires March 5, 2019                [Page 59]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3301,7 +3357,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 59]
+Fussell & Hammett         Expires March 5, 2019                [Page 60]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
@@ -3357,4 +3413,4 @@ Authors' Addresses
 
 
 
-Fussell & Hammett         Expires March 5, 2019                [Page 60]
+Fussell & Hammett         Expires March 5, 2019                [Page 61]

--- a/src/acvp_sub_kas_ecc.xml
+++ b/src/acvp_sub_kas_ecc.xml
@@ -70,7 +70,7 @@
                 <!-- uri and facsimile elements may also be added -->
             </address>
         </author>
-        <date month="September" year="2018"/>
+        <date month="November" year="2018"/>
         <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
          in the current day for you. If only the current year is specified, xml2rfc will fill
 	 in the current day and month for you. If the year is not the current one, it is
@@ -116,21 +116,21 @@
         <section anchor="test_types" title="Test Types and Test Coverage">
             <t>The ACVP server performs a set of tests on the KAS protocol in order to assess the
                 correctness and robustness of the implementation. A typical ACVP validation session
-                would require multiple tests to be performed for every supported permutation of KAS
+                SHALL require multiple tests to be performed for every supported permutation of KAS
                 capabilities. This section describes the design of the tests used to validate
                 implementations of KAS algorithms. There are two test types for KAS testing: <list
                     style="testtype">
-                    <t>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT is expected to
-                        act as a party in the Key Agreement with the ACVP server. The server will
+                    <t>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT SHALL 
+                        act as a party in the Key Agreement with the ACVP server. The server SHALL
                         generate and provide all necessary information for the IUT to perform a
-                        successful key agreement; both the server and IUT can act as party U/V, as
+                        successful key agreement; both the server and IUT MAY act as party U/V, as
                         well as recipient/provider to key confirmation.</t>
-                    <t>"VAL" - Validation test. In the VAL test mode, The ACVP server generates a
+                    <t>"VAL" - Validation test. In the VAL test mode, The ACVP server MUST generate a
                         complete (from both party U and party V's perspectives) key agreement, and
                         expects the IUT to be able to determine if that agreement is valid. Various
-                        types of errors are introduced in varying portions of the key agreement
-                        process (like bad DKM, bad key, bad hash, etc), that the IUT should be able
-                        to detect and report on.</t>
+                        types of errors MSUT be introduced in varying portions of the key agreement
+                        process (changed DKM, changed key, changed hash digest, etc), that the IUT 
+                        MUST be able to detect and report on.</t>
                 </list>
             </t>
             <section anchor="test_coverage" title="Test Coverage">
@@ -147,41 +147,40 @@
                                 both take the roles of party U/V, and as such the "performer" of
                                 steps depicted in "Figure 2: Key Agreement process" can vary.</t>
                             <t>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of
-                                performing KAS make use of a hash function. The hash function may be
-                                used for confirmation of a successfully generated shared secret Z
+                                performing KAS SHALL make use of a hash function. The hash function MAY
+                                be used for confirmation of a successfully generated shared secret Z
                                 (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc
                                 and kdfKc).</t>
                             <t>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC
                                 is utilized for confirmation of success for kdfNoKc and kdfKc modes
-                                of KAS. Note - a MAC prerequisite is required only for kdfKc, though
+                                of KAS. Note - a MAC prerequisite is REQUIRED only for kdfKc, though
                                 is utilized for both kdfNoKc and kdfKc.</t>
                             <t>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes
-                                - both the ACVP server and IUT are expected to be able to generate
+                                - both the ACVP server and IUT SHALL be expected to generate
                                 nonces.</t>
-                            <t>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation is
+                            <t>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation SHALL be 
                                 performed solely from the ACVP server, with constraints from the
-                                IUTs capabilities registration. It is expected that the same set of
-                                domain parameters will generate all keypairs (party U/V,
-                                static/ephemeral) for a single test case.</t>
+                                IUTs capabilities registration. The same set of domain parameters SHALL
+                                generate all keypairs (party U/V, static/ephemeral) for a single test case.</t>
                             <t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in
                                 each KAS scheme, the generation of said key-pairs is out of scope
-                                for KAS testing. Random tests from the VAL groups, shall inject bad
-                                keypairs that the IUT should be able detect. These random tests are
+                                for KAS testing. Random tests from the VAL groups, MAY inject bad
+                                keypairs that the IUT MUST be able detect. These random tests are
                                 only present in groups given appropriate assurance functions see:
                                     <xref target="supported_functions"/>
                             </t>
                             <t>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC
                                 Primitives. Depending on the scheme used, either Diffie Hellman or
-                                MQV is used to negotiate a shared secret of z. Testing and
+                                MQV SHALL be used to negotiate a shared secret of z. Testing and
                                 validation of such key exchanges is covered under their respective
                                 schemes.</t>
                             <t>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-                                All schemes/modes save noKdfNoKc (component) make use of a KDF. KDF
-                                construction utilizes <xref target="oiPatternConstruction"/> for its
+                                All schemes/modes save noKdfNoKc (component) MUST make use of a KDF. KDF
+                                construction SHALL utilize <xref target="oiPatternConstruction"/> for its
                                 pattern. </t>
                             <t>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key
-                                Confirmation process, the ACVP server and IUT can be Providers or
-                                Recipients of said confirmation. Additionally, key confirmation can
+                                Confirmation process, the ACVP server and IUT MAY be Providers or
+                                Recipients of said confirmation. Additionally, key confirmation MAY
                                 be performed on one or both parties (depending on scheme).</t>
                             <t>SP 800-56a - 6 Key Agreement Schemes. All schemes specified in
                                 referenced document are supported for validation with the ACVP
@@ -193,36 +192,36 @@
                     title="KAS-ECC Requirements Not Covered">
                     <t>
                         <list>
-                            <t>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server does
-                                not make a distinction between IUT generated keys via a trusted
+                            <t>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server SHALL
+                                NOT make a distinction between IUT generated keys via a trusted
                                 third party and the IUT itself.</t>
-                            <t>SP 800-56a - 5.3 Random Number Generation. It is expected the IUT
-                                performs all random number generation with a validated random number
-                                generator. A DRBG is expected as a prerequisite to KAS, but is out
-                                of the scope of testing assurances. </t>
+                            <t>SP 800-56a - 5.3 Random Number Generation. The IUT MUST
+                                perform all random number generation with a validated random number
+                                generator. A DRBG is REQUIRED as a prerequisite to KAS, but SHALL NOT
+                                be in the scope testing assurances. </t>
                             <t>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several
                                 schemes. The various methods of generating a nonce described in
-                                section 5.5 are expected to be used, however their generation is out
-                                of scope of KAS testing assurances</t>
+                                section 5.5 MUST be used, however their generation SHALL NOT 
+                                be in scope of KAS testing assurances</t>
                             <t>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP
-                                server generates all domain parameters, IUT validation of such
-                                parameters is out of scope for KAS testing.</t>
+                                server SHALL generate all domain parameters, IUT validation of such
+                                parameters is SHALL NOT be in scope for KAS testing.</t>
                             <t>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter
-                                Management is out of scope for KAS testing.</t>
-                            <t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in
+                                Management SHALL NOT be in scope for KAS testing.</t>
+                            <t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs MUST be used in
                                 each KAS scheme, the generation, assurances, and management of said
-                                key-pairs is out of scope for KAS testing.</t>
+                                key-pairs SHALL NOT be in scope of KAS testing.</t>
                             <t>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-                                Two-step Key-Derivation (Extraction-then-Expansion) is not utilized
+                                Two-step Key-Derivation (Extraction-then-Expansion) SHALL NOT be utilized
                                 in KAS testing.</t>
                             <t>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as
-                                being a valid MAC function; it however is not (currently) supported
+                                being a valid MAC function; it however SHALL NOT (currently) be supported
                                 in KAS testing.</t>
                             <t>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is
                                 expected that the IUT registers all schemes it supports in its
                                 capabilities registration. Selecting specific schemes from a KAS
-                                testing perspective is out of scope.</t>
-                            <t>SP 800-56a - 8 Key Recovery. Key Recovery is not in scope of KAS
+                                testing perspective SHALL NOT be in scope.</t>
+                            <t>SP 800-56a - 8 Key Recovery. Key Recovery SHALL NOT be in scope of KAS
                                 testing.</t>
                         </list>
                     </t>
@@ -230,7 +229,7 @@
             </section>
         </section>
         <section anchor="caps_reg" title="Capabilities Registration">
-            <t>ACVP requires crypto modules to register their capabilities. This allows the crypto
+            <t>ACVP REQUIRES crypto modules to register their capabilities. This allows the crypto
                 module to advertise support for specific algorithms, notifying the ACVP server which
                 algorithms need test vectors generated for the validation process. This section
                 describes the constructs for advertising support of KAS ECC algorithms to the ACVP
@@ -294,31 +293,31 @@
                     <ttcol align="left">Prerequisite Algorithm</ttcol>
                     <ttcol align="left">Condition</ttcol>
                     <c>DRBG</c>
-                    <c>Always required</c>
+                    <c>Always REQUIRED</c>
                     <c/>
                     <c/>
                     <c>SHA</c>
-                    <c>Always required</c>
+                    <c>Always REQUIRED</c>
                     <c/>
                     <c/>
                     <c>ECDSA</c>
-                    <c> ECDSA.PKV validation required when IUT using assurance functions of
-                        "fullVal", "keyPairGen", or "keyRegen". ECDSA.KeyPair validation required
+                    <c> ECDSA.PKV validation REQUIRED when IUT using assurance functions of
+                        "fullVal", "keyPairGen", or "keyRegen". ECDSA.KeyPair validation REQUIRED
                         when IUT using assurances functions of "keyPairGen", or "keyRegen". </c>
                     <c/>
                     <c/>
                     <c>AES-CCM</c>
-                    <c>AES-CCM validation required when IUT is performing KeyConfirmation (KC) and
+                    <c>AES-CCM validation REQUIRED when IUT is performing KeyConfirmation (KC) and
                         utilizing AES-CCM.</c>
                     <c/>
                     <c/>
                     <c>CMAC</c>
-                    <c>CMAC validation required when IUT is performing KeyConfirmation (KC) and
+                    <c>CMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and
                         utilizing CMAC.</c>
                     <c/>
                     <c/>
                     <c>HMAC</c>
-                    <c>HMAC validation required when IUT is performing KeyConfirmation (KC) and
+                    <c>HMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and
                         utilizing HMAC.</c>
                     <c/>
                     <c/>
@@ -393,7 +392,7 @@
                     ACVP client during registration.</t>
             </section>
             <section anchor="supported_functions" title="Supported KAS ECC Functions">
-                <t>The following function types may be advertised by the ACVP compliant crypto
+                <t>The following function types MAY be advertised by the ACVP compliant crypto
                     module:</t>
                 <t>
                     <list style="symbols">
@@ -411,9 +410,9 @@
             </section>
             <section anchor="schemes" title="KAS ECC Schemes">
                 <section anchor="supported_schemes" title="KAS ECC Scheme Capabilities JSON Values">
-                    <t> All other scheme capability advertised is a self-contained JSON object using
+                    <t> All other scheme capabilities are advertised as a self-contained JSON object using
                         the following values. Note that at least one of "noKdfNoKc", "kdfNoKc", or
-                        "kdfKc" must be supplied with the registration. See <xref
+                        "kdfKc" MUST be supplied with the registration. See <xref
                             target="supported_scheme_values"/> for allowed ECC scheme types. </t>
                     <texttable anchor="scheme_caps_table" title="KAS ECC Capabilities JSON Values">
                         <ttcol align="left">JSON Value</ttcol>
@@ -433,7 +432,7 @@
                         <c/>
                         <c>noKdfNoKc</c>
                         <c>Indicates no KDF, no KC tests are to be generated. Note this is a
-                            COMPONENT mode only test. This property can only be used with "KAS-ECC"
+                            COMPONENT mode only test. This property MUST only be used with "KAS-ECC"
                             / "Component"</c>
                         <c>object</c>
                         <c>
@@ -447,7 +446,7 @@
                         <c/>
                         <c>kdfNoKc</c>
                         <c>Indicates KDF, no KC tests are to be generated. Note this is a KAS-ECC
-                            only test. This mode is only valid for registrations with "KAS-ECC" (no
+                            only test. This mode MAY only be used for registrations with "KAS-ECC" (no
                             mode)</c>
                         <c>object</c>
                         <c>
@@ -461,7 +460,7 @@
                         <c/>
                         <c>kdfKc</c>
                         <c>Indicates KDF, KC tests are to be generated. Note this is a KAS-ECC only
-                            test. This mode is only valid for registrations with "KAS-ECC" (no
+                            test. This mode MAY only be used for registrations with "KAS-ECC" (no
                             mode)</c>
                         <c>object</c>
                         <c>
@@ -476,7 +475,7 @@
                     </texttable>
                 </section>
                 <section anchor="supported_scheme_values" title="Supported KAS ECC Schemes">
-                    <t>The following schemes may be advertised by the ACVP compliant crypto
+                    <t>The following schemes MAY be advertised by the ACVP compliant crypto
                         module:</t>
                     <t>
                         <list style="symbols">
@@ -494,7 +493,7 @@
             </section>
             <section anchor="kasMode" title="KAS ECC Modes">
                 <section anchor="noKdfNoKc" title="KAS ECC noKdfNoKc">
-                    <t>Contains properties required for "noKdfNoKc" registration. </t>
+                    <t>Contains properties REQUIRED for "noKdfNoKc" registration. </t>
                     <texttable anchor="noKdfNoKc_table" title="NoKdfNoKc Capabilities">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
@@ -516,7 +515,7 @@
                     </texttable>
                 </section>
                 <section anchor="kdfNoKc" title="KAS ECC kdfNoKc">
-                    <t>Contains properties required for "kdfNoKc" registration. </t>
+                    <t>Contains properties REQUIRED for "kdfNoKc" registration. </t>
                     <texttable anchor="kdfNoKc_table" title="kdfNoKc Capabilities">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
@@ -550,7 +549,7 @@
                     </texttable>
                 </section>
                 <section anchor="kdfKc" title="KAS ECC kdfKc">
-                    <t>Contains properties required for "kdfKc" registration. </t>
+                    <t>Contains properties REQUIRED for "kdfKc" registration. </t>
                     <texttable anchor="kdfKc_table" title="kdfKc Capabilities">
                         <ttcol align="left">JSON Value</ttcol>
                         <ttcol align="left">Description</ttcol>
@@ -600,7 +599,7 @@
                 <section anchor="parameter_set" title="KAS ECC Parameter Set">
                     <t>Each parameter set advertised is a self-contained JSON object using the
                         following values. Note that at least one parameter set ("eb", "ec", "ed",
-                        "ee") is required.</t>
+                        "ee") is REQUIRED.</t>
                     <texttable anchor="parameter_set_table"
                         title="KAS ECC Parameter Set Capabilities JSON Values">
                         <ttcol align="left">JSON Value</ttcol>
@@ -663,9 +662,9 @@
                         min macSize - 64</t>
                     <t>ee: Len n - 512+, min Len h - 256, min hash len - 512, min keySize - 256, min
                         macSize - 64</t>
-                    <t>"noKdfNoKc" requires "hashAlg"</t>
-                    <t>"kdfNoKc" requires "hashAlg" and at least one valid MAC registration</t>
-                    <t>"kdfKc" requires "hashAlg" and at least one valid MAC registration</t>
+                    <t>"noKdfNoKc" REQUIRES "hashAlg"</t>
+                    <t>"kdfNoKc" REQUIRES "hashAlg" and at least one valid MAC registration</t>
+                    <t>"kdfKc" REQUIRES "hashAlg" and at least one valid MAC registration</t>
                     <texttable anchor="parameter_set_details_table"
                         title="KAS ECC Parameter Set Details Capabilities JSON Values">
                         <ttcol align="left">JSON Value</ttcol>
@@ -710,7 +709,7 @@
                 </section>
             </section>
             <section anchor="supported_curves" title="Supported ECC Curves">
-                <t>The following ECC Curves may be advertised by the ACVP compliant crypto
+                <t>The following ECC Curves MAY be advertised by the ACVP compliant crypto
                     module:</t>
                 <texttable anchor="curves" title="Supported Curves per parameter set.">
                     <ttcol align="left">Parameter Set</ttcol>
@@ -752,7 +751,7 @@
                 </texttable>
             </section>
             <section anchor="supported_hashAlg" title="Supported Hash Algorithm Methods">
-                <t>The following SHA methods may be advertised by the ACVP compliant crypto
+                <t>The following SHA methods MAY be advertised by the ACVP compliant crypto
                     module:</t>
                 <t>
                     <list style="symbols">
@@ -764,7 +763,7 @@
                 </t>
             </section>
             <section anchor="supported_macOption" title="Supported KAS ECC MAC Options">
-                <t>The following MAC options are available for registration under a "kdfNoKc" and
+                <t>The following MAC options MAY be advertised for registration under a "kdfNoKc" and
                     "kdfKc" kasMode:</t>
                 <t>
                     <list style="symbols">
@@ -786,7 +785,7 @@
                     <c>The supported keyLens for the selected MAC.</c>
                     <c>Domain</c>
                     <c> AES based MACs limited to 128, 192, 256. HashAlg based MACs mod 8. All
-                        keySizes minimum must conform to parameter set requirements See <xref
+                        keySizes minimum MUST conform to parameter set requirements See <xref
                             target="parameter_set_details"/> . </c>
                     <c>No</c>
                     <c/>
@@ -797,7 +796,7 @@
                     <c>nonceLen</c>
                     <c>The nonce len for use with AES-CCM mac</c>
                     <c>value</c>
-                    <c>Input as bits, 56-104, odd byte values only (7-13). Additionally minimum must
+                    <c>Input as bits, 56-104, odd byte values only (7-13). Additionally minimum MUST
                         conform to parameter set requirements See <xref
                             target="parameter_set_details"/> . </c>
                     <c>Yes (required for AES-CCM)</c>
@@ -809,8 +808,8 @@
                     <c>macLen</c>
                     <c>The mac len for use with mac</c>
                     <c>value</c>
-                    <c>Input as bits, mod 8, minimum must conform to parameter set requirements See
-                            <xref target="parameter_set_details"/> , maximum may not exceed block
+                    <c>Input as bits, mod 8, minimum MUST conform to parameter set requirements See
+                            <xref target="parameter_set_details"/> , maximum SHALL NOT exceed block
                         size.. </c>
                     <c>Yes (required for AES-CCM)</c>
                     <c/>
@@ -847,10 +846,10 @@
                     <c/>
                 </texttable>
                 <section anchor="oiPatternConstruction" title="Other Information Construction">
-                    <t> Some IUTs require a specific pattern for the OtherInfo portion of the KDFs
+                    <t> Some IUTs MAY require a specific pattern for the OtherInfo portion of the KDFs
                         for KAS. An "oiPattern" is specified in the KDF registration to accommodate
                         such requirements. Regardless of the oiPattern specified, the OI bitlength
-                        must be 240 for FFC, and 376 for ECC. The OI will be padded with random bits
+                        MUST be 240 for FFC, and 376 for ECC. The OI SHALL be padded with random bits
                         (or the most significant bits utilized) when the specified OI pattern does
                         not meet the bitlength requirement </t>
                     <t>Pattern candidates:</t>
@@ -2459,7 +2458,7 @@
                     <c/>
                     <c/>
                     <c>macType</c>
-                    <c>The MAC being used. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The MAC being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>See <xref target="supported_macOption"/>
                     </c>
                     <c>Yes</c>
@@ -2468,7 +2467,7 @@
                     <c/>
                     <c/>
                     <c>keyLen</c>
-                    <c>The key length of the MAC. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The key length of the MAC. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>See <xref target="supported_macOption"/>
                     </c>
                     <c>Yes</c>
@@ -2477,7 +2476,7 @@
                     <c/>
                     <c/>
                     <c>nonceAesCcmLen</c>
-                    <c>The nonce length of the MAC (applies only to AES-CCM). Required for "kdfNoKc"
+                    <c>The nonce length of the MAC (applies only to AES-CCM). REQUIRED for "kdfNoKc"
                         and "kdfKc" modes using a AES-CCM MAC.</c>
                     <c>See <xref target="supported_macOption"/>
                     </c>
@@ -2487,7 +2486,7 @@
                     <c/>
                     <c/>
                     <c>macLen</c>
-                    <c>The mac length. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The mac length. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>See <xref target="supported_macOption"/>
                     </c>
                     <c>Yes</c>
@@ -2496,7 +2495,7 @@
                     <c/>
                     <c/>
                     <c>kdfType</c>
-                    <c>The KDF being used. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The KDF being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>concatenation, asn1</c>
                     <c>Yes</c>
                     <c/>
@@ -2504,7 +2503,7 @@
                     <c/>
                     <c/>
                     <c>idServerLen</c>
-                    <c>The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>value</c>
                     <c>Yes</c>
                     <c/>
@@ -2512,7 +2511,7 @@
                     <c/>
                     <c/>
                     <c>idServer</c>
-                    <c>The server ID. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>value</c>
                     <c>Yes</c>
                     <c/>
@@ -2520,7 +2519,7 @@
                     <c/>
                     <c/>
                     <c>idIutLen</c>
-                    <c>The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.
+                    <c>The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.
                         Provided in response by IUT for AFT tests.</c>
                     <c>value</c>
                     <c>Yes</c>
@@ -2529,7 +2528,7 @@
                     <c/>
                     <c/>
                     <c>idIut</c>
-                    <c>The server ID. Required for "kdfNoKc" and "kdfKc" modes. Provided in response
+                    <c>The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes. Provided in response
                         by IUT for AFT tests.</c>
                     <c>value</c>
                     <c>Yes</c>
@@ -2538,7 +2537,7 @@
                     <c/>
                     <c/>
                     <c>oiPattern</c>
-                    <c>The oiPattern used in the KDF. Required for "kdfNoKc" and "kdfKc" modes.</c>
+                    <c>The oiPattern used in the KDF. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
                     <c>See <xref target="oiPatternConstruction"/>
                     </c>
                     <c>Yes</c>
@@ -2547,7 +2546,7 @@
                     <c/>
                     <c/>
                     <c>kcRole</c>
-                    <c>Key confirmation roles supported. Required for "kdfKc" modes.</c>
+                    <c>Key confirmation roles supported. REQUIRED for "kdfKc" modes.</c>
                     <c>provider, recipient</c>
                     <c>Yes</c>
                     <c/>
@@ -2555,7 +2554,7 @@
                     <c/>
                     <c/>
                     <c>kcType</c>
-                    <c>Key confirmation types supported. Required for "kdfKc" modes.</c>
+                    <c>Key confirmation types supported. REQUIRED for "kdfKc" modes.</c>
                     <c>unilateral and/or bilateral</c>
                     <c>Yes</c>
                     <c/>
@@ -3090,37 +3089,7 @@
                 <c/>
                 <c/>
             </texttable>
-            <t>Note. the following bullet lists outline which JSON keywords must be provided for the
-                respective KAS ECC test types in the shared secret generation test vector
-                response.</t>
-            <t>ephemeralUnified:</t>
-            <t>
-                <list style="symbols">
-                    <t>ephemeralPublicIutX</t>
-                    <t>ephemeralPublicIutY</t>
-                    <t>hashZIut</t>
-                </list>
-            </t>
-            <t>fullMqv: TBD</t>
-            <t>fullUnified: TBD</t>
-            <t>onePassDh</t>
-            <t>
-                <list style="symbols">
-                    <t>ephemeralPublicIutX</t>
-                    <t>ephemeralPublicIutY</t>
-                    <t>hashZIut</t>
-                </list>
-            </t>
-            <t>onePassMqv: TBD</t>
-            <t>onePassUnified: TBD</t>
-            <t>staticUnified</t>
-            <t>
-                <list style="symbols">
-                    <t>staticPublicIutX</t>
-                    <t>staticPublicIutY</t>
-                    <t>hashZIut</t>
-                </list>
-            </t>
+            
             <section anchor="app-results-ex" title="Example Test Results JSON Object">
                 <t>The following is a example JSON object for KAS ECC test results sent from the
                     crypto module to the ACVP server.</t>

--- a/src/acvp_sub_kas_ffc.xml
+++ b/src/acvp_sub_kas_ffc.xml
@@ -120,117 +120,116 @@
 				capabilities. This section describes the design of the tests used to validate
 				implementations of KAS algorithms. There are two test types for KAS testing: <list
 					style="testtype">
-					<t>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT is expected to
-						act as a party in the Key Agreement with the ACVP server. The server will
+					<t>"AFT" - Algorithm Function Test. In the AFT test mode, the IUT MUST
+						act as a party in the Key Agreement with the ACVP server. The server SHALL 
 						generate and provide all necessary information for the IUT to perform a
-						successful key agreement; both the server and IUT can act as party U/V, as
+						successful key agreement; both the server and IUT MAY act as party U/V, as
 						well as recipient/provider to key confirmation.</t>
 					<t>"VAL" - Validation test. In the VAL test mode, The ACVP server generates a
 						complete (from both party U and party V's perspectives) key agreement, and
-						expects the IUT to be able to determine if that agreement is valid. Various
-						types of errors are introduced in varying portions of the key agreement
-						process (like bad DKM, bad key, bad hash, etc), that the IUT should be able
+						REQUIRES the IUT to determine if that agreement is valid. Various
+						types of errors SHALL be introduced in varying portions of the key agreement
+						process (changed DKM, changed key, changed hash, etc), that the IUT MUST be able
 						to detect and report on.</t>
 				</list>
 			</t>
 			<section anchor="test_coverage" title="Test Coverage">
-				<t>The tests described in this document have the intention of ensuring an
-					implementation is conformant to <xref target="SP800-56a"/>. </t>
-				<section anchor="requirements_covered_kas_ffc" title="KAS-FFC Requirements Covered">
-					<t>
-						<list>
-							<t>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is
-								responsible for generating domain parameters as per the IUT's
-								capability registration.</t>
-							<t>SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT
-								participate in the Key Agreement process. The server and IUT can
-								both take the roles of party U/V, and as such the "performer" of
-								steps depicted in "Figure 2: Key Agreement process" can vary.</t>
-							<t>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of
-								performing KAS make use of a hash function. The hash function may be
-								used for confirmation of a successfully generated shared secret Z
-								(noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc
-								and kdfKc).</t>
-							<t>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC
-								is utilized for confirmation of success for kdfNoKc and kdfKc modes
-								of KAS. Note - a MAC prerequisite is required only for kdfKc, though
-								is utilized for both kdfNoKc and kdfKc.</t>
-							<t>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes
-								- both the ACVP server and IUT are expected to be able to generate
-								nonces.</t>
-							<t>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation is
-								performed solely from the ACVP server, with constraints from the
-								IUTs capabilities registration. It is expected that the same set of
-								domain parameters will generate all keypairs (party U/V,
-								static/ephemeral) for a single test case.</t>
-							<t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in
-								each KAS scheme, the generation of said key-pairs is out of scope
-								for KAS testing. Random tests from the VAL groups, shall inject bad
-								keypairs that the IUT should be able detect. These random tests are
-								only present in groups given appropriate assurance functions see:
-									<xref target="supported_functions"/>
-							</t>
-							<t>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC
-								Primitives. Depending on the scheme used, either Diffie Hellman or
-								MQV is used to negotiate a shared secret of z. Testing and
-								validation of such key exchanges is covered under their respective
-								schemes.</t>
-							<t>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-								All schemes/modes save noKdfNoKc (component) make use of a KDF. KDF
-								construction utilizes <xref target="oiPatternConstruction"/> for its
-								pattern. </t>
-							<t>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key
-								Confirmation process, the ACVP server and IUT can be Providers or
-								Recipients of said confirmation. Additionally, key confirmation can
-								be performed on one or both parties (depending on scheme).</t>
-							<t>SP 800-56a - 6 Key Agreement Schemes. All schemes specified in
-								referenced document are supported for validation with the ACVP
-								server.</t>
-						</list>
-					</t>
-				</section>
-				<section anchor="requirements_not_covered_kas_ffc"
-					title="KAS-FFC Requirements Not Covered">
-					<t>
-						<list>
-							<t>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server does
-								not make a distinction between IUT generated keys via a trusted
-								third party and the IUT itself.</t>
-							<t>SP 800-56a - 5.3 Random Number Generation. It is expected the IUT
-								performs all random number generation with a validated random number
-								generator. A DRBG is expected as a prerequisite to KAS, but is out
-								of the scope of testing assurances. </t>
-							<t>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several
-								schemes. The various methods of generating a nonce described in
-								section 5.5 are expected to be used, however their generation is out
-								of scope of KAS testing assurances</t>
-							<t>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP
-								server generates all domain parameters, IUT validation of such
-								parameters is out of scope for KAS testing.</t>
-							<t>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter
-								Management is out of scope for KAS testing.</t>
-							<t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in
-								each KAS scheme, the generation, assurances, and management of said
-								key-pairs is out of scope for KAS testing.</t>
-							<t>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
-								Two-step Key-Derivation (Extraction-then-Expansion) is not utilized
-								in KAS testing.</t>
-							<t>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as
-								being a valid MAC function; it however is not (currently) supported
-								in KAS testing.</t>
-							<t>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is
-								expected that the IUT registers all schemes it supports in its
-								capabilities registration. Selecting specific schemes from a KAS
-								testing perspective is out of scope.</t>
-							<t>SP 800-56a - 8 Key Recovery. Key Recovery is not in scope of KAS
-								testing.</t>
-						</list>
-					</t>
-				</section>
-			</section>
+                <t>The tests described in this document have the intention of ensuring an
+                    implementation is conformant to <xref target="SP800-56a"/>. </t>
+                <section anchor="requirements_covered_kas_ecc" title="KAS-ECC Requirements Covered">
+                    <t>
+                        <list>
+                            <t>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is
+                                responsible for generating domain parameters as per the IUT's
+                                capability registration.</t>
+                            <t>SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT
+                                participate in the Key Agreement process. The server and IUT can
+                                both take the roles of party U/V, and as such the "performer" of
+                                steps depicted in "Figure 2: Key Agreement process" can vary.</t>
+                            <t>SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of
+                                performing KAS SHALL make use of a hash function. The hash function MAY
+                                be used for confirmation of a successfully generated shared secret Z
+                                (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc
+                                and kdfKc).</t>
+                            <t>SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC
+                                is utilized for confirmation of success for kdfNoKc and kdfKc modes
+                                of KAS. Note - a MAC prerequisite is REQUIRED only for kdfKc, though
+                                is utilized for both kdfNoKc and kdfKc.</t>
+                            <t>SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes
+                                - both the ACVP server and IUT SHALL be expected to generate
+                                nonces.</t>
+                            <t>SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation SHALL be 
+                                performed solely from the ACVP server, with constraints from the
+                                IUTs capabilities registration. The same set of domain parameters SHALL
+                                generate all keypairs (party U/V, static/ephemeral) for a single test case.</t>
+                            <t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in
+                                each KAS scheme, the generation of said key-pairs is out of scope
+                                for KAS testing. Random tests from the VAL groups, MAY inject bad
+                                keypairs that the IUT MUST be able detect. These random tests are
+                                only present in groups given appropriate assurance functions see:
+                                    <xref target="supported_functions"/>
+                            </t>
+                            <t>SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC
+                                Primitives. Depending on the scheme used, either Diffie Hellman or
+                                MQV SHALL be used to negotiate a shared secret of z. Testing and
+                                validation of such key exchanges is covered under their respective
+                                schemes.</t>
+                            <t>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
+                                All schemes/modes save noKdfNoKc (component) MUST make use of a KDF. KDF
+                                construction SHALL utilize <xref target="oiPatternConstruction"/> for its
+                                pattern. </t>
+                            <t>SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key
+                                Confirmation process, the ACVP server and IUT MAY be Providers or
+                                Recipients of said confirmation. Additionally, key confirmation MAY
+                                be performed on one or both parties (depending on scheme).</t>
+                            <t>SP 800-56a - 6 Key Agreement Schemes. All schemes specified in
+                                referenced document are supported for validation with the ACVP
+                                server.</t>
+                        </list>
+                    </t>
+                </section>
+                <section anchor="requirements_not_covered_kas_ecc"
+                    title="KAS-ECC Requirements Not Covered">
+                    <t>
+                        <list>
+                            <t>SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server SHALL
+                                NOT make a distinction between IUT generated keys via a trusted
+                                third party and the IUT itself.</t>
+                            <t>SP 800-56a - 5.3 Random Number Generation. The IUT MUST
+                                perform all random number generation with a validated random number
+                                generator. A DRBG is REQUIRED as a prerequisite to KAS, but SHALL NOT
+                                be in the scope testing assurances. </t>
+                            <t>SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several
+                                schemes. The various methods of generating a nonce described in
+                                section 5.5 MUST be used, however their generation SHALL NOT 
+                                be in scope of KAS testing assurances</t>
+                            <t>SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP
+                                server SHALL generate all domain parameters, IUT validation of such
+                                parameters is SHALL NOT be in scope for KAS testing.</t>
+                            <t>SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter
+                                Management SHALL NOT be in scope for KAS testing.</t>
+                            <t>SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs MUST be used in
+                                each KAS scheme, the generation, assurances, and management of said
+                                key-pairs SHALL NOT be in scope of KAS testing.</t>
+                            <t>SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes.
+                                Two-step Key-Derivation (Extraction-then-Expansion) SHALL NOT be utilized
+                                in KAS testing.</t>
+                            <t>SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as
+                                being a valid MAC function; it however SHALL NOT (currently) be supported
+                                in KAS testing.</t>
+                            <t>SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is
+                                expected that the IUT registers all schemes it supports in its
+                                capabilities registration. Selecting specific schemes from a KAS
+                                testing perspective SHALL NOT be in scope.</t>
+                            <t>SP 800-56a - 8 Key Recovery. Key Recovery SHALL NOT be in scope of KAS
+                                testing.</t>
+                        </list>
+                    </t>
+                </section>
+            </section>
 		</section>
 		<section anchor="caps_reg" title="Capabilities Registration">
-			<t>ACVP requires crypto modules to register their capabilities. This allows the crypto
+			<t>ACVP REQUIRES crypto modules to register their capabilities. This allows the crypto
 				module to advertise support for specific algorithms, notifying the ACVP server which
 				algorithms need test vectors generated for the validation process. This section
 				describes the constructs for advertising support of KAS FFC algorithms to the ACVP
@@ -294,32 +293,32 @@
 					<ttcol align="left">Prerequisite Algorithm</ttcol>
 					<ttcol align="left">Condition</ttcol>
 					<c>DRBG</c>
-					<c>Always required</c>
+					<c>Always REQUIRED</c>
 					<c/>
 					<c/>
 					<c>SHA</c>
-					<c>Always required</c>
+					<c>Always REQUIRED</c>
 					<c/>
 					<c/>
 					<c>DSA</c>
-					<c> DSA.PQGGen validation required when IUT using assurance function of "dpGen".
-						DSA.PQGVer validation required when IUT using assurance function of "dpVal".
-						DSA.KeyPairGen validation required when IUT using assurances functions of
+					<c> DSA.PQGGen validation REQUIRED when IUT using assurance function of "dpGen".
+						DSA.PQGVer validation REQUIRED when IUT using assurance function of "dpVal".
+						DSA.KeyPairGen validation REQUIRED when IUT using assurances functions of
 						"keyPairGen", or "keyRegen". </c>
 					<c/>
 					<c/>
 					<c>AES-CCM</c>
-					<c>AES-CCM validation required when IUT is performing KeyConfirmation (KC) and
+					<c>AES-CCM validation REQUIRED when IUT is performing KeyConfirmation (KC) and
 						utilizing AES-CCM.</c>
 					<c/>
 					<c/>
 					<c>CMAC</c>
-					<c>CMAC validation required when IUT is performing KeyConfirmation (KC) and
+					<c>CMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and
 						utilizing CMAC.</c>
 					<c/>
 					<c/>
 					<c>HMAC</c>
-					<c>HMAC validation required when IUT is performing KeyConfirmation (KC) and
+					<c>HMAC validation REQUIRED when IUT is performing KeyConfirmation (KC) and
 						utilizing HMAC.</c>
 					<c/>
 					<c/>
@@ -389,12 +388,12 @@
 					<c/>
 					<c/>
 				</texttable>
-				<t>Note: Some optional values are required depending on the algorithm. Failure to
+				<t>Note: Some optional values are REQUIRED depending on the algorithm. Failure to
 					provide these values will result in the ACVP server returning an error to the
 					ACVP client during registration.</t>
 			</section>
 			<section anchor="supported_functions" title="Supported KAS FFC Functions">
-				<t>The following function types may be advertised by the ACVP compliant crypto
+				<t>The following function types MAY be advertised by the ACVP compliant crypto
 					module:</t>
 				<t>
 					<list style="symbols">
@@ -412,9 +411,9 @@
 			</section>
 			<section anchor="schemes" title="KAS FFC Schemes">
 				<section anchor="supported_schemes" title="KAS FFC Scheme Capabilities JSON Values">
-					<t> All other scheme capability advertised is a self-contained JSON object using
+					<t> All other scheme capabilities are advertised is a self-contained JSON object using
 						the following values. Note that at least one of "noKdfNoKc", "kdfNoKc", or
-						"kdfKc" must be supplied with the registration. See <xref
+						"kdfKc" MUST be supplied with the registration. See <xref
 							target="supported_scheme_values"/> for allowed FFC scheme types. </t>
 					<texttable anchor="scheme_caps_table" title="KAS FFC Capabilities JSON Values">
 						<ttcol align="left">JSON Value</ttcol>
@@ -434,7 +433,7 @@
 						<c/>
 						<c>noKdfNoKc</c>
 						<c>Indicates no KDF, no KC tests are to be generated. Note this is a
-							COMPONENT mode only test. This property can only be used with "KAS-FFC"
+							COMPONENT mode only test. This property MUST only be used with "KAS-FFC"
 							/ "Component"</c>
 						<c>object</c>
 						<c>
@@ -448,7 +447,7 @@
 						<c/>
 						<c>kdfNoKc</c>
 						<c>Indicates KDF, no KC tests are to be generated. Note this is a KAS-FFC
-							only test. This mode is only valid for registrations with "KAS-FFC" (no
+							only test. This mode MUST only be used for registrations with "KAS-FFC" (no
 							mode)</c>
 						<c>object</c>
 						<c>
@@ -461,7 +460,9 @@
 						<c/>
 						<c/>
 						<c>kdfKc</c>
-						<c>Indicates KDF, KC tests are to be generated.</c>
+						 <c>Indicates KDF, KC tests are to be generated. Note this is a KAS-FFC only
+                            test. This mode MAY only be used for registrations with "KAS-FFC" (no
+                            mode)</c>
 						<c>object</c>
 						<c>
 							<xref target="kdfKc"/>
@@ -475,7 +476,7 @@
 					</texttable>
 				</section>
 				<section anchor="supported_scheme_values" title="Supported KAS FFC Schemes">
-					<t>The following schemes may be advertised by the ACVP compliant crypto
+					<t>The following schemes MAY be advertised by the ACVP compliant crypto
 						module:</t>
 					<t>
 						<list style="symbols">
@@ -493,7 +494,7 @@
 			</section>
 			<section anchor="kasMode" title="KAS FFC Modes">
 				<section anchor="noKdfNoKc" title="KAS FFC noKdfNoKc">
-					<t>Contains properties required for "noKdfNoKc" registration. </t>
+					<t>Contains properties REQUIRED for "noKdfNoKc" registration. </t>
 					<texttable anchor="noKdfNoKc_table" title="NoKdfNoKc Capabilities">
 						<ttcol align="left">JSON Value</ttcol>
 						<ttcol align="left">Description</ttcol>
@@ -515,7 +516,7 @@
 					</texttable>
 				</section>
 				<section anchor="kdfNoKc" title="KAS FFC kdfNoKc">
-					<t>Contains properties required for "kdfNoKc" registration. </t>
+					<t>Contains properties REQUIRED for "kdfNoKc" registration. </t>
 					<texttable anchor="kdfNoKc_table" title="kdfNoKc Capabilities">
 						<ttcol align="left">JSON Value</ttcol>
 						<ttcol align="left">Description</ttcol>
@@ -549,7 +550,7 @@
 					</texttable>
 				</section>
 				<section anchor="kdfKc" title="KAS FFC kdfKc">
-					<t>Contains properties required for "kdfKc" registration. </t>
+					<t>Contains properties REQUIRED for "kdfKc" registration. </t>
 					<texttable anchor="kdfKc_table" title="kdfKc Capabilities">
 						<ttcol align="left">JSON Value</ttcol>
 						<ttcol align="left">Description</ttcol>
@@ -598,8 +599,7 @@
 			<section anchor="parameterSet" title="Parameter Sets">
 				<section anchor="parameter_set" title="KAS FFC Parameter Set">
 					<t>Each parameter set advertised is a self-contained JSON object using the
-						following values. Note that at least one parameter set ("fb", "fc") is
-						required.</t>
+						following values. Note that at least one parameter set ("fb", "fc") MUST be provided.</t>
 					<texttable anchor="parameter_set_table"
 						title="KAS FFC Parameter Set Capabilities JSON Values">
 						<ttcol align="left">JSON Value</ttcol>
@@ -637,9 +637,9 @@
 						macSize - 64</t>
 					<t>fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min
 						macSize - 64</t>
-					<t>"noKdfNoKc" requires "hashAlg"</t>
-					<t>"kdfNoKc" requires "hashAlg" and at least one valid MAC registration</t>
-					<t>"kdfKc" requires "hashAlg" and at least one valid MAC registration</t>
+					<t>"noKdfNoKc" REQUIRES "hashAlg"</t>
+					<t>"kdfNoKc" REQUIRES "hashAlg" and at least one valid MAC registration</t>
+					<t>"kdfKc" REQUIRES "hashAlg" and at least one valid MAC registration</t>
 					<texttable anchor="parameter_set_details_table"
 						title="KAS FFC Parameter Set Details Capabilities JSON Values">
 						<ttcol align="left">JSON Value</ttcol>
@@ -673,7 +673,7 @@
 				</section>
 			</section>
 			<section anchor="supported_hashAlg" title="Supported Hash Algorithm Methods">
-				<t>The following SHA methods may be advertised by the ACVP compliant crypto
+				<t>The following SHA methods MAY be advertised by the ACVP compliant crypto
 					module:</t>
 				<t>
 					<list style="symbols">
@@ -685,7 +685,7 @@
 				</t>
 			</section>
 			<section anchor="supported_macOption" title="Supported KAS FFC MAC Options">
-				<t>The following MAC options are available for registration under a "kdfNoKc" and
+				<t>The following MAC options MAY be advertised for registration under a "kdfNoKc" and
 					"kdfKc" kasMode:</t>
 				<t>
 					<list style="symbols">
@@ -707,7 +707,7 @@
 					<c>The supported keyLens for the selected MAC.</c>
 					<c>Domain</c>
 					<c> AES based MACs limited to 128, 192, 256. HashAlg based MACs mod 8. All
-						keySizes minimum must conform to parameter set requirements See <xref
+						keySizes minimum MUST conform to parameter set requirements See <xref
 							target="parameter_set_details"/> . </c>
 					<c>No</c>
 					<c/>
@@ -718,10 +718,10 @@
 					<c>nonceLen</c>
 					<c>The nonce len for use with AES-CCM mac</c>
 					<c>value</c>
-					<c>Input as bits, 56-104, odd byte values only (7-13). Additionally minimum must
+					<c>Input as bits, 56-104, odd byte values only (7-13). Additionally minimum MUST
 						conform to parameter set requirements See <xref
 							target="parameter_set_details"/> . </c>
-					<c>Yes (required for AES-CCM)</c>
+					<c>Yes (REQUIRED for AES-CCM)</c>
 					<c/>
 					<c/>
 					<c/>
@@ -730,10 +730,10 @@
 					<c>macLen</c>
 					<c>The mac len for use with mac</c>
 					<c>value</c>
-					<c>Input as bits, mod 8, minimum must conform to parameter set requirements See
-							<xref target="parameter_set_details"/> , maximum may not exceed block
+					<c>Input as bits, mod 8, minimum MUST conform to parameter set requirements See
+							<xref target="parameter_set_details"/> , maximum MAY NOT exceed block
 						size.. </c>
-					<c>Yes (required for AES-CCM)</c>
+					<c>Yes (REQUIRED for AES-CCM)</c>
 					<c/>
 					<c/>
 					<c/>
@@ -768,10 +768,10 @@
 					<c/>
 				</texttable>
 				<section anchor="oiPatternConstruction" title="Other Information Construction">
-					<t> Some IUTs require a specific pattern for the OtherInfo portion of the KDFs
+					<t> Some IUTs MAY require a specific pattern for the OtherInfo portion of the KDFs
 						for KAS. An "oiPattern" is specified in the KDF registration to accommodate
 						such requirements. Regardless of the oiPattern specified, the OI bitlength
-						must be 240 for FFC, and 376 for ECC. The OI will be padded with random bits
+						MUST be 240 for FFC, and 376 for ECC. The OI will be padded with random bits
 						(or the most significant bits utilized) when the specified OI pattern does
 						not meet the bitlength requirement </t>
 					<t>Pattern candidates:</t>
@@ -2374,7 +2374,7 @@
 				<t>The testGroups element at the top level in the test vector JSON object is an
 					array of test groups. Test vectors are grouped into similar test cases to reduce
 					the amount of data transmitted in the vector set. For instance, all test vectors
-					that use the same key size would be grouped together. The Test Group JSON object
+					that use the same key size MAY be grouped together. The Test Group JSON object
 					contains meta data that applies to all test vectors within the group. The
 					following table describes the secure hash JSON elements of the Test Group JSON
 					object.</t>
@@ -2449,7 +2449,7 @@
 					<c/>
 					<c/>
 					<c>macType</c>
-					<c>The MAC being used. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The MAC being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
 					<c>See <xref target="supported_macOption"/>
 					</c>
 					<c>Yes</c>
@@ -2458,7 +2458,7 @@
 					<c/>
 					<c/>
 					<c>keyLen</c>
-					<c>The key length of the MAC. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The key length of the MAC. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
 					<c>See <xref target="supported_macOption"/>
 					</c>
 					<c>Yes</c>
@@ -2467,7 +2467,7 @@
 					<c/>
 					<c/>
 					<c>nonceAesCcmLen</c>
-					<c>The nonce length of the MAC (applies only to AES-CCM). Required for "kdfNoKc"
+					<c>The nonce length of the MAC (applies only to AES-CCM). REQUIRED for "kdfNoKc"
 						and "kdfKc" modes using a AES-CCM MAC.</c>
 					<c>See <xref target="supported_macOption"/>
 					</c>
@@ -2477,7 +2477,7 @@
 					<c/>
 					<c/>
 					<c>macLen</c>
-					<c>The mac length. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The mac length. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
 					<c>See <xref target="supported_macOption"/>
 					</c>
 					<c>Yes</c>
@@ -2486,7 +2486,7 @@
 					<c/>
 					<c/>
 					<c>kdfType</c>
-					<c>The KDF being used. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The KDF being used. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
 					<c>concatenation, asn1</c>
 					<c>Yes</c>
 					<c/>
@@ -2494,7 +2494,7 @@
 					<c/>
 					<c/>
 					<c>idServerLen</c>
-					<c>The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
 					<c>value</c>
 					<c>Yes</c>
 					<c/>
@@ -2502,7 +2502,7 @@
 					<c/>
 					<c/>
 					<c>idServer</c>
-					<c>The server ID. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.</c>
 					<c>value</c>
 					<c>Yes</c>
 					<c/>
@@ -2510,7 +2510,7 @@
 					<c/>
 					<c/>
 					<c>idIutLen</c>
-					<c>The length of the server ID. Required for "kdfNoKc" and "kdfKc" modes.
+					<c>The length of the server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes.
 						Provided in response by IUT for AFT tests.</c>
 					<c>value</c>
 					<c>Yes</c>
@@ -2519,7 +2519,7 @@
 					<c/>
 					<c/>
 					<c>idIut</c>
-					<c>The server ID. Required for "kdfNoKc" and "kdfKc" modes. Provided in response
+					<c>The server ID. REQUIRED for "kdfNoKc" and "kdfKc" modes. Provided in response
 						by IUT for AFT tests.</c>
 					<c>value</c>
 					<c>Yes</c>
@@ -2528,7 +2528,7 @@
 					<c/>
 					<c/>
 					<c>oiPattern</c>
-					<c>The oiPattern used in the KDF. Required for "kdfNoKc" and "kdfKc" modes.</c>
+					<c>The oiPattern used in the KDF. For "kdfNoKc" and "kdfKc" modes.</c>
 					<c>See <xref target="oiPatternConstruction"/>
 					</c>
 					<c>Yes</c>
@@ -2537,7 +2537,7 @@
 					<c/>
 					<c/>
 					<c>kcRole</c>
-					<c>Key confirmation roles supported. Required for "kdfKc" modes.</c>
+					<c>Key confirmation roles supported. REQUIRED for "kdfKc" modes.</c>
 					<c>provider, recipient</c>
 					<c>Yes</c>
 					<c/>
@@ -2545,7 +2545,7 @@
 					<c/>
 					<c/>
 					<c>kcType</c>
-					<c>Key confirmation types supported. Required for "kdfKc" modes.</c>
+					<c>Key confirmation types supported. REQUIRED for "kdfKc" modes.</c>
 					<c>unilateral and/or bilateral</c>
 					<c>Yes</c>
 					<c/>
@@ -2629,7 +2629,7 @@
 					<c/>
 					<c/>
 					<c>nonceNoKc</c>
-					<c>The 16 byte nonce concatenated to the "Standard Test Message". Used for No
+					<c>The 16 byte nonce concatenated to the "Standard Test Message". REQUIRED for No
 						Key Confirmation tests only.</c>
 					<c>value</c>
 					<c>Yes</c>
@@ -3606,7 +3606,7 @@
 			</section>
 		</section>
 		<section anchor="vector_responses" title="Test Vector Responses">
-			<t>After the ACVP client downloads and processes a vector set, it must send the response
+			<t>After the ACVP client downloads and processes a vector set, it SHALL send the response
 				vectors back to the ACVP server. The following table describes the JSON object that
 				represents a vector set response.</t>
 			<texttable anchor="vr_top_table" title="Vector Set Response JSON Object">


### PR DESCRIPTION
I think I ended up getting most of the changes in the previous update to this spec, so I mostly went through and tried to update for RFC 2119.

One thing that is definitely, at least currently, different from the symmetric spec, was my placement of the JSON samples.  In the KAS specs I had kept them along with the definitions of the properties.  What is everyone's thoughts on this?  With how much variation there is to the different methods of running KAS, I felt it was better suited along with the property definition; but this of course makes it differ from the symmetric spec.  

Should the KAS json be moved to the appendix? Should the symmetric spec have its JSON moved up along with the section? Or is fine to have this difference since the size and scope of these algorithms is just so different?