### PR TITLE
Add message length to SHA1,2

### DIFF
--- a/artifacts/draft-celi-sha-00.html
+++ b/artifacts/draft-celi-sha-00.html
@@ -400,12 +400,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.10.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.8.2 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
 
@@ -426,7 +426,7 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">November 1, 2018</td>
+<td class="right">November 2018</td>
 </tr>
 <tr>
 <td class="left">Expires: May 5, 2019</td>
@@ -598,7 +598,7 @@ MD[0] = MD[1] = MD[2] = SEED
 </tr>
 <tr>
 <td class="left">messageLength</td>
-<td class="left">The message lengths supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</td>
+<td class="left">The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</td>
 <td class="left">domain</td>
 </tr>
 </tbody>

--- a/artifacts/draft-celi-sha-00.html
+++ b/artifacts/draft-celi-sha-00.html
@@ -405,7 +405,7 @@
 
   <meta name="dct.creator" content="Celi, C., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-11-08" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
 
@@ -426,10 +426,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">November 8, 2018</td>
+<td class="right">November 1, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: May 12, 2019</td>
+<td class="left">Expires: May 5, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -446,7 +446,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 12, 2019.</p>
+<p>This Internet-Draft will expire on May 5, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -537,7 +537,7 @@
 <p id="rfc.section.3.p.1">This section describes the design of the tests used to validate implementations of SHA-1 and SHA-2.  There are two types of tests for SHA-1 and SHA-2: functional tests and Monte Carlo tests. Each has a specific value to be used in the testType field. The testType field definitions are: </p>
 
 <ul>
-<li>"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'hash' operation.  AFTs cause the implementation under test to exercise nomral operations on a single block, multiple blocks, or partial blocks. In all cases, random data is used. The functional tests are designed to verify that the logical components of the hash function (block chunking, block padding etc.) are opertaing correctly.  </li>
+<li>"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'hash' operation.  AFTs cause the implementation under test to exercise nomral operations on a single block, multiple blocks, or partial blocks. In all cases, random data is used. The functional tests are designed to verify that the logical components of the hash function (block chunking, block padding etc.) are operating correctly.  </li>
 <li>"MCT" - Monte Carlo Test. These tests exercise the implementation under test under stenuous circumstances. The implementation under test must process the test vectors according to the correct algorithm and mode in this document. MCTs can help detect potential memory leaks over time, and problems in allocation of resources, addressing variables, error handling, and generally improper behavior in response to random inputs. Each MCT processes 100 pseudorandom tests. Each algorithm and mode SHOULD have at least one MCT group. See <a href="#MC_test" class="xref">Section 3.1</a> for implementation details.  </li>
 </ul>
 
@@ -576,7 +576,7 @@ MD[0] = MD[1] = MD[2] = SEED
 <h1 id="rfc.section.4">
 <a href="#rfc.section.4">4.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
 </h1>
-<p id="rfc.section.4.p.1">This section describes the constructs for advertising support of hash algorithms to the ACVP server. ACVP REQURIES cryptographic modules to register their capabilities in a registration.  This allows the cryptographic module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  </p>
+<p id="rfc.section.4.p.1">This section describes the constructs for advertising support of hash algorithms to the ACVP server. ACVP REQUIRES cryptographic modules to register their capabilities in a registration.  This allows the cryptographic module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  </p>
 <p id="rfc.section.4.p.2">The hash algorithm capabilities MUST be advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value MUST be an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value MUST be part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP Protocol Specification Section XXX for details on the registration message.  Each hash algorithm capability advertised SHALL be a self-contained JSON object.  </p>
 <h1 id="rfc.section.4.1">
 <a href="#rfc.section.4.1">4.1.</a> <a href="#hash_caps_reg" id="hash_caps_reg">HASH Algorithm Capabilities Registration</a>
@@ -597,14 +597,9 @@ MD[0] = MD[1] = MD[2] = SEED
 <td class="left">string</td>
 </tr>
 <tr>
-<td class="left">inBit</td>
-<td class="left">Implementation does accept bit-oriented messages</td>
-<td class="left">boolean</td>
-</tr>
-<tr>
-<td class="left">inEmpty</td>
-<td class="left">Implementation does accept null (zero-length) messages</td>
-<td class="left">boolean</td>
+<td class="left">messageLength</td>
+<td class="left">The message lengths supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</td>
+<td class="left">domain</td>
 </tr>
 </tbody>
 </table>
