### PR TITLE
Change outLength to domain in SHAKE registration example

### DIFF
--- a/src/draft-celi-sha3-00.xml
+++ b/src/draft-celi-sha3-00.xml
@@ -465,10 +465,11 @@
 	"inBit": true,
 	"inEmpty": true,
 	"outBit": true,
-	"outLength": {
+	"outLength": [
+        {
 		"min": 16,
 		"max": 1024
-	}
+	}]
 }
 ]]>
 				</artwork>


### PR DESCRIPTION
Fixes error pointed out in #545