### PR TITLE
Fix/rsa decrypt prim modulo

### DIFF
--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -2596,7 +2596,6 @@
    {
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
-      "modulo": 2048,
       "prereqVals": 
         [
             {"algorithm": "DRBG", "valValue": "123456"}, 

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -2629,7 +2629,7 @@
                  "randPQ" : "B.3.2",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1145
@@ -2644,7 +2644,7 @@
                 "randPQ": "B.3.2",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1147
@@ -2659,7 +2659,7 @@
                  "randPQ" : "B.3.4",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1149
@@ -2674,7 +2674,7 @@
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1151
@@ -2689,7 +2689,7 @@
                  "randPQ" : "B.3.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1153
@@ -2704,7 +2704,7 @@
                 "randPQ": "B.3.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1155
@@ -2719,7 +2719,7 @@
                  "randPQ" : "B.3.6",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1157
@@ -2734,7 +2734,7 @@
                 "randPQ": "B.3.6",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1159
@@ -2748,7 +2748,7 @@
                  "tgId": 9,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 2048,
                  "tests" : [
                     {
@@ -2770,7 +2770,7 @@
                  "tgId": 10,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 3072,
                  "tests" : [
                     {
@@ -2785,7 +2785,7 @@
                  "tgId": 11,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 2048,
                  "tests" : [
                     {
@@ -2807,7 +2807,7 @@
                  "tgId": 12,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 3072,
                  "tests" : [
                     {
@@ -2839,7 +2839,7 @@
             {
                 "tgId": 1,
                 "modulo" : 2048,
-                "testType" : "aft",
+                "testType" : "AFT",
                 "randPQ" : "B.3.4",
                 "pubExpMode" : "fixed",
                 "keyFormat" : "standard",
@@ -2864,7 +2864,7 @@
             }, {
                 "tgId": 2,
                 "modulo" : 3072,
-                "testType" : "aft",
+                "testType" : "AFT",
                 "randPQ" : "B.3.4",
                 "pubExpMode" : "fixed",
                 "keyFormat" : "standard",
@@ -2997,7 +2997,7 @@
                  "tgId": 1,
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -3014,7 +3014,7 @@
                  "sigType" : "ansx9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "89ca09",
                  "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
                  "tests" : [
@@ -3030,7 +3030,7 @@
                  "sigType" : "pkcs1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "49d2a1",
                  "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",  
                  "tests" : [
@@ -3046,7 +3046,7 @@
                 "sigType" : "pkcs1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
                 "tests" : [
@@ -3062,7 +3062,7 @@
                  "sigType" : "pss",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "10e43f",
                  "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",  
                  "tests" : [
@@ -3078,7 +3078,7 @@
                 "sigType" : "pss",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-512",
-                "testType": "aft",
+                "testType": "AFT",
                 "e" : "fe3079",
                 "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
                 "tests" : [

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -2208,7 +2208,6 @@ A.6.  Example decryptionPrimitive Capabilities JSON Objects
       {
          "algorithm": "RSA",
          "mode": "decryptionPrimitive",
-         "modulo": 2048,
          "prereqVals":
            [
                {"algorithm": "DRBG", "valValue": "123456"},
@@ -2234,6 +2233,7 @@ B.1.  Example Test Vectors for keyGen JSON Objects
      "mode": "keyGen",
      "infoGeneratedByServer": false,
      "pubExpMode" : "random",
+     "keyFormat": "standard",
 
 
 
@@ -2242,7 +2242,6 @@ Vassilev                 Expires August 5, 2018                [Page 40]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-     "keyFormat": "standard",
      "testGroups" : [
              {
                  "tgId": 1,
@@ -2290,6 +2289,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  ]
              },
              {
+                "tgId": 4,
 
 
 
@@ -2298,7 +2298,6 @@ Vassilev                 Expires August 5, 2018                [Page 41]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                "tgId": 4,
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
@@ -2346,6 +2345,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "tgId": 7,
                  "randPQ" : "B.3.6",
                  "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
 
 
 
@@ -2354,7 +2354,6 @@ Vassilev                 Expires August 5, 2018                [Page 42]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                 "hashAlg" : "SHA2-256",
                  "testType": "aft",
                  "tests" : [
                     {
@@ -2402,6 +2401,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     }
                  ]
              },
+             {
 
 
 
@@ -2410,7 +2410,6 @@ Vassilev                 Expires August 5, 2018                [Page 43]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-             {
                  "tgId": 10,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -2458,6 +2457,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1124,
                       "e" : "535c97",
                       "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
 
 
 
@@ -2466,7 +2466,6 @@ Vassilev                 Expires August 5, 2018                [Page 44]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
              }
@@ -2514,6 +2513,7 @@ B.2.  Example Test Vectors for keyGen when infoGeneratedByServer is true
                     {
                         "tcId" : 1,
                         "bitlens" : [ 143, 160, 235, 249 ],
+                        "seed" : "3CE2DBBFFE28316F8E21BD73201E2D2B060EB14B53C4327627800E07"
 
 
 
@@ -2522,7 +2522,6 @@ Vassilev                 Expires August 5, 2018                [Page 45]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                        "seed" : "3CE2DBBFFE28316F8E21BD73201E2D2B060EB14B53C4327627800E07"
                     }, {
                         "tcId" : 2,
                         "bitlens" : [ 169, 316, 277, 168 ],
@@ -2570,6 +2569,7 @@ B.3.  Example Test Vectors for sigGen JSON Objects
  [
    { "acvVersion": <acvp-version> },
    { "vsId": 1163,
+      "algorithm": "RSA",
 
 
 
@@ -2578,7 +2578,6 @@ Vassilev                 Expires August 5, 2018                [Page 46]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-      "algorithm": "RSA",
       "mode": "sigGen",
       "testGroups" : [
              {
@@ -2626,6 +2625,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     {
                       "tcId" : 1168,
                       "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
+                    }
 
 
 
@@ -2634,7 +2634,6 @@ Vassilev                 Expires August 5, 2018                [Page 47]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                    }
                  ]
              },
              {
@@ -2682,6 +2681,7 @@ B.4.  Example Test Vectors for sigVer JSON Objects
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
                  "testType": "aft",
+                 "modulo" : 2048,
 
 
 
@@ -2690,7 +2690,6 @@ Vassilev                 Expires August 5, 2018                [Page 48]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                 "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
                  "tests" : [
@@ -2738,6 +2737,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pkcs1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
+                "testType": "aft",
 
 
 
@@ -2746,7 +2746,6 @@ Vassilev                 Expires August 5, 2018                [Page 49]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                "testType": "aft",
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
                 "tests" : [
@@ -2792,6 +2791,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
           ]
       }
   ]
+
 
 
 

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -2248,7 +2248,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "randPQ" : "B.3.2",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1145
@@ -2263,7 +2263,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "randPQ": "B.3.2",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1147
@@ -2278,7 +2278,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "randPQ" : "B.3.4",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1149
@@ -2301,7 +2301,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1151
@@ -2316,7 +2316,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "randPQ" : "B.3.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1153
@@ -2331,7 +2331,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "randPQ": "B.3.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1155
@@ -2354,7 +2354,7 @@ Vassilev                 Expires August 5, 2018                [Page 42]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1157
@@ -2369,7 +2369,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "randPQ": "B.3.6",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1159
@@ -2383,7 +2383,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "tgId": 9,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 2048,
                  "tests" : [
                     {
@@ -2413,7 +2413,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "tgId": 10,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 3072,
                  "tests" : [
                     {
@@ -2428,7 +2428,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "tgId": 11,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 2048,
                  "tests" : [
                     {
@@ -2450,7 +2450,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "tgId": 12,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 3072,
                  "tests" : [
                     {
@@ -2502,7 +2502,7 @@ B.2.  Example Test Vectors for keyGen when infoGeneratedByServer is true
             {
                 "tgId": 1,
                 "modulo" : 2048,
-                "testType" : "aft",
+                "testType" : "AFT",
                 "randPQ" : "B.3.4",
                 "pubExpMode" : "fixed",
                 "keyFormat" : "standard",
@@ -2535,7 +2535,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
             }, {
                 "tgId": 2,
                 "modulo" : 3072,
-                "testType" : "aft",
+                "testType" : "AFT",
                 "randPQ" : "B.3.4",
                 "pubExpMode" : "fixed",
                 "keyFormat" : "standard",
@@ -2680,7 +2680,7 @@ B.4.  Example Test Vectors for sigVer JSON Objects
                  "tgId": 1,
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "modulo" : 2048,
 
 
@@ -2705,7 +2705,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "sigType" : "ansx9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "89ca09",
                  "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
                  "tests" : [
@@ -2721,7 +2721,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "sigType" : "pkcs1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "49d2a1",
                  "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
                  "tests" : [
@@ -2737,7 +2737,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pkcs1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
 
 
 
@@ -2761,7 +2761,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "sigType" : "pss",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "10e43f",
                  "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
                  "tests" : [
@@ -2777,7 +2777,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pss",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-512",
-                "testType": "aft",
+                "testType": "AFT",
                 "e" : "fe3079",
                 "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
                 "tests" : [

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -1928,7 +1928,7 @@
                  "randPQ" : "B.3.2",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1145
@@ -1943,7 +1943,7 @@
                 "randPQ": "B.3.2",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1147
@@ -1958,7 +1958,7 @@
                  "randPQ" : "B.3.4",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1149
@@ -1973,7 +1973,7 @@
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1151
@@ -1988,7 +1988,7 @@
                  "randPQ" : "B.3.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1153
@@ -2003,7 +2003,7 @@
                 "randPQ": "B.3.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1155
@@ -2018,7 +2018,7 @@
                  "randPQ" : "B.3.6",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "tests" : [
                     {
                       "tcId" : 1157
@@ -2033,7 +2033,7 @@
                 "randPQ": "B.3.6",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "tests": [
                   {
                     "tcId": 1159
@@ -2047,7 +2047,7 @@
                  "tgId": 9,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 2048,
                  "tests" : [
                     {
@@ -2069,7 +2069,7 @@
                  "tgId": 10,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 3072,
                  "tests" : [
                     {
@@ -2084,7 +2084,7 @@
                  "tgId": 11,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 2048,
                  "tests" : [
                     {
@@ -2106,7 +2106,7 @@
                  "tgId": 12,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC3",
-                 "testType": "kat",
+                 "testType": "KAT",
                  "modulo" : 3072,
                  "tests" : [
                     {
@@ -2146,7 +2146,7 @@
             {
                 "tgId": 1,
                 "modulo" : 2048,
-                "testType" : "aft",
+                "testType" : "AFT",
                 "randPQ" : "B.3.4",
                 "pubExpMode" : "fixed",
                 "keyFormat" : "standard",
@@ -2171,7 +2171,7 @@
             }, {
                 "tgId": 2,
                 "modulo" : 3072,
-                "testType" : "aft",
+                "testType" : "AFT",
                 "randPQ" : "B.3.4",
                 "pubExpMode" : "fixed",
                 "keyFormat" : "standard",
@@ -2306,7 +2306,7 @@
                  "tgId": 1,
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
@@ -2323,7 +2323,7 @@
                  "sigType" : "ansx9.31",
                  "modulo" : 3072,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "89ca09",
                  "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
                  "tests" : [
@@ -2339,7 +2339,7 @@
                  "sigType" : "pkcs1v1.5",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "49d2a1",
                  "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",  
                  "tests" : [
@@ -2355,7 +2355,7 @@
                 "sigType" : "pkcs1v1.5",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
-                "testType": "aft",
+                "testType": "AFT",
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
                 "tests" : [
@@ -2371,7 +2371,7 @@
                  "sigType" : "pss",
                  "modulo" : 2048,
                  "hashAlg" : "SHA2-256",
-                 "testType": "aft",
+                 "testType": "AFT",
                  "e" : "10e43f",
                  "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",  
                  "tests" : [
@@ -2387,7 +2387,7 @@
                 "sigType" : "pss",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-512",
-                "testType": "aft",
+                "testType": "AFT",
                 "e" : "fe3079",
                 "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
                 "tests" : [

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -1895,7 +1895,6 @@
    {
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
-      "modulo": 2048,
       "prereqVals": 
         [
             {"algorithm": "DRBG", "valValue": "123456"}, 


### PR DESCRIPTION
Removes "modulo" property from RSA-DecryptionPrimitive registration.
- closes #539 
- corrects casing on "AFT" and "KAT" test types within json samples.