@@ -670,16 +665,6 @@ MD[0] = MD[1] = MD[2] = SEED
 <td class="left">testType</td>
 <td class="left">Test category type (AFT or MCT). See <a href="#testtypes" class="xref">Section 3</a> for more information</td>
 <td class="left">string</td>
-</tr>
-<tr>
-<td class="left">inBit</td>
-<td class="left">States that each test case in the group may contain a message with a length not at a byte boundary</td>
-<td class="left">boolean</td>
-</tr>
-<tr>
-<td class="left">inEmpty</td>
-<td class="left">States that the empty message is included in the group</td>
-<td class="left">boolean</td>
 </tr>
 <tr>
 <td class="left">tests</td>
@@ -813,7 +798,7 @@ MD[0] = MD[1] = MD[2] = SEED
 <h1 id="rfc.section.5.5">
 <a href="#rfc.section.5.5">5.5.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.5.5.p.1">This memo includes requests to IANA to join draft XXX.</p>
+<p id="rfc.section.5.5.p.1">This memo includes requests to IANA to join draft-vassilev-acvp-iana-00.</p>
 <h1 id="rfc.section.5.6">
 <a href="#rfc.section.5.6">5.6.</a> <a href="#Security" id="Security">Security Considerations</a>
 </h1>
@@ -826,7 +811,7 @@ MD[0] = MD[1] = MD[2] = SEED
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
 <td class="top">
-<a title="NIST">authSurName, authInitials.</a>, "<a>ACVP Specification</a>", 2016.</td>
+<a title="Cisco">Fussell, B.</a>, "<a>ACVP Specification</a>", 2019.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
@@ -856,8 +841,7 @@ MD[0] = MD[1] = MD[2] = SEED
 					
 {
 	"algorithm": "SHA2-256",
-	"inBit": true,
-	"inEmpty": true
+	"messageLength": [{"min": 0, "max": 65535, "increment": 1}]
 }
 
 				</pre>

--- a/artifacts/draft-celi-sha-00.txt
+++ b/artifacts/draft-celi-sha-00.txt
@@ -4,8 +4,8 @@
 
 TBD                                                         C. Celi, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                          November 8, 2018
-Expires: May 12, 2019
+Intended status: Informational                          November 1, 2018
+Expires: May 5, 2019
 
 
           ACVP Secure Hash Algorithm (SHA) JSON Specification
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 12, 2019.
+   This Internet-Draft will expire on May 5, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Celi                      Expires May 12, 2019                  [Page 1]
+Celi                       Expires May 5, 2019                  [Page 1]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -73,7 +73,7 @@ Table of Contents
    5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
      5.1.  Test Groups . . . . . . . . . . . . . . . . . . . . . . .   6
      5.2.  Test Case . . . . . . . . . . . . . . . . . . . . . . . .   7
-     5.3.  Test Vector Responses . . . . . . . . . . . . . . . . . .   8
+     5.3.  Test Vector Responses . . . . . . . . . . . . . . . . . .   7
      5.4.  Acknowledgements  . . . . . . . . . . . . . . . . . . . .   9
      5.5.  IANA Considerations . . . . . . . . . . . . . . . . . . .   9
      5.6.  Security Considerations . . . . . . . . . . . . . . . . .   9
@@ -82,8 +82,8 @@ Table of Contents
      6.2.  Informative References  . . . . . . . . . . . . . . . . .   9
    Appendix A.  Example Secure Hash Capabilities JSON Object . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  10
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  12
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  11
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Celi                      Expires May 12, 2019                  [Page 2]
+Celi                       Expires May 5, 2019                  [Page 2]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -153,7 +153,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
       single block, multiple blocks, or partial blocks.  In all cases,
       random data is used.  The functional tests are designed to verify
       that the logical components of the hash function (block chunking,
-      block padding etc.) are opertaing correctly.
+      block padding etc.) are operating correctly.
 
    o  "MCT" - Monte Carlo Test.  These tests exercise the implementation
       under test under stenuous circumstances.  The implementation under
