### PR TITLE
ECDSA Specifies that `capabilities` is optional.

### DIFF
--- a/artifacts/acvp_sub_ecdsa.html
+++ b/artifacts/acvp_sub_ecdsa.html
@@ -410,12 +410,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subecdsa-0.3" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-6" />
+  <meta name="dct.issued" scheme="ISO8601" content="2016-06-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using ECDSA algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using ECDSA algorithms with the ACVP specification." />
 
@@ -436,7 +436,7 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">June 2016</td>
+<td class="right">June 1, 2016</td>
 </tr>
 <tr>
 <td class="left">Expires: December 3, 2016</td>
@@ -690,6 +690,7 @@
 <td class="left">array of JSON objects, each with fields pertaining to the global ECDSA mode indicated above and identified uniquely by the combination of the ECDSA "mode" and indicated properties</td>
 <td class="left">Array of JSON objects</td>
 <td class="left">See <a href="#supported_modes" class="xref">Section 4.3</a> </td>
+<td class="left">Yes</td>
 </tr>
 </tbody>
 </table>
@@ -1109,7 +1110,7 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP.800-89">[SP.800-89]</b></td>
@@ -1135,7 +1136,7 @@
 				"valValue": "123456"
 			}
 		],
-		"Curve": [
+		"curve": [
 			"P-224",
 			"P-256",
 			"P-384",
@@ -1149,7 +1150,7 @@
 			"K-409",
 			"K-571"
 		],
-		"SecretGenerationMode": [
+		"secretGenerationMode": [
 			"extra bits",
 			"testing candidates"
 		]

--- a/artifacts/acvp_sub_ecdsa.txt
+++ b/artifacts/acvp_sub_ecdsa.txt
@@ -4,7 +4,7 @@
 
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                                 June 2016
+Intended status: Informational                              June 1, 2016
 Expires: December 3, 2016
 
 
@@ -294,28 +294,28 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |              | validated    |              | "sigGen", |          |
    |              |              |              | or        |          |
    |              |              |              | "sigVer"  |          |
-   | prereqVals   | prerequistie | array of     | See       | No       |
-   |              | algorithm    | prereqAlgVal | Section   |          |
-   |              | validations  | objects      | 4.1       |          |
-   | capabilities | array of     | Array of     | See       |
-   |              | JSON         | JSON objects | Section   |
-   |              | objects,     |              | 4.3       |
-   |              | each with    |              |           |
-   |              | fields       |              |           |
-   |              | pertaining   |              |           |
-   |              | to the       |              |           |
-   |              | global ECDSA |              |           |
-   |              | mode         |              |           |
-   |              | indicated    |              |           |
-   |              | above and    |              |           |
-   |              | identified   |              |           |
-   |              | uniquely by  |              |           |
-   |              | the          |              |           |
-   |              | combination  |              |           |
-   |              | of the ECDSA |              |           |
-   |              | "mode" and   |              |           |
-   |              | indicated    |              |           |
-   |              | properties   |              |           |
+   | prereqVals   | prerequistie | array of     | See Secti | No       |
+   |              | algorithm    | prereqAlgVal | on 4.1    |          |
+   |              | validations  | objects      |           |          |
+   | capabilities | array of     | Array of     | See Secti | Yes      |
+   |              | JSON         | JSON objects | on 4.3    |          |
+   |              | objects,     |              |           |          |
+   |              | each with    |              |           |          |
+   |              | fields       |              |           |          |
+   |              | pertaining   |              |           |          |
+   |              | to the       |              |           |          |
+   |              | global ECDSA |              |           |          |
+   |              | mode         |              |           |          |
+   |              | indicated    |              |           |          |
+   |              | above and    |              |           |          |
+   |              | identified   |              |           |          |
+   |              | uniquely by  |              |           |          |
+   |              | the          |              |           |          |
+   |              | combination  |              |           |          |
+   |              | of the ECDSA |              |           |          |
+   |              | "mode" and   |              |           |          |
+   |              | indicated    |              |           |          |
+   |              | properties   |              |           |          |
    +--------------+--------------+--------------+-----------+----------+
 
              Table 2: ECDSA Algorithm Capabilities JSON Values
@@ -745,8 +745,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [SP.800-89]
               NIST, "Recommendation for Obtaining Assurances for Digital
@@ -773,7 +773,7 @@ Appendix A.  Example Capabilities JSON Object
                                    "valValue": "123456"
                            }
                    ],
-                   "Curve": [
+                   "curve": [
                            "P-224",
                            "P-256",
                            "P-384",
@@ -795,7 +795,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                            "K-409",
                            "K-571"
                    ],
-                   "SecretGenerationMode": [
+                   "secretGenerationMode": [
                            "extra bits",
                            "testing candidates"
                    ]

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -243,6 +243,7 @@
                         
                         <xref target="supported_modes" />
                     </c>
+                    <c>Yes</c>
                 </texttable>
             </section>
             <section anchor="supported_modes" title="Supported ECDSA Modes Capabilities">
@@ -571,7 +572,7 @@
 				"valValue": "123456"
 			}
 		],
-		"Curve": [
+		"curve": [
 			"P-224",
 			"P-256",
 			"P-384",
@@ -585,7 +586,7 @@
 			"K-409",
 			"K-571"
 		],
-		"SecretGenerationMode": [
+		"secretGenerationMode": [
 			"extra bits",
 			"testing candidates"
 		]


### PR DESCRIPTION
- continues to be required for SigGen and SigVer
- corrected casing on a few json samples
- fixes #572