### PR TITLE
Removal of "keyingOption" from TDES-KW.

### DIFF
--- a/artifacts/draft-celi-block-ciph-00.html
+++ b/artifacts/draft-celi-block-ciph-00.html
@@ -427,7 +427,7 @@
 
   <meta name="dct.creator" content="Celi, C., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-celi-block-ciph-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-11-30" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using symmetric block cipher algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using symmetric block cipher algorithms with the ACVP specification." />
 
@@ -448,10 +448,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">November 30, 2018</td>
+<td class="right">November 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: June 3, 2019</td>
+<td class="left">Expires: May 5, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -468,7 +468,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on June 3, 2019.</p>
+<p>This Internet-Draft will expire on May 5, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -1478,7 +1478,6 @@ For i = 0 to 399
 <th class="left">direction</th>
 <th class="left">keyLen</th>
 <th class="left">kwCipher</th>
-<th class="left">keyingOption</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1486,26 +1485,22 @@ For i = 0 to 399
 <td class="left">["encrypt", "decrypt"]</td>
 <td class="left">[128, 192, 256]</td>
 <td class="left">["cipher", "inverse"]</td>
-<td class="left"></td>
 </tr>
 <tr>
 <td class="left">AES-KWP</td>
 <td class="left">["encrypt", "decrypt"]</td>
 <td class="left">[128, 192, 256]</td>
 <td class="left">["cipher", "inverse"]</td>
-<td class="left"></td>
 </tr>
 <tr>
 <td class="left">TDES-KW</td>
 <td class="left">["encrypt", "decrypt"]</td>
 <td class="left"></td>
 <td class="left">["cipher", "inverse"]</td>
-<td class="left">[1, 2] Note: 2 is only available for decrypt operations</td>
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.2.p.7">Note: keyingOption 2 SHALL only available for decrypt operations.</p>
-<p id="rfc.section.4.2.p.8">The following grid outlines which properties are REQUIRED, as well as the possible values a server MAY support for each miscellaneous block cipher algorithm:</p>
+<p id="rfc.section.4.2.p.7">The following grid outlines which properties are REQUIRED, as well as the possible values a server MAY support for each miscellaneous block cipher algorithm:</p>
 <div id="rfc.table.6"></div>
 <div id="property_grid_misc"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1553,7 +1548,7 @@ For i = 0 to 399
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.4.2.p.9">Note: keyingOption 2 SHALL only available for decrypt operations.</p>
+<p id="rfc.section.4.2.p.8">Note: keyingOption 2 SHALL only available for decrypt operations.</p>
 <h1 id="rfc.section.5">
 <a href="#rfc.section.5">5.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
 </h1>
@@ -1847,7 +1842,6 @@ For i = 0 to 399
 <thead><tr>
 <th class="left">algorithm</th>
 <th class="left">keyLen</th>
-<th class="left">keyingOption</th>
 <th class="left">kwCipher</th>
 <th class="left">payloadLen</th>
 </tr></thead>
@@ -1855,21 +1849,18 @@ For i = 0 to 399
 <tr>
 <td class="left">AES-KW</td>
 <td class="left">128, 192, 256</td>
-<td class="left"></td>
 <td class="left">"cipher", "inverse"</td>
 <td class="left">within domain</td>
 </tr>
 <tr>
 <td class="left">AES-KWP</td>
 <td class="left">128, 192, 256</td>
-<td class="left"></td>
 <td class="left">"cipher", "inverse"</td>
 <td class="left">within domain</td>
 </tr>
 <tr>
 <td class="left">TDES-KW</td>
 <td class="left"></td>
-<td class="left">1, 2</td>
 <td class="left">"cipher", "inverse"</td>
 <td class="left">within domain</td>
 </tr>