@@ -165,7 +165,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires May 12, 2019                  [Page 3]
+Celi                       Expires May 5, 2019                  [Page 3]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -221,7 +221,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires May 12, 2019                  [Page 4]
+Celi                       Expires May 5, 2019                  [Page 4]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -229,7 +229,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 4.  Capabilities Registration
 
    This section describes the constructs for advertising support of hash
-   algorithms to the ACVP server.  ACVP REQURIES cryptographic modules
+   algorithms to the ACVP server.  ACVP REQUIRES cryptographic modules
    to register their capabilities in a registration.  This allows the
    cryptographic module to advertise support for specific algorithms,
    notifying the ACVP server which algorithms need test vectors
@@ -247,17 +247,16 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 4.1.  HASH Algorithm Capabilities Registration
 
-   +-----------+--------------------------------------------+----------+
-   | JSON      | Description                                | JSON     |
-   | Value     |                                            | type     |
-   +-----------+--------------------------------------------+----------+
-   | algorithm | The hash algorithm and mode to be          | string   |
-   |           | validated.                                 |          |
-   | inBit     | Implementation does accept bit-oriented    | boolean  |
-   |           | messages                                   |          |
-   | inEmpty   | Implementation does accept null (zero-     | boolean  |
-   |           | length) messages                           |          |
-   +-----------+--------------------------------------------+----------+
+   +---------------+------------------------------------------+--------+
+   | JSON Value    | Description                              | JSON   |
+   |               |                                          | type   |
+   +---------------+------------------------------------------+--------+
+   | algorithm     | The hash algorithm and mode to be        | string |
+   |               | validated.                               |        |
+   | messageLength | The message lengths supported by the     | domain |
+   |               | IUT. Minimum allowed is 0, maximum       |        |
+   |               | allowed is 65535.                        |        |
+   +---------------+------------------------------------------+--------+
 
              Table 1: Hash Algorithm Capabilities JSON Values
 
@@ -273,17 +272,15 @@ Internet-Draft                Sym Alg JSON                 November 2018
    require the client to download and process multiple test vector sets.
    Each test vector set SHALL represent an individual cryptographic
    algorithm, such as SHA-1, SHA2-256, SHA2-512, etc.  This section
+   describes the JSON schema for a test vector set used with hash
+   algorithms.
 
 
 
-
-Celi                      Expires May 12, 2019                  [Page 5]
+Celi                       Expires May 5, 2019                  [Page 5]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
-
-   describes the JSON schema for a test vector set used with hash
-   algorithms.
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta-data for the entire vector set.  The test vector set
@@ -333,28 +330,27 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires May 12, 2019                  [Page 6]
+
+
+
+Celi                       Expires May 5, 2019                  [Page 6]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-   +----------+-----------------------------------------+--------------+
-   | JSON     | Description                             | JSON type    |
-   | Value    |                                         |              |
-   +----------+-----------------------------------------+--------------+
-   | tgId     | Numeric identifier for the test group,  | integer      |
-   |          | unique across the entire vector set     |              |
-   | testType | Test category type (AFT or MCT). See    | string       |
-   |          | Section 3 for more information          |              |
-   | inBit    | States that each test case in the group | boolean      |
-   |          | may contain a message with a length not |              |
-   |          | at a byte boundary                      |              |
-   | inEmpty  | States that the empty message is        | boolean      |
-   |          | included in the group                   |              |
-   | tests    | Array of individual test case JSON      | array of     |
-   |          | objects, which are defined in           | testCase     |
-   |          | Section 5.2                             | objects      |
-   +----------+-----------------------------------------+--------------+
+   +----------+---------------------------------------+----------------+
+   | JSON     | Description                           | JSON type      |
+   | Value    |                                       |                |
+   +----------+---------------------------------------+----------------+
+   | tgId     | Numeric identifier for the test       | integer        |
+   |          | group, unique across the entire       |                |
+   |          | vector set                            |                |
+   | testType | Test category type (AFT or MCT). See  | string         |
+   |          | Section 3 for more information        |                |
+   | tests    | Array of individual test case JSON    | array of       |
+   |          | objects, which are defined in         | testCase       |
+   |          | Section 5.2                           | objects        |
+   +----------+---------------------------------------+----------------+
 
                       Table 3: Test Group JSON Object
 
@@ -384,22 +380,19 @@ Internet-Draft                Sym Alg JSON                 November 2018
    All properties described in the previous table MUST appear in the
    prompt file from the server for every testCase object.
 
-
-
-
-
-
-Celi                      Expires May 12, 2019                  [Page 7]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 5.3.  Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it SHALL
    send the response vectors back to the ACVP server within the alloted
    timeframe.  The following table describes the JSON object that
    represents a vector set response.
+
+
+
+Celi                       Expires May 5, 2019                  [Page 7]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
 
    +-------------+-----------------------------------------+-----------+
    | JSON Value  | Description                             | JSON type |
@@ -445,7 +438,14 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Celi                      Expires May 12, 2019                  [Page 8]
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                  [Page 8]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -475,7 +475,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 5.5.  IANA Considerations
 
-   This memo includes requests to IANA to join draft XXX.
+   This memo includes requests to IANA to join draft-vassilev-acvp-iana-
+   00.
 
 5.6.  Security Considerations
 
@@ -485,7 +486,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 6.1.  Normative References
 
-   [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
+   [ACVP]     Fussell, B., "ACVP Specification", 2019.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -500,8 +501,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-Celi                      Expires May 12, 2019                  [Page 9]
+Celi                       Expires May 5, 2019                  [Page 9]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -517,8 +517,7 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
 
    {
            "algorithm": "SHA2-256",
-           "inBit": true,
-           "inEmpty": true
+           "messageLength": [{"min": 0, "max": 65535, "increment": 1}]
    }
 
 
@@ -553,17 +552,14 @@ Appendix B.  Example Test Vectors JSON Object
         }]
 
 
-
-
-
-
-Celi                      Expires May 12, 2019                 [Page 10]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
    The following is another example JSON object for secure hash test
    vectors sent from the ACVP server to the crypto module.
+
+
+
+Celi                       Expires May 5, 2019                 [Page 10]
+
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    [
@@ -609,19 +605,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
      }]
 
 
-
-
-
-
-Celi                      Expires May 12, 2019                 [Page 11]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 Appendix C.  Example Test Results JSON Object
 
    The following is a example JSON object for secure hash test results
    sent from the crypto module to the ACVP server.
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 11]
+
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 [
@@ -667,14 +661,18 @@ Appendix C.  Example Test Results JSON Object
   }
 
 
+Author's Address
 
 
-Celi                      Expires May 12, 2019                 [Page 12]
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 12]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
-
-Author's Address
 
    Christopher Celi (editor)
    National Institute of Standards and Technology
@@ -725,4 +723,6 @@ Author's Address
 
 
 
-Celi                      Expires May 12, 2019                 [Page 13]
+
+
+Celi                       Expires May 5, 2019                 [Page 13]

--- a/artifacts/draft-celi-sha-00.txt
+++ b/artifacts/draft-celi-sha-00.txt
@@ -4,7 +4,7 @@
 
 TBD                                                         C. Celi, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                          November 1, 2018
+Intended status: Informational                             November 2018
 Expires: May 5, 2019
 
 
@@ -253,8 +253,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    +---------------+------------------------------------------+--------+
    | algorithm     | The hash algorithm and mode to be        | string |
    |               | validated.                               |        |
-   | messageLength | The message lengths supported by the     | domain |
-   |               | IUT. Minimum allowed is 0, maximum       |        |
+   | messageLength | The message lengths in bits supported by | domain |
+   |               | the IUT. Minimum allowed is 0, maximum   |        |
    |               | allowed is 65535.                        |        |
    +---------------+------------------------------------------+--------+
 
@@ -402,8 +402,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |             | vector set                              |           |
    | testResults | Array of JSON objects that represent    | array of  |
    |             | each test vector result, which uses the | testGroup |
-   |             | same JSON schema as defined in          | objects   |
-   |             | Section 5.2                             |           |
+   |             | same JSON schema as defined in Section  | objects   |
+   |             | 5.2                                     |           |
    +-------------+-----------------------------------------+-----------+
 
                  Table 5: Vector Set Response JSON Object