@@ -2602,9 +2593,6 @@ POST [
                     ],
                     "kwCipher": [
                         "cipher"
-                    ],
-                    "keyLen": [
-                        192
                     ],
                     "payloadLen": [
                         512,

--- a/artifacts/draft-celi-block-ciph-00.txt
+++ b/artifacts/draft-celi-block-ciph-00.txt
@@ -4,8 +4,8 @@
 
 TBD                                                         C. Celi, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                         November 30, 2018
-Expires: June 3, 2019
+Intended status: Informational                             November 2018
+Expires: May 5, 2019
 
 
         ACVP Symmetric Block Cipher Algorithm JSON Specification
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 3, 2019.
+   This Internet-Draft will expire on May 5, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Celi                      Expires June 3, 2019                  [Page 1]
+Celi                       Expires May 5, 2019                  [Page 1]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -94,8 +94,8 @@ Table of Contents
      4.2.  Block Cipher Algorithm Capabilities JSON Values . . . . .  21
    5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  27
      5.1.  Test Groups . . . . . . . . . . . . . . . . . . . . . . .  28
-     5.2.  Test Cases  . . . . . . . . . . . . . . . . . . . . . . .  33
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  34
+     5.2.  Test Cases  . . . . . . . . . . . . . . . . . . . . . . .  32
+   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  33
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  35
    8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  35
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  35
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Celi                      Expires June 3, 2019                  [Page 2]
+Celi                       Expires May 5, 2019                  [Page 2]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 3]
+Celi                       Expires May 5, 2019                  [Page 3]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -221,7 +221,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 4]
+Celi                       Expires May 5, 2019                  [Page 4]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -277,7 +277,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 5]
+Celi                       Expires May 5, 2019                  [Page 5]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -333,7 +333,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 6]
+Celi                       Expires May 5, 2019                  [Page 6]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -389,7 +389,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 7]
+Celi                       Expires May 5, 2019                  [Page 7]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -445,7 +445,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 8]
+Celi                       Expires May 5, 2019                  [Page 8]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -501,7 +501,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                  [Page 9]
+Celi                       Expires May 5, 2019                  [Page 9]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -557,7 +557,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 10]
+Celi                       Expires May 5, 2019                 [Page 10]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -613,7 +613,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 11]
+Celi                       Expires May 5, 2019                 [Page 11]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -669,7 +669,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 12]
+Celi                       Expires May 5, 2019                 [Page 12]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -725,7 +725,7 @@ For i = 0 to 399
 
 
 
-Celi                      Expires June 3, 2019                 [Page 13]
+Celi                       Expires May 5, 2019                 [Page 13]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -781,7 +781,7 @@ For i = 0 to 399
 
 
 
-Celi                      Expires June 3, 2019                 [Page 14]
+Celi                       Expires May 5, 2019                 [Page 14]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -837,7 +837,7 @@ For i = 0 to 399
 
 
 
-Celi                      Expires June 3, 2019                 [Page 15]
+Celi                       Expires May 5, 2019                 [Page 15]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -893,7 +893,7 @@ For i = 0 to 399
 
 
 
-Celi                      Expires June 3, 2019                 [Page 16]
+Celi                       Expires May 5, 2019                 [Page 16]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -949,7 +949,7 @@ For i = 0 to 399
 
 
 
-Celi                      Expires June 3, 2019                 [Page 17]
+Celi                       Expires May 5, 2019                 [Page 17]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1005,7 +1005,7 @@ For i = 0 to 399
 
 
 