--- a/src/draft-celi-sha-00.xml
+++ b/src/draft-celi-sha-00.xml
@@ -234,7 +234,7 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>string</c>
 
 					<c>messageLength</c>
-					<c>The message lengths supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</c>
+					<c>The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</c>
 					<c>domain</c>
 				</texttable>
 				<t>

--- a/src/draft-celi-sha-00.xml
+++ b/src/draft-celi-sha-00.xml
@@ -149,7 +149,7 @@
 						"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'hash' operation.
 						AFTs cause the implementation under test to exercise nomral operations on a single block, multiple blocks, or partial blocks. In all cases,
 						random data is used. The functional tests are designed to verify that the logical components of the hash function (block chunking, block padding etc.)
-						are opertaing correctly.
+						are operating correctly.
 					</t>
 					<t>
 						"MCT" - Monte Carlo Test. These tests exercise the implementation under test under stenuous circumstances. The implementation under test
@@ -208,7 +208,7 @@ MD[0] = MD[1] = MD[2] = SEED
 		<section anchor="caps_reg" title="Capabilities Registration">
             <t>
                 This section describes the constructs for advertising support of hash algorithms to the
-                ACVP server. ACVP REQURIES cryptographic modules to register their capabilities in a registration.
+                ACVP server. ACVP REQUIRES cryptographic modules to register their capabilities in a registration.
                 This allows the cryptographic module to advertise support for specific algorithms, notifying the ACVP server which
                 algorithms need test vectors generated for the validation process.
             </t>
@@ -233,13 +233,9 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>The hash algorithm and mode to be validated.</c>
 					<c>string</c>
 
-					<c>inBit</c>
-					<c>Implementation does accept bit-oriented messages</c>
-					<c>boolean</c>
-
-					<c>inEmpty</c>
-					<c>Implementation does accept null (zero-length) messages</c>
-					<c>boolean</c>
+					<c>messageLength</c>
+					<c>The message lengths supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</c>
+					<c>domain</c>
 				</texttable>
 				<t>
 					The value of the algorithm property MUST be one of the elements from the list in <xref target="supported_algs"/>.
@@ -301,14 +297,6 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>testType</c>
 					<c>Test category type (AFT or MCT). See <xref target="testtypes"/> for more information</c>
 					<c>string</c>
-
-					<c>inBit</c>
-					<c>States that each test case in the group may contain a message with a length not at a byte boundary</c>
-					<c>boolean</c>
-
-					<c>inEmpty</c>
-					<c>States that the empty message is included in the group</c>
-					<c>boolean</c>
 
 					<c>tests</c>
 					<c>Array of individual test case JSON objects, which are defined in	<xref target="tcjs"/></c>
@@ -425,7 +413,7 @@ MD[0] = MD[1] = MD[2] = SEED
 			<!-- Possibly a 'Contributors' section ... -->
 
 			<section anchor="IANA" title="IANA Considerations">
-				<t>This memo includes requests to IANA to join draft XXX.</t>
+				<t>This memo includes requests to IANA to join draft-vassilev-acvp-iana-00.</t>
 			</section>
 
 			<section anchor="Security" title="Security Considerations">
@@ -440,10 +428,10 @@ MD[0] = MD[1] = MD[2] = SEED
 			&RFC2119;			<reference anchor="ACVP">
 				<front>
 					<title>ACVP Specification</title>
-					<author initials="authInitials" surname="authSurName">
-						<organization>NIST</organization>
+					<author initials="B" surname="Fussell">
+						<organization>Cisco</organization>
 					</author>
-					<date year="2016"/>
+					<date year="2019"/>
 				</front>
 			</reference>
 		</references>
@@ -477,8 +465,7 @@ MD[0] = MD[1] = MD[2] = SEED
 					<![CDATA[
 {
 	"algorithm": "SHA2-256",
-	"inBit": true,
-	"inEmpty": true
+	"messageLength": [{"min": 0, "max": 65535, "increment": 1}]
 }
 ]]>
 				</artwork>


### PR DESCRIPTION
This change removes the two boolean values (`"inEmpty"` and `"inBit"`) from the registrations for SHA1 and SHA2 in favor of a domain that expresses the same information (and more).