-Celi                      Expires June 3, 2019                 [Page 18]
+Celi                       Expires May 5, 2019                 [Page 18]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1061,7 +1061,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 19]
+Celi                       Expires May 5, 2019                 [Page 19]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1117,7 +1117,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 20]
+Celi                       Expires May 5, 2019                 [Page 20]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1173,7 +1173,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 21]
+Celi                       Expires May 5, 2019                 [Page 21]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1229,7 +1229,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 22]
+Celi                       Expires May 5, 2019                 [Page 22]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1285,7 +1285,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 23]
+Celi                       Expires May 5, 2019                 [Page 23]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1341,7 +1341,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 24]
+Celi                       Expires May 5, 2019                 [Page 24]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1397,30 +1397,24 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 25]
+Celi                       Expires May 5, 2019                 [Page 25]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-   +-----------+-------------+--------+------------+-------------------+
-   | algorithm | direction   | keyLen | kwCipher   | keyingOption      |
-   +-----------+-------------+--------+------------+-------------------+
-   | AES-KW    | ["encrypt", | [128,  | ["cipher", |                   |
-   |           | "decrypt"]  | 192,   | "inverse"] |                   |
-   |           |             | 256]   |            |                   |
-   | AES-KWP   | ["encrypt", | [128,  | ["cipher", |                   |
-   |           | "decrypt"]  | 192,   | "inverse"] |                   |
-   |           |             | 256]   |            |                   |
-   | TDES-KW   | ["encrypt", |        | ["cipher", | [1, 2] Note: 2 is |
-   |           | "decrypt"]  |        | "inverse"] | only available    |
-   |           |             |        |            | for decrypt       |
-   |           |             |        |            | operations        |
-   +-----------+-------------+--------+------------+-------------------+
+   +-----------+-------------------+---------------+-------------------+
+   | algorithm | direction         | keyLen        | kwCipher          |
+   +-----------+-------------------+---------------+-------------------+
+   | AES-KW    | ["encrypt",       | [128, 192,    | ["cipher",        |
+   |           | "decrypt"]        | 256]          | "inverse"]        |
+   | AES-KWP   | ["encrypt",       | [128, 192,    | ["cipher",        |
+   |           | "decrypt"]        | 256]          | "inverse"]        |
+   | TDES-KW   | ["encrypt",       |               | ["cipher",        |
+   |           | "decrypt"]        |               | "inverse"]        |
+   +-----------+-------------------+---------------+-------------------+
 
     Table 5: Key-Wrap Block Cipher Algorithm Capabilities Applicability
                                    Grid
-
-   Note: keyingOption 2 SHALL only available for decrypt operations.
 
    The following grid outlines which properties are REQUIRED, as well as
    the possible values a server MAY support for each miscellaneous block
@@ -1453,7 +1447,13 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 26]
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 26]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1509,7 +1509,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 27]
+Celi                       Expires May 5, 2019                 [Page 27]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1565,7 +1565,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 28]
+Celi                       Expires May 5, 2019                 [Page 28]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1621,7 +1621,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 29]
+Celi                       Expires May 5, 2019                 [Page 29]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1677,7 +1677,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 30]
+Celi                       Expires May 5, 2019                 [Page 30]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1719,37 +1719,24 @@ Internet-Draft                Sym Alg JSON                 November 2018
    The following grid defines when each property is REQUIRED from a
    server for a key-wrap block cipher:
 
+    +-----------+---------------+---------------------+---------------+
+    | algorithm | keyLen        | kwCipher            | payloadLen    |
+    +-----------+---------------+---------------------+---------------+
+    | AES-KW    | 128, 192, 256 | "cipher", "inverse" | within domain |
+    | AES-KWP   | 128, 192, 256 | "cipher", "inverse" | within domain |
+    | TDES-KW   |               | "cipher", "inverse" | within domain |
+    +-----------+---------------+---------------------+---------------+
+
+   Table 11: Prompt Test Group Key-Wrap Block Cipher Applicability Grid
 
 
 
 
 
-
-
-
-
-
-
-
-
-
-Celi                      Expires June 3, 2019                 [Page 31]
+Celi                       Expires May 5, 2019                 [Page 31]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
-
-   +-----------+-----------+--------------+---------------+------------+
-   | algorithm | keyLen    | keyingOption | kwCipher      | payloadLen |
-   +-----------+-----------+--------------+---------------+------------+
-   | AES-KW    | 128, 192, |              | "cipher",     | within     |
-   |           | 256       |              | "inverse"     | domain     |
-   | AES-KWP   | 128, 192, |              | "cipher",     | within     |
-   |           | 256       |              | "inverse"     | domain     |
-   | TDES-KW   |           | 1, 2         | "cipher",     | within     |
-   |           |           |              | "inverse"     | domain     |
-   +-----------+-----------+--------------+---------------+------------+
-
-   Table 11: Prompt Test Group Key-Wrap Block Cipher Applicability Grid
 
    Note: The particular values of a domain are REQUIRED to be an integer
    element of the domain present in the registration used.  The ACVP
@@ -1783,23 +1770,29 @@ Internet-Draft                Sym Alg JSON                 November 2018
    features (ex. on a block boundary, or not on a block boundary) within
    the domain the client provided in the registration.
 
-
-
-
-
-
-
-Celi                      Expires June 3, 2019                 [Page 32]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 5.2.  Test Cases
 
    Each test group SHALL contain an array of one or more test cases.
    Each test case is a JSON object that represents a single case to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each test case.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 32]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
 
    +------------+--------------------------------------------+---------+
    | JSON Value | Description                                | JSON    |
@@ -1839,23 +1832,23 @@ Internet-Draft                Sym Alg JSON                 November 2018
    Section 3 for more information.  The tcId property MUST appear within
    every test case sent to and from the server.
 
-
-
-
-
-
-
-Celi                      Expires June 3, 2019                 [Page 33]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 6.  Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it SHALL
    send the response vectors back to the ACVP server within the alloted
    timeframe.  The following table describes the JSON object that
    represents a vector set response.
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 33]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
 
    +------------+--------------------------------------+---------------+
    | JSON Value | Description                          | JSON type     |
@@ -1901,7 +1894,14 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 34]
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 34]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1957,7 +1957,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 35]
+Celi                       Expires May 5, 2019                 [Page 35]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2013,7 +2013,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 36]
+Celi                       Expires May 5, 2019                 [Page 36]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2069,7 +2069,7 @@ POST [
 
 
 
-Celi                      Expires June 3, 2019                 [Page 37]
+Celi                       Expires May 5, 2019                 [Page 37]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2125,7 +2125,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 38]
+Celi                       Expires May 5, 2019                 [Page 38]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2181,7 +2181,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 39]
+Celi                       Expires May 5, 2019                 [Page 39]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2237,7 +2237,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 40]
+Celi                       Expires May 5, 2019                 [Page 40]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2293,7 +2293,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 41]
+Celi                       Expires May 5, 2019                 [Page 41]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2349,7 +2349,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 42]
+Celi                       Expires May 5, 2019                 [Page 42]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2405,7 +2405,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 43]
+Celi                       Expires May 5, 2019                 [Page 43]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2461,7 +2461,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 44]
+Celi                       Expires May 5, 2019                 [Page 44]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2508,23 +2508,20 @@ Internet-Draft                Sym Alg JSON                 November 2018
                     "kwCipher": [
                         "cipher"
                     ],
-                    "keyLen": [
-                        192
-                    ],
                     "payloadLen": [
                         512,
                         192,
+                        128
+                    ]
+                }
 
 
 
-Celi                      Expires June 3, 2019                 [Page 45]
+Celi                       Expires May 5, 2019                 [Page 45]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-                        128
-                    ]
-                }
  ]
 
 Appendix B.  Example Vector Set Request/Responses JSON Object
@@ -2570,17 +2567,17 @@ Appendix B.  Example Vector Set Request/Responses JSON Object
                    {
                "tgId": 19,
                "testType": "AFT",
+               "direction": "decrypt",
+               "keyLen": 128,
+               "ivLen": 96,
 
 
 
-Celi                      Expires June 3, 2019                 [Page 46]
+Celi                       Expires May 5, 2019                 [Page 46]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-               "direction": "decrypt",
-               "keyLen": 128,
-               "ivLen": 96,
                "ivGen": "external",
                "ivGenMode": "8.2.2",
                "payloadLen": 0,
@@ -2629,7 +2626,10 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 47]
+
+
+
+Celi                       Expires May 5, 2019                 [Page 47]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2685,7 +2685,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 48]
+Celi                       Expires May 5, 2019                 [Page 48]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2741,7 +2741,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 49]
+Celi                       Expires May 5, 2019                 [Page 49]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2797,7 +2797,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 50]
+Celi                       Expires May 5, 2019                 [Page 50]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2853,7 +2853,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 51]
+Celi                       Expires May 5, 2019                 [Page 51]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2909,7 +2909,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 52]
+Celi                       Expires May 5, 2019                 [Page 52]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2965,7 +2965,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 53]
+Celi                       Expires May 5, 2019                 [Page 53]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3021,7 +3021,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 54]
+Celi                       Expires May 5, 2019                 [Page 54]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3077,7 +3077,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 55]
+Celi                       Expires May 5, 2019                 [Page 55]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3133,7 +3133,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 56]
+Celi                       Expires May 5, 2019                 [Page 56]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3189,7 +3189,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 57]
+Celi                       Expires May 5, 2019                 [Page 57]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3245,7 +3245,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 58]
+Celi                       Expires May 5, 2019                 [Page 58]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3301,7 +3301,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 59]
+Celi                       Expires May 5, 2019                 [Page 59]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3357,7 +3357,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 60]
+Celi                       Expires May 5, 2019                 [Page 60]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3413,7 +3413,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 61]
+Celi                       Expires May 5, 2019                 [Page 61]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3469,7 +3469,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 62]
+Celi                       Expires May 5, 2019                 [Page 62]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3525,7 +3525,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 63]
+Celi                       Expires May 5, 2019                 [Page 63]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3581,7 +3581,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 64]
+Celi                       Expires May 5, 2019                 [Page 64]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3637,7 +3637,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 65]
+Celi                       Expires May 5, 2019                 [Page 65]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3693,7 +3693,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 66]
+Celi                       Expires May 5, 2019                 [Page 66]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3749,7 +3749,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 67]
+Celi                       Expires May 5, 2019                 [Page 67]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3805,7 +3805,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 68]
+Celi                       Expires May 5, 2019                 [Page 68]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3861,7 +3861,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 69]
+Celi                       Expires May 5, 2019                 [Page 69]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3917,7 +3917,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 70]
+Celi                       Expires May 5, 2019                 [Page 70]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -3973,7 +3973,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 71]
+Celi                       Expires May 5, 2019                 [Page 71]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4029,7 +4029,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 72]
+Celi                       Expires May 5, 2019                 [Page 72]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4085,7 +4085,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 73]
+Celi                       Expires May 5, 2019                 [Page 73]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4141,7 +4141,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 74]
+Celi                       Expires May 5, 2019                 [Page 74]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4197,7 +4197,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 75]
+Celi                       Expires May 5, 2019                 [Page 75]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4253,7 +4253,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 76]
+Celi                       Expires May 5, 2019                 [Page 76]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4309,7 +4309,7 @@ Appendix C.  Example TDES Test and Results JSON Object
 
 
 
-Celi                      Expires June 3, 2019                 [Page 77]
+Celi                       Expires May 5, 2019                 [Page 77]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4365,7 +4365,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 78]
+Celi                       Expires May 5, 2019                 [Page 78]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4421,7 +4421,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 79]
+Celi                       Expires May 5, 2019                 [Page 79]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4477,7 +4477,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 80]
+Celi                       Expires May 5, 2019                 [Page 80]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4533,7 +4533,7 @@ Appendix D.  Example TDES MCT Test and Results JSON Object
 
 
 
-Celi                      Expires June 3, 2019                 [Page 81]
+Celi                       Expires May 5, 2019                 [Page 81]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4589,7 +4589,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires June 3, 2019                 [Page 82]
+Celi                       Expires May 5, 2019                 [Page 82]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -4645,4 +4645,4 @@ Author's Address
 
 
 
-Celi                      Expires June 3, 2019                 [Page 83]
+Celi                       Expires May 5, 2019                 [Page 83]

--- a/src/draft-celi-block-ciph-00.xml
+++ b/src/draft-celi-block-ciph-00.xml
@@ -1018,12 +1018,11 @@ For i = 0 to 399
                 </texttable>
                 <t>The following grid outlines which properties are REQUIRED, as well as the possible values a server MAY support for each key-wrap block cipher algorithm:</t>
                 <texttable anchor="property_grid_kw" title="Key-Wrap Block Cipher Algorithm Capabilities Applicability Grid">
-                    <ttcol align="left">algorithm</ttcol><ttcol align="left">direction</ttcol><ttcol align="left">keyLen</ttcol><ttcol align="left">kwCipher</ttcol><ttcol align="left">keyingOption</ttcol>
-                    <c>AES-KW</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>["cipher", "inverse"]</c><c></c>
-                    <c>AES-KWP</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>["cipher", "inverse"]</c><c></c>
-                    <c>TDES-KW</c><c>["encrypt", "decrypt"]</c><c></c><c>["cipher", "inverse"]</c><c>[1, 2] Note: 2 is only available for decrypt operations</c>
+                    <ttcol align="left">algorithm</ttcol><ttcol align="left">direction</ttcol><ttcol align="left">keyLen</ttcol><ttcol align="left">kwCipher</ttcol>
+                    <c>AES-KW</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>["cipher", "inverse"]</c>
+                    <c>AES-KWP</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>["cipher", "inverse"]</c>
+                    <c>TDES-KW</c><c>["encrypt", "decrypt"]</c><c></c><c>["cipher", "inverse"]</c>
                 </texttable>
-                <t>Note: keyingOption 2 SHALL only available for decrypt operations.</t>
                 <t>The following grid outlines which properties are REQUIRED, as well as the possible values a server MAY support for each miscellaneous block cipher algorithm:</t>
                 <texttable anchor="property_grid_misc" title="Miscellaneous Block Cipher Algorithm Capabilities Applicability Grid">
                     <ttcol align="left">algorithm</ttcol><ttcol align="left">direction</ttcol><ttcol align="left">keyLen</ttcol><ttcol align="left">payloadLen</ttcol><ttcol align="left">tweakMode</ttcol><ttcol align="left">keyingOption</ttcol><ttcol align="left">overflowCounter</ttcol><ttcol align="left">incrementalCounter</ttcol>
@@ -1275,22 +1274,18 @@ For i = 0 to 399
                 <texttable anchor="property_grid_prompt_kw" title="Prompt Test Group Key-Wrap Block Cipher Applicability Grid">
                     <ttcol align="left">algorithm</ttcol>
                     <ttcol align="left">keyLen</ttcol>
-                    <ttcol align="left">keyingOption</ttcol>
                     <ttcol align="left">kwCipher</ttcol>
                     <ttcol align="left">payloadLen</ttcol>
                     <c>AES-KW</c>
                     <c>128, 192, 256</c>
-                    <c/>
                     <c>"cipher", "inverse"</c>
                     <c>within domain</c>
                     <c>AES-KWP</c>
                     <c>128, 192, 256</c>
-                    <c/>
                     <c>"cipher", "inverse"</c>
                     <c>within domain</c>
                     <c>TDES-KW</c>
                     <c/>
-                    <c>1, 2</c>
                     <c>"cipher", "inverse"</c>
                     <c>within domain</c>
                 </texttable>
@@ -2101,9 +2096,6 @@ POST [
                     ],
                     "kwCipher": [
                         "cipher"
-                    ],
-                    "keyLen": [
-                        192
                     ],
                     "payloadLen": [
                         512,


### PR DESCRIPTION
- only keying option 1 is valid for TDES-KW, previously (incorrectly) allowed for both 1 and 2 keying options.
- Fixes #533, note should preferably not be merged into master until the change is deployed