### PR TITLE
Testing Revision

### DIFF
--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -400,12 +400,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-11-13" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
 
@@ -426,10 +426,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">November 13, 2018</td>
+<td class="right">November 1, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: May 17, 2019</td>
+<td class="left">Expires: May 5, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -444,12 +444,12 @@
 <p>This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification.</p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 17, 2019.</p>
+<p>This Internet-Draft will expire on May 5, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -1025,6 +1025,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">1.0</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">derFuncEnabled</td>
 <td class="left">derivation function option, see the notes below            <a href="#caps_table" class="xref">Table 5</a> for more information.</td>
 <td class="left">boolean</td>
@@ -1238,6 +1252,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">The DRBG algorithm mode used for the test vectors.  See          <a href="#supported_algs" class="xref">Section 3.1</a> for possible values.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1729,7 +1753,7 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP800-90A">[SP800-90A]</b></td>
@@ -1744,6 +1768,7 @@
 <pre>
 {
   "algorithm": "ctrDRBG",
+  "revision": "1.0",
   "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "TDES", "valValue": "5678"}],
   "predResistanceEnabled": [
     true,
@@ -1894,6 +1919,7 @@
 <pre>
         {
   "algorithm": "hashDRBG",
+  "revision": "1.0",
   "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
   "predResistanceEnabled": [
     true,
@@ -2033,6 +2059,7 @@
                 { "vectorSetId": 1133,
                   "algorithm": "ctrDRBG",
                   "mode": "3KeyTDEA",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -2086,6 +2113,7 @@
                 { "vectorSetId": 1146,
                   "algorithm": "hmacDRBG",
                   "mode": "AES-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -2138,6 +2166,7 @@
                 { "vectorSetId": 1156,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -2190,6 +2219,7 @@
                 { "vectorSetId": 1157,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -2248,6 +2278,7 @@
                 { "vectorSetId": 1167,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,

--- a/artifacts/acvp_sub_drbg.html
+++ b/artifacts/acvp_sub_drbg.html
@@ -404,7 +404,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdrbg-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification." />
@@ -438,7 +438,7 @@
   </table>
 
   <p class="title">ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subdrbg-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subdrbg-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for testing DRBG implementations from SP 800-90A  with the ACVP specification.</p>

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -4,8 +4,8 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                         November 13, 2018
-Expires: May 17, 2019
+Intended status: Informational                          November 1, 2018
+Expires: May 5, 2019
 
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
@@ -25,14 +25,14 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 17, 2019.
+   This Internet-Draft will expire on May 5, 2019.
 
 Copyright Notice
 
@@ -41,7 +41,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 1]
+Vassilev                   Expires May 5, 2019                  [Page 1]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -82,7 +82,7 @@ Table of Contents
    9.  Normative References  . . . . . . . . . . . . . . . . . . . .  18
    Appendix A.  Example DRBG Capabilities JSON Object  . . . . . . .  19
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  25
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  30
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  31
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  33
 
 1.  Introduction
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 2]
+Vassilev                   Expires May 5, 2019                  [Page 2]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 3]
+Vassilev                   Expires May 5, 2019                  [Page 3]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -221,7 +221,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 4]
+Vassilev                   Expires May 5, 2019                  [Page 4]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -277,7 +277,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 5]
+Vassilev                   Expires May 5, 2019                  [Page 5]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -333,7 +333,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 6]
+Vassilev                   Expires May 5, 2019                  [Page 6]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -389,7 +389,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                  [Page 7]
+Vassilev                   Expires May 5, 2019                  [Page 7]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -416,6 +416,12 @@ Internet-Draft                DRBG Alg JSON                November 2018
    |                | be        |        |                 |           |
    |                | validated |        |                 |           |
    |                |           |        |                 |           |
+   | revision       | The       | value  | 1.0             | No        |
+   |                | algorithm |        |                 |           |
+   |                | testing   |        |                 |           |
+   |                | revision  |        |                 |           |
+   |                | to use.   |        |                 |           |
+   |                |           |        |                 |           |
    | derFuncEnabled | derivatio | boolea | true/false      | Yes, appl |
    |                | n         | n      |                 | icable to |
    |                | function  |        |                 | ctrDRBG   |
@@ -436,20 +442,20 @@ Internet-Draft                DRBG Alg JSON                November 2018
    |                | entropy   |        | the mechanism/o |           |
    |                | input.    |        | ption, max -    |           |
    |                | See       |        | larger values   |           |
+
+
+
+Vassilev                   Expires May 5, 2019                  [Page 8]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
    |                | Table 5   |        | are optional,   |           |
    |                | notes     |        | step -          |           |
    |                | below.    |        | increment.      |           |
    |                |           |        |                 |           |
    | nonceLen       | See       | Domain | min - at least  | No        |
    |                | Table 5   |        | one half of the |           |
-
-
-
-Vassilev                  Expires May 17, 2019                  [Page 8]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
    |                | notes     |        | maximum         |           |
    |                | below.    |        | security        |           |
    |                |           |        | strength        |           |
@@ -492,20 +498,20 @@ Internet-Draft                DRBG Alg JSON                November 2018
    |                |           |        | supported       |           |
    |                |           |        | length, step -  |           |
    |                |           |        | increment to    |           |
+
+
+
+Vassilev                   Expires May 5, 2019                  [Page 9]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
    |                |           |        | calculate all   |           |
    |                |           |        | supported       |           |
    |                |           |        | lengths; set    |           |
    |                |           |        | all to zero (0) |           |
    |                |           |        | if not          |           |
    |                |           |        | supported.      |           |
-
-
-
-Vassilev                  Expires May 17, 2019                  [Page 9]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
    |                |           |        |                 |           |
    | returnedBitsLe | See       | value  |                 | No        |
    | n              | Table 5   |        |                 |           |
@@ -532,8 +538,8 @@ Internet-Draft                DRBG Alg JSON                November 2018
    |                  | isite       | rereqAlgVa |           |         |
    |                  | algorithm   | l objects  |           |         |
    |                  | validations | - see      |           |         |
-   |                  |             | Section    |           |         |
-   |                  |             | 3.2        |           |         |
+   |                  |             | Section 3. |           |         |
+   |                  |             | 2          |           |         |
    |                  |             |            |           |         |
    | predResistanceEn | an implemen | array of   | [true],   | No      |
    | abled            | tation that | boolean    | [true,    |         |
@@ -548,20 +554,20 @@ Internet-Draft                DRBG Alg JSON                November 2018
    |                  |             |            |           |         |
    | reseedImplemente | Reseeding   | boolean    | true/fals | No      |
    | d                | of the DRBG |            | e         |         |
+
+
+
+Vassilev                   Expires May 5, 2019                 [Page 10]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
    |                  | shall be    |            |           |         |
    |                  | performed   |            |           |         |
    |                  | in          |            |           |         |
    |                  | accordance  |            |           |         |
    |                  | with the sp |            |           |         |
    |                  | ecification |            |           |         |
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 10]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
    |                  | for the     |            |           |         |
    |                  | given DRBG  |            |           |         |
    |                  | mechanism.  |            |           |         |
@@ -605,19 +611,18 @@ Internet-Draft                DRBG Alg JSON                November 2018
    Note 6: For ctrDRBG implementations, the derFuncEnabled property must
    be included.
 
+
+
+Vassilev                   Expires May 5, 2019                 [Page 11]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
    Note 7: All DRBGs are tested at their maximum supported security
    strength so this is the minimum bit length of the entropy input that
    ACVP will accept.  The maximum supported security strength is also
    the default value for this input.  Longer entropy inputs are
    permitted, with the following exception: for ctrDRBG with
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 11]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
    derFuncEnabled set to false, the bit length must equal the seed
    length.  See Tables 2 and 3 in [SP800-90A] for help on choosing
    appropriate parameter values for the DRBG being tested.
@@ -664,12 +669,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-
-
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 12]
+Vassilev                   Expires May 5, 2019                 [Page 12]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -690,6 +690,8 @@ Internet-Draft                DRBG Alg JSON                November 2018
    | mode        | The DRBG algorithm mode used for the test   | value |
    |             | vectors.  See          Section 3.1 for      |       |
    |             | possible values.                            |       |
+   |             |                                             |       |
+   | revision    | The algorithm testing revision to use.      | value |
    |             |                                             |       |
    | testGroups  | Array of test group JSON objects, which are | array |
    |             | defined in          Section 4.1             |       |
@@ -720,16 +722,16 @@ Internet-Draft                DRBG Alg JSON                November 2018
    |                   | for the test group,   |            |          |
    |                   | unique across the     |            |          |
    |                   | entire vector set.    |            |          |
-   |                   |                       |            |          |
-   | mode              | the mode of the DRBG, | value      | No       |
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 13]
+Vassilev                   Expires May 5, 2019                 [Page 13]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+   |                   |                       |            |          |
+   | mode              | the mode of the DRBG, | value      | No       |
    |                   | see                   |            |          |
    |                   | Section 3.1           |            |          |
    |                   |                       |            |          |
@@ -775,17 +777,18 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
                       Table 7: Test Group JSON Object
 
-   Note 11: According to SP 800-90A [SP800-90A] , a DRBG implementation
-   has two separate controls for determining the correct test procedure
-   for handling addtional entropy and other data in providing prediction
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 14]
+
+Vassilev                   Expires May 5, 2019                 [Page 14]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+   Note 11: According to SP 800-90A [SP800-90A] , a DRBG implementation
+   has two separate controls for determining the correct test procedure
+   for handling addtional entropy and other data in providing prediction
    resistance assurances.  Depending on the capabilities advertised by
    the predResistanceEnabled and reseedImplemented flags ACVP generates
    test data according to the following test scenarios:
@@ -834,10 +837,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 15]
+Vassilev                   Expires May 5, 2019                 [Page 15]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -893,7 +893,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 16]
+Vassilev                   Expires May 5, 2019                 [Page 16]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -949,7 +949,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 17]
+Vassilev                   Expires May 5, 2019                 [Page 17]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -992,8 +992,8 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [SP800-90A]
               Barker, E. and J. Kelsey, "Recommendation for Random
@@ -1005,7 +1005,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 18]
+Vassilev                   Expires May 5, 2019                 [Page 18]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -1017,6 +1017,7 @@ Appendix A.  Example DRBG Capabilities JSON Object
 
 {
   "algorithm": "ctrDRBG",
+  "revision": "1.0",
   "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "TDES", "valValue": "5678"}],
   "predResistanceEnabled": [
     true,
@@ -1057,15 +1058,15 @@ Appendix A.  Example DRBG Capabilities JSON Object
         320
       ],
       "returnedBitsLen": 512
-    },
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 19]
+Vassilev                   Expires May 5, 2019                 [Page 19]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+    },
     {
       "mode": "AES-256",
       "derFuncEnabled": true,
@@ -1113,15 +1114,15 @@ Internet-Draft                DRBG Alg JSON                November 2018
         256
       ],
       "additionalInputLen": [
-        256
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 20]
+Vassilev                   Expires May 5, 2019                 [Page 20]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+        256
       ],
       "returnedBitsLen": 512
     },
@@ -1169,15 +1170,15 @@ Internet-Draft                DRBG Alg JSON                November 2018
         232
       ],
       "persoStringLen": [
-        232
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 21]
+Vassilev                   Expires May 5, 2019                 [Page 21]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+        232
       ],
       "additionalInputLen": [
         232
@@ -1193,6 +1194,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
         {
   "algorithm": "hashDRBG",
+  "revision": "1.0",
   "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
   "predResistanceEnabled": [
     true,
@@ -1224,16 +1226,16 @@ Internet-Draft                DRBG Alg JSON                November 2018
         224
       ],
       "nonceLen": [
-        224
-      ],
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 22]
+Vassilev                   Expires May 5, 2019                 [Page 22]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+        224
+      ],
       "persoStringLen": [
         224
       ],
@@ -1280,16 +1282,16 @@ Internet-Draft                DRBG Alg JSON                November 2018
       "mode": "SHA2-512",
       "derFuncEnabled": false,
       "entropyInputLen": [
-        512
-      ],
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 23]
+Vassilev                   Expires May 5, 2019                 [Page 23]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+        512
+      ],
       "nonceLen": [
         512
       ],
@@ -1336,15 +1338,15 @@ Internet-Draft                DRBG Alg JSON                November 2018
       "returnedBitsLen": 1024
     }
   ]
-}
 
 
 
-
-Vassilev                  Expires May 17, 2019                 [Page 24]
+Vassilev                   Expires May 5, 2019                 [Page 24]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
+
+}
 
 Appendix B.  Example Test Vectors JSON Object
 
@@ -1356,6 +1358,7 @@ Appendix B.  Example Test Vectors JSON Object
                 { "vectorSetId": 1133,
                   "algorithm": "ctrDRBG",
                   "mode": "3KeyTDEA",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1391,17 +1394,17 @@ Appendix B.  Example Test Vectors JSON Object
                              {"intendedUse" : "generate",
                               "additionalInput" : "356a6e908bfce2d660f20f3fbd1e",
                               "entropyInput" : "bed693401bfd53ce4c36c2233ada"},
-                             {"intendedUse" : "generate",
-                              "additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
-                              "entropyInput" : "a632ef16f20da17f02e484df4a41"}
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 25]
+Vassilev                   Expires May 5, 2019                 [Page 25]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+                             {"intendedUse" : "generate",
+                              "additionalInput" : "4321b3ab3a0ce88e02bdcd0306d9",
+                              "entropyInput" : "a632ef16f20da17f02e484df4a41"}
                           ]
                         }
                       ]
@@ -1418,6 +1421,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
                 { "vectorSetId": 1146,
                   "algorithm": "hmacDRBG",
                   "mode": "AES-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1446,18 +1450,18 @@ Internet-Draft                DRBG Alg JSON                November 2018
                         {
                           "tcId": 2112,
                           "entropyInput" : "a0ace75784b97224de2957e5f60dc85b25331fcf7901f37418d3c9de17ed4261",
-                          "nonce": "b671308068fc7909a360c772f62a4c5e",
-                          "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
-                          "otherInput" : [
-                             {"intendedUse" : "generate",
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 26]
+Vassilev                   Expires May 5, 2019                 [Page 26]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
 
+                          "nonce": "b671308068fc7909a360c772f62a4c5e",
+                          "persoString" : "338d5f2bd93262da154385e9ed90b7862e3c892f13e1d7d19924b2eb8b3bab21",
+                          "otherInput" : [
+                             {"intendedUse" : "generate",
                               "additionalInput" : "7acd8bfae17ff4edbac3437817d6b3fce12a04c4034ac6bef0b1b88f7dcd7c85",
                               "entropyInput" : "47b26bbe93a5cc19a410523a072e04333f06c54af0049fc41e66213763020ef7"},
                              {"intendedUse" : "generate",
@@ -1481,6 +1485,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
                 { "vectorSetId": 1156,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1501,19 +1506,19 @@ Internet-Draft                DRBG Alg JSON                November 2018
                                {"intendedUse" : "generate",
                                 "additionalInput": "",
                                 "entropyInput": "4852aed7c47fd305aa680a6557d2f6e4112342a04eb91ed9f843671d0673cecd"},
+
+
+
+Vassilev                   Expires May 5, 2019                 [Page 27]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
                                {"intendedUse" : "generate",
                                 "additionalInput" : "",
                                 "entropyInput" : "8b8a35a12e2d112685258742a9ad81931595fb06a7443329317e4eab9814e888"}
                             ]
                           },
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 27]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
                         {
                           "tcId": 2152,
                           "entropyInput" : "26d8c9a9b982cd7016c9208fe95b2f4003e0ebf84c1e80a4087f2bc3e0fc5674",
@@ -1544,6 +1549,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
                 { "vectorSetId": 1157,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1556,20 +1562,20 @@ Internet-Draft                DRBG Alg JSON                November 2018
                       "returnedBitsLen": 1024,
                       "tests": [
                         {
+
+
+
+Vassilev                   Expires May 5, 2019                 [Page 28]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
                           "tcId": 3151,
                           "entropyInput": "860d051cedbb935a32ef3ba4f4437cf67c1a85a46a13a7f4db382933629890a8",
                           "nonce": "5813070f9774d21e644d64e8d291b511",
                           "persoString": "545ba29faf1bb1bf26756782f9c1fa00170f47012b05168ad82565f594af46b1",
                           "otherInput" : [
                                {"intendedUse" : "reSeed",
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 28]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
                                  "additionalInput": "95b082d603393b2207975607ac6b6472bd458c5d3d4727e1e92ebc031130231d",
                                 "entropyInput": "2e92955b17e7e76fc75a478ba88f5f5b805c42945cbbcf8c669b1996c52ae3af"},
                                {"intendedUse" : "generate",
@@ -1612,20 +1618,21 @@ Internet-Draft                DRBG Alg JSON                November 2018
                 { "acvVersion": <acvp-version> },
                 { "vectorSetId": 1167,
                   "algorithm": "hashDRBG",
+
+
+
+Vassilev                   Expires May 5, 2019                 [Page 29]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
                       "predResistance": false,
                       "reSeed": false,
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 29]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
-
                       "entropyInputLen": 256,
                       "nonceLen": 128,
                       "persoStringLen": 256,
@@ -1666,21 +1673,19 @@ Internet-Draft                DRBG Alg JSON                November 2018
                 }
              ]
 
+
+
+
+
+Vassilev                   Expires May 5, 2019                 [Page 30]
+
+Internet-Draft                DRBG Alg JSON                November 2018
+
+
 Appendix C.  Example Test Results JSON Object
 
    The following is a example JSON object for ctrDRBG with 3KeyTDEA test
    results sent from the crypto module to the ACVP server.
-
-
-
-
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 30]
-
-Internet-Draft                DRBG Alg JSON                November 2018
-
 
           [{
               "acvVersion": <acvp-version>
@@ -1726,17 +1731,15 @@ Internet-Draft                DRBG Alg JSON                November 2018
             }
           ]
 
-   The following is a example JSON object for hashDRBG test results sent
-   from the crypto module to the ACVP server.
 
 
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 31]
+Vassilev                   Expires May 5, 2019                 [Page 31]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
+
+   The following is a example JSON object for hashDRBG test results sent
+   from the crypto module to the ACVP server.
 
           [{
               "acvVersion": <acvp-version>
@@ -1786,10 +1789,7 @@ Internet-Draft                DRBG Alg JSON                November 2018
 
 
 
-
-
-
-Vassilev                  Expires May 17, 2019                 [Page 32]
+Vassilev                   Expires May 5, 2019                 [Page 32]
 
 Internet-Draft                DRBG Alg JSON                November 2018
 
@@ -1845,4 +1845,4 @@ Author's Address
 
 
 
-Vassilev                  Expires May 17, 2019                 [Page 33]
+Vassilev                   Expires May 5, 2019                 [Page 33]

--- a/artifacts/acvp_sub_drbg.txt
+++ b/artifacts/acvp_sub_drbg.txt
@@ -10,7 +10,7 @@ Expires: May 5, 2019
 
      ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON
                              Specification
-                      draft-ietf-acvp-subdrbg-0.5
+                      draft-ietf-acvp-subdrbg-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_dsa.html
+++ b/artifacts/acvp_sub_dsa.html
@@ -417,7 +417,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdsa-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subdsa-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2016-06-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using DSA algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using DSA algorithms with the ACVP specification." />
@@ -451,7 +451,7 @@
   </table>
 
   <p class="title">ACVP DSA Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subdsa-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subdsa-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using DSA algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_dsa.html
+++ b/artifacts/acvp_sub_dsa.html
@@ -690,6 +690,13 @@
 <td class="left">No</td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">prerequistie algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -984,6 +991,11 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">The DSA mode used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1370,6 +1382,7 @@
 [{
 		"algorithm": "DSA",
 		"mode": "pqgGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1440,6 +1453,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "pqgVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1531,6 +1545,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "keyGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1557,6 +1572,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "sigGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1610,6 +1626,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "sigVer",
+        "revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1693,6 +1710,7 @@
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "pqgGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -1830,6 +1848,8 @@
     {
         "vsId": 1564,
         "algorithm": "DSA",
+        "mode": "pqgVer",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,
@@ -1972,6 +1992,7 @@
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "keyGen",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,
@@ -2030,6 +2051,7 @@
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -2090,6 +2112,8 @@
     {
         "vsId": 1564,
         "algorithm": "DSA",
+        "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,

--- a/artifacts/acvp_sub_dsa.txt
+++ b/artifacts/acvp_sub_dsa.txt
@@ -9,7 +9,7 @@ Expires: December 3, 2016
 
 
                  ACVP DSA Algorithm JSON Specification
-                       draft-ietf-acvp-subdsa-0.5
+                       draft-ietf-acvp-subdsa-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_dsa.txt
+++ b/artifacts/acvp_sub_dsa.txt
@@ -70,7 +70,7 @@ Table of Contents
    4.  Capabilities Registration . . . . . . . . . . . . . . . . . .   5
      4.1.  Required Prerequisite Algorithms for DSA Validations  . .   5
      4.2.  DSA Algorithm Capabilities Registration . . . . . . . . .   6
-     4.3.  Supported DSA Modes Capabilities  . . . . . . . . . . . .   6
+     4.3.  Supported DSA Modes Capabilities  . . . . . . . . . . . .   7
        4.3.1.  The pqgGen Mode Capabilities  . . . . . . . . . . . .   7
          4.3.1.1.  pqgGen Full Set of Capabilities . . . . . . . . .   7
        4.3.2.  The pqgVer Mode Capabilities  . . . . . . . . . . . .   8
@@ -299,12 +299,17 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |              | validated    |              | "keyGen", |          |
    |              |              |              | "sigGen", |          |
    |              |              |              | "sigVer"  |          |
-   | prereqVals   | prerequistie | array of     | See       | No       |
-   |              | algorithm    | prereqAlgVal | Section   |          |
-   |              | validations  | objects      | 4.1       |          |
-   | capabilities | array of     | Array of     | See       | No       |
-   |              | JSON         | JSON objects | Section   |          |
-   |              | objects,     |              | 4.3       |          |
+   | revision     | The          | value        | "1.0"     | No       |
+   |              | algorithm    |              |           |          |
+   |              | testing      |              |           |          |
+   |              | revision to  |              |           |          |
+   |              | use.         |              |           |          |
+   | prereqVals   | prerequistie | array of     | See Secti | No       |
+   |              | algorithm    | prereqAlgVal | on 4.1    |          |
+   |              | validations  | objects      |           |          |
+   | capabilities | array of     | Array of     | See Secti | No       |
+   |              | JSON         | JSON objects | on 4.3    |          |
+   |              | objects,     |              |           |          |
    |              | each with    |              |           |          |
    |              | fields       |              |           |          |
    |              | pertaining   |              |           |          |
@@ -325,11 +330,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
               Table 2: DSA Algorithm Capabilities JSON Values
 
-4.3.  Supported DSA Modes Capabilities
-
-   The DSA mode capabilities are advertised as JSON objects within the
-   'capabilities' value of the ACVP registration message - see Table 2 .
-   The 'capabilities' value is an array, where each array element is a
 
 
 
@@ -338,6 +338,11 @@ Fussell                 Expires December 3, 2016                [Page 6]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+4.3.  Supported DSA Modes Capabilities
+
+   The DSA mode capabilities are advertised as JSON objects within the
+   'capabilities' value of the ACVP registration message - see Table 2 .
+   The 'capabilities' value is an array, where each array element is a
    JSON object corresponding to a particular DSA mode defined in this
    section.  The 'capabilities' value is part of the
    'capability_exchange' element of the ACVP JSON registration message.
@@ -359,11 +364,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of DSA pqg generation capabilities may be
    advertised by the ACVP compliant crypto module:
-
-
-
-
-
 
 
 
@@ -683,6 +683,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |            | set                                         |        |
    | algorithm  | DSA                                         | value  |
    | mode       | The DSA mode used for the test vectors.     | value  |
+   | revision   | The algorithm testing revision to use.      | value  |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 5.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -701,7 +702,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Group JSON object.
 
    The test group for DSA is as follows:
-
 
 
 
@@ -940,12 +940,12 @@ Appendix A.  Example Capabilities JSON Object
    [{
                    "algorithm": "DSA",
                    "mode": "pqgGen",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
                            },
                            {
-                                   "algorithm": "DRBG",
 
 
 
@@ -954,6 +954,7 @@ Fussell                 Expires December 3, 2016               [Page 17]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   "algorithm": "DRBG",
                                    "valValue": "123456"
                            }
                    ],
@@ -1001,7 +1002,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "provable"
                                    ],
                                    "gGen": [
-                                           "unverifiable",
 
 
 
@@ -1010,6 +1010,7 @@ Fussell                 Expires December 3, 2016               [Page 18]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                           "unverifiable",
                                            "canonical"
                                    ],
                                    "l": 3072,
@@ -1026,6 +1027,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            {
                    "algorithm": "DSA",
                    "mode": "pqgVer",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -1056,8 +1058,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "SHA2-512/256"
                                    ]
                            },
-                           {
-                                   "pqGen": [
 
 
 
@@ -1066,6 +1066,8 @@ Fussell                 Expires December 3, 2016               [Page 19]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           {
+                                   "pqGen": [
                                            "probable",
                                            "provable"
                                    ],
@@ -1112,8 +1114,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "canonical"
                                    ],
                                    "l": 3072,
-                                   "n": 256,
-                                   "hashAlg": [
 
 
 
@@ -1122,6 +1122,8 @@ Fussell                 Expires December 3, 2016               [Page 20]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   "n": 256,
+                                   "hashAlg": [
                                            "SHA2-256",
                                            "SHA2-384",
                                            "SHA2-512",
@@ -1133,6 +1135,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            {
                    "algorithm": "DSA",
                    "mode": "keyGen",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -1159,6 +1162,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            {
                    "algorithm": "DSA",
                    "mode": "sigGen",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -1166,10 +1170,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                            {
                                    "algorithm": "DRBG",
                                    "valValue": "123456"
-                           }
-                   ],
-                   "capabilities": [{
-                                   "n": 224,
 
 
 
@@ -1178,6 +1178,10 @@ Fussell                 Expires December 3, 2016               [Page 21]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           }
+                   ],
+                   "capabilities": [{
+                                   "n": 224,
                                    "l": 2048,
                                    "hashAlg": [
                                            "SHA-1",
@@ -1220,12 +1224,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
            {
                    "algorithm": "DSA",
                    "mode": "sigVer",
+           "revision": "1.0",
                    "prereqVals": [{
-                                   "algorithm": "SHA",
-                                   "valValue": "123456"
-                           },
-                           {
-                                   "algorithm": "DRBG",
 
 
 
@@ -1234,6 +1234,11 @@ Fussell                 Expires December 3, 2016               [Page 22]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   "algorithm": "SHA",
+                                   "valValue": "123456"
+                           },
+                           {
+                                   "algorithm": "DRBG",
                                    "valValue": "123456"
                            }
                    ],
@@ -1277,11 +1282,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    ]
                            },
                            {
-                                   "n": 256,
-                                   "l": 3072,
-                                   "hashAlg": [
-                                           "SHA-1",
-                                           "SHA2-224",
 
 
 
@@ -1290,6 +1290,11 @@ Fussell                 Expires December 3, 2016               [Page 23]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   "n": 256,
+                                   "l": 3072,
+                                   "hashAlg": [
+                                           "SHA-1",
+                                           "SHA2-224",
                                            "SHA2-256",
                                            "SHA2-384",
                                            "SHA2-512",
@@ -1318,6 +1323,7 @@ B.1.  Example Test DSA PQGGen JSON Object
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "pqgGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -1332,12 +1338,6 @@ B.1.  Example Test DSA PQGGen JSON Object
                     }
                 ]
             },
-            {
-                "tgId": 2,
-                "l": 2048,
-                "n": 224,
-                "hashAlg": "SHA2-384",
-                "pqMode": "provable",
 
 
 
@@ -1346,6 +1346,12 @@ Fussell                 Expires December 3, 2016               [Page 24]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+            {
+                "tgId": 2,
+                "l": 2048,
+                "n": 224,
+                "hashAlg": "SHA2-384",
+                "pqMode": "provable",
                 "testType": "GDT",
                 "tests": [
                     {
@@ -1390,16 +1396,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
 ]
 
 
-   The following is a example JSON object for DSA PQGGen test results
-   sent from the crypto module to the ACVP server.
-
-
-
-
 
 Fussell                 Expires December 3, 2016               [Page 25]
 
 Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   The following is a example JSON object for DSA PQGGen test results
+   sent from the crypto module to the ACVP server.
 
 
 [
@@ -1446,10 +1450,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
               ]
             },
             {
-              "tgId": 4,
-              "tests": [
-                {
-                  "tcId": 4,
 
 
 
@@ -1458,6 +1458,10 @@ Fussell                 Expires December 3, 2016               [Page 26]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+              "tgId": 4,
+              "tests": [
+                {
+                  "tcId": 4,
                   "g": "5C4AB5D4C901A37511DCC0A21D9E19356D31C521C1377C357DC38D5F997D1743CBF9A200D5D6F084EA75220DC7136189FC60E4461F9902E7BEDF2A0A58739E672BCD00D178684756E8E5B2D9425640CE728FD183A4BD24EFC0B2806B722CF33EC7B39E9E70AE128DBF03F8188B279926B3773C572D5A5CAC30B9FB278F66957B803F3DC8C67827184CC7ACA32088A4DDB7343F6207F8803833D403BD73D752AAB9F1F75E6242C0EF25F1F14C451EA3A2614248291EBD8D184C103F83A77BC7667C4096C72C2E5D5A629F6555B7C00C094DE65C4311765823E18C7FC150984BF4A53997D560F2186BCC0AD62F21A71E7DA2E1A26D90DB3BCC5C98CD85F856A4B1"
                 }
               ]
@@ -1480,6 +1484,8 @@ B.2.  Example Test DSA PQGVer JSON Object
     {
         "vsId": 1564,
         "algorithm": "DSA",
+        "mode": "pqgVer",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,
@@ -1500,12 +1506,6 @@ B.2.  Example Test DSA PQGVer JSON Object
           },
           {
             "tgId": 2,
-            "l": 1024,
-            "n": 160,
-            "hashAlg": "SHA-1",
-            "testType": "GDT",
-            "pqMode": "provable",
-            "tests": [
 
 
 
@@ -1514,6 +1514,12 @@ Fussell                 Expires December 3, 2016               [Page 27]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+            "l": 1024,
+            "n": 160,
+            "hashAlg": "SHA-1",
+            "testType": "GDT",
+            "pqMode": "provable",
+            "tests": [
               {
                 "tcId": 36,
                 "p": "4BDC98F8302E24CEDCE682F8040E65D6920A29499CDB7C0E4BC15EAF7496A60A7BF3D9717658831945D558B845C2D293D31BEC1285BCF1254D0F50B3486AA4359FC7BAD7A139F17E1DAF068D00C91D9B75A61918CB45D235CA7BAA68D6A0C94B635982625E4739EC34B85857F1BBA0F778275311B6088E212A181EDB26263775",
@@ -1556,12 +1562,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "p": "9A1B46A4498962D12FDE300EB25B65E06DB00ED31D3AB653D5244894A243A149034FF193EC603C2872287F2B14E628C1B9C9391A56B544DA0906103BB308BC1196CA0BF92C7BFE4CA3C593243CB695C1EFC727557D85B9E0B0A07599636C6692DCD8895C87F66797CC9F61B3AE06FA94A2301D40A0D280E60DE40F66310244C9",
                 "q": "B70E07662CADF2A4191470948B040BE39BD56671",
                 "g": "45659A0B48B5B581E5CA68C8B81731DEE8381619A0F6EF421E20FB26CB0F78DE3571C73C98441BAE2E2C7B1201E95A32E4BD28D347AC5DFEA5848E9AD48C579D17756AF49E4E620B85E9EE4FFE1C4F8B111F161FA2FF292529FAF97776877B34C3B35950C0A1A27FBEC78164B1D48AD6E0F8D58E09EA2E5ACE96C3F8C0250678",
-                "index": "45"
-              },
-            ]
-          }
-        ]
-    }
 
 
 
@@ -1570,17 +1570,17 @@ Fussell                 Expires December 3, 2016               [Page 28]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                "index": "45"
+              },
+            ]
+          }
+        ]
+    }
 ]
 
 
    The following is a example JSON object for DSA PQGVer test results
    sent from the crypto module to the ACVP server.
-
-
-
-
-
-
 
 
 
@@ -1696,6 +1696,7 @@ B.3.  Example Test DSA KeyGen JSON Object
            "vsId": 1564,
            "algorithm": "DSA",
            "mode": "keyGen",
+           "revision": "1.0",
            "testGroups": [
              {
                "tgId": 1,
@@ -1714,7 +1715,6 @@ B.3.  Example Test DSA KeyGen JSON Object
 
    The following is a example JSON object for DSA KeyGen test results
    sent from the crypto module to the ACVP server.
-
 
 
 
@@ -1802,6 +1802,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -1822,7 +1823,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The following is a example JSON object for DSA SigGen test results
    sent from the crypto module to the ACVP server.
-
 
 
 
@@ -1913,6 +1913,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
     {
         "vsId": 1564,
         "algorithm": "DSA",
+        "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,
@@ -1939,8 +1941,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The following is a example JSON object for DSA generation test
    results sent from the crypto module to the ACVP server.
-
-
 
 
 

--- a/artifacts/acvp_sub_ecdsa.html
+++ b/artifacts/acvp_sub_ecdsa.html
@@ -679,6 +679,13 @@
 <td class="left">No</td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">prerequistie algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -885,6 +892,11 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">The ECDSA mode used for the test vectors</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1127,6 +1139,7 @@
 [{
 		"algorithm": "ECDSA",
 		"mode": "keyGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1158,6 +1171,7 @@
 	{
 		"algorithm": "ECDSA",
 		"mode": "keyVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1188,6 +1202,7 @@
 	{
 		"algorithm": "ECDSA",
 		"mode": "sigGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1225,6 +1240,7 @@
 	{
 		"algorithm": "ECDSA",
 		"mode": "sigVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1283,6 +1299,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "keyGen",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -1339,6 +1356,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "keyVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -1394,6 +1412,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -1452,6 +1471,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,

--- a/artifacts/acvp_sub_ecdsa.html
+++ b/artifacts/acvp_sub_ecdsa.html
@@ -414,7 +414,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subecdsa-0.3" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subecdsa-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2016-06-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using ECDSA algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using ECDSA algorithms with the ACVP specification." />
@@ -448,7 +448,7 @@
   </table>
 
   <p class="title">ACVP ECDSA Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subecdsa-0.3</span></p>
+  <span class="filename">draft-ietf-acvp-subecdsa-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using ECDSA algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_ecdsa.txt
+++ b/artifacts/acvp_sub_ecdsa.txt
@@ -9,7 +9,7 @@ Expires: December 3, 2016
 
 
                 ACVP ECDSA Algorithm JSON Specification
-                      draft-ietf-acvp-subecdsa-0.3
+                      draft-ietf-acvp-subecdsa-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_ecdsa.txt
+++ b/artifacts/acvp_sub_ecdsa.txt
@@ -75,25 +75,25 @@ Table of Contents
          4.3.1.1.  keyGen Full Set of Capabilities . . . . . . . . .   7
        4.3.2.  The keyVer Mode Capabilities  . . . . . . . . . . . .   8
          4.3.2.1.  keyVer Full Set of Capabilities . . . . . . . . .   8
-       4.3.3.  The sigGen Mode Capabilities  . . . . . . . . . . . .   8
-         4.3.3.1.  sigGen Full Set of Capabilities . . . . . . . . .   8
-       4.3.4.  The sigVer Mode Capabilities  . . . . . . . . . . . .   9
-         4.3.4.1.  sigVer Full Set of Capabilities . . . . . . . . .  10
-   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  11
-     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  11
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  12
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  13
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  14
-   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  14
-   Appendix B.  Example Vector Set Request/Responses JSON Object . .  17
-     B.1.  Example Test ECDSA KeyGen JSON Object . . . . . . . . . .  17
-     B.2.  Example Test ECDSA KeyVer JSON Object . . . . . . . . . .  19
-     B.3.  Example Test ECDSA Signature Generation JSON Object . . .  21
-     B.4.  Example Test ECDSA SigVer JSON Object . . . . . . . . . .  23
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  25
+       4.3.3.  The sigGen Mode Capabilities  . . . . . . . . . . . .   9
+         4.3.3.1.  sigGen Full Set of Capabilities . . . . . . . . .   9
+       4.3.4.  The sigVer Mode Capabilities  . . . . . . . . . . . .  10
+         4.3.4.1.  sigVer Full Set of Capabilities . . . . . . . . .  11
+   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  12
+     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  13
+   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  14
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  15
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  15
+   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  15
+   Appendix B.  Example Vector Set Request/Responses JSON Object . .  18
+     B.1.  Example Test ECDSA KeyGen JSON Object . . . . . . . . . .  18
+     B.2.  Example Test ECDSA KeyVer JSON Object . . . . . . . . . .  20
+     B.3.  Example Test ECDSA Signature Generation JSON Object . . .  22
+     B.4.  Example Test ECDSA SigVer JSON Object . . . . . . . . . .  24
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  26
 
 1.  Introduction
 
@@ -294,6 +294,11 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |              | validated    |              | "sigGen", |          |
    |              |              |              | or        |          |
    |              |              |              | "sigVer"  |          |
+   | revision     | The          | value        | "1.0"     | No       |
+   |              | algorithm    |              |           |          |
+   |              | testing      |              |           |          |
+   |              | revision to  |              |           |          |
+   |              | use.         |              |           |          |
    | prereqVals   | prerequistie | array of     | See Secti | No       |
    |              | algorithm    | prereqAlgVal | on 4.1    |          |
    |              | validations  | objects      |           |          |
@@ -325,11 +330,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    The ECDSA mode capabilities are advertised as JSON objects within the
    'capabilities' value of the ACVP registration message - see Table 2 .
    The 'capabilities' value is an array, where each array element is a
-   JSON object corresponding to a particular ECDSA mode defined in this
-   section.  The 'capabilities' value is part of the
-   'capability_exchange' element of the ACVP JSON registration message.
-   See the ACVP specification for details on the registration message.
-
 
 
 
@@ -337,6 +337,11 @@ Fussell                 Expires December 3, 2016                [Page 6]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
+
+   JSON object corresponding to a particular ECDSA mode defined in this
+   section.  The 'capabilities' value is part of the
+   'capability_exchange' element of the ACVP JSON registration message.
+   See the ACVP specification for details on the registration message.
 
    Each ECDSA mode's capabilities are advertised as JSON objects.
 
@@ -354,6 +359,40 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of ECDSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 7]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    +--------------------+------------+-------+--------------+----------+
    | JSON Value         | Descriptio | JSON  | Valid Values | Optional |
@@ -385,15 +424,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
               Table 3: ECDSA keyGen Capabilities JSON Values
 
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 7]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
 4.3.2.  The keyVer Mode Capabilities
 
    The ECDSA keyVer mode capabilities are advertised as JSON objects,
@@ -408,6 +438,17 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of ECDSA key verification capabilities may be
    advertised by the ACVP compliant crypto module:
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 8]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    +-------+-------------+-------+--------------------------+----------+
    | JSON  | Description | JSON  | Valid Values             | Optional |
@@ -445,7 +486,22 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016                [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 9]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -501,7 +557,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016                [Page 9]
+Fussell                 Expires December 3, 2016               [Page 10]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -557,7 +613,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 10]
+Fussell                 Expires December 3, 2016               [Page 11]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -586,6 +642,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |            | set                                         |        |
    | algorithm  | ECDSA                                       | value  |
    | mode       | The ECDSA mode used for the test vectors    | value  |
+   | revision   | The algorithm testing revision to use.      | value  |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 5.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -612,8 +669,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-Fussell                 Expires December 3, 2016               [Page 11]
+Fussell                 Expires December 3, 2016               [Page 12]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -669,7 +725,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 12]
+Fussell                 Expires December 3, 2016               [Page 13]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -725,7 +781,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 13]
+Fussell                 Expires December 3, 2016               [Page 14]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -764,6 +820,7 @@ Appendix A.  Example Capabilities JSON Object
    [{
                    "algorithm": "ECDSA",
                    "mode": "keyGen",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -777,15 +834,15 @@ Appendix A.  Example Capabilities JSON Object
                            "P-224",
                            "P-256",
                            "P-384",
-                           "P-521",
 
 
 
-Fussell                 Expires December 3, 2016               [Page 14]
+Fussell                 Expires December 3, 2016               [Page 15]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           "P-521",
                            "B-233",
                            "B-283",
                            "B-409",
@@ -803,6 +860,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            {
                    "algorithm": "ECDSA",
                    "mode": "keyVer",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -832,16 +890,17 @@ Internet-Draft                Sym Alg JSON                     June 2016
            },
            {
                    "algorithm": "ECDSA",
-                   "mode": "sigGen",
-                   "prereqVals": [{
 
 
 
-Fussell                 Expires December 3, 2016               [Page 15]
+Fussell                 Expires December 3, 2016               [Page 16]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                   "mode": "sigGen",
+                   "revision": "1.0",
+                   "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
                            },
@@ -878,6 +937,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            {
                    "algorithm": "ECDSA",
                    "mode": "sigVer",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -886,18 +946,18 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "algorithm": "DRBG",
                                    "valValue": "123456"
                            }
-                   ],
-                   "capabilities": [{
-                           "curve": [
-                                   "P-192",
 
 
 
-Fussell                 Expires December 3, 2016               [Page 16]
+Fussell                 Expires December 3, 2016               [Page 17]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                   ],
+                   "capabilities": [{
+                           "curve": [
+                                   "P-192",
                                    "P-224",
                                    "P-256",
                                    "P-384",
@@ -945,11 +1005,7 @@ B.1.  Example Test ECDSA KeyGen JSON Object
 
 
 
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 17]
+Fussell                 Expires December 3, 2016               [Page 18]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -962,6 +1018,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
            "vsId": 1564,
            "algorithm": "ECDSA",
            "mode": "keyGen",
+           "revision": "1.0",
            "testGroups": [
                {
                                    "tgId": 1,
@@ -1004,8 +1061,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-Fussell                 Expires December 3, 2016               [Page 18]
+Fussell                 Expires December 3, 2016               [Page 19]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1061,7 +1117,7 @@ B.2.  Example Test ECDSA KeyVer JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 19]
+Fussell                 Expires December 3, 2016               [Page 20]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1074,6 +1130,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "keyVer",
+        "revision": "1.0",
         "testGroups": [
             {
                                 "tgId": 1,
@@ -1116,8 +1173,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-Fussell                 Expires December 3, 2016               [Page 20]
+Fussell                 Expires December 3, 2016               [Page 21]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1173,7 +1229,7 @@ B.3.  Example Test ECDSA Signature Generation JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 21]
+Fussell                 Expires December 3, 2016               [Page 22]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1186,6 +1242,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
                                 "tgId": 1,
@@ -1228,8 +1285,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-Fussell                 Expires December 3, 2016               [Page 22]
+Fussell                 Expires December 3, 2016               [Page 23]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1285,7 +1341,7 @@ B.4.  Example Test ECDSA SigVer JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 23]
+Fussell                 Expires December 3, 2016               [Page 24]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1298,6 +1354,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
             {
                                 "tgId": 1,
@@ -1340,8 +1397,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-Fussell                 Expires December 3, 2016               [Page 24]
+Fussell                 Expires December 3, 2016               [Page 25]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1397,4 +1453,4 @@ Author's Address
 
 
 
-Fussell                 Expires December 3, 2016               [Page 25]
+Fussell                 Expires December 3, 2016               [Page 26]

--- a/artifacts/acvp_sub_eddsa.html
+++ b/artifacts/acvp_sub_eddsa.html
@@ -415,7 +415,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subeddsa-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subeddsa-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using EDDSA algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using EDDSA algorithms with the ACVP specification." />
@@ -449,7 +449,7 @@
   </table>
 
   <p class="title">ACVP EDDSA Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subeddsa-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subeddsa-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using EDDSA algorithms with the ACVP specification.</p>
@@ -1230,7 +1230,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1258,7 +1258,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1286,7 +1286,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1315,7 +1315,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1342,7 +1342,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1392,7 +1392,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1438,7 +1438,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,
@@ -1470,7 +1470,7 @@
                         
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": &lt;acvp-version&gt;
     },
     {
         "vsId": 1564,

--- a/artifacts/acvp_sub_eddsa.html
+++ b/artifacts/acvp_sub_eddsa.html
@@ -411,12 +411,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subeddsa-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-8" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using EDDSA algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using EDDSA algorithms with the ACVP specification." />
 
@@ -437,7 +437,7 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">August 2018</td>
+<td class="right">August 1, 2018</td>
 </tr>
 <tr>
 <td class="left">Expires: February 2, 2019</td>
@@ -455,12 +455,12 @@
 <p>This document defines the JSON schema for using EDDSA algorithms with the ACVP specification.</p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
 <p>This Internet-Draft will expire on February 2, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -676,6 +676,13 @@
 <td class="left">No</td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">prerequistie algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -881,6 +888,11 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">The EDDSA mode used for the test vectors</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1111,7 +1123,7 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.appendix.A">
@@ -1126,6 +1138,7 @@
 [{
 		"algorithm": "EDDSA",
 		"mode": "keyGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1147,6 +1160,7 @@
 	{
 		"algorithm": "EDDSA",
 		"mode": "keyVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1164,6 +1178,7 @@
 	{
 		"algorithm": "EDDSA",
 		"mode": "sigGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1183,6 +1198,7 @@
 	{
 		"algorithm": "EDDSA",
 		"mode": "sigVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1220,6 +1236,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "keyGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "curve": "ED-25519",
@@ -1275,6 +1292,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "keyVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -1330,6 +1348,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -1425,6 +1444,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,

--- a/artifacts/acvp_sub_eddsa.txt
+++ b/artifacts/acvp_sub_eddsa.txt
@@ -4,7 +4,7 @@
 
 TBD                                                         C. Celi, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                               August 2018
+Intended status: Informational                            August 1, 2018
 Expires: February 2, 2019
 
 
@@ -24,7 +24,7 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
@@ -40,7 +40,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -73,7 +73,7 @@ Table of Contents
      4.3.  Supported EDDSA Modes Capabilities  . . . . . . . . . . .   6
        4.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   7
          4.3.1.1.  keyGen Full Set of Capabilities . . . . . . . . .   7
-       4.3.2.  The keyVer Mode Capabilities  . . . . . . . . . . . .   7
+       4.3.2.  The keyVer Mode Capabilities  . . . . . . . . . . . .   8
          4.3.2.1.  keyVer Full Set of Capabilities . . . . . . . . .   8
        4.3.3.  The sigGen Mode Capabilities  . . . . . . . . . . . .   8
          4.3.3.1.  sigGen Full Set of Capabilities . . . . . . . . .   8
@@ -89,11 +89,11 @@ Table of Contents
    10. Normative References  . . . . . . . . . . . . . . . . . . . .  14
    Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  15
      A.1.  Example EDDSA Capabilities JSON Object  . . . . . . . . .  15
-   Appendix B.  Example Vector Set Request/Responses JSON Object . .  16
+   Appendix B.  Example Vector Set Request/Responses JSON Object . .  17
      B.1.  Example Test EDDSA KeyGen JSON Object . . . . . . . . . .  17
      B.2.  Example Test EDDSA KeyVer JSON Object . . . . . . . . . .  18
      B.3.  Example Test EDDSA Signature Generation JSON Object . . .  20
-     B.4.  Example Test EDDSA SigVer JSON Object . . . . . . . . . .  22
+     B.4.  Example Test EDDSA SigVer JSON Object . . . . . . . . . .  23
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  24
 
 1.  Introduction
@@ -294,12 +294,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | validated    |              | "sigGen", |          |
    |              |              |              | or        |          |
    |              |              |              | "sigVer"  |          |
-   | prereqVals   | prerequistie | array of     | See       | No       |
-   |              | algorithm    | prereqAlgVal | Section   |          |
-   |              | validations  | objects      | 4.1       |          |
-   | capabilities | array of     | Array of     | See       |
-   |              | JSON         | JSON objects | Section   |
-   |              | objects,     |              | 4.3       |
+   | revision     | The          | value        | "1.0"     | No       |
+   |              | algorithm    |              |           |          |
+   |              | testing      |              |           |          |
+   |              | revision to  |              |           |          |
+   |              | use.         |              |           |          |
+   | prereqVals   | prerequistie | array of     | See Secti | No       |
+   |              | algorithm    | prereqAlgVal | on 4.1    |          |
+   |              | validations  | objects      |           |          |
+   | capabilities | array of     | Array of     | See Secti |
+   |              | JSON         | JSON objects | on 4.3    |
+   |              | objects,     |              |           |
    |              | each with    |              |           |
    |              | fields       |              |           |
    |              | pertaining   |              |           |
@@ -325,11 +330,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    The EDDSA mode capabilities are advertised as JSON objects within the
    'capabilities' value of the ACVP registration message - see Table 2.
    The 'capabilities' value is an array, where each array element is a
-   JSON object corresponding to a particular EDDSA mode defined in this
-   section.  The 'capabilities' value is part of the
-   'capability_exchange' element of the ACVP JSON registration message.
-   See the ACVP specification for details on the registration message.
-
 
 
 
@@ -337,6 +337,11 @@ Celi                    Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   JSON object corresponding to a particular EDDSA mode defined in this
+   section.  The 'capabilities' value is part of the
+   'capability_exchange' element of the ACVP JSON registration message.
+   See the ACVP specification for details on the registration message.
 
    Each EDDSA mode's capabilities are advertised as JSON objects.
 
@@ -377,6 +382,18 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
               Table 3: EDDSA keyGen Capabilities JSON Values
 
+
+
+
+
+
+
+
+Celi                    Expires February 2, 2019                [Page 7]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
 4.3.2.  The keyVer Mode Capabilities
 
    The EDDSA keyVer mode capabilities are advertised as JSON objects,
@@ -386,13 +403,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    Each EDDSA keyVer mode capability set is advertised as a self-
    contained JSON object.
-
-
-
-Celi                    Expires February 2, 2019                [Page 7]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
 4.3.2.1.  keyVer Full Set of Capabilities
 
@@ -425,16 +435,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The complete list of EDDSA signature generation capabilities may be
    advertised by the ACVP compliant crypto module:
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -571,6 +571,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    | algorithm  | EDDSA                                       | value  |
    | mode       | The EDDSA mode used for the test vectors    | value  |
+   | revision   | The algorithm testing revision to use.      | value  |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 5.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -589,7 +590,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Group JSON object.
 
    The test group for EDDSA is as follows:
-
 
 
 
@@ -776,8 +776,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
 
 
@@ -799,6 +799,7 @@ A.1.  Example EDDSA Capabilities JSON Object
    [{
                    "algorithm": "EDDSA",
                    "mode": "keyGen",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -820,6 +821,7 @@ A.1.  Example EDDSA Capabilities JSON Object
            {
                    "algorithm": "EDDSA",
                    "mode": "keyVer",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -832,8 +834,6 @@ A.1.  Example EDDSA Capabilities JSON Object
                    "curve": [
                            "ED-25519",
                            "ED-448"
-                   ]
-           },
 
 
 
@@ -842,9 +842,12 @@ Celi                    Expires February 2, 2019               [Page 15]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                   ]
+           },
            {
                    "algorithm": "EDDSA",
                    "mode": "sigGen",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -864,6 +867,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
            {
                    "algorithm": "EDDSA",
                    "mode": "sigVer",
+                   "revision": "1.0",
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
@@ -884,10 +888,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    ]
 
 
-Appendix B.  Example Vector Set Request/Responses JSON Object
-
-
-
 
 
 
@@ -897,6 +897,8 @@ Celi                    Expires February 2, 2019               [Page 16]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+Appendix B.  Example Vector Set Request/Responses JSON Object
 
 B.1.  Example Test EDDSA KeyGen JSON Object
 
@@ -912,6 +914,7 @@ B.1.  Example Test EDDSA KeyGen JSON Object
            "vsId": 1564,
            "algorithm": "EDDSA",
            "mode": "keyGen",
+           "revision": "1.0",
            "testGroups": [
                {
                    "curve": "ED-25519",
@@ -930,9 +933,6 @@ B.1.  Example Test EDDSA KeyGen JSON Object
 
    The following is a example JSON object for EDDSA KeyGen test results
    sent from the crypto module to the ACVP server.
-
-
-
 
 
 
@@ -1018,6 +1018,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "keyVer",
+        "revision": "1.0",
         "testGroups": [
             {
                                 "tgId": 1,
@@ -1037,7 +1038,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The following is a example JSON object for EDDSA KeyVer test results
    sent from the crypto module to the ACVP server.
-
 
 
 
@@ -1130,6 +1130,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
                                 "tgId": 1,
@@ -1168,14 +1169,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
 ]
 
 
-   The following is a example JSON object for EDDSA SigGen test results
-   sent from the crypto module to the ACVP server.
+
 
 
 
 Celi                    Expires February 2, 2019               [Page 21]
 
 Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   The following is a example JSON object for EDDSA SigGen test results
+   sent from the crypto module to the ACVP server.
 
 
 [
@@ -1218,10 +1222,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 ]
 
 
-B.4.  Example Test EDDSA SigVer JSON Object
-
-   The following is a example JSON object for EDDSA SigVer, test vectors
-   sent from the ACVP server to the crypto module and the response.
 
 
 
@@ -1234,6 +1234,12 @@ Celi                    Expires February 2, 2019               [Page 22]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+B.4.  Example Test EDDSA SigVer JSON Object
+
+   The following is a example JSON object for EDDSA SigVer, test vectors
+   sent from the ACVP server to the crypto module and the response.
+
+
 [
     {
         "acvVersion": "0.5"
@@ -1242,6 +1248,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
             {
                                 "tgId": 1,
@@ -1264,13 +1271,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The following is a example JSON object for EDDSA generation test
    results sent from the crypto module to the ACVP server.
-
-
-
-
-
-
-
 
 
 

--- a/artifacts/acvp_sub_eddsa.txt
+++ b/artifacts/acvp_sub_eddsa.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
                 ACVP EDDSA Algorithm JSON Specification
-                      draft-ietf-acvp-subeddsa-0.5
+                      draft-ietf-acvp-subeddsa-1.0
 
 Abstract
 
@@ -908,7 +908,7 @@ B.1.  Example Test EDDSA KeyGen JSON Object
 
    [
        {
-           "acvVersion": "0.5"
+           "acvVersion": <acvp-version>
        },
        {
            "vsId": 1564,
@@ -956,7 +956,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -1012,7 +1012,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -1068,7 +1068,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [
        {
-           "acvVersion": "0.5"
+           "acvVersion": <acvp-version>
        },
        {
            "vsId": 1564,
@@ -1124,7 +1124,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -1184,7 +1184,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -1242,7 +1242,7 @@ B.4.  Example Test EDDSA SigVer JSON Object
 
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -1292,7 +1292,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [
        {
-           "acvVersion": "0.5"
+           "acvVersion": <acvp-version>
        },
        {
            "vsId": 1564,

--- a/artifacts/acvp_sub_kas_ecc.html
+++ b/artifacts/acvp_sub_kas_ecc.html
@@ -427,12 +427,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasecc-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-11-7" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification." />
 
@@ -456,12 +456,12 @@
 <td class="right">R. Hammett, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: May 11, 2019</td>
+<td class="left">Expires: May 5, 2019</td>
 <td class="right">G2, Inc.</td>
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">November 7, 2018</td>
+<td class="right">November 1, 2018</td>
 </tr>
 
     	
@@ -475,12 +475,12 @@
 <p>This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification.</p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 11, 2019.</p>
+<p>This Internet-Draft will expire on May 5, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -814,6 +814,20 @@
 <td class="left">value</td>
 <td class="left">Component</td>
 <td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1570,6 +1584,7 @@
 
 {
 	"algorithm": "KAS-ECC",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "ECDSA",
 			"valValue": "123456"
@@ -1634,6 +1649,7 @@
 {
 	"algorithm": "KAS-ECC",
 	"mode": "Component",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "ECDSA",
 			"valValue": "123456"
@@ -3285,6 +3301,16 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">type</td>
 <td class="left">Type of operation supported</td>
 <td class="left">value</td>
@@ -3936,6 +3962,7 @@
 	{
 		"vsId": 1564,
 		"algorithm": "KAS-ECC",
+		"revision": "1.0",
 		"testGroups": [
 			{
                 "tgId": 1,
@@ -4061,6 +4088,7 @@
 		"vsId": 1565,
 		"algorithm": "KAS-ECC",
 		"mode": "Component",
+		"revision": "1.0",
 		"testGroups": [{
                 "tgId": 1,
 				"scheme": "ephemeralUnified",
@@ -4363,6 +4391,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -4402,6 +4444,7 @@
 {
 	"algorithm": "KAS-ECC",
 	"mode": "CDH-Component",
+	"revision": "1.0",
 	"prereqVals": [{
 		"algorithm": "ECDSA",
 		"valValue": "123456"
@@ -4446,6 +4489,20 @@
 <td class="left">The algorithm mode under test</td>
 <td class="left">value</td>
 <td class="left">CDH-Component</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -4630,6 +4687,7 @@
 		"vsId": 1750,
 		"algorithm": "KAS-ECC",
 		"mode": "CDH-Component",
+		"revision": "1.0",
 		"testGroups": [{
 				"tgId": 1,
 				"testType": "AFT",
@@ -4867,7 +4925,7 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP800-56a">[SP800-56a]</b></td>

--- a/artifacts/acvp_sub_kas_ecc.html
+++ b/artifacts/acvp_sub_kas_ecc.html
@@ -431,7 +431,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasecc-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasecc-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification." />
@@ -469,7 +469,7 @@
   </table>
 
   <p class="title">ACVP KAS ECC JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkasecc-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkasecc-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using KAS ECC algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kas_ecc.txt
+++ b/artifacts/acvp_sub_kas_ecc.txt
@@ -10,7 +10,7 @@ Expires: May 5, 2019                                            G2, Inc.
 
 
                     ACVP KAS ECC JSON Specification
-                     draft-ietf-acvp-subkasecc-0.5
+                     draft-ietf-acvp-subkasecc-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kas_ecc.txt
+++ b/artifacts/acvp_sub_kas_ecc.txt
@@ -5,8 +5,8 @@
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
 Intended status: Informational                           R. Hammett, Ed.
-Expires: May 11, 2019                                           G2, Inc.
-                                                        November 7, 2018
+Expires: May 5, 2019                                            G2, Inc.
+                                                        November 1, 2018
 
 
                     ACVP KAS ECC JSON Specification
@@ -25,14 +25,14 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 11, 2019.
+   This Internet-Draft will expire on May 5, 2019.
 
 Copyright Notice
 
@@ -41,7 +41,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 1]
+Fussell & Hammett          Expires May 5, 2019                  [Page 1]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -95,7 +95,7 @@ Table of Contents
      5.3.  Example Test Vectors JSON Object  . . . . . . . . . . . .  37
      5.4.  Example Test Vectors Component JSON Object  . . . . . . .  40
    6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  42
-     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  42
+     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  43
      6.2.  Example Test Results Component JSON Object  . . . . . . .  44
    7.  ECC CDH Component Test  . . . . . . . . . . . . . . . . . . .  45
      7.1.  ECC CDH Component Capabilities JSON Values  . . . . . . .  46
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 2]
+Fussell & Hammett          Expires May 5, 2019                  [Page 2]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 3]
+Fussell & Hammett          Expires May 5, 2019                  [Page 3]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -221,7 +221,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 4]
+Fussell & Hammett          Expires May 5, 2019                  [Page 4]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -277,7 +277,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 5]
+Fussell & Hammett          Expires May 5, 2019                  [Page 5]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -333,7 +333,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 6]
+Fussell & Hammett          Expires May 5, 2019                  [Page 6]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -389,7 +389,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 7]
+Fussell & Hammett          Expires May 5, 2019                  [Page 7]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -445,7 +445,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                  [Page 8]
+Fussell & Hammett          Expires May 5, 2019                  [Page 8]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -460,17 +460,22 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | mode       | The algorithm  | value        | Component | Yes      |
    |            | mode.          |              |           |          |
    |            |                |              |           |          |
-   | prereqVals | Prerequisite   | array of     | See       | No       |
-   |            | algorithm      | prereqAlgVal | Section   |          |
-   |            | validations    | objects      | 3.1       |          |
+   | revision   | The algorithm  | value        | "1.0"     | No       |
+   |            | testing        |              |           |          |
+   |            | revision to    |              |           |          |
+   |            | use.           |              |           |          |
    |            |                |              |           |          |
-   | function   | Type of        | array        | See       | No       |
-   |            | function       |              | Section   |          |
-   |            | supported      |              | 3.3       |          |
+   | prereqVals | Prerequisite   | array of     | See Secti | No       |
+   |            | algorithm      | prereqAlgVal | on 3.1    |          |
+   |            | validations    | objects      |           |          |
    |            |                |              |           |          |
-   | scheme     | Array of       | object       | See       | No       |
-   |            | supported key  |              | Section   |          |
-   |            | agreement      |              | 3.4.1     |          |
+   | function   | Type of        | array        | See Secti | No       |
+   |            | function       |              | on 3.3    |          |
+   |            | supported      |              |           |          |
+   |            |                |              |           |          |
+   | scheme     | Array of       | object       | See Secti | No       |
+   |            | supported key  |              | on 3.4.1  |          |
+   |            | agreement      |              |           |          |
    |            | schemes each   |              |           |          |
    |            | having their   |              |           |          |
    |            | own            |              |           |          |
@@ -493,18 +498,18 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
    o  dpVal - IUT can perform domain parameter validation (FFC only)
 
+
+
+
+Fussell & Hammett          Expires May 5, 2019                  [Page 9]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
    o  keyPairGen - IUT can perform keypair generation.
 
    o  fullVal - IUT can perform full public key validation ( [SP800-56a]
       section 5.6.2.3.1 / 5.6.2.3.3)
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                  [Page 9]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
 
    o  partialVal - IUT can perform partial public key validation (
       [SP800-56a] section 5.6.2.3.2 / 5.6.2.3.4)
@@ -552,12 +557,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 10]
+Fussell & Hammett          Expires May 5, 2019                 [Page 10]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -570,8 +570,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |           | key agreement         |        | and/or    |          |
    |           |                       |        | responder |          |
    |           |                       |        |           |          |
-   | noKdfNoKc | Indicates no KDF, no  | object | Section   | Yes      |
-   |           | KC tests are to be    |        | 3.5.1     |          |
+   | noKdfNoKc | Indicates no KDF, no  | object | Section 3 | Yes      |
+   |           | KC tests are to be    |        | .5.1      |          |
    |           | generated. Note this  |        |           |          |
    |           | is a COMPONENT mode   |        |           |          |
    |           | only test. This       |        |           |          |
@@ -579,8 +579,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |           | used with "KAS-ECC" / |        |           |          |
    |           | "Component"           |        |           |          |
    |           |                       |        |           |          |
-   | kdfNoKc   | Indicates KDF, no KC  | object | Section   | Yes      |
-   |           | tests are to be       |        | 3.5.2     |          |
+   | kdfNoKc   | Indicates KDF, no KC  | object | Section 3 | Yes      |
+   |           | tests are to be       |        | .5.2      |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-ECC only     |        |           |          |
    |           | test. This mode MAY   |        |           |          |
@@ -588,8 +588,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |           | registrations with    |        |           |          |
    |           | "KAS-ECC" (no mode)   |        |           |          |
    |           |                       |        |           |          |
-   | kdfKc     | Indicates KDF, KC     | object | Section   | Yes      |
-   |           | tests are to be       |        | 3.5.3     |          |
+   | kdfKc     | Indicates KDF, KC     | object | Section 3 | Yes      |
+   |           | tests are to be       |        | .5.3      |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-ECC only     |        |           |          |
    |           | test. This mode MAY   |        |           |          |
@@ -613,7 +613,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 11]
+Fussell & Hammett          Expires May 5, 2019                 [Page 11]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -669,7 +669,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 12]
+Fussell & Hammett          Expires May 5, 2019                 [Page 12]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -725,7 +725,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 13]
+Fussell & Hammett          Expires May 5, 2019                 [Page 13]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -734,17 +734,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | JSON     | Description      | JSON     | Valid Values  | Optional |
    | Value    |                  | type     |               |          |
    +----------+------------------+----------+---------------+----------+
-   | eb       | The eb parameter | object   | See Section   | Yes      |
-   |          | set              |          | 3.6.2         |          |
+   | eb       | The eb parameter | object   | See           | Yes      |
+   |          | set              |          | Section 3.6.2 |          |
    |          |                  |          |               |          |
-   | ec       | The ec parameter | object   | See Section   | Yes      |
-   |          | set              |          | 3.6.2         |          |
+   | ec       | The ec parameter | object   | See           | Yes      |
+   |          | set              |          | Section 3.6.2 |          |
    |          |                  |          |               |          |
-   | ed       | The ed parameter | object   | See Section   | Yes      |
-   |          | set              |          | 3.6.2         |          |
+   | ed       | The ed parameter | object   | See           | Yes      |
+   |          | set              |          | Section 3.6.2 |          |
    |          |                  |          |               |          |
-   | ee       | The ee parameter | object   | See Section   | Yes      |
-   |          | set              |          | 3.6.2         |          |
+   | ee       | The ee parameter | object   | See           | Yes      |
+   |          | set              |          | Section 3.6.2 |          |
    |          |                  |          |               |          |
    +----------+------------------+----------+---------------+----------+
 
@@ -781,7 +781,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 14]
+Fussell & Hammett          Expires May 5, 2019                 [Page 14]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -790,17 +790,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | JSON      | Description           | JSON   | Valid     | Optional |
    | Value     |                       | type   | Values    |          |
    +-----------+-----------------------+--------+-----------+----------+
-   | curve     | The elliptic curve to | value  | See       | No       |
-   |           | use for key           |        | Section   |          |
-   |           | generation.           |        | 3.7       |          |
+   | curve     | The elliptic curve to | value  | See Secti | No       |
+   |           | use for key           |        | on 3.7    |          |
+   |           | generation.           |        |           |          |
    |           |                       |        |           |          |
-   | hashAlg   | The hash algorithms   | array  | See       | No       |
-   |           | to use for KDF (and   |        | Section   |          |
-   |           | noKdfNoKc)            |        | 3.8       |          |
+   | hashAlg   | The hash algorithms   | array  | See Secti | No       |
+   |           | to use for KDF (and   |        | on 3.8    |          |
+   |           | noKdfNoKc)            |        |           |          |
    |           |                       |        |           |          |
-   | macOption | The macOption(s) to   | object | See       | Yes      |
-   |           | use with "kdfNoKc"    |        | Section   |          |
-   |           | and/or "kdfKc"        |        | 3.9       |          |
+   | macOption | The macOption(s) to   | object | See Secti | Yes      |
+   |           | use with "kdfNoKc"    |        | on 3.9    |          |
+   |           | and/or "kdfKc"        |        |           |          |
    |           |                       |        |           |          |
    +-----------+-----------------------+--------+-----------+----------+
 
@@ -837,7 +837,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 15]
+Fussell & Hammett          Expires May 5, 2019                 [Page 15]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -893,7 +893,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 16]
+Fussell & Hammett          Expires May 5, 2019                 [Page 16]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -949,7 +949,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 17]
+Fussell & Hammett          Expires May 5, 2019                 [Page 17]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -958,9 +958,9 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | JSON      | Description           | JSON  | Valid      | Optional |
    | Value     |                       | type  | Values     |          |
    +-----------+-----------------------+-------+------------+----------+
-   | oiPattern | The OI pattern to use | value | See        | No       |
-   |           | for constructing      |       | Section    |          |
-   |           | OtherInformation.     |       | 3.10.1 .   |          |
+   | oiPattern | The OI pattern to use | value | See Sectio | No       |
+   |           | for constructing      |       | n 3.10.1 . |          |
+   |           | OtherInformation.     |       |            |          |
    |           |                       |       |            |          |
    +-----------+-----------------------+-------+------------+----------+
 
@@ -1005,7 +1005,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 18]
+Fussell & Hammett          Expires May 5, 2019                 [Page 18]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1055,17 +1055,18 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 {
         "algorithm": "KAS-ECC",
+        "revision": "1.0",
         "prereqVals": [{
                         "algorithm": "ECDSA",
-                        "valValue": "123456"
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 19]
+Fussell & Hammett          Expires May 5, 2019                 [Page 19]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+                        "valValue": "123456"
                 },
                 {
                         "algorithm": "DRBG",
@@ -1113,13 +1114,16 @@ Internet-Draft                Sym Alg JSON                 November 2018
                         }
                 }
         }
-}
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 20]
+Fussell & Hammett          Expires May 5, 2019                 [Page 20]
 
 Internet-Draft                Sym Alg JSON                 November 2018
+
+
+}
+
 
 
 3.13.  Example KAS ECC Component Capabilities JSON Object
@@ -1169,11 +1173,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 21]
+Fussell & Hammett          Expires May 5, 2019                 [Page 21]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1181,6 +1181,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 {
         "algorithm": "KAS-ECC",
         "mode": "Component",
+        "revision": "1.0",
         "prereqVals": [{
                         "algorithm": "ECDSA",
                         "valValue": "123456"
@@ -1228,8 +1229,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 22]
+Fussell & Hammett          Expires May 5, 2019                 [Page 22]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1285,7 +1285,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 23]
+Fussell & Hammett          Expires May 5, 2019                 [Page 23]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1341,7 +1341,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 24]
+Fussell & Hammett          Expires May 5, 2019                 [Page 24]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1397,7 +1397,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 25]
+Fussell & Hammett          Expires May 5, 2019                 [Page 25]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1453,7 +1453,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 26]
+Fussell & Hammett          Expires May 5, 2019                 [Page 26]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1509,7 +1509,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 27]
+Fussell & Hammett          Expires May 5, 2019                 [Page 27]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1565,7 +1565,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 28]
+Fussell & Hammett          Expires May 5, 2019                 [Page 28]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1621,7 +1621,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 29]
+Fussell & Hammett          Expires May 5, 2019                 [Page 29]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1677,7 +1677,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 30]
+Fussell & Hammett          Expires May 5, 2019                 [Page 30]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -1692,6 +1692,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |            | set                                         |        |
    |            |                                             |        |
    | algorithm  | KAS-ECC                                     | value  |
+   |            |                                             |        |
+   | revision   | The algorithm testing revision to use.      | value  |
    |            |                                             |        |
    | type       | Type of operation supported                 | value  |
    |            |                                             |        |
@@ -1728,16 +1730,16 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |                | possible values      |                |          |
    |                |                      |                |          |
    | testType       | The type of          | AFT, VAL       | No       |
-   |                | testCases expected   |                |          |
-   |                | within the group.    |                |          |
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 31]
+Fussell & Hammett          Expires May 5, 2019                 [Page 31]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   |                | testCases expected   |                |          |
+   |                | within the group.    |                |          |
    |                | AFT (Functional)     |                |          |
    |                | tests produce test   |                |          |
    |                | cases where the      |                |          |
@@ -1768,37 +1770,37 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | parmSet        | Parameter set value  | eb, ec, ed, ee | No       |
    |                | to use               |                |          |
    |                |                      |                |          |
-   | hashAlg        | hashAlg values being | See Section    | No       |
-   |                | used                 | 3.8            |          |
+   | hashAlg        | hashAlg values being | See            | No       |
+   |                | used                 | Section 3.8    |          |
    |                |                      |                |          |
-   | macType        | The MAC being used.  | See Section    | Yes      |
-   |                | REQUIRED for         | 3.9            |          |
+   | macType        | The MAC being used.  | See            | Yes      |
+   |                | REQUIRED for         | Section 3.9    |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
-   | keyLen         | The key length of    | See Section    | Yes      |
-   |                | the MAC. REQUIRED    | 3.9            |          |
+   | keyLen         | The key length of    | See            | Yes      |
+   |                | the MAC. REQUIRED    | Section 3.9    |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
-   | nonceAesCcmLen | The nonce length of  | See Section    | Yes      |
-   |                | the MAC (applies     | 3.9            |          |
+   | nonceAesCcmLen | The nonce length of  | See            | Yes      |
+   |                | the MAC (applies     | Section 3.9    |          |
    |                | only to AES-CCM).    |                |          |
-   |                | REQUIRED for         |                |          |
-   |                | "kdfNoKc" and        |                |          |
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 32]
+Fussell & Hammett          Expires May 5, 2019                 [Page 32]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   |                | REQUIRED for         |                |          |
+   |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes using  |                |          |
    |                | a AES-CCM MAC.       |                |          |
    |                |                      |                |          |
-   | macLen         | The mac length.      | See Section    | Yes      |
-   |                | REQUIRED for         | 3.9            |          |
+   | macLen         | The mac length.      | See            | Yes      |
+   |                | REQUIRED for         | Section 3.9    |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
@@ -1833,23 +1835,23 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |                | by IUT for AFT       |                |          |
    |                | tests.               |                |          |
    |                |                      |                |          |
-   | oiPattern      | The oiPattern used   | See Section    | Yes      |
-   |                | in the KDF. REQUIRED | 3.10.1         |          |
+   | oiPattern      | The oiPattern used   | See            | Yes      |
+   |                | in the KDF. REQUIRED | Section 3.10.1 |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | kcRole         | Key confirmation     | provider,      | Yes      |
    |                | roles supported.     | recipient      |          |
-   |                | REQUIRED for "kdfKc" |                |          |
-   |                | modes.               |                |          |
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 33]
+Fussell & Hammett          Expires May 5, 2019                 [Page 33]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   |                | REQUIRED for "kdfKc" |                |          |
+   |                | modes.               |                |          |
    |                |                      |                |          |
    | kcType         | Key confirmation     | unilateral     | Yes      |
    |                | types supported.     | and/or         |          |
@@ -1862,8 +1864,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | tests          | Array of individual  | array          | No       |
    |                | test vector JSON     |                |          |
    |                | objects, which are   |                |          |
-   |                | defined in Section   |                |          |
-   |                | 5.2                  |                |          |
+   |                | defined in           |                |          |
+   |                | Section 5.2          |                |          |
    +----------------+----------------------+----------------+----------+
 
                     Table 16: Vector Group JSON Object
@@ -1896,16 +1898,16 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | X                     | public key X         |         |          |
    |                       | coordinate           |         |          |
    |                       |                      |         |          |
-   | ephemeralPublicServer | The ECDSA ephemeral  | value   | Yes      |
-   | Y                     | public key Y         |         |          |
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 34]
+Fussell & Hammett          Expires May 5, 2019                 [Page 34]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   | ephemeralPublicServer | The ECDSA ephemeral  | value   | Yes      |
+   | Y                     | public key Y         |         |          |
    |                       | coordinate           |         |          |
    |                       |                      |         |          |
    | nonceEphemeralServer  | nonceEphemeralServer | value   | Yes      |
@@ -1952,16 +1954,16 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |                       | Y coordinate         |         |          |
    |                       |                      |         |          |
    | oiLen                 | Length of the        | value   | Yes      |
-   |                       | OtherInfo field      |         |          |
-   |                       |                      |         |          |
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 35]
+Fussell & Hammett          Expires May 5, 2019                 [Page 35]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   |                       | OtherInfo field      |         |          |
+   |                       |                      |         |          |
    | oi                    | OtherInfo field      | value   | Yes      |
    |                       |                      |         |          |
    | dkm                   | Derived Keying       | value   | Yes      |
@@ -2008,16 +2010,16 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |                       | value.               |         |          |
    |                       |                      |         |          |
    | nonceAesCcm           | Nonce used by the    | value   | Yes      |
-   |                       | CCM function, if CCM |         |          |
-   |                       | is used to generate  |         |          |
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 36]
+Fussell & Hammett          Expires May 5, 2019                 [Page 36]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   |                       | CCM function, if CCM |         |          |
+   |                       | is used to generate  |         |          |
    |                       | the Tag.             |         |          |
    |                       |                      |         |          |
    | macData               | The message to be    | value   | Yes      |
@@ -2062,18 +2064,19 @@ Internet-Draft                Sym Alg JSON                 November 2018
         {
                 "vsId": 1564,
                 "algorithm": "KAS-ECC",
+                "revision": "1.0",
                 "testGroups": [
-                        {
-                "tgId": 1,
-                                "scheme": "ephemeralUnified",
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 37]
+Fussell & Hammett          Expires May 5, 2019                 [Page 37]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+                        {
+                "tgId": 1,
+                                "scheme": "ephemeralUnified",
                                 "testType": "AFT",
                                 "kasRole": "initiator",
                                 "kasMode": "kdfNoKc",
@@ -2119,17 +2122,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
                         },
                         {
                 "tgId": 3,
-                                "scheme": "ephemeralUnified",
-                                "testType": "VAL",
-                                "kasRole": "initiator",
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 38]
+Fussell & Hammett          Expires May 5, 2019                 [Page 38]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+                                "scheme": "ephemeralUnified",
+                                "testType": "VAL",
+                                "kasRole": "initiator",
                                 "kasMode": "kdfNoKc",
                                 "parmSet": "eb",
                                 "hashAlg": "SHA2-224",
@@ -2175,17 +2178,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
                                         "tcId": 231,
                                         "ephemeralPublicServerX": "A0457CF2F5D38B72FF1BF3A2CF4C7CE30F215B5E52A53C39193B1639",
                                         "ephemeralPublicServerY": "38CA7951888E462D6C5F4E46FA953FF231F43D5A4F3FEBAEEBF3D52B",
-                                        "nonceNoKc": "A889762176F5F02F8C1E4BBC0C669805",
-                                        "ephemeralPrivateIut": "5F76009454AE9158797467C297229569C6E2027D6AFC226A63489444",
-                                        "ephemeralPublicIutX": "1060CEE336B183738952CF13760D542E2F3AA60124D560EFA10F392C",
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 39]
+Fussell & Hammett          Expires May 5, 2019                 [Page 39]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+                                        "nonceNoKc": "A889762176F5F02F8C1E4BBC0C669805",
+                                        "ephemeralPrivateIut": "5F76009454AE9158797467C297229569C6E2027D6AFC226A63489444",
+                                        "ephemeralPublicIutX": "1060CEE336B183738952CF13760D542E2F3AA60124D560EFA10F392C",
                                         "ephemeralPublicIutY": "216EA3B35E630A1EA4A91C430E5B63306A83624F0FFD8ADFF63A380E",
                                         "oiLen": 376,
                                         "otherInfo": "454156536964A1B2C3D4E5CAFECAFE9EF1EA2DC20EE820E7562CDD4DBCD5FD8CD57DB1F54961D8B0C83342C09B7D72",
@@ -2211,6 +2214,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
                 "vsId": 1565,
                 "algorithm": "KAS-ECC",
                 "mode": "Component",
+                "revision": "1.0",
                 "testGroups": [{
                 "tgId": 1,
                                 "scheme": "ephemeralUnified",
@@ -2230,18 +2234,18 @@ Internet-Draft                Sym Alg JSON                 November 2018
                                 "scheme": "ephemeralUnified",
                                 "testType": "AFT",
                                 "kasRole": "responder",
-                                "kasMode": "noKdfNoKc",
-                                "parmSet": "eb",
-                                "hashAlg": "SHA2-224",
-                                "curve": "P-224",
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 40]
+Fussell & Hammett          Expires May 5, 2019                 [Page 40]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+                                "kasMode": "noKdfNoKc",
+                                "parmSet": "eb",
+                                "hashAlg": "SHA2-224",
+                                "curve": "P-224",
                                 "tests": [{
                                         "tcId": 21,
                                         "ephemeralPublicServerX": "747EDBB8F62E1F06BD542FC2DD93169CB24DA6EF9E2FED4FE60FCBE6",
@@ -2286,16 +2290,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
                                         "hashZIut": "BB61FA1DCA5D93A6FBB43317AABCAE22A3EDF7F72216516115935D4E"
                                 }]
                         }
+
+
+
+Fussell & Hammett          Expires May 5, 2019                 [Page 41]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
                 ]
         }
 ]
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 41]
-
-Internet-Draft                Sym Alg JSON                 November 2018
 
 
 6.  Test Vector Responses
@@ -2338,6 +2343,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
               Table 19: Vector Set Group Response JSON Object
 
+
+
+
+
+
+
+Fussell & Hammett          Expires May 5, 2019                 [Page 42]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
 6.1.  Example Test Results JSON Object
 
    The following is a example JSON object for KAS ECC test results sent
@@ -2346,14 +2362,6 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 [{
                 "acvVersion": <acvp-version>
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 42]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
         },
         {
                 "vsId": 1564,
@@ -2394,6 +2402,14 @@ Internet-Draft                Sym Alg JSON                 November 2018
                                 }]
                         },
                         {
+
+
+
+Fussell & Hammett          Expires May 5, 2019                 [Page 43]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
                                 "tgId": 4,
                                 "tests": [{
                                         "tcId": 231,
@@ -2402,14 +2418,6 @@ Internet-Draft                Sym Alg JSON                 November 2018
                         }
                 ]
         }
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 43]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 ]
 
 
@@ -2453,15 +2461,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-
-
-
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 44]
+Fussell & Hammett          Expires May 5, 2019                 [Page 44]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2517,7 +2517,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 45]
+Fussell & Hammett          Expires May 5, 2019                 [Page 45]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2539,12 +2539,18 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |           | algorithm   |              |               |          |
    |           | mode        |              |               |          |
    |           |             |              |               |          |
-   | prereqVal | Prerequisit | array of     | See Section   | No       |
-   | s         | e algorithm | prereqAlgVal | 3.1           |          |
+   | revision  | The         | value        | "1.0"         | No       |
+   |           | algorithm   |              |               |          |
+   |           | testing     |              |               |          |
+   |           | revision to |              |               |          |
+   |           | use.        |              |               |          |
+   |           |             |              |               |          |
+   | prereqVal | Prerequisit | array of     | See           | No       |
+   | s         | e algorithm | prereqAlgVal | Section 3.1   |          |
    |           | validations | objects      |               |          |
    |           |             |              |               |          |
-   | curve     | Array of    | array        | See Section   | No       |
-   |           | supported   |              | 3.7           |          |
+   | curve     | Array of    | array        | See           | No       |
+   |           | supported   |              | Section 3.7   |          |
    |           | curves      |              |               |          |
    |           |             |              |               |          |
    +-----------+-------------+--------------+---------------+----------+
@@ -2558,9 +2564,24 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
+
+
+
+
+
+
+
+
+
+Fussell & Hammett          Expires May 5, 2019                 [Page 46]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
    {
            "algorithm": "KAS-ECC",
            "mode": "CDH-Component",
+           "revision": "1.0",
            "prereqVals": [{
                    "algorithm": "ECDSA",
                    "valValue": "123456"
@@ -2569,13 +2590,6 @@ Internet-Draft                Sym Alg JSON                 November 2018
            "curve": ["p-192", "k-163", "b-163"]
    }
 
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 46]
-
-Internet-Draft                Sym Alg JSON                 November 2018
 
 
 7.2.  ECC CDH Component TestVectors JSON Values
@@ -2589,6 +2603,10 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |            |                   |       |               |          |
    | mode       | The algorithm     | value | CDH-Component | No       |
    |            | mode under test   |       |               |          |
+   |            |                   |       |               |          |
+   | revision   | The algorithm     | value | "1.0"         | No       |
+   |            | testing revision  |       |               |          |
+   |            | to use.           |       |               |          |
    |            |                   |       |               |          |
    | testGroups | Array of          | Array | Array of test | No       |
    |            | individual test   |       | group         |          |
@@ -2611,25 +2629,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 47]
+Fussell & Hammett          Expires May 5, 2019                 [Page 47]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2685,7 +2685,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 48]
+Fussell & Hammett          Expires May 5, 2019                 [Page 48]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2741,7 +2741,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 49]
+Fussell & Hammett          Expires May 5, 2019                 [Page 49]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2753,6 +2753,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
                 "vsId": 1750,
                 "algorithm": "KAS-ECC",
                 "mode": "CDH-Component",
+                "revision": "1.0",
                 "testGroups": [{
                                 "tgId": 1,
                                 "testType": "AFT",
@@ -2792,15 +2793,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
-   table describes the JSON object that represents a vector set
-   response.
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 50]
+
+Fussell & Hammett          Expires May 5, 2019                 [Page 50]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
+
+   table describes the JSON object that represents a vector set
+   response.
 
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
@@ -2850,10 +2853,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
-
-
-Fussell & Hammett         Expires May 11, 2019                 [Page 51]
+Fussell & Hammett          Expires May 5, 2019                 [Page 51]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2909,7 +2909,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 52]
+Fussell & Hammett          Expires May 5, 2019                 [Page 52]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2965,7 +2965,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 53]
+Fussell & Hammett          Expires May 5, 2019                 [Page 53]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
@@ -2980,8 +2980,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [SP800-56a]
               NIST, "Recommendation for Pair-Wise Key-Establishment
@@ -3021,4 +3021,4 @@ Authors' Addresses
 
 
 
-Fussell & Hammett         Expires May 11, 2019                 [Page 54]
+Fussell & Hammett          Expires May 5, 2019                 [Page 54]

--- a/artifacts/acvp_sub_kas_ffc.html
+++ b/artifacts/acvp_sub_kas_ffc.html
@@ -417,12 +417,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasffc-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-9" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-09-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using KAS FFC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using KAS FFC algorithms with the ACVP specification." />
 
@@ -451,7 +451,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">September 2018</td>
+<td class="right">September 1, 2018</td>
 </tr>
 
     	
@@ -465,12 +465,12 @@
 <p>This document defines the JSON schema for using KAS FFC algorithms with the ACVP specification.</p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
 <p>This Internet-Draft will expire on March 5, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -784,6 +784,20 @@
 <td class="left">value</td>
 <td class="left">Component</td>
 <td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
 </tr>
 <tr>
 <td class="left"></td>
@@ -1432,6 +1446,7 @@
 
 {
 	"algorithm": "KAS-FFC",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "DSA",
 			"valValue": "123456"
@@ -1557,6 +1572,7 @@
 {
 	"algorithm": "KAS-FFC",
 	"mode": "Component",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "DSA",
 			"valValue": "123456"
@@ -3217,6 +3233,16 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">type</td>
 <td class="left">Type of operation supported</td>
 <td class="left">value</td>
@@ -3844,6 +3870,7 @@
 	{
 		"vsId": 1564,
 		"algorithm": "KAS-FFC",
+		"revision": "1.0",
 		"testGroups": [
 			{
 				"tgId": 1,
@@ -4516,6 +4543,7 @@
 		"vsId": 1564,
 		"algorithm": "KAS-FFC",
 		"mode": "Component",
+		"revision": "1.0",
 		"testGroups": [{
 				"tgId": 1,
 				"scheme": "dhEphem",
@@ -5002,7 +5030,7 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP800-56a">[SP800-56a]</b></td>

--- a/artifacts/acvp_sub_kas_ffc.html
+++ b/artifacts/acvp_sub_kas_ffc.html
@@ -421,7 +421,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasffc-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkasffc-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-09-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using KAS FFC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using KAS FFC algorithms with the ACVP specification." />
@@ -459,7 +459,7 @@
   </table>
 
   <p class="title">ACVP KAS FFC JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkasffc-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkasffc-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using KAS FFC algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kas_ffc.txt
+++ b/artifacts/acvp_sub_kas_ffc.txt
@@ -6,7 +6,7 @@ TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
 Intended status: Informational                           R. Hammett, Ed.
 Expires: March 5, 2019                                          G2, Inc.
-                                                          September 2018
+                                                       September 1, 2018
 
 
                     ACVP KAS FFC JSON Specification
@@ -25,7 +25,7 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
@@ -41,7 +41,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -93,13 +93,13 @@ Table of Contents
      5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  34
      5.3.  Example Test Vectors JSON Object  . . . . . . . . . . . .  37
      5.4.  Example Test Vectors Component JSON Object  . . . . . . .  51
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  53
-     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  54
-     6.2.  Example Test Results Component JSON Object  . . . . . . .  59
+   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  54
+     6.1.  Example Test Results JSON Object  . . . . . . . . . . . .  55
+     6.2.  Example Test Results Component JSON Object  . . . . . . .  60
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  60
    8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  60
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  60
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  60
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  61
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  61
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  61
 
 
@@ -460,17 +460,22 @@ Internet-Draft                Sym Alg JSON                September 2018
    | mode       | The algorithm  | value        | Component | Yes      |
    |            | mode.          |              |           |          |
    |            |                |              |           |          |
-   | prereqVals | Prerequisite   | array of     | See       | No       |
-   |            | algorithm      | prereqAlgVal | Section   |          |
-   |            | validations    | objects      | 3.1       |          |
+   | revision   | The algorithm  | value        | "1.0"     | No       |
+   |            | testing        |              |           |          |
+   |            | revision to    |              |           |          |
+   |            | use.           |              |           |          |
    |            |                |              |           |          |
-   | function   | Type of        | array        | See       | No       |
-   |            | function       |              | Section   |          |
-   |            | supported      |              | 3.3       |          |
+   | prereqVals | Prerequisite   | array of     | See Secti | No       |
+   |            | algorithm      | prereqAlgVal | on 3.1    |          |
+   |            | validations    | objects      |           |          |
    |            |                |              |           |          |
-   | scheme     | Array of       | object       | See       | No       |
-   |            | supported key  |              | Section   |          |
-   |            | agreement      |              | 3.4.1     |          |
+   | function   | Type of        | array        | See Secti | No       |
+   |            | function       |              | on 3.3    |          |
+   |            | supported      |              |           |          |
+   |            |                |              |           |          |
+   | scheme     | Array of       | object       | See Secti | No       |
+   |            | supported key  |              | on 3.4.1  |          |
+   |            | agreement      |              |           |          |
    |            | schemes each   |              |           |          |
    |            | having their   |              |           |          |
    |            | own            |              |           |          |
@@ -493,11 +498,6 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    o  dpVal - IUT can perform domain parameter validation (FFC only)
 
-   o  keyPairGen - IUT can perform keypair generation.
-
-   o  fullVal - IUT can perform full public key validation ( [SP800-56a]
-      section 5.6.2.3.1 / 5.6.2.3.3)
-
 
 
 
@@ -505,6 +505,11 @@ Fussell & Hammett         Expires March 5, 2019                 [Page 9]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
+
+   o  keyPairGen - IUT can perform keypair generation.
+
+   o  fullVal - IUT can perform full public key validation ( [SP800-56a]
+      section 5.6.2.3.1 / 5.6.2.3.3)
 
    o  partialVal - IUT can perform partial public key validation (
       [SP800-56a] section 5.6.2.3.2 / 5.6.2.3.4)
@@ -552,11 +557,6 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 
 
-
-
-
-
-
 Fussell & Hammett         Expires March 5, 2019                [Page 10]
 
 Internet-Draft                Sym Alg JSON                September 2018
@@ -570,8 +570,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | key agreement         |        | and/or    |          |
    |           |                       |        | responder |          |
    |           |                       |        |           |          |
-   | noKdfNoKc | Indicates no KDF, no  | object | Section   | Yes      |
-   |           | KC tests are to be    |        | 3.5.1     |          |
+   | noKdfNoKc | Indicates no KDF, no  | object | Section 3 | Yes      |
+   |           | KC tests are to be    |        | .5.1      |          |
    |           | generated. Note this  |        |           |          |
    |           | is a COMPONENT mode   |        |           |          |
    |           | only test. This       |        |           |          |
@@ -579,8 +579,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | used with "KAS-FFC" / |        |           |          |
    |           | "Component"           |        |           |          |
    |           |                       |        |           |          |
-   | kdfNoKc   | Indicates KDF, no KC  | object | Section   | Yes      |
-   |           | tests are to be       |        | 3.5.2     |          |
+   | kdfNoKc   | Indicates KDF, no KC  | object | Section 3 | Yes      |
+   |           | tests are to be       |        | .5.2      |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-FFC only     |        |           |          |
    |           | test. This mode MUST  |        |           |          |
@@ -588,8 +588,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    |           | registrations with    |        |           |          |
    |           | "KAS-FFC" (no mode)   |        |           |          |
    |           |                       |        |           |          |
-   | kdfKc     | Indicates KDF, KC     | object | Section   | Yes      |
-   |           | tests are to be       |        | 3.5.3     |          |
+   | kdfKc     | Indicates KDF, KC     | object | Section 3 | Yes      |
+   |           | tests are to be       |        | .5.3      |          |
    |           | generated. Note this  |        |           |          |
    |           | is a KAS-FFC only     |        |           |          |
    |           | test. This mode MAY   |        |           |          |
@@ -708,11 +708,11 @@ Internet-Draft                Sym Alg JSON                September 2018
    | JSON     | Description      | JSON     | Valid Values  | Optional |
    | Value    |                  | type     |               |          |
    +----------+------------------+----------+---------------+----------+
-   | fb       | The fb parameter | object   | See Section   | Yes      |
-   |          | set              |          | 3.6.2         |          |
+   | fb       | The fb parameter | object   | See           | Yes      |
+   |          | set              |          | Section 3.6.2 |          |
    |          |                  |          |               |          |
-   | fc       | The fc parameter | object   | See Section   | Yes      |
-   |          | set              |          | 3.6.2         |          |
+   | fc       | The fc parameter | object   | See           | Yes      |
+   |          | set              |          | Section 3.6.2 |          |
    |          |                  |          |               |          |
    +----------+------------------+----------+---------------+----------+
 
@@ -750,13 +750,13 @@ Internet-Draft                Sym Alg JSON                September 2018
    | JSON      | Description           | JSON   | Valid     | Optional |
    | Value     |                       | type   | Values    |          |
    +-----------+-----------------------+--------+-----------+----------+
-   | hashAlg   | The hash algorithms   | array  | See       | Yes      |
-   |           | to use for DSA (and   |        | Section   |          |
-   |           | noKdfNoKc)            |        | 3.7       |          |
+   | hashAlg   | The hash algorithms   | array  | See Secti | Yes      |
+   |           | to use for DSA (and   |        | on 3.7    |          |
+   |           | noKdfNoKc)            |        |           |          |
    |           |                       |        |           |          |
-   | macOption | The macOption(s) to   | object | See       | Yes      |
-   |           | use with "kdfNoKc"    |        | Section   |          |
-   |           | and/or "kdfKc"        |        | 3.8       |          |
+   | macOption | The macOption(s) to   | object | See Secti | Yes      |
+   |           | use with "kdfNoKc"    |        | on 3.8    |          |
+   |           | and/or "kdfKc"        |        |           |          |
    |           |                       |        |           |          |
    +-----------+-----------------------+--------+-----------+----------+
 
@@ -902,9 +902,9 @@ Internet-Draft                Sym Alg JSON                September 2018
    | JSON      | Description           | JSON  | Valid      | Optional |
    | Value     |                       | type  | Values     |          |
    +-----------+-----------------------+-------+------------+----------+
-   | oiPattern | The OI pattern to use | value | See        | No       |
-   |           | for constructing      |       | Section    |          |
-   |           | OtherInformation.     |       | 3.9.1 .    |          |
+   | oiPattern | The OI pattern to use | value | See Sectio | No       |
+   |           | for constructing      |       | n 3.9.1 .  |          |
+   |           | OtherInformation.     |       |            |          |
    |           |                       |       |            |          |
    +-----------+-----------------------+-------+------------+----------+
 
@@ -999,9 +999,9 @@ Internet-Draft                Sym Alg JSON                September 2018
 
 {
         "algorithm": "KAS-FFC",
+        "revision": "1.0",
         "prereqVals": [{
                         "algorithm": "DSA",
-                        "valValue": "123456"
 
 
 
@@ -1010,6 +1010,7 @@ Fussell & Hammett         Expires March 5, 2019                [Page 18]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+                        "valValue": "123456"
                 },
                 {
                         "algorithm": "DRBG",
@@ -1057,7 +1058,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                 },
                 "mqv1": {
                         "kasRole": ["initiator", "responder"],
-                        "kdfNoKc": {
 
 
 
@@ -1066,6 +1066,7 @@ Fussell & Hammett         Expires March 5, 2019                [Page 19]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+                        "kdfNoKc": {
                                 "kdfOption": {
                                         "concatenation": "uPartyInfo||vPartyInfo",
                                         "ASN1": "uPartyInfo||vPartyInfo"
@@ -1113,7 +1114,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                                 }
                                         },
                                         "fc": {
-                                                "hashAlg": ["SHA2-256"],
 
 
 
@@ -1122,6 +1122,7 @@ Fussell & Hammett         Expires March 5, 2019                [Page 20]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+                                                "hashAlg": ["SHA2-256"],
                                                 "macOption": {
                                                         "AES-CCM": {
                                                                 "keyLen": [128],
@@ -1148,6 +1149,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 {
         "algorithm": "KAS-FFC",
         "mode": "Component",
+        "revision": "1.0",
         "prereqVals": [{
                         "algorithm": "DSA",
                         "valValue": "123456"
@@ -1168,8 +1170,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                         "algorithm": "CMAC",
                         "valValue": "123456"
                 },
-                {
-                        "algorithm": "HMAC",
 
 
 
@@ -1178,6 +1178,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 21]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+                {
+                        "algorithm": "HMAC",
                         "valValue": "123456"
                 }
         ],
@@ -1224,8 +1226,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    | brid | dfN | iato |       |         |       |       |       | se  |
    | 1    | oKc | rPar |       |         |       |       |       |     |
    |      |     | tyU  |       |         |       |       |       |     |
-   |      |     |      |       |         |       |       |       |     |
-   | DhHy | NoK | Resp | None  | None    | True  | True  | False | Fal |
 
 
 
@@ -1234,6 +1234,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 22]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   |      |     |      |       |         |       |       |       |     |
+   | DhHy | NoK | Resp | None  | None    | True  | True  | False | Fal |
    | brid | dfN | onde |       |         |       |       |       | se  |
    | 1    | oKc | rPar |       |         |       |       |       |     |
    |      |     | tyV  |       |         |       |       |       |     |
@@ -1280,8 +1282,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |      |     |      |       |         |       |       |       |     |
    | DhHy | Kdf | Resp | Recip | Unilate | True  | True  | False | Fal |
    | brid | Kc  | onde | ient  | ral     |       |       |       | se  |
-   | 1    |     | rPar |       |         |       |       |       |     |
-   |      |     | tyV  |       |         |       |       |       |     |
 
 
 
@@ -1290,6 +1290,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 23]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   | 1    |     | rPar |       |         |       |       |       |     |
+   |      |     | tyV  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
    | DhHy | Kdf | Resp | Recip | Bilater | True  | True  | False | Fal |
    | brid | Kc  | onde | ient  | al      |       |       |       | se  |
@@ -1336,8 +1338,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |      |     | rPar |       |         |       |       |       |     |
    |      |     | tyU  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
-   | Mqv2 | Kdf | Resp | Provi | Unilate | True  | True  | False | Fal |
-   |      | Kc  | onde | der   | ral     |       |       |       | se  |
 
 
 
@@ -1346,6 +1346,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 24]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   | Mqv2 | Kdf | Resp | Provi | Unilate | True  | True  | False | Fal |
+   |      | Kc  | onde | der   | ral     |       |       |       | se  |
    |      |     | rPar |       |         |       |       |       |     |
    |      |     | tyV  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
@@ -1392,8 +1394,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    | DhHy | NoK | Resp | None  | None    | True  | False | False | Fal |
    | brid | dfN | onde |       |         |       |       |       | se  |
    | OneF | oKc | rPar |       |         |       |       |       |     |
-   | low  |     | tyV  |       |         |       |       |       |     |
-   |      |     |      |       |         |       |       |       |     |
 
 
 
@@ -1402,6 +1402,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 25]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   | low  |     | tyV  |       |         |       |       |       |     |
+   |      |     |      |       |         |       |       |       |     |
    | DhHy | Kdf | Init | None  | None    | True  | True  | False | Fal |
    | brid | NoK | iato |       |         |       |       |       | se  |
    | OneF | c   | rPar |       |         |       |       |       |     |
@@ -1448,8 +1450,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    | low  |     | tyV  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
    | DhHy | Kdf | Resp | Recip | Bilater | True  | False | True  | Fal |
-   | brid | Kc  | onde | ient  | al      |       |       |       | se  |
-   | OneF |     | rPar |       |         |       |       |       |     |
 
 
 
@@ -1458,6 +1458,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 26]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   | brid | Kc  | onde | ient  | al      |       |       |       | se  |
+   | OneF |     | rPar |       |         |       |       |       |     |
    | low  |     | tyV  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
    | Mqv1 | NoK | Init | None  | None    | True  | True  | False | Fal |
@@ -1504,8 +1506,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |      | Kc  | onde | der   | ral     |       |       |       | se  |
    |      |     | rPar |       |         |       |       |       |     |
    |      |     | tyV  |       |         |       |       |       |     |
-   |      |     |      |       |         |       |       |       |     |
-   | Mqv1 | Kdf | Resp | Provi | Bilater | True  | False | True  | Fal |
 
 
 
@@ -1514,6 +1514,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 27]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   |      |     |      |       |         |       |       |       |     |
+   | Mqv1 | Kdf | Resp | Provi | Bilater | True  | False | True  | Fal |
    |      | Kc  | onde | der   | al      |       |       |       | se  |
    |      |     | rPar |       |         |       |       |       |     |
    |      |     | tyV  |       |         |       |       |       |     |
@@ -1560,8 +1562,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |      |     |      |       |         |       |       |       |     |
    | DhSt | NoK | Init | None  | None    | True  | False | False | Fal |
    | atic | dfN | iato |       |         |       |       |       | se  |
-   |      | oKc | rPar |       |         |       |       |       |     |
-   |      |     | tyU  |       |         |       |       |       |     |
 
 
 
@@ -1570,6 +1570,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 28]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   |      | oKc | rPar |       |         |       |       |       |     |
+   |      |     | tyU  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
    | DhSt | NoK | Resp | None  | None    | True  | False | False | Fal |
    | atic | dfN | onde |       |         |       |       |       | se  |
@@ -1616,8 +1618,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |      |     | rPar |       |         |       |       |       |     |
    |      |     | tyV  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
-   | DhSt | Kdf | Resp | Recip | Unilate | True  | False | True  | Fal |
-   | atic | Kc  | onde | ient  | ral     |       |       |       | se  |
 
 
 
@@ -1626,6 +1626,8 @@ Fussell & Hammett         Expires March 5, 2019                [Page 29]
 Internet-Draft                Sym Alg JSON                September 2018
 
 
+   | DhSt | Kdf | Resp | Recip | Unilate | True  | False | True  | Fal |
+   | atic | Kc  | onde | ient  | ral     |       |       |       | se  |
    |      |     | rPar |       |         |       |       |       |     |
    |      |     | tyV  |       |         |       |       |       |     |
    |      |     |      |       |         |       |       |       |     |
@@ -1653,6 +1655,33 @@ Internet-Draft                Sym Alg JSON                September 2018
    test vectors to be processed by the ACVP client.The following table
    describes the JSON elements at the top level of the hierarchy.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 30]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
    |            |                                             | type   |
@@ -1664,6 +1693,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    |            |                                             |        |
    | algorithm  | KAS-FFC                                     | value  |
    |            |                                             |        |
+   | revision   | The algorithm testing revision to use.      | value  |
+   |            |                                             |        |
    | type       | Type of operation supported                 | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
@@ -1671,16 +1702,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    +------------+---------------------------------------------+--------+
 
                      Table 14: Vector Set JSON Object
-
-
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 30]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
 
 5.1.  Test Groups JSON Schema
 
@@ -1709,6 +1730,14 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | possible values      |                |          |
    |                |                      |                |          |
    | testType       | The type of          | AFT, VAL       | No       |
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 31]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    |                | testCases expected   |                |          |
    |                | within the group.    |                |          |
    |                | AFT (Functional)     |                |          |
@@ -1730,14 +1759,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | IUT on such tests is |                |          |
    |                | to determine if the  |                |          |
    |                | KAS negotiation was  |                |          |
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 31]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
    |                | successful or not.   |                |          |
    |                |                      |                |          |
    | kasRole        | The KAS role         | initiator,     | No       |
@@ -1749,29 +1770,37 @@ Internet-Draft                Sym Alg JSON                September 2018
    | parmSet        | Parameter set value  | fb, fc         | No       |
    |                | to use               |                |          |
    |                |                      |                |          |
-   | hashAlg        | hashAlg values being | See Section    | No       |
-   |                | used                 | 3.7            |          |
+   | hashAlg        | hashAlg values being | See            | No       |
+   |                | used                 | Section 3.7    |          |
    |                |                      |                |          |
-   | macType        | The MAC being used.  | See Section    | Yes      |
-   |                | REQUIRED for         | 3.8            |          |
+   | macType        | The MAC being used.  | See            | Yes      |
+   |                | REQUIRED for         | Section 3.8    |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
-   | keyLen         | The key length of    | See Section    | Yes      |
-   |                | the MAC. REQUIRED    | 3.8            |          |
+   | keyLen         | The key length of    | See            | Yes      |
+   |                | the MAC. REQUIRED    | Section 3.8    |          |
    |                | for "kdfNoKc" and    |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
-   | nonceAesCcmLen | The nonce length of  | See Section    | Yes      |
-   |                | the MAC (applies     | 3.8            |          |
+   | nonceAesCcmLen | The nonce length of  | See            | Yes      |
+   |                | the MAC (applies     | Section 3.8    |          |
    |                | only to AES-CCM).    |                |          |
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 32]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes using  |                |          |
    |                | a AES-CCM MAC.       |                |          |
    |                |                      |                |          |
-   | macLen         | The mac length.      | See Section    | Yes      |
-   |                | REQUIRED for         | 3.8            |          |
+   | macLen         | The mac length.      | See            | Yes      |
+   |                | REQUIRED for         | Section 3.8    |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
@@ -1786,14 +1815,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | idServer       | The server ID.       | value          | Yes      |
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 32]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
    |                | REQUIRED for         |                |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
@@ -1814,13 +1835,21 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                | by IUT for AFT       |                |          |
    |                | tests.               |                |          |
    |                |                      |                |          |
-   | oiPattern      | The oiPattern used   | See Section    | Yes      |
-   |                | in the KDF. For      | 3.9.1          |          |
+   | oiPattern      | The oiPattern used   | See            | Yes      |
+   |                | in the KDF. For      | Section 3.9.1  |          |
    |                | "kdfNoKc" and        |                |          |
    |                | "kdfKc" modes.       |                |          |
    |                |                      |                |          |
    | kcRole         | Key confirmation     | provider,      | Yes      |
    |                | roles supported.     | recipient      |          |
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 33]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    |                | REQUIRED for "kdfKc" |                |          |
    |                | modes.               |                |          |
    |                |                      |                |          |
@@ -1841,16 +1870,8 @@ Internet-Draft                Sym Alg JSON                September 2018
    | tests          | Array of individual  | array          | No       |
    |                | test vector JSON     |                |          |
    |                | objects, which are   |                |          |
-   |                | defined in Section   |                |          |
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 33]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
-   |                | 5.2                  |                |          |
+   |                | defined in           |                |          |
+   |                | Section 5.2          |                |          |
    +----------------+----------------------+----------------+----------+
 
                     Table 15: Vector Group JSON Object
@@ -1877,6 +1898,14 @@ Internet-Draft                Sym Alg JSON                September 2018
    | ephemeralPublicServer | The DSA ephemeral    | value   | Yes      |
    |                       | public key           |         |          |
    |                       |                      |         |          |
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 34]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    | nonceEphemeralServer  | nonceEphemeralServer | value   | Yes      |
    |                       | ONLY USED BY C(1,2)  |         |          |
    |                       | and C(0,2) schemes   |         |          |
@@ -1898,14 +1927,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                       | field in the         |         |          |
    |                       | PartyUInfo field.    |         |          |
    |                       |                      |         |          |
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 34]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
    | staticPrivateIut      | The IUT DSA static   | value   | Yes      |
    |                       | private key          |         |          |
    |                       |                      |         |          |
@@ -1933,6 +1954,14 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                       | the DKM to MAC the   |         |          |
    |                       | Message with the     |         |          |
    |                       | specified method     |         |          |
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 35]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    |                       |                      |         |          |
    | nonceEphemeralIut     | nonceEphemeralIut    | value   | Yes      |
    |                       | ONLY USED BY C(1,2)  |         |          |
@@ -1954,14 +1983,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                       | supplied by the      |         |          |
    |                       | initiator to be used |         |          |
    |                       | in the OI field in   |         |          |
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 35]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
    |                       | the PartyUInfo       |         |          |
    |                       | field.               |         |          |
    |                       |                      |         |          |
@@ -1989,6 +2010,14 @@ Internet-Draft                Sym Alg JSON                September 2018
    |                       | material using a key |         |          |
    |                       | derivation function. |         |          |
    |                       |                      |         |          |
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 36]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
    | hashZServer           | The hashed shared    | value   | Yes      |
    |                       | secret, only         |         |          |
    |                       | provided in          |         |          |
@@ -2010,14 +2039,6 @@ Internet-Draft                Sym Alg JSON                September 2018
 
                       Table 16: Test Case JSON Object
 
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 36]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
 5.3.  Example Test Vectors JSON Object
 
    The following is a example JSON object for KAS FFC test vectors sent
@@ -2030,6 +2051,7 @@ Internet-Draft                Sym Alg JSON                September 2018
         {
                 "vsId": 1564,
                 "algorithm": "KAS-FFC",
+                "revision": "1.0",
                 "testGroups": [
                         {
                                 "tgId": 1,
@@ -2044,6 +2066,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "aesCcmNonceLen": 56,
                                 "macLen": 64,
                                 "kdfType": "asn1",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 37]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "idServerLen": 48,
                                 "idServer": "434156536964",
                                 "oiPattern": "uPartyInfo||vPartyInfo",
@@ -2066,14 +2096,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "hashAlg": "SHA2-226",
                                 "macType": "AES-CCM",
                                 "keyLen": 128,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 37]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "aesCcmNonceLen": 56,
                                 "macLen": 64,
                                 "kdfType": "asn1",
@@ -2100,6 +2122,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                         {
                                 "tgId": 3,
                                 "scheme": "mqv1",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 38]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "testType": "AFT",
                                 "kasRole": "initiator",
                                 "kasMode": "kdfNoKc",
@@ -2122,14 +2152,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                         },
                         {
                                 "tgId": 4,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 38]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "scheme": "mqv1",
                                 "testType": "AFT",
                                 "kasRole": "responder",
@@ -2156,6 +2178,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tgId": 5,
                                 "scheme": "mqv1",
                                 "testType": "VAL",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 39]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "kasRole": "initiator",
                                 "kasMode": "kdfNoKc",
                                 "parmSet": "fb",
@@ -2178,14 +2208,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "staticPublicIut": "3771A4584C3A30238D8F1173EE34C6BAEF78F37C30D1A2159AA9147DC530FCADDB950198C1473063C4D9AC2F29E64E1C18F9BDC617F8BED0821BDD526896049F12E4D91C06D66D3E3CE3F92345881A5A443E715CE3027CFFEB46919557037AE7BC23BCB57EBBE92F4444C7839975A44C7F8F4416A2C05E6195060E9DE79C2684754FCA2B0028AAC4207E4E754EBF9110573380D7262DCF7A9A5EE76AF5FC183415403455B0E639D314C4A18F96A2A19E64DEFC926AB61AB50F5DF04D9CDCA98F156C06E47F11FBACC27467406910329D5700676EC30F27E9F0735C4528E66CCB55BD361A5EE600F64870E8F61DB416201BF12D7C87571A74BA7E3C9E2578B8D3",
                                         "ephemeralPrivateIut": "5610BA8A79D92592D44BF65A634E7CA81BA276F4023CBE01F888B7D7",
                                         "ephemeralPublicIut": "3DD2FB97DDD2A59B209146806CEF7218BF53445FB5F6ED4444E608A923BDEE4BA84C78B0ED1A50513B77985F859A65FD0DE63ED05A39E1ECF9E338DF9919820F1086433B868BA97ACF19A4FC07267BF4A49BA22E26B1F65402FB9D53FFCDFF560FB7826D95C222A0137E7FB8FD927C60F3A877FF34B587BBC123FD785856EAD897BE9833DA08DD8248CF642B03248392EE113D1D3EC6BB8C854171FB8E0617258507A7E614D465AD5B8A26F4C8CE313C5D12312B2A93D143DB8BBBA25BD13A90D686C8CAE1C5CAC15154F1EE4308C25477277ABCA2C786A5992B4B2630B73B6E436E12A102875BFE2C6FE9ACA97266A81138D0AB1D59BE7353B6C78C1322BB19",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 39]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "oiLen": 240,
                                         "oi": "A1B2C3D4E5434156536964CAFECAFE0C702E54817AD2878111B540EE479C",
                                         "tagIut": "72E1D9346A2840777B3860D9B930A411"
@@ -2212,6 +2234,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tests": [{
                                         "tcId": 511,
                                         "staticPublicServer": "5009DB149D378FCD02BADFEA1AD5A4A1FAFA90E6144F10211D325E977C9FFC38457AA85E0885E35551EA5EAFA25539934493477C1609942A7CFE44BF3F553386FB2B27A7F05468991B56D3BEF186D751A24C299E4959CC7C7AE931A0EC7D548A0FC383ECB0B6AF3725A1A57CC8F76762D8E30AA082A7632458E06C2B62B52AFF7D6F2BCC48244B5C1B2B22864014D3683D14EC7BCDB964DD49FBE9CC35B3EC49E5600C1D3009E4C04EE2BDBB5AFAD2FA4B1DE49B2F9A820B5A443C20DF3121FC6BFA080D4035996227F34E68496E4044A9F8D13A4DC252C2F48C1C1A9DBBFBDCA43B529BE19746C2AEE434A13E249BE8B67A3C145CD9E15AB14FF88B2117EF43",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 40]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "ephemeralPublicServer": "29C3A5172136C0D17DE1C7B46C7B8E300E49C00E485DBDB0F2349F912B1D649C5A0EDF69D196B3061AF90FF2FF54365613EDD78ACE456EE066B1B7B177A0FB00F429169AD6D6143DD9B883D28EBDF56F2AEB63ABEADE1306B3F4F6959395CA26086D69B53A6DDBC736C5AF048ACFF9C1171E647B2CFBCF7B1020D83792188F0B3807BF8EC7E21D11380FB1C4A2450A459EBE1391FE72C39759A8B7DE8D08E1EAEFE8F8A227C076CF0A0DA29909D40F729D4E0F47870E662ADEF0F4AAE632868EEF50C3F9E256622DB9F79404774EA851B296938F5E5C76C2C4C4A934B91A16F4A9F7B8833D494F231A492457BAF986DD3273FF67FBB163F54A54ACC5CB2049F9",
                                         "nonceNoKc": "6BC3341BD73345D9771F842A44768699",
                                         "staticPrivateIut": "31DFEBA03A0F42B3CA14F45B413527C0CB78AB9FC840F6781F3F1546",
@@ -2234,14 +2264,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "aesCcmNonceLen": 64,
                                 "macLen": 128,
                                 "kdfType": "asn1",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 40]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "idServerLen": 48,
                                 "idServer": "434156536964",
                                 "kcRole": "provider",
@@ -2268,6 +2290,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "keyLen": 256,
                                 "aesCcmNonceLen": 64,
                                 "macLen": 128,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 41]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "kdfType": "asn1",
                                 "idServerLen": 48,
                                 "idServer": "434156536964",
@@ -2290,14 +2320,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "kasRole": "initiator",
                                 "kasMode": "kdfKc",
                                 "parmSet": "fb",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 41]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "hashAlg": "SHA2-224",
                                 "macType": "HMAC-SHA2-224",
                                 "keyLen": 128,
@@ -2324,6 +2346,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "parmSet": "fb",
                                 "hashAlg": "SHA2-224",
                                 "macType": "AES-CCM",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 42]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "keyLen": 256,
                                 "aesCcmNonceLen": 64,
                                 "macLen": 128,
@@ -2346,14 +2376,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tgId": 11,
                                 "scheme": "mqv1",
                                 "testType": "AFT",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 42]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "kasRole": "responder",
                                 "kasMode": "kdfKc",
                                 "parmSet": "fb",
@@ -2380,6 +2402,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                         {
                                 "tgId": 12,
                                 "scheme": "mqv1",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 43]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "testType": "AFT",
                                 "kasRole": "responder",
                                 "kasMode": "kdfKc",
@@ -2402,14 +2432,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "staticPublicServer": "94C031FB6C908E2BC36A9429F667BF6035D659C0E4E3CDA9F2D77FF09B8A56E6D73E641C2D4B27104FCAF643A998112AE875E79FBFC7DE584B80BD4AA7A32095E1EA6A55DD94A5A3B63645E0F52AEEFDB8FFBAD1251F6F7EAF277663C0F844CD88F064D9AB351447AA50273CB40248889423CD75F195286882E6872A7FA0690A1E84B2DF798B9C6FFE54FF2BBEC20F655A28099215EA4579FFAC969C4B09DE209F88CC6969E9536AD5CA05EF2F8F71C62B09C2F8E67E42C0D5E322E7C0BF551124408B37B32E814F05DB794719CD7F4BE94240986B91CE488D5B76630243D92474E22DA92885469D5F6686DB1127F1191CD6B9046E52E5FCAC1D552001FF8063",
                                         "ephemeralPublicServer": "3AD77DACE248A4A680EC9EE722EBA556BC156F0AB49B14319313791D71438FD89880C1E57C502A2D82C7B51351F53ED7102766EE4DA86240B1E29FFB10409441AB73274765E88BF4E7E2AB8EC29F3CEA9BDDEC0412301BD3724C3C2D4E62EEDE8FAE7949AD1B9F769008562FE66734F06896B730141A93B9245543A948C3B7911E2955AB9BBA2EA3A48FD0CBF0642A9ABC736120A12C8C41997C9494A90647D17A8B3363D07B11887AC8709EB3AD4BF5D072862F6C7ADB3B1CB8B2A1C2361D1CF13D662CB89F4CC9BF059F7269FAA448CD5B296670FA53EA0517C5786DD6B0E1736BE435BB077E7A1E2EB3A6EB6560F9F26E92F0DACE7CC467089A68DD6B7AFE",
                                         "nonceAesCcm": "EDE971BC462678E6"
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 43]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 }]
                         },
                         {
@@ -2436,6 +2458,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "tcId": 921,
                                         "staticPublicServer": "DA81318338F7CF051CA00EF5D21B07F62C2E2B6C18A7E54AA3439704F68FD61B969EF8A88F645A8BCF29E7FB5665B990F5BAD473342E39BBB29D414D6D697E7A1DCD79053E4BD39F312D33654E03512C915CE5B755C50A4D50479E4C4E3D2880104B2D0B3EB3CAE2166210AA19FEE9A85C58D17A214A1884C258A283AD5E1A630A24B9C5DE8399F68A3DA25C918F6DDF6A3612809215B82E8CA4534CE0DA2A5CD91A5F8C001A7E4877D62489D35A3824525865F7AAFF04B000EDABA184B1E59C7715933D191B9B92BD7893CFBAF4D16A3E125F0234166A7A8F00810FD886526BC2D509DEB370CF03C37D818CB234C4A6BA3F6AFE93540E46DC2FAA98D51F3037",
                                         "ephemeralPublicServer": "66E9F8D8EC9D30654E3213DD4EC045A92177ECF6B08669A68DDDFD12484EA28158AA2BB33E16576C69C8A01A7BFB28AD944C383B73C7FC298784127347755E89A699F42B6B427699F45F88E88463EFD563511B1B141CA005670BAC16A716C3D87B51497AE43ADBBE51CDD8C733E78B128EDECB0D90F80E91E51251C24BE2CD8FD224B474EC991AC5AF5EE68E3971147979226F88A212D42E9F8739ACA657EB5EE3B1F29A2C3F0DD04835FE507D249EFFDB386C6E7391BFA4700CBAF916AC9EC071B6570518E2207298FE65F6EBF764D0A5E929E0AF230FC9DEBA24EFCC239E623822250177305324D8F35FFEDA7900995A550E1E112F6D7A0DB1AB8CC69A442C",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 44]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "nonceAesCcm": "35DEA4B3B6FE3427"
                                 }]
                         },
@@ -2458,14 +2488,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "kcType": "bilateral",
                                 "p": "DAEA7C71588BFCA3B8ED40E103CE87E49701D228822CF4CD3A5A5FBA7F07895EEA4928234724E50521054CCD84DCB24D65DA6F940D132AD08261FAE24605870C7EF2D4B68E2F55C3AF40F296EBC5782C163BB93B8D37C8CB22E6F128012D1EC0E0E3B43167CFE7050A396A1C96CDFA3BDC3116C3DE1A0970F6F390FACD10B7999C47A833ECBA92ADDDF401A30BC13B34C4040D025E530B06986A2FB7E308C4B5BF25A905DA6504C58313D2BE55BC2AA79F92D312EEFCE1C78518635B7FC6195DFCC30DB761B25C60752CB544B666B7A1BB6DB7B7AEB92037D9E7EEE6D925D0C5BC8A9CAEFC28924CC2E82A4052812E508B5EAD44991298F4EE2AA18C15602217",
                                 "q": "F3C65FD74CBA905970D1E32925D7FD88E2412AA88C1614E579890A75",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 44]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "g": "61376016993BBA8A477E30C8A78C5846F02A6A8D7A80664C26FA815CFA7243A528400F86013960B1E78D9EE976AC5E63BFA71304ED85D82D589A2D07EAFA35485922B9D02B0B8B4F1A0C61F86AAE0EB0C34ED89CCEBF07DAFCEFE9CAC55711B3C66A8DBF4198CB9B431E05680AC23795DF7003F8069716F05991346AF46E7870FB944DC2BA01FD539F833F7B3ED80BE6A8C3923534666C46A49914D6CF15055F7A7027034F2F54FAED83EBFF3D445044326CB97CEE3237DF1CDEF814991F66318DC2316782E851E9BAF78BC969AF376110E514E58A9BB0464C946A62F4EAC030A17C01F5C1488E4A7EDC3F11D6A224D2A7C06EED2596819178F6A2564F048F81",
                                 "tests": [{
                                         "tcId": 981,
@@ -2492,6 +2514,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "idIutLen": 0,
                                 "kcRole": "provider",
                                 "kcType": "unilateral",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 45]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "p": "DAEA7C71588BFCA3B8ED40E103CE87E49701D228822CF4CD3A5A5FBA7F07895EEA4928234724E50521054CCD84DCB24D65DA6F940D132AD08261FAE24605870C7EF2D4B68E2F55C3AF40F296EBC5782C163BB93B8D37C8CB22E6F128012D1EC0E0E3B43167CFE7050A396A1C96CDFA3BDC3116C3DE1A0970F6F390FACD10B7999C47A833ECBA92ADDDF401A30BC13B34C4040D025E530B06986A2FB7E308C4B5BF25A905DA6504C58313D2BE55BC2AA79F92D312EEFCE1C78518635B7FC6195DFCC30DB761B25C60752CB544B666B7A1BB6DB7B7AEB92037D9E7EEE6D925D0C5BC8A9CAEFC28924CC2E82A4052812E508B5EAD44991298F4EE2AA18C15602217",
                                 "q": "F3C65FD74CBA905970D1E32925D7FD88E2412AA88C1614E579890A75",
                                 "g": "61376016993BBA8A477E30C8A78C5846F02A6A8D7A80664C26FA815CFA7243A528400F86013960B1E78D9EE976AC5E63BFA71304ED85D82D589A2D07EAFA35485922B9D02B0B8B4F1A0C61F86AAE0EB0C34ED89CCEBF07DAFCEFE9CAC55711B3C66A8DBF4198CB9B431E05680AC23795DF7003F8069716F05991346AF46E7870FB944DC2BA01FD539F833F7B3ED80BE6A8C3923534666C46A49914D6CF15055F7A7027034F2F54FAED83EBFF3D445044326CB97CEE3237DF1CDEF814991F66318DC2316782E851E9BAF78BC969AF376110E514E58A9BB0464C946A62F4EAC030A17C01F5C1488E4A7EDC3F11D6A224D2A7C06EED2596819178F6A2564F048F81",
@@ -2514,14 +2544,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "scheme": "mqv1",
                                 "testType": "VAL",
                                 "kasRole": "initiator",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 45]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "kasMode": "kdfKc",
                                 "parmSet": "fb",
                                 "hashAlg": "SHA2-224",
@@ -2548,6 +2570,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "ephemeralPublicIut": "D51C6F1214D83C2D0695DA2E85CE153848B8FF511220DB4ADA7831B67171AC4C4D70952B8E59F7A24554851CDE8A940924CCD01F074F97CE65511CC6F426B39321FC6DEA4CABA7132C087026360B3CAD0DFCAA594139D977A6454894A14A148C2B91814109FA567BB1D4B33AAB20E88FEB6D9B37192A9417ED3B891BCE3CABB610364635B5386BF00480999AF110687C53909FF05E9060A7AEA9FA5149E55565EDBD0A58D423A2E49953BABA1D299AFE75317262EEC333E82E41CF38BB7876BB35DA0F668C036BDBC06D6F49F31F0C83C69ADA3CAF5C1D873C0B940DBC9E453D996BDFD572F210657DCA782C128FBEB1CE30C919E1D3B1A47678DB301CA6A49C",
                                         "oiLen": 240,
                                         "oi": "A1B2C3D4E5434156536964CAFE12344F588C8270ABDEB66A5FC6170247D0",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 46]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "nonceAesCcm": "9F697AC59FAFAC14",
                                         "tagIut": "DD8630597AC383B79424268E560966A5"
                                 }]
@@ -2570,14 +2600,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "idIutLen": 0,
                                 "kcRole": "recipient",
                                 "kcType": "unilateral",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 46]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "p": "DAEA7C71588BFCA3B8ED40E103CE87E49701D228822CF4CD3A5A5FBA7F07895EEA4928234724E50521054CCD84DCB24D65DA6F940D132AD08261FAE24605870C7EF2D4B68E2F55C3AF40F296EBC5782C163BB93B8D37C8CB22E6F128012D1EC0E0E3B43167CFE7050A396A1C96CDFA3BDC3116C3DE1A0970F6F390FACD10B7999C47A833ECBA92ADDDF401A30BC13B34C4040D025E530B06986A2FB7E308C4B5BF25A905DA6504C58313D2BE55BC2AA79F92D312EEFCE1C78518635B7FC6195DFCC30DB761B25C60752CB544B666B7A1BB6DB7B7AEB92037D9E7EEE6D925D0C5BC8A9CAEFC28924CC2E82A4052812E508B5EAD44991298F4EE2AA18C15602217",
                                 "q": "F3C65FD74CBA905970D1E32925D7FD88E2412AA88C1614E579890A75",
                                 "g": "61376016993BBA8A477E30C8A78C5846F02A6A8D7A80664C26FA815CFA7243A528400F86013960B1E78D9EE976AC5E63BFA71304ED85D82D589A2D07EAFA35485922B9D02B0B8B4F1A0C61F86AAE0EB0C34ED89CCEBF07DAFCEFE9CAC55711B3C66A8DBF4198CB9B431E05680AC23795DF7003F8069716F05991346AF46E7870FB944DC2BA01FD539F833F7B3ED80BE6A8C3923534666C46A49914D6CF15055F7A7027034F2F54FAED83EBFF3D445044326CB97CEE3237DF1CDEF814991F66318DC2316782E851E9BAF78BC969AF376110E514E58A9BB0464C946A62F4EAC030A17C01F5C1488E4A7EDC3F11D6A224D2A7C06EED2596819178F6A2564F048F81",
@@ -2604,6 +2626,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "hashAlg": "SHA2-224",
                                 "macType": "AES-CCM",
                                 "keyLen": 256,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 47]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "aesCcmNonceLen": 64,
                                 "macLen": 128,
                                 "kdfType": "asn1",
@@ -2626,14 +2656,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "oiLen": 240,
                                         "oi": "A1B2C3D4E5434156536964CAFE1234A490B28BFA803CE2ED934F0AE8DCCA",
                                         "nonceAesCcm": "B682D26D3E3857A8",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 47]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "tagIut": "25CAEE5040F7AA018D82C5066AD7881F"
                                 }]
                         },
@@ -2660,6 +2682,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "g": "61376016993BBA8A477E30C8A78C5846F02A6A8D7A80664C26FA815CFA7243A528400F86013960B1E78D9EE976AC5E63BFA71304ED85D82D589A2D07EAFA35485922B9D02B0B8B4F1A0C61F86AAE0EB0C34ED89CCEBF07DAFCEFE9CAC55711B3C66A8DBF4198CB9B431E05680AC23795DF7003F8069716F05991346AF46E7870FB944DC2BA01FD539F833F7B3ED80BE6A8C3923534666C46A49914D6CF15055F7A7027034F2F54FAED83EBFF3D445044326CB97CEE3237DF1CDEF814991F66318DC2316782E851E9BAF78BC969AF376110E514E58A9BB0464C946A62F4EAC030A17C01F5C1488E4A7EDC3F11D6A224D2A7C06EED2596819178F6A2564F048F81",
                                 "tests": [{
                                         "tcId": 1641,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 48]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "staticPublicServer": "2575B8BCD7682B01F664BE1764265F69C33EE0680507AF5C4DA9C4A6B2D3D334674BD0B2D41935A99AE748FCB7C0A4B8E0DAD0D91F13CC66E2AB66B7EB6F94EBBEE7215201AA2240B4A4DE46C42436FDCF4D88AA46F768F836C3CDAC52DC81D32A44ED4BEA4A6596E1455BDD7C2D71279D87FC59FDF408BE7950E63B1CEB1072431C987A02FCFF6AD116D2B96453CDDC5255240E1CB0C727FEFD65D8D4812689D34F77D19B1B369A0FEB78125CFE559D2A084999BCC90CD5289BD173803B752CAC891E099AF3DC064C7FCF305E4C880A20EA4E8A95DE059FB762FDE5E5B01272BD3858047B9B3CA8B747489430B7B0538B2C0F7F93BDB6ED55F90CD4B08B4908",
                                         "ephemeralPublicServer": "B3F76590E308FEB6F4C7B0C0AE68EB250A400F94C06AC56DB020D6745B7F6385D3206C36C75016EBE3751A2446B22FB0D7BFA9C77D43E9D8643F176902E1E955F96B76DC98A49A751C10C369CCCB871C220D93474DF87E5C26EBCDB8D4576293937548BEAFE19ACD588947E0F74430C071B1D041BA4BCF7093529C3F8EA3086D389F56AB08351C295E9634D30A15D06E8EF88DAB32D6AEF11B4AE8DBFF86617F0A01689052C4980D756E3E06701BD6CD41EE8AE7471F9FDD8117EE0F6EC6B6C54BA8814E5336C9BA69A1845A28A1A7EE100E7F8208E0C1AA4F370340EB81D3A97BE15E9E91EA552C3FDC69E23CEB02BF87AFC50F0CDE6A4697C72C8385E86A22",
                                         "staticPrivateIut": "278FB569309A162DDA6E41F24BCBB2D514AC393C80F3E0CB32843FE7",
@@ -2682,14 +2712,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "keyLen": 256,
                                 "aesCcmNonceLen": 64,
                                 "macLen": 128,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 48]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "kdfType": "asn1",
                                 "idServerLen": 48,
                                 "idServer": "434156536964",
@@ -2716,6 +2738,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tgId": 21,
                                 "scheme": "mqv1",
                                 "testType": "VAL",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 49]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "kasRole": "responder",
                                 "kasMode": "kdfKc",
                                 "parmSet": "fb",
@@ -2738,14 +2768,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "staticPublicServer": "D91479786D5E975DBF77B6B2425AB0AC68C593E291DF9CB8B56A52A8BA4469E583ACEFB62430E24633A573B214CF6CC4FBD71DDD97F65D9B894412845DB60A385C17EDDC7E6BDDE41AF8F36EDB1FB229DC0060B8651EFAF743B5972824CA8FC23F0F09BAD935158CBFA563E70FEE3DBBA79B6280449E0E61253E56E37BF917F7AB50D6A0015BB2BE9313409202151FC630FBCE8E54C54B1F3995852DE6D49AEDDC8557B078C643EC05CEF68B912D184602743DA8A32B93911DE89E3B374D69A14615178CA9117EB6005A21BD56078926A57904A181A92F4412CA0895D93C55699C0187638E60342A7FFC4AE9F6448BF2466B0E6F2B4B68726387500856FA6DDA",
                                         "ephemeralPublicServer": "03019E8B2EF4688CD771C9A1B032E09541DBCFB4AC9EDA3B9C965D175DD45E4F3642CB31694EAD9331FA0597BA8351EBD311711DAED038D32719BEBA16283923ECA02559626EE4DFEA6918D6F300E8A811138CD05DFF6DBAB5C030F0DC963184AA191484116F989853938BF5AFF9A135539D8A4D0A0D5DF8AC19ABBA4D95C0462262DA349A50915EBA8E3B202E9F4F3C926FEB0F4B0AB647CC2915A4498DAD6DC3F3EA9063D2FBFCAB35FC2BC4314B8F4AC071E275F1C78CB0F13DB922FF86F5DFE829173D9F5983865615DC0B093054E0A8A23418A8480A894AEE5AB2F11AE7B7CA2017CBF242ED8C2FBE0DE9CE352F817FA328A4DF56FA9877C50B028B763A",
                                         "staticPrivateIut": "D97952EE78B1C2431AC50868E756AC14C6B29D18883515D1665D023A",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 49]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "staticPublicIut": "D0E1766A6B479411B50AD54961E042FEF80429DFA17D863381D4853EF080700D2B4DC262040EC4592DDBA5A975DDA3022DC4DC5BF4B6C270D681253A3F1C00AD4F2CAC8EBEAC915361BDB4D757917223E0801C8E35221DB6A361C84FD961914134E2F8402176FA044E794658AE74979C6D322E7BDC14AD750887048633573D40FC308A21B09B38F14A86A57984DDB7D56DD6C9514298E2E60C84C225979418AF5574AB9817AD063CE2A81F92FF80B902F8ACA3FCB28802BF6476FFB4BA2E37B65D0B15DF5DBC548B41ED1E44743AAD250648AF37FB4EFB6A064055936C3B0B99DCC1E5C8975C006DFF7CDCF1CBD444E67B098B1B7FC032105CCF1F5516883A89",
                                         "nonceEphemeralIut": "E5D188DAD2A9E863287AEBA62D059921BC13DFE9451344FD767E5C5DA5E78957AB24E0F7E67580C98179D7DF604559B3C86CF0FE37A258C5C96F4F527269DD005A4BEB86B9628DAC12168B9DD80D6CC6D1CEC783E8E4A397AB9A59742293DF0D17B0EDCC0B2A8290F0D8E2DA39036022E472E55277F4B14718F7B13CF27D85F5F1C5A038305038B6213E78992BBB8F5DD74BF2A788D1D3B7E91D1D44E1A4CE68720E96C961376ED6196E234AAC9A64363C93E0C0E6F704878E01709E2752254488243490F2CBF0B80CD89E8D5861B959BC459606E8578CA69F889451EF7AAFB7FB7BAC66F4217BD39AC918739DA31023535F19D60A20C0358B28B16D9E8A8124",
                                         "oiLen": 240,
@@ -2772,6 +2794,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "idIutLen": 0,
                                 "kcRole": "recipient",
                                 "kcType": "bilateral",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 50]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "p": "DAEA7C71588BFCA3B8ED40E103CE87E49701D228822CF4CD3A5A5FBA7F07895EEA4928234724E50521054CCD84DCB24D65DA6F940D132AD08261FAE24605870C7EF2D4B68E2F55C3AF40F296EBC5782C163BB93B8D37C8CB22E6F128012D1EC0E0E3B43167CFE7050A396A1C96CDFA3BDC3116C3DE1A0970F6F390FACD10B7999C47A833ECBA92ADDDF401A30BC13B34C4040D025E530B06986A2FB7E308C4B5BF25A905DA6504C58313D2BE55BC2AA79F92D312EEFCE1C78518635B7FC6195DFCC30DB761B25C60752CB544B666B7A1BB6DB7B7AEB92037D9E7EEE6D925D0C5BC8A9CAEFC28924CC2E82A4052812E508B5EAD44991298F4EE2AA18C15602217",
                                 "q": "F3C65FD74CBA905970D1E32925D7FD88E2412AA88C1614E579890A75",
                                 "g": "61376016993BBA8A477E30C8A78C5846F02A6A8D7A80664C26FA815CFA7243A528400F86013960B1E78D9EE976AC5E63BFA71304ED85D82D589A2D07EAFA35485922B9D02B0B8B4F1A0C61F86AAE0EB0C34ED89CCEBF07DAFCEFE9CAC55711B3C66A8DBF4198CB9B431E05680AC23795DF7003F8069716F05991346AF46E7870FB944DC2BA01FD539F833F7B3ED80BE6A8C3923534666C46A49914D6CF15055F7A7027034F2F54FAED83EBFF3D445044326CB97CEE3237DF1CDEF814991F66318DC2316782E851E9BAF78BC969AF376110E514E58A9BB0464C946A62F4EAC030A17C01F5C1488E4A7EDC3F11D6A224D2A7C06EED2596819178F6A2564F048F81",
@@ -2793,15 +2823,6 @@ Internet-Draft                Sym Alg JSON                September 2018
 ]
 
 
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 50]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
 5.4.  Example Test Vectors Component JSON Object
 
    The following is a example JSON object for KAS FFC test vectors sent
@@ -2815,6 +2836,7 @@ Internet-Draft                Sym Alg JSON                September 2018
                 "vsId": 1564,
                 "algorithm": "KAS-FFC",
                 "mode": "Component",
+                "revision": "1.0",
                 "testGroups": [{
                                 "tgId": 1,
                                 "scheme": "dhEphem",
@@ -2828,6 +2850,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "g": "45308211a07f231181276b44b873eb67726ca6aa5ecd39b4274f780409e15bfc98ac4680be5220a23b963e3b494602a80ce6cb6eb3f056e2a911ff7529f07fc53fa8840174698aac6a9dd540e86171cf2896a7337c0a839bfd9f24779c83f75b376da3c3c4d25d6b454e09dadbe230ee42115ae7ea79ace00b3c73bfd0c9913b0251177de4aae0ed54c041ff071346b2603360e5175faa9bbbc8fc50c5c657bba28da146674fa8a4f936da9d86511959785cd8e34c4b1f390b2cc68f574fd85e96e894d1b225ad43b3489af729c560b513a671e7fde2bd138fbd20605c74347e76ac50e230c57fec6dda275df29f770d47b91631e135778a51f3032bb1ef292f",
                                 "tests": [{
                                         "tcId": 3000,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 51]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "ephemeralPublicServer": "2cc5dcb3cae0bd0052838991e371fca0bb827598c1ffa554f2699ccc29b5bb085bf77634ab3fec24fb81ab1e435c17229bb6872eb4fcf30acee2a3fe9891363f51112f94d2a48ae506bd4dba9e8db6ad59713d4b8a5afbdb717a27483680998bea79baa30e42294005bfacb3e67d113549fa48d058cff1dce03ea2d89be3b61358618c540db7b11b06d4d0e545d5a5ad8d93246946f5d9a9710ebd40a48a2c70e7b93928497fa02d08cb1c591dc3c204e88e933ac2e8c68b85e3757af1b44448d60ec63fc1323f3be369662b2937a419648dc9f3b4b19496e8a4feebaed8e0ccb02d56000e5b1832b2132384efab47950e40eb8482f2d7bd344e019e9c573384"
                                 }]
                         },
@@ -2850,14 +2880,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 }]
                         },
                         {
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 51]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "tgId": 3,
                                 "scheme": "mqv1",
                                 "testType": "AFT",
@@ -2884,6 +2906,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "p": "E4E85DB7DF0C5AA669C26DFA7A8920C0580975FA36F761347C081F9631C120C1EFA7E1165859B1564F7EFA2E8825E7CEE0110721DD985CD6AE920FF16459A23D3DF0F7027B0F240364BB81AD3720465AB54663D0E2D87EDA05E1973FE4AB1E8A0E7036C016CA11190B9642C3CE45376C6CEA8160B2F7BE3EE84CC0BCFEA157986A7DAF58208EE0F4819848A2E2DEC3E498CA4445AFD8CCD780E5560A5254D9985E926B384109B75F0143E4AF0464DCF3410B781E8D4C54814B92BA3EBD0B072C19918B4CF3C75C32280AE86EBF8A14D9D215ED4478F9945EE7CF2A8FFEE58CA00519A64971A00CD57D654DC25763A41224441A4E9E9FC6C1DF571C0C0231D4B5",
                                 "q": "A1B3E7100F528EE0824F2A5A6F3B022F1ADFBFF02307F5FCC0224F5D",
                                 "g": "1AB425960434544374CA03EDAF1AEA9ADC3EACF233D2FDE6A594A58C1BB93F08C8D01B7CE7160FD439A2E6426EBD1E8F63C2B96C679315A7AE8A255B4E531F8379CBFE561A77BB695BE31BF6CF632B1442F93272475FDDE6E74BA02DD8A6F23C18748E13DAA99CE57A952293D490E9330CE4B4992A0EDB60EA88F494F3A424091CF4F62AC8AE0493DDF5F57BD1C14E93B28E536DB874DD89E69310CC70A400727A017BF53C6F5CC54ABFB83ED07C15ACEB055060F62B23F2881CE771B0165338A23487C9BB03388262F97B4CBEA9188B7F6336C59091FA32CC4B885D495518873089401605ECCE5D380E903F0F916A968DCCE0C56074CF3BB1CCE5EFDCD850EB",
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 52]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "tests": [{
                                         "tcId": 301,
                                         "staticPublicServer": "6C679621CD67F982CAC083BF7ED8938C80BB336A7CE5F752274E006EBA7F9F4F91F87414FEF3040711F6D0DCBFC145226455D0CFACBA57D418C8D2F6234FFC10D667B94261349220F67B59385597EEF575DF1D461722C59C99CA624795F46DFFDA9850EFBB49194941166175BE2F7871B43794BC7BC8C0F759191443C938BD4E77A0B32733AB08B8D32D7BBE5844801DBE5969C18A13E8A0A3F8497686B0FEB0AD4129A29F07854630CEF65DFC99CCCE833E610FC50FD0CEEDB94F5699A4B37A1DF3F2C138A63B81FA65E496911B331805EF47E126CAACC81F4EC66243E270A83DDD50BCC169D90539A5AEBE874902A716AF3A2B26DFDB1B75F38B871ED2FC99",
@@ -2906,14 +2936,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "staticPublicServer": "B853A15F818A3748CA8E160E2A12E3CF2D517E5002C29497A072164861F4A069C3D867999EEBF560633686B767C398CC5190B5A147A90CF0ED856AB3629AEB9D83D1EED230F95AA86598A3B05A8C84374E47B29B2D9DCDC33680835BC45A735958E636D48B950B9D3B6F8B4D4F56DF20C96F10486D0D59A846020B5E8BDC09279477E807AD1DD90B4BEB084EA09798A8098732E9BC3D1383BD40459158CC9DA0A1DC45E9106B521E3B1D48367DDD5FE30474DF3B25E00B23891F49BCDB048F7195CF1D796DD6331435CAD6E8A411501462194D4AD39573728336237EF17470B57F01D4A663DE6DACBE98E2AE3FF8E390665CD7B2072E100A5B03F4ABECD0BE99",
                                         "staticPrivateIut": "03271FB1CB05B4C2A45A067CABB560B3BAF9550DA0E26299E0567874",
                                         "staticPublicIut": "AD62D4942746A618B69078E411766A62C1355C5015ABB970326B01B080A1DCD5D6A006EACF9B72F2746BD0537C0CFDF39EC8E195E4FEC72434AF5E3C06B5E53B3F2A9381A0E752674F9BEC5F336A13BB17DEEC3433DAB87404FEDA24BF778DBCDA111E099B41782A7203733ACCBD754D321B7A53C06ECEEE5C126640E53725CD730ADA5528D93D109F22F648253A3ED4B39900268D1B5D06C9DBC4E25F4034F37366B941109A0AEEF98E3C7394EE479CCB9C361EB1A7BBB056BDDDD0B1941F8D3AD642B7F1E3545610BBFA017947C8B907624DDEE9C5BE8A4D6D92E23B1FD7956E98491C84B9D9A8194BC74056799958E95E60CB1923749034A3282F6ABB2C06",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 52]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "ephemeralPrivateIut": "1DB3456FFA3A40B37D2EFD7B51084340E101280A48DC412BA4C6FC89",
                                         "ephemeralPublicIut": "4A712F5AA0F4E72BD12E07F708EF937468615D865051847C9BA19751A4CA92F3071F42D2646C55EA773530F499E636437D62B0D59492C89BD862210A695433A907B84E76ABFDD09C9B33A61DA3A5621FBD062226F4CDF17F332F797144FFDCB002940BBB709C608279580B6C1196F45BDAA2F4025C2FD09964F13202CB5B37605B59A0FC03C65EEE9B57B2D73436A4D73347C8FE37028308A19AD9309ABE660424EB2949ECA25F1D70E618A5EDD5745E6965227A203B5923266E203A0E30E5199E8CD991C78D5FB4DAC9AF8862A61B300D08E8C80F486CB1E3695E3FBFAF7B5B3A90E74F96856447E158591D012E6EE770E68F91F92E0F56850AD291C8847E49",
                                         "hashZIut": "408FB2DA722F83A8BEF6E4B11B61D6EE3F68F5063AF0F6FF767F9AEDC19454346220F8342D24B4FC1F3A950FFE7DB921586539C2E2BC6BAA75882B3411A348E0"
@@ -2940,6 +2962,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 }]
                         }
                 ]
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 53]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
         }
 ]
 
@@ -2950,25 +2980,6 @@ Internet-Draft                Sym Alg JSON                September 2018
    send the response vectors back to the ACVP server.  The following
    table describes the JSON object that represents a vector set
    response.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 53]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
 
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
@@ -3003,6 +3014,18 @@ Internet-Draft                Sym Alg JSON                September 2018
 
               Table 18: Vector Set Group Response JSON Object
 
+
+
+
+
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 54]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
 6.1.  Example Test Results JSON Object
 
    The following is a example JSON object for KAS FFC test results sent
@@ -3018,14 +3041,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tgId": 1,
                                 "tests": [{
                                         "tcId": 4000,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 54]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "nonceAesCcm": "67dc43e8d722e9",
                                         "ephemeralPublicIut": "55b25962987f35576d371abe075741d4b20b04e989d4ea6dcee252b3d90aee720445816127ad49d4d8144e6f5fb4e1d459abbc48bfd419f33489599f4ad56e0f49d9b914d66bd18e159917f390073edeb0a186a25ec07dfa24585555eb0fa73a36551e6f4becf8f18e5154638f9f46539679438d68ba06db780a02416add027b2d36688bf1988d376148d9db6cbe11b6bebe4cadbd0a0a60d73e95d7438d5b8985bd3147f0fa09a638d229a175d0a48cc764d97643b962a202ea0fa283d869e2685b67345cc70771276c584ab6525a803c4649282572637ce378777b1d52cca631d229b052c8f10dbe2f5d408a4a43459b6cdaf4e7f0f6abd12b290b7f253942",
                                         "iutIdLen": 40,
@@ -3059,6 +3074,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                         },
                         {
                                 "tgId": 4,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 55]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "tests": [{
                                         "tcId": 441,
                                         "nonceNoKc": "DC04E3B3C2E0C0F14CDB425D04B48E58",
@@ -3074,14 +3097,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tgId": 5,
                                 "tests": [{
                                         "tcId": 461,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 55]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "testPassed": true
                                 }]
                         },
@@ -3115,6 +3130,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "idIutLen": 40,
                                         "idIut": "A1B2C3D4E5",
                                         "oiLen": 240,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 56]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "oi": "A1B2C3D4E5434156536964CAFE12346485B01764B240882CA93582E428D0",
                                         "nonceAesCcm": "E660DC439C9112B0",
                                         "tagIut": "EE9B29AF0C99A4467473CBB62640887B"
@@ -3130,14 +3153,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "idIut": "A1B2C3D4E5",
                                         "oiLen": 240,
                                         "oi": "A1B2C3D4E5434156536964CAFE12340D4994262F58263CE2A09FB84E1936",
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 56]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "tagIut": "C89F779369214060CE5616A76C3C57C3"
                                 }]
                         },
@@ -3171,6 +3186,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                         {
                                 "tgId": 12,
                                 "tests": [{
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 57]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                         "tcId": 861,
                                         "staticPublicIut": "BA4ADE415B3E0A2A88595BE522D77A2963A5B843C0F8E457861A9BDBE8BF4B8769BED1A0D822E988B1089A91DAA498A07A63C10A23525A835159EC02880AD3C26401C67B021DC9B42F980BE7E59075F6AE5CD121C297E1C534B1F8FEB3498381AB14737FA6770727C669A6ABE0789ACCF0D67B32871C1C6A01EACB9541110DEC002EBA820FFF567FBB60119AE43A18F45811058771B2EA3D50CA6A0ADCD75E8667DA97B3C1879C780EC0C7B5F4C25939D0A968A9D5CAE588192CC3F55291C260D238B79B50CF2324FA08C3BC3D68642658AB405A2B5E37440C8F300744B84F991473D8CA88601D5687390EA445499E9EB749F5A4C9CD11C73B941CCB1713772D",
                                         "nonceEphemeralIut": "DF3C33CC7A92236708D9CDEFDC25AD0BE92C13E03C1376710A27C922B1BFB5610474A64A801B81FC031B5F2837BABF362CA4B6F25840698686B4E7FB8E2682680204AA9C5CD9AFA01F6C20A59AFD26F12357483428B865AF11032430BBA06824C1F9265DACE38E75D8DEAABEF07A89ABE4A29CF64A44622961577FEA4F877EC92A112023A80B94BF4D93788AE1C70690EE73B83A6A9335E21DCF6840A2DC0851698C86F60B771E9DDC06897F2680F8C99722C757D8E855B1072C9BC7A870C6D7129F0ADA919DB2B5CB9122BF443C0EB99710B168B31AF074661794BE2DE92EFFC6CDBB35398FDA498B7A72C95CBCC99BEAC8B1D6708CA5CED444696BE73D2F3D",
@@ -3186,14 +3209,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                                 "tgId": 13,
                                 "tests": [{
                                         "tcId": 921,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 57]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                         "staticPublicIut": "A1A36FEF2BF595E6F121E5DDC06BB73E309A602BE7559111766CB89A4C0A525DEBCCC26E3A86130381DED487BBC294AFF8D0CFB4A3F9AE38C779D13B6B4E03FC6339D7C53FCF9BA40176DBF1D8DF680ABBA8C56CB3C6A087A3B1D8DB5AF079317A051A881C5BACA5BC4DB3BE3AC88CC4E0E895101744BFE2E1B902CF9D6D4D5DEC154DC1F75A2368554F31A238FCB002B586BBEF45D8DDD44D2D3F5971A7EAF1B58B31C375350C391088C9B6AA603E85D10D722FEA17D4FD89FC4863E3CC7EAECFCDF340D2C6F1FB306847F99C95F1EE3B014CE3B29427D79816E818F13CC34E18D932292D0C787946F4E0C32DB557123CD06E1A6FEEDB71FFA756E09068F802",
                                         "nonceEphemeralIut": "1D57658278BB2DDB8C284C7E5FCC875E2A1F5DDE68E5C2FB07373D1799EFD20438BCB654DAD4009D33C54914352405174234501C90F505D3AC3F57785861A0D53C81A364E3CA927A3CEDD46DB96E3A5FB0967839C50E86DB21991E6C4F3D8A083202827083B5ADBB6D152B16D0266DCAABA6B6E369D3D7BFF22619918500906704A4942639E6066679E10D9DCD78023A2AA36DDFA48EACC728BC56891B269D7BB2F98FD261986E19865A72169A007B48B035B7227B42609377F5BEA8FF8CC1EBF8A79D49C1B26FE2C6E922052224BCE7645516DC12952250425085D07A3402A960943A56E8E09EC711CAB79E93A3E4FDC639DC0236218032FE86295F7A81AD7E",
                                         "idIutLen": 40,
@@ -3227,6 +3242,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                         },
                         {
                                 "tgId": 16,
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 58]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                                 "tests": [{
                                         "tcId": 1191,
                                         "testPassed": true
@@ -3242,14 +3265,6 @@ Internet-Draft                Sym Alg JSON                September 2018
                         },
                         {
                                 "tgId": 18,
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 58]
-
-Internet-Draft                Sym Alg JSON                September 2018
-
-
                                 "tests": [{
                                         "tcId": 1491,
                                         "testPassed": true
@@ -3283,6 +3298,14 @@ Internet-Draft                Sym Alg JSON                September 2018
                                         "testPassed": false
                                 }]
                         }
+
+
+
+Fussell & Hammett         Expires March 5, 2019                [Page 59]
+
+Internet-Draft                Sym Alg JSON                September 2018
+
+
                 ]
         }
 ]
@@ -3292,18 +3315,6 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    The following is a example JSON object for KAS FFC Component test
    results sent from the crypto module to the ACVP server.
-
-
-
-
-
-
-
-
-
-Fussell & Hammett         Expires March 5, 2019                [Page 59]
-
-Internet-Draft                Sym Alg JSON                September 2018
 
 
 [{
@@ -3339,18 +3350,7 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    This memo includes no request to IANA.
 
-9.  Security Considerations
 
-   Security considerations are addressed by the ACVP specification.
-
-10.  Normative References
-
-   [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
-
-   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
 
 
 
@@ -3361,6 +3361,19 @@ Fussell & Hammett         Expires March 5, 2019                [Page 60]
 
 Internet-Draft                Sym Alg JSON                September 2018
 
+
+9.  Security Considerations
+
+   Security considerations are addressed by the ACVP specification.
+
+10.  Normative References
+
+   [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [SP800-56a]
               NIST, "Recommendation for Pair-Wise Key-Establishment
@@ -3387,19 +3400,6 @@ Authors' Addresses
    USA
 
    Email: russ.hammett@g2-inc.com
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/artifacts/acvp_sub_kas_ffc.txt
+++ b/artifacts/acvp_sub_kas_ffc.txt
@@ -10,7 +10,7 @@ Expires: March 5, 2019                                          G2, Inc.
 
 
                     ACVP KAS FFC JSON Specification
-                     draft-ietf-acvp-subkasffc-0.5
+                     draft-ietf-acvp-subkasffc-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf108.html
+++ b/artifacts/acvp_sub_kdf108.html
@@ -400,7 +400,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf108-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf108-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-108 KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-108 KDF algorithms with the ACVP specification." />
@@ -434,7 +434,7 @@
   </table>
 
   <p class="title">ACVP SP800-108 Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf108-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf108-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-108 KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf108.html
+++ b/artifacts/acvp_sub_kdf108.html
@@ -605,6 +605,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">prerequistie algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -794,6 +808,16 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">See <a href="#supported_algs" class="xref">Section 2.3</a> </td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1146,6 +1170,7 @@
           
 {
     "algorithm": "KDF",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -1276,6 +1301,7 @@
 	{
 		"vsId": 1564,
 		"algorithm": "counterMode",
+		"revision": "1.0",
 		"testGroups": [{
 			"tgId": 1,
 			"kdfMode": "counter",

--- a/artifacts/acvp_sub_kdf108.txt
+++ b/artifacts/acvp_sub_kdf108.txt
@@ -67,7 +67,7 @@ Table of Contents
            Validations . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  SP800-108 KDF Algorithm Capabilities Registration . . . .   4
      2.3.  Supported SP800-108 KDF Modes . . . . . . . . . . . . . .   5
-     2.4.  Supported KDF Modes Capabilities  . . . . . . . . . . . .   5
+     2.4.  Supported KDF Modes Capabilities  . . . . . . . . . . . .   6
      2.5.  Supported SP800-108 KDF MACs  . . . . . . . . . . . . . .   8
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   8
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
@@ -233,13 +233,18 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | algorithm    | The KDF to be  | value        | "KDF"   | No       |
    |              | validated      |              |         |          |
    |              |                |              |         |          |
-   | prereqVals   | prerequistie   | array of     | See     | No       |
-   |              | algorithm      | prereqAlgVal | Section |          |
-   |              | validations    | objects      | 2.1     |          |
+   | revision     | The algorithm  | value        | "1.0"   | No       |
+   |              | testing        |              |         |          |
+   |              | revision to    |              |         |          |
+   |              | use.           |              |         |          |
    |              |                |              |         |          |
-   | capabilities | array of JSON  | Array of     | See     |
-   |              | objects, each  | JSON objects | Section |
-   |              | with fields    |              | 2.4     |
+   | prereqVals   | prerequistie   | array of     | See Sec | No       |
+   |              | algorithm      | prereqAlgVal | tion 2. |          |
+   |              | validations    | objects      | 1       |          |
+   |              |                |              |         |          |
+   | capabilities | array of JSON  | Array of     | See Sec |
+   |              | objects, each  | JSON objects | tion 2. |
+   |              | with fields    |              | 4       |
    |              | pertaining to  |              |         |
    |              | the KDF mode   |              |         |
    |              | identified     |              |         |
@@ -268,12 +273,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  double pipeline iteration
 
-2.4.  Supported KDF Modes Capabilities
 
-   The KDF mode capabilities are advertised as JSON objects within the
-   'capabilities' value of the ACVP registration message - see Table 2 .
-   The 'capabilities' value is an array, where each array element is a
-   JSON object corresponding to a particular KDF mode defined in this
 
 
 
@@ -282,6 +282,12 @@ Fussell                 Expires February 2, 2019                [Page 5]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+2.4.  Supported KDF Modes Capabilities
+
+   The KDF mode capabilities are advertised as JSON objects within the
+   'capabilities' value of the ACVP registration message - see Table 2 .
+   The 'capabilities' value is an array, where each array element is a
+   JSON object corresponding to a particular KDF mode defined in this
    section.  The 'capabilities' value is part of the
    'capability_exchange' element of the ACVP JSON registration message.
    See the ACVP specification for details on the registration message.
@@ -295,8 +301,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | JSON Value       | Description | JSON    | Valid       | Optional |
    |                  |             | type    | Values      |          |
    +------------------+-------------+---------+-------------+----------+
-   | kdfMode          | The KDF     | value   | See Section | No       |
-   |                  | mode for    |         | 2.3         |          |
+   | kdfMode          | The KDF     | value   | See         | No       |
+   |                  | mode for    |         | Section 2.3 |          |
    |                  | testing.    |         |             |          |
    |                  |             |         |             |          |
    | macMode          | The MAC     | array   | Any non-    | No       |
@@ -324,12 +330,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                  | data        |         | fixed       |          |
    |                  |             |         | data",      |          |
    |                  |             |         | "before     |          |
-   |                  |             |         | fixed       |          |
-   |                  |             |         | data",      |          |
-   |                  |             |         | "middle     |          |
-   |                  |             |         | fixed       |          |
-   |                  |             |         | data",      |          |
-   |                  |             |         | "before     |          |
 
 
 
@@ -338,6 +338,12 @@ Fussell                 Expires February 2, 2019                [Page 6]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+   |                  |             |         | fixed       |          |
+   |                  |             |         | data",      |          |
+   |                  |             |         | "middle     |          |
+   |                  |             |         | fixed       |          |
+   |                  |             |         | data",      |          |
+   |                  |             |         | "before     |          |
    |                  |             |         | iterator"}. |          |
    |                  |             |         | Note that   |          |
    |                  |             |         | "none" and  |          |
@@ -380,12 +386,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                  | empty IV.   |         |             |          |
    +------------------+-------------+---------+-------------+----------+
 
-                   Table 3: KDF Capabilities JSON Values
-
-
-
-
-
 
 
 
@@ -393,6 +393,8 @@ Fussell                 Expires February 2, 2019                [Page 7]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+                   Table 3: KDF Capabilities JSON Values
 
 2.5.  Supported SP800-108 KDF MACs
 
@@ -443,8 +445,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
 Fussell                 Expires February 2, 2019                [Page 8]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -460,6 +460,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | algorithm  | See Section 2.3                             | value  |
+   |            |                                             |        |
+   | revision   | The algorithm testing revision to use.      | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
@@ -499,8 +501,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
 Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -515,8 +515,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                 | the entire vector set.     |         |          |
    |                 |                            |         |          |
    | kdfMode         | The kdfMode used for the   | value   | No       |
-   |                 | test group.  See Section   |         |          |
-   |                 | 2.3 for possible values    |         |          |
+   |                 | test group.  See           |         |          |
+   |                 | Section 2.3 for possible   |         |          |
+   |                 | values                     |         |          |
    |                 |                            |         |          |
    | macMode         | Psuedorandom function HMAC | value   | No       |
    |                 | or CMAC used               |         |          |
@@ -550,7 +551,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each SP800-108 KDF test vector.
-
 
 
 
@@ -737,6 +737,7 @@ Appendix A.  Example SP800-108 KDF Capabilities JSON Object
 
    {
        "algorithm": "KDF",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm": "SHA",
@@ -777,7 +778,6 @@ Appendix A.  Example SP800-108 KDF Capabilities JSON Object
                    8,
                    16,
                    24,
-                   32
 
 
 
@@ -786,6 +786,7 @@ Fussell                 Expires February 2, 2019               [Page 14]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                   32
                ],
                "supportsEmptyIv": false
            },
@@ -833,7 +834,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                    "CMAC-TDES",
                    "HMAC-SHA1",
                    "HMAC-SHA224",
-                   "HMAC-SHA256",
 
 
 
@@ -842,6 +842,7 @@ Fussell                 Expires February 2, 2019               [Page 15]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                   "HMAC-SHA256",
                    "HMAC-SHA384",
                    "HMAC-SHA512"
                ],
@@ -892,7 +893,6 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
 Fussell                 Expires February 2, 2019               [Page 16]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -904,6 +904,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         {
                 "vsId": 1564,
                 "algorithm": "counterMode",
+                "revision": "1.0",
                 "testGroups": [{
                         "tgId": 1,
                         "kdfMode": "counter",
@@ -931,7 +932,6 @@ Appendix C.  Example Test Results JSON Object
 
    The following is a example JSON object for SP800-108 KDF test results
    sent from the crypto module to the ACVP server.
-
 
 
 

--- a/artifacts/acvp_sub_kdf108.txt
+++ b/artifacts/acvp_sub_kdf108.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
   ACVP SP800-108 Key Derivation Function Algorithm JSON Specification
-                     draft-ietf-acvp-subkdf108-0.5
+                     draft-ietf-acvp-subkdf108-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_ikev1.html
+++ b/artifacts/acvp_sub_kdf135_ikev1.html
@@ -613,6 +613,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -780,6 +794,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"ikev1"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1172,6 +1196,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ikev1",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -1298,7 +1323,9 @@
 	},
 	{
 		"vsId": 1564,
-		"algorithm": "IKEv1",
+		"algorithm": "kdf-components",
+		"mode": "ikev1",
+		"revision": "1.0",
 		"testGroups": [{
 				"tgId": 1,
 				"authenticationMethod": "dsa",

--- a/artifacts/acvp_sub_kdf135_ikev1.html
+++ b/artifacts/acvp_sub_kdf135_ikev1.html
@@ -398,7 +398,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ikev1-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ikev1-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using the SP800-135 IKEv1 KDF algorithm with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using the SP800-135 IKEv1 KDF algorithm with the ACVP specification." />
@@ -432,7 +432,7 @@
   </table>
 
   <p class="title">ACVP IKEv1 Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-ikev1-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-ikev1-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using the SP800-135 IKEv1 KDF algorithm with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_ikev1.txt
+++ b/artifacts/acvp_sub_kdf135_ikev1.txt
@@ -188,12 +188,18 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | to be       |             |                |         |
    |            | validated   |             |                |         |
    |            |             |             |                |         |
-   | prereqVals | Prerequisit | array of pr | See Section    | No      |
-   |            | e algorithm | ereqAlgVal  | 2.1            |         |
+   | revision   | The         | value       | "1.0"          | No      |
+   |            | algorithm   |             |                |         |
+   |            | testing     |             |                |         |
+   |            | revision to |             |                |         |
+   |            | use.        |             |                |         |
+   |            |             |             |                |         |
+   | prereqVals | Prerequisit | array of pr | See            | No      |
+   |            | e algorithm | ereqAlgVal  | Section 2.1    |         |
    |            | validations | objects     |                |         |
    |            |             |             |                |         |
-   | capabiliti | array of    | Array of    | See Section    |
-   | es         | JSON        | JSON        | 2.3            |
+   | capabiliti | array of    | Array of    | See            |
+   | es         | JSON        | JSON        | Section 2.3    |
    |            | objects,    | objects     |                |
    |            | each with   |             |                |
    |            | fields      |             |                |
@@ -213,18 +219,16 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
       Table 2: SP800-135 IKEv1 KDF Algorithm Capabilities JSON Values
 
-   Note: Some optional values are required depending on the algorithm.
-   Failure to provide these values will result in the ACVP server
-   returning an error to the ACVP client during registration.
-
-
-
 
 
 Fussell                 Expires February 2, 2019                [Page 4]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   Note: Some optional values are required depending on the algorithm.
+   Failure to provide these values will result in the ACVP server
+   returning an error to the ACVP client during registration.
 
 2.3.  Supported SP800-135 IKEv1 KDF Capabilities
 
@@ -270,10 +274,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | diffieHellmanShared | The       | doma | Minimum must be | No     |
    | SecretLength        | lengths   | in   | greater than or |        |
    |                     | of Diffie |      | equal to 224.   |        |
-   |                     | Hellman   |      | Maximum must be |        |
-   |                     | shared    |      | less than or    |        |
-   |                     | secrets   |      | equal to 8192.  |        |
-   |                     | the IUT   |      |                 |        |
 
 
 
@@ -282,6 +282,10 @@ Fussell                 Expires February 2, 2019                [Page 5]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+   |                     | Hellman   |      | Maximum must be |        |
+   |                     | shared    |      | less than or    |        |
+   |                     | secrets   |      | equal to 8192.  |        |
+   |                     | the IUT   |      |                 |        |
    |                     | supports  |      |                 |        |
    |                     | in bits.  |      |                 |        |
    |                     |           |      |                 |        |
@@ -329,10 +333,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-
-
 Fussell                 Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -351,6 +351,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                             |        |
    | mode       | "ikev1"                                     | value  |
    |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
+   |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -367,8 +369,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    meta data that applies to all test vectors within the group.  The
    following table describes the IKEv1 JSON elements of the Test Group
    JSON object.
-
-
 
 
 
@@ -592,6 +592,7 @@ Appendix A.  Example SP800-135 IKEv1 KDF Capabilities JSON Object
    {
        "algorithm": "kdf-components",
        "mode": "ikev1",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm": "SHA",
@@ -609,7 +610,6 @@ Appendix A.  Example SP800-135 IKEv1 KDF Capabilities JSON Object
                    {
                        "min": 64,
                        "max": 2048,
-                       "increment": 1
 
 
 
@@ -618,6 +618,7 @@ Fussell                 Expires February 2, 2019               [Page 11]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                       "increment": 1
                    }
                ],
                "responderNonceLength": [
@@ -665,7 +666,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                        "increment": 1
                    }
                ],
-               "diffieHellmanSharedSecretLength": [
 
 
 
@@ -674,6 +674,7 @@ Fussell                 Expires February 2, 2019               [Page 12]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+               "diffieHellmanSharedSecretLength": [
                    {
                        "min": 224,
                        "max": 8192,
@@ -724,7 +725,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell                 Expires February 2, 2019               [Page 13]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -741,7 +741,9 @@ Appendix B.  Example Test Vectors JSON Object
         },
         {
                 "vsId": 1564,
-                "algorithm": "IKEv1",
+                "algorithm": "kdf-components",
+                "mode": "ikev1",
+                "revision": "1.0",
                 "testGroups": [{
                                 "tgId": 1,
                                 "authenticationMethod": "dsa",
@@ -776,8 +778,6 @@ Appendix B.  Example Test Vectors JSON Object
                                         "preSharedKey": "6C"
                                 }]
                         },
-                        {
-                                "tgId": 3,
 
 
 
@@ -786,6 +786,8 @@ Fussell                 Expires February 2, 2019               [Page 14]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                        {
+                                "tgId": 3,
                                 "authenticationMethod": "pke",
                                 "hashAlg": "SHA-1",
                                 "nInitLength": 784,
@@ -809,8 +811,6 @@ Appendix C.  Example Test Results JSON Object
 
    The following is a example JSON object for SP800-135 IKEv1 KDF test
    results sent from the crypto module to the ACVP server.
-
-
 
 
 

--- a/artifacts/acvp_sub_kdf135_ikev1.txt
+++ b/artifacts/acvp_sub_kdf135_ikev1.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
     ACVP IKEv1 Key Derivation Function Algorithm JSON Specification
-                  draft-ietf-acvp-subkdf135-ikev1-0.5
+                  draft-ietf-acvp-subkdf135-ikev1-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_ikev2.html
+++ b/artifacts/acvp_sub_kdf135_ikev2.html
@@ -398,7 +398,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ikev2-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ikev2-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using the SP800-135 IKEv2 KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using the SP800-135 IKEv2 KDF algorithms with the ACVP specification." />
@@ -432,7 +432,7 @@
   </table>
 
   <p class="title">ACVP IKEv2 Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-ikev2-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-ikev2-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using the SP800-135 IKEv2 KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_ikev2.html
+++ b/artifacts/acvp_sub_kdf135_ikev2.html
@@ -613,6 +613,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -766,6 +780,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"ikev2"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1163,6 +1187,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ikev2",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -1225,7 +1250,9 @@
     },
     {
         "vsId": 1564,
-        "algorithm": "IKEv2",
+        "algorithm": "kdf-components",
+        "mode": "ikev2",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/artifacts/acvp_sub_kdf135_ikev2.txt
+++ b/artifacts/acvp_sub_kdf135_ikev2.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
     ACVP IKEv2 Key Derivation Function Algorithm JSON Specification
-                  draft-ietf-acvp-subkdf135-ikev2-0.5
+                  draft-ietf-acvp-subkdf135-ikev2-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_ikev2.txt
+++ b/artifacts/acvp_sub_kdf135_ikev2.txt
@@ -188,6 +188,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | to be       |             |                |         |
    |            | validated   |             |                |         |
    |            |             |             |                |         |
+   | revision   | The         | value       | "1.0"          | No      |
+   |            | algorithm   |             |                |         |
+   |            | testing     |             |                |         |
+   |            | revision to |             |                |         |
+   |            | use.        |             |                |         |
+   |            |             |             |                |         |
    | prereqVals | Prerequisit | array of pr | See            | No      |
    |            | e algorithm | ereqAlgVal  | Section 2.1    |         |
    |            | validations | objects     |                |         |
@@ -213,18 +219,16 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
       Table 2: SP800-135 IKEv2 KDF Algorithm Capabilities JSON Values
 
-   Note: Some optional values are required depending on the algorithm.
-   Failure to provide these values will result in the ACVP server
-   returning an error to the ACVP client during registration.
-
-
-
 
 
 Fussell                 Expires February 2, 2019                [Page 4]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   Note: Some optional values are required depending on the algorithm.
+   Failure to provide these values will result in the ACVP server
+   returning an error to the ACVP client during registration.
 
 2.3.  Supported SP800-135 IKEv2 KDF Capabilities
 
@@ -270,10 +274,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                         |          |       | to 2048.   |         |
    |                         |          |       |            |         |
    | diffieHellmanSharedSecr | The      | domai | Minimum    | No      |
-   | etLength                | lengths  | n     | must be    |         |
-   |                         | of       |       | greater    |         |
-   |                         | Diffie   |       | than or    |         |
-   |                         | Hellman  |       | equal to   |         |
 
 
 
@@ -282,6 +282,10 @@ Fussell                 Expires February 2, 2019                [Page 5]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+   | etLength                | lengths  | n     | must be    |         |
+   |                         | of       |       | greater    |         |
+   |                         | Diffie   |       | than or    |         |
+   |                         | Hellman  |       | equal to   |         |
    |                         | shared   |       | 224.       |         |
    |                         | secrets  |       | Maximum    |         |
    |                         | the IUT  |       | must be    |         |
@@ -326,10 +330,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta data for the entire vector set as well as individual
-   test vectors to be processed by the ACVP client.The following table
-   describes the JSON elements at the top level of the hierarchy.
-
-
 
 
 
@@ -337,6 +337,9 @@ Fussell                 Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   test vectors to be processed by the ACVP client.The following table
+   describes the JSON elements at the top level of the hierarchy.
 
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
@@ -350,6 +353,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | algorithm  | "kdf-components"                            | value  |
    |            |                                             |        |
    | mode       | "ikev2"                                     | value  |
+   |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
@@ -367,11 +372,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    meta data that applies to all test vectors within the group.  The
    following table describes the IKEv2 JSON elements of the Test Group
    JSON object.
-
-
-
-
-
 
 
 
@@ -592,6 +592,7 @@ Appendix A.  Example SP800-135 IKEv2 KDF Capabilities JSON Object
    {
        "algorithm": "kdf-components",
        "mode": "ikev2",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm": "SHA",
@@ -609,7 +610,6 @@ Appendix A.  Example SP800-135 IKEv2 KDF Capabilities JSON Object
                "SHA2-256",
                "SHA2-384",
                "SHA2-512"
-           ],
 
 
 
@@ -618,6 +618,7 @@ Fussell                 Expires February 2, 2019               [Page 11]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+           ],
            "initiatorNonceLength": [
                {
                    "min": 64,
@@ -668,7 +669,6 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
 Fussell                 Expires February 2, 2019               [Page 12]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -680,7 +680,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
     },
     {
         "vsId": 1564,
-        "algorithm": "IKEv2",
+        "algorithm": "kdf-components",
+        "mode": "ikev2",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -710,8 +712,6 @@ Appendix C.  Example Test Results JSON Object
 
    The following is a example JSON object for SP800-135 IKEv2 KDF test
    results sent from the crypto module to the ACVP server.
-
-
 
 
 

--- a/artifacts/acvp_sub_kdf135_snmp.html
+++ b/artifacts/acvp_sub_kdf135_snmp.html
@@ -610,6 +610,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -695,6 +709,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"snmp"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -957,6 +981,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "snmp",
+    "revision" "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -991,6 +1016,7 @@
 		"vsId": 1564,
 		"algorithm": "kdf-components",
 		"mode": "snmp",
+    "revision": "1.0",
 		"testGroups": [{
 			"tgId": 1,
 			"engineId": "12345678912345678900",

--- a/artifacts/acvp_sub_kdf135_snmp.html
+++ b/artifacts/acvp_sub_kdf135_snmp.html
@@ -397,7 +397,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-snmp-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-snmp-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 SNMP KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 SNMP KDF algorithms with the ACVP specification." />
@@ -431,7 +431,7 @@
   </table>
 
   <p class="title">ACVP SNMP Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-snmp-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-snmp-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-135 SNMP KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_snmp.txt
+++ b/artifacts/acvp_sub_kdf135_snmp.txt
@@ -66,7 +66,7 @@ Table of Contents
      2.1.  Required Prerequisite Algorithms for KDF135 SNMP
            Validations . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  KDF135 SNMP Algorithm Capabilities JSON Values  . . . . .   4
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   5
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   6
    4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   6
@@ -188,8 +188,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |             | to be      |             |                |         |
    |             | validated  |             |                |         |
    |             |            |             |                |         |
-   | prereqVals  | Prerequisi | array of pr | See Section    | No      |
-   |             | te         | ereqAlgVal  | 2.1            |         |
+   | revision    | The        | value       | "1.0"          | No      |
+   |             | algorithm  |             |                |         |
+   |             | testing    |             |                |         |
+   |             | revision   |             |                |         |
+   |             | to use.    |             |                |         |
+   |             |            |             |                |         |
+   | prereqVals  | Prerequisi | array of pr | See            | No      |
+   |             | te         | ereqAlgVal  | Section 2.1    |         |
    |             | algorithm  | objects     |                |         |
    |             | validation |             |                |         |
    |             | s          |             |                |         |
@@ -213,12 +219,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Failure to provide these values will result in the ACVP server
    returning an error to the ACVP client during registration.
 
-3.  Test Vectors
-
-   The ACVP server provides test vectors to the ACVP client, which are
-   then processed and returned to the ACVP server for validation.  A
-   typical ACVP validation session would require multiple test vector
-
 
 
 Fussell                 Expires February 2, 2019                [Page 4]
@@ -226,6 +226,11 @@ Fussell                 Expires February 2, 2019                [Page 4]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+3.  Test Vectors
+
+   The ACVP server provides test vectors to the ACVP client, which are
+   then processed and returned to the ACVP server for validation.  A
+   typical ACVP validation session would require multiple test vector
    sets to be downloaded and processed by the ACVP client.  Each test
    vector set represents an individual Key Derivation Function (KDF),
    such as SNMP, SSH, etc.  This section describes the JSON schema for a
@@ -249,6 +254,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                             |        |
    | mode       | "snmp"                                      | value  |
    |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
+   |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -267,13 +274,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Group JSON object.
 
    The KDF test group for SNMP is as follows:
-
-
-
-
-
-
-
 
 
 
@@ -453,6 +453,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    {
        "algorithm": "kdf-components",
        "mode": "snmp",
+       "revision" "1.0",
        "prereqVals": [
            {
                "algorithm": "SHA",
@@ -500,7 +501,6 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
 Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -513,6 +513,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
                 "vsId": 1564,
                 "algorithm": "kdf-components",
                 "mode": "snmp",
+    "revision": "1.0",
                 "testGroups": [{
                         "tgId": 1,
                         "engineId": "12345678912345678900",
@@ -549,7 +550,6 @@ Appendix C.  Example Test Results JSON Object
 
 
 Author's Address
-
 
 
 

--- a/artifacts/acvp_sub_kdf135_snmp.txt
+++ b/artifacts/acvp_sub_kdf135_snmp.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
      ACVP SNMP Key Derivation Function Algorithm JSON Specification
-                   draft-ietf-acvp-subkdf135-snmp-0.5
+                   draft-ietf-acvp-subkdf135-snmp-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_srtp.html
+++ b/artifacts/acvp_sub_kdf135_srtp.html
@@ -397,7 +397,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-srtp-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-srtp-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 SRTP KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 SRTP KDF algorithms with the ACVP specification." />
@@ -431,7 +431,7 @@
   </table>
 
   <p class="title">ACVP SRTP Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-srtp-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-srtp-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-135 SRTP KDF algorithms with the ACVP specification.</p>
@@ -610,6 +610,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -709,6 +723,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"srtp"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1057,6 +1081,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "srtp",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "AES",
@@ -1110,7 +1135,9 @@
     },
     {
         "vsId": 1564,
-        "algorithm": "SRTP",
+        "algorithm": "kdf-components",
+        "mode": "srtp",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/artifacts/acvp_sub_kdf135_srtp.txt
+++ b/artifacts/acvp_sub_kdf135_srtp.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
      ACVP SRTP Key Derivation Function Algorithm JSON Specification
-                   draft-ietf-acvp-subkdf135-srtp-0.5
+                   draft-ietf-acvp-subkdf135-srtp-1.0
 
 Abstract
 
@@ -68,16 +68,16 @@ Table of Contents
      2.2.  KDF135 SRTP Algorithm Capabilities JSON Values  . . . . .   4
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   6
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   6
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   7
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   7
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   8
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   9
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
    8.  Normative References  . . . . . . . . . . . . . . . . . . . .   9
-   Appendix A.  Example SP800-135 SRTP KDF Capabilities JSON Object    9
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  11
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  11
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  12
+   Appendix A.  Example SP800-135 SRTP KDF Capabilities JSON Object   10
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  12
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  12
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
 
 1.  Introduction
 
@@ -188,8 +188,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | to be      |            |                |         |
    |              | validated  |            |                |         |
    |              |            |            |                |         |
-   | prereqVals   | Prerequisi | array of p | See Section    | No      |
-   |              | te         | rereqAlgVa | 2.1            |         |
+   | revision     | The        | value      | "1.0"          | No      |
+   |              | algorithm  |            |                |         |
+   |              | testing    |            |                |         |
+   |              | revision   |            |                |         |
+   |              | to use.    |            |                |         |
+   |              |            |            |                |         |
+   | prereqVals   | Prerequisi | array of p | See            | No      |
+   |              | te         | rereqAlgVa | Section 2.1    |         |
    |              | algorithm  | l objects  |                |         |
    |              | validation |            |                |         |
    |              | s          |            |                |         |
@@ -212,12 +218,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | exponent   |            |                |         |
    |              | of 2. So a |            |                |         |
    |              | supported  |            |                |         |
-   |              | value of   |            |                |         |
-   |              | 3, corresp |            |                |         |
-   |              | onds to an |            |                |         |
-   |              | actual KDF |            |                |         |
-   |              | of 2^3 or  |            |                |         |
-   |              | "04" in    |            |                |         |
 
 
 
@@ -226,6 +226,12 @@ Fussell                 Expires February 2, 2019                [Page 4]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+   |              | value of   |            |                |         |
+   |              | 3, corresp |            |                |         |
+   |              | onds to an |            |                |         |
+   |              | actual KDF |            |                |         |
+   |              | of 2^3 or  |            |                |         |
+   |              | "04" in    |            |                |         |
    |              | hex, as    |            |                |         |
    |              | the third  |            |                |         |
    |              | least sign |            |                |         |
@@ -255,6 +261,27 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test vectors to be processed by the ACVP client.The following table
    describes the JSON elements at the top level of the hierarchy.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 5]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
    |            |                                             | type   |
@@ -268,19 +295,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                             |        |
    | mode       | "srtp"                                      | value  |
    |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
+   |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
    +------------+---------------------------------------------+--------+
 
                       Table 3: Vector Set JSON Object
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 5]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
 3.1.  Test Groups JSON Schema
 
@@ -294,6 +315,28 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Group JSON object.
 
    The KDF test group for SRTP is as follows:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 6]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    +--------------+---------------------------------+-------+----------+
    | JSON Value   | Description                     | JSON  | Optional |
@@ -323,21 +366,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    processed by the ACVP client.  The following table describes the JSON
    elements for each SP800-135 SRTP KDF test vector.
 
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 6]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    +------------+-----------------------------------+-------+----------+
    | JSON Value | Description                       | JSON  | Optional |
    |            |                                   | type  |          |
@@ -356,6 +384,15 @@ Internet-Draft                Sym Alg JSON                   August 2018
    +------------+-----------------------------------+-------+----------+
 
                       Table 5: Test Case JSON Object
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 7]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
 4.  Test Vector Responses
 
@@ -386,14 +423,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    SHALL require the client to send back group level properties in their
    response.  This structure helps accommodate that.
 
-
-
-
-Fussell                 Expires February 2, 2019                [Page 7]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    +-----------+--------------------------------------------+----------+
    | JSON      | Description                                | JSON     |
    | Value     |                                            | type     |
@@ -409,6 +438,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The following table describes the JSON object that represents a
    vector set response for SRTP.
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 8]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    +---------+------------------------------------------------+--------+
    | JSON    | Description                                    | JSON   |
@@ -441,15 +481,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    This memo includes no request to IANA.
 
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 8]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
 7.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
@@ -462,6 +493,18 @@ Internet-Draft                Sym Alg JSON                   August 2018
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 9]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
 Appendix A.  Example SP800-135 SRTP KDF Capabilities JSON Object
 
@@ -501,7 +544,20 @@ Appendix A.  Example SP800-135 SRTP KDF Capabilities JSON Object
 
 
 
-Fussell                 Expires February 2, 2019                [Page 9]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -509,6 +565,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    {
        "algorithm": "kdf-components",
        "mode": "srtp",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm": "AES",
@@ -556,8 +613,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-Fussell                 Expires February 2, 2019               [Page 10]
+Fussell                 Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -574,7 +630,9 @@ Appendix B.  Example Test Vectors JSON Object
     },
     {
         "vsId": 1564,
-        "algorithm": "SRTP",
+        "algorithm": "kdf-components",
+        "mode": "srtp",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -611,9 +669,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-
-
-Fussell                 Expires February 2, 2019               [Page 11]
+Fussell                 Expires February 2, 2019               [Page 12]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -669,4 +725,4 @@ Author's Address
 
 
 
-Fussell                 Expires February 2, 2019               [Page 12]
+Fussell                 Expires February 2, 2019               [Page 13]

--- a/artifacts/acvp_sub_kdf135_ssh.html
+++ b/artifacts/acvp_sub_kdf135_ssh.html
@@ -397,7 +397,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ssh-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ssh-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 SSH KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 SSH KDF algorithms with the ACVP specification." />
@@ -431,7 +431,7 @@
   </table>
 
   <p class="title">ACVP SSH Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-ssh-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-ssh-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-135 SSH KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_ssh.html
+++ b/artifacts/acvp_sub_kdf135_ssh.html
@@ -610,6 +610,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -695,6 +709,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"ssh"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1031,6 +1055,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ssh",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm":"TDES",
@@ -1075,6 +1100,7 @@
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "ssh",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/artifacts/acvp_sub_kdf135_ssh.txt
+++ b/artifacts/acvp_sub_kdf135_ssh.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
      ACVP SSH Key Derivation Function Algorithm JSON Specification
-                   draft-ietf-acvp-subkdf135-ssh-0.5
+                   draft-ietf-acvp-subkdf135-ssh-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_ssh.txt
+++ b/artifacts/acvp_sub_kdf135_ssh.txt
@@ -66,7 +66,7 @@ Table of Contents
      2.1.  Required Prerequisite Algorithms for KDF135 SSH
            Validations . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  KDF135 SSH Algorithm Capabilities JSON Values . . . . . .   4
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   5
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   6
    4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   7
@@ -188,6 +188,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |          | to be       |             |                 |          |
    |          | validated   |             |                 |          |
    |          |             |             |                 |          |
+   | revision | The         | value       | "1.0"           | No       |
+   |          | algorithm   |             |                 |          |
+   |          | testing     |             |                 |          |
+   |          | revision to |             |                 |          |
+   |          | use.        |             |                 |          |
+   |          |             |             |                 |          |
    | prereqVa | Prerequisit | array of pr | See Section 2.1 | No       |
    | ls       | e algorithm | ereqAlgVal  |                 |          |
    |          | validations | objects     |                 |          |
@@ -209,6 +215,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Failure to provide these values will result in the ACVP server
    returning an error to the ACVP client during registration.
 
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 4]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
 3.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
@@ -218,13 +235,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    vector set represents an individual Key Derivation Function (KDF),
    such as SNMP, SSH, etc.  This section describes the JSON schema for a
    test vector set used with SP800-135 SSH KDF algorithms.
-
-
-
-Fussell                 Expires February 2, 2019                [Page 4]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta data for the entire vector set as well as individual
@@ -244,6 +254,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                             |        |
    | mode       | "ssh"                                       | value  |
    |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
+   |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -262,18 +274,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Group JSON object.
 
    The KDF test group for SSH is as follows:
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -459,6 +459,7 @@ Appendix A.  Example SP800-135 SSH KDF Capabilities JSON Object
    {
        "algorithm": "kdf-components",
        "mode": "ssh",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm":"TDES",
@@ -500,7 +501,6 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
 Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -514,6 +514,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "ssh",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -537,7 +538,6 @@ Appendix C.  Example Test Results JSON Object
 
    The following is a example JSON object for SP800-135 SSH KDF test
    results sent from the crypto module to the ACVP server.
-
 
 
 

--- a/artifacts/acvp_sub_kdf135_tls.html
+++ b/artifacts/acvp_sub_kdf135_tls.html
@@ -397,7 +397,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135--tls-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135--tls-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 TLS KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 TLS KDF algorithms with the ACVP specification." />
@@ -431,7 +431,7 @@
   </table>
 
   <p class="title">ACVP TLS Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135--tls-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135--tls-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-135 TLS KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_tls.html
+++ b/artifacts/acvp_sub_kdf135_tls.html
@@ -393,12 +393,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.10.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135--tls-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-08-28" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 TLS KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 TLS KDF algorithms with the ACVP specification." />
 
@@ -419,10 +419,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">August 28, 2018</td>
+<td class="right">August 1, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: March 1, 2019</td>
+<td class="left">Expires: February 2, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -439,7 +439,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on March 1, 2019.</p>
+<p>This Internet-Draft will expire on February 2, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -610,6 +610,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -695,6 +709,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"tls"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1039,6 +1063,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "tls",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "HMAC",
@@ -1075,6 +1100,7 @@
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "tls",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/artifacts/acvp_sub_kdf135_tls.txt
+++ b/artifacts/acvp_sub_kdf135_tls.txt
@@ -4,8 +4,8 @@
 
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                           August 28, 2018
-Expires: March 1, 2019
+Intended status: Informational                            August 1, 2018
+Expires: February 2, 2019
 
 
      ACVP TLS Key Derivation Function Algorithm JSON Specification
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 1, 2019.
+   This Internet-Draft will expire on February 2, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 1]
+Fussell                 Expires February 2, 2019                [Page 1]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -66,18 +66,18 @@ Table of Contents
      2.1.  Required Prerequisite Algorithms for KDF135 TLS
            Validations . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  KDF135 TLS Algorithm Capabilities JSON Values . . . . . .   4
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
-     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   5
-     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   6
-   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   7
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .   9
-   Appendix A.  Example SP800-135 TLS KDF Capabilities JSON Object .   9
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .   9
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  10
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  11
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   6
+     3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   6
+     3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   7
+   4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   8
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   9
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .  10
+   Appendix A.  Example SP800-135 TLS KDF Capabilities JSON Object .  10
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  10
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  11
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 2]
+Fussell                 Expires February 2, 2019                [Page 2]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -165,7 +165,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 3]
+Fussell                 Expires February 2, 2019                [Page 3]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -174,6 +174,57 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 4]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    +----------+-------------+-------------+-----------------+----------+
    | JSON     | Description | JSON type   | Valid Values    | Optional |
@@ -187,6 +238,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |          | Component   |             |                 |          |
    |          | to be       |             |                 |          |
    |          | validated   |             |                 |          |
+   |          |             |             |                 |          |
+   | revision | The         | value       | "1.0"           | No       |
+   |          | algorithm   |             |                 |          |
+   |          | testing     |             |                 |          |
+   |          | revision to |             |                 |          |
+   |          | use.        |             |                 |          |
    |          |             |             |                 |          |
    | prereqVa | Prerequisit | array of pr | See Section 2.1 | No       |
    | ls       | e algorithm | ereqAlgVal  |                 |          |
@@ -220,8 +277,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-Fussell                   Expires March 1, 2019                 [Page 4]
+Fussell                 Expires February 2, 2019                [Page 5]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -254,6 +310,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                             |        |
    | mode       | "tls"                                       | value  |
    |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
+   |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 3.1                      |        |
    +------------+---------------------------------------------+--------+
@@ -275,9 +333,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-Fussell                   Expires March 1, 2019                 [Page 5]
+Fussell                 Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -333,7 +389,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 6]
+Fussell                 Expires February 2, 2019                [Page 7]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -389,7 +445,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 7]
+Fussell                 Expires February 2, 2019                [Page 8]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -445,7 +501,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 8]
+Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -468,6 +524,7 @@ Appendix A.  Example SP800-135 TLS KDF Capabilities JSON Object
    {
        "algorithm": "kdf-components",
        "mode": "tls",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm": "HMAC",
@@ -500,8 +557,7 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
-Fussell                   Expires March 1, 2019                 [Page 9]
+Fussell                 Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -514,6 +570,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "tls",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -556,8 +613,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-
-Fussell                   Expires March 1, 2019                [Page 10]
+Fussell                 Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -613,4 +669,4 @@ Author's Address
 
 
 
-Fussell                   Expires March 1, 2019                [Page 11]
+Fussell                 Expires February 2, 2019               [Page 12]

--- a/artifacts/acvp_sub_kdf135_tls.txt
+++ b/artifacts/acvp_sub_kdf135_tls.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
      ACVP TLS Key Derivation Function Algorithm JSON Specification
-                   draft-ietf-acvp-subkdf135--tls-0.5
+                   draft-ietf-acvp-subkdf135--tls-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_tpm.html
+++ b/artifacts/acvp_sub_kdf135_tpm.html
@@ -398,7 +398,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-tpm-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-tpm-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 TPM KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 TPM KDF algorithms with the ACVP specification." />
@@ -432,7 +432,7 @@
   </table>
 
   <p class="title">ACVP TPM Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-tpm-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-tpm-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-135 TPM KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_tpm.html
+++ b/artifacts/acvp_sub_kdf135_tpm.html
@@ -394,12 +394,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.10.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-tpm-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-08-28" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 TPM KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 TPM KDF algorithms with the ACVP specification." />
 
@@ -420,10 +420,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">August 28, 2018</td>
+<td class="right">August 1, 2018</td>
 </tr>
 <tr>
-<td class="left">Expires: March 1, 2019</td>
+<td class="left">Expires: February 2, 2019</td>
 <td class="right"></td>
 </tr>
 
@@ -440,7 +440,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on March 1, 2019.</p>
+<p>This Internet-Draft will expire on February 2, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -572,6 +572,20 @@
 <tbody>
 <tr>
 <td class="left">algorithm</td>
+<td class="left">The algorithm to be validated</td>
+<td class="left">value</td>
+<td class="left">kdf-components</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algorithm</td>
 <td class="left">The KDF to be validated</td>
 <td class="left">value</td>
 <td class="left">See            <a href="#supported_algs" class="xref">Section 2.3</a> </td>
@@ -649,7 +663,27 @@
 </tr>
 <tr>
 <td class="left">algorithm</td>
-<td class="left">TPM</td>
+<td class="left">kdf-components</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">mode</td>
+<td class="left">tpm</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -911,7 +945,9 @@
 
 
             {
-                "algorithm": "TPM",
+                "algorithm": "kdf-components",
+                "mode": "tpm",
+                "revision": "1.0",
                 "prereqVals" : [{"algorithm" : "HMAC", "valValue" : "123456"},
 		                {"algorithm" : "SHA", "valValue" : "123456"}]
             }
@@ -926,7 +962,9 @@
 	},
 	{
 		"vsId": 1564,
-		"algorithm": "TPM",
+		"algorithm": "kdf-components",
+		"mode": "tpm",
+		"revision": "1.0",
 		"testGroups": [{
 			"tgId": 1,
 			"tests": [{

--- a/artifacts/acvp_sub_kdf135_tpm.txt
+++ b/artifacts/acvp_sub_kdf135_tpm.txt
@@ -4,8 +4,8 @@
 
 TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
-Intended status: Informational                           August 28, 2018
-Expires: March 1, 2019
+Intended status: Informational                            August 1, 2018
+Expires: February 2, 2019
 
 
      ACVP TPM Key Derivation Function Algorithm JSON Specification
@@ -31,7 +31,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 1, 2019.
+   This Internet-Draft will expire on February 2, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 1]
+Fussell                 Expires February 2, 2019                [Page 1]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -67,7 +67,7 @@ Table of Contents
            Validations . . . . . . . . . . . . . . . . . . . . . . .   3
      2.2.  KDF135 TPM Algorithm Capabilities JSON Values . . . . . .   3
      2.3.  Supported SP800-135 KDF Algorithms  . . . . . . . . . . .   4
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   5
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   6
    4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   6
@@ -78,7 +78,7 @@ Table of Contents
    Appendix A.  Example SP800-135 TPM KDF Capabilities JSON Object .   8
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .   9
    Appendix C.  Example Test Results JSON Object . . . . . . . . . .   9
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   9
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  10
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 2]
+Fussell                 Expires February 2, 2019                [Page 2]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -165,23 +165,28 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 3]
+Fussell                 Expires February 2, 2019                [Page 3]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-   +------------+----------------+--------------+-----------+----------+
-   | JSON Value | Description    | JSON type    | Valid     | Optional |
-   |            |                |              | Values    |          |
-   +------------+----------------+--------------+-----------+----------+
-   | algorithm  | The KDF to be  | value        | See       | No       |
-   |            | validated      |              | Section 2 |          |
-   |            |                |              | .3        |          |
-   |            |                |              |           |          |
-   | prereqVals | Prerequisite   | array of     | See       | No       |
-   |            | algorithm      | prereqAlgVal | Section 2 |          |
-   |            | validations    | objects      | .1        |          |
-   +------------+----------------+--------------+-----------+----------+
+   +-----------+-------------+-------------+----------------+----------+
+   | JSON      | Description | JSON type   | Valid Values   | Optional |
+   | Value     |             |             |                |          |
+   +-----------+-------------+-------------+----------------+----------+
+   | algorithm | The         | value       | kdf-components | No       |
+   |           | algorithm   |             |                |          |
+   |           | to be       |             |                |          |
+   |           | validated   |             |                |          |
+   |           |             |             |                |          |
+   | algorithm | The KDF to  | value       | See            | No       |
+   |           | be          |             | Section 2.3    |          |
+   |           | validated   |             |                |          |
+   |           |             |             |                |          |
+   | prereqVal | Prerequisit | array of pr | See            | No       |
+   | s         | e algorithm | ereqAlgVal  | Section 2.1    |          |
+   |           | validations | objects     |                |          |
+   +-----------+-------------+-------------+----------------+----------+
 
        Table 2: SP800-135 TPM KDF Algorithm Capabilities JSON Values
 
@@ -210,6 +215,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  TPM
 
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 4]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
 3.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
@@ -217,15 +233,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    typical ACVP validation session would require multiple test vector
    sets to be downloaded and processed by the ACVP client.  Each test
    vector set represents an individual Key Derivation Function (KDF),
-
-
-
-
-Fussell                   Expires March 1, 2019                 [Page 4]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    such as SNMP, SSH, etc.  This section describes the JSON schema for a
    test vector set used with SP800-135 TPM KDF algorithms.
 
@@ -243,7 +250,11 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | vsId       | Unique numeric identifier for the vector    | value  |
    |            | set                                         |        |
    |            |                                             |        |
-   | algorithm  | TPM                                         | value  |
+   | algorithm  | kdf-components                              | value  |
+   |            |                                             |        |
+   | mode       | tpm                                         | value  |
+   |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in          Section 3.1             |        |
@@ -266,18 +277,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-Fussell                   Expires March 1, 2019                 [Page 5]
+Fussell                 Expires February 2, 2019                [Page 5]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -333,7 +333,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 6]
+Fussell                 Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -389,7 +389,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                   Expires March 1, 2019                 [Page 7]
+Fussell                 Expires February 2, 2019                [Page 7]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -436,16 +436,16 @@ Appendix A.  Example SP800-135 TPM KDF Capabilities JSON Object
 
 
             {
-                "algorithm": "TPM",
+                "algorithm": "kdf-components",
+                "mode": "tpm",
+                "revision": "1.0",
                 "prereqVals" : [{"algorithm" : "HMAC", "valValue" : "123456"},
                                 {"algorithm" : "SHA", "valValue" : "123456"}]
             }
 
 
 
-
-
-Fussell                   Expires March 1, 2019                 [Page 8]
+Fussell                 Expires February 2, 2019                [Page 8]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -460,7 +460,9 @@ Appendix B.  Example Test Vectors JSON Object
         },
         {
                 "vsId": 1564,
-                "algorithm": "TPM",
+                "algorithm": "kdf-components",
+                "mode": "tpm",
+                "revision": "1.0",
                 "testGroups": [{
                         "tgId": 1,
                         "tests": [{
@@ -493,18 +495,18 @@ Appendix C.  Example Test Results JSON Object
         }
 ]
 
-Author's Address
 
 
 
 
 
 
-
-Fussell                   Expires March 1, 2019                 [Page 9]
+Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+Author's Address
 
    Barry Fussell (editor)
    Cisco Systems, Inc.
@@ -555,6 +557,4 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-Fussell                   Expires March 1, 2019                [Page 10]
+Fussell                 Expires February 2, 2019               [Page 10]

--- a/artifacts/acvp_sub_kdf135_tpm.txt
+++ b/artifacts/acvp_sub_kdf135_tpm.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
      ACVP TPM Key Derivation Function Algorithm JSON Specification
-                   draft-ietf-acvp-subkdf135-tpm-0.5
+                   draft-ietf-acvp-subkdf135-tpm-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_kdf135_x963.html
+++ b/artifacts/acvp_sub_kdf135_x963.html
@@ -610,6 +610,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">Prerequisite algorithm validations</td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -723,6 +737,16 @@
 <tr>
 <td class="left">mode</td>
 <td class="left">"ansix9.63"</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">"1.0"</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1021,6 +1045,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ansix9.63",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -1062,6 +1087,7 @@
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "ansix9.63",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/artifacts/acvp_sub_kdf135_x963.html
+++ b/artifacts/acvp_sub_kdf135_x963.html
@@ -397,7 +397,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ansx963-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subkdf135-ansx963-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SP800-135 ANS X9.63 KDF algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SP800-135 ANS X9.63 KDF algorithms with the ACVP specification." />
@@ -431,7 +431,7 @@
   </table>
 
   <p class="title">ACVP ANS X9.63 Key Derivation Function Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subkdf135-ansx963-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subkdf135-ansx963-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SP800-135 ANS X9.63 KDF algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_kdf135_x963.txt
+++ b/artifacts/acvp_sub_kdf135_x963.txt
@@ -68,17 +68,17 @@ Table of Contents
      2.2.  KDF135 ANS X9.63 Algorithm Capabilities JSON Values . . .   4
    3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
    4.  Test Groups JSON Schema . . . . . . . . . . . . . . . . . . .   6
-   5.  Test Case JSON Schema . . . . . . . . . . . . . . . . . . . .   6
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   7
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .   8
+   5.  Test Case JSON Schema . . . . . . . . . . . . . . . . . . . .   7
+   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .   8
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   9
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .   9
    Appendix A.  Example SP800-135 ANS X9.63 KDF Capabilities JSON
-                Object . . . . . . . . . . . . . . . . . . . . . . .   9
-   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .   9
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  10
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  11
+                Object . . . . . . . . . . . . . . . . . . . . . . .  10
+   Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  10
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  11
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
 
@@ -188,8 +188,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | to be       |            |               |         |
    |              | validated   |            |               |         |
    |              |             |            |               |         |
-   | prereqVals   | Prerequisit | array of p | See Section   | No      |
-   |              | e algorithm | rereqAlgVa | 2.1           |         |
+   | revision     | The         | value      | "1.0"         | No      |
+   |              | algorithm   |            |               |         |
+   |              | testing     |            |               |         |
+   |              | revision to |            |               |         |
+   |              | use.        |            |               |         |
+   |              |             |            |               |         |
+   | prereqVals   | Prerequisit | array of p | See           | No      |
+   |              | e algorithm | rereqAlgVa | Section 2.1   |         |
    |              | validations | l objects  |               |         |
    |              |             |            |               |         |
    | hashAlg      | SHA         | array      | SHA-224,      | No      |
@@ -212,12 +218,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              |             |            |               |         |
    | fieldSize    | ANSI X9.63: | array      | Any non-empty | No      |
    |              | Minimum and |            | subset of     |         |
-   |              | Maximum     |            | {224, 233,    |         |
-   |              | field size  |            | 256, 283,     |         |
-   |              | in          |            | 384, 409,     |         |
-   |              |             |            | 521, 571}.    |         |
-   |              |             |            |               |         |
-   | sharedInfoLe | ANSI X9.63: | domain     | Minimum must  | No      |
 
 
 
@@ -226,6 +226,12 @@ Fussell                 Expires February 2, 2019                [Page 4]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+   |              | Maximum     |            | {224, 233,    |         |
+   |              | field size  |            | 256, 283,     |         |
+   |              | in          |            | 384, 409,     |         |
+   |              |             |            | 521, 571}.    |         |
+   |              |             |            |               |         |
+   | sharedInfoLe | ANSI X9.63: | domain     | Minimum must  | No      |
    | ngth         | Minimum and |            | be greater    |         |
    |              | Maximum     |            | than or equal |         |
    |              | sharedinfo  |            | to 0. Maximum |         |
@@ -255,6 +261,27 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test vectors to be processed by the ACVP client.The following table
    describes the JSON elements at the top level of the hierarchy.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 5]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
    |            |                                             | type   |
@@ -268,19 +295,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            |                                             |        |
    | mode       | "ansix9.63"                                 | value  |
    |            |                                             |        |
+   | revision   | "1.0"                                       | value  |
+   |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 4                        |        |
    +------------+---------------------------------------------+--------+
 
                       Table 3: Vector Set JSON Object
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 5]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
 4.  Test Groups JSON Schema
 
@@ -294,6 +315,28 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Group JSON object.
 
    The KDF test group for ANS X9.63 is as follows:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 6]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    +------------------+-----------------------------+-------+----------+
    | JSON Value       | Description                 | JSON  | Optional |
@@ -333,7 +376,20 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019                [Page 6]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires February 2, 2019                [Page 7]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -389,7 +445,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019                [Page 7]
+Fussell                 Expires February 2, 2019                [Page 8]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -445,7 +501,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell                 Expires February 2, 2019                [Page 8]
+Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -464,6 +520,7 @@ Appendix A.  Example SP800-135 ANS X9.63 KDF Capabilities JSON Object
    {
        "algorithm": "kdf-components",
        "mode": "ansix9.63",
+       "revision": "1.0",
        "prereqVals": [
            {
                "algorithm": "SHA",
@@ -500,8 +557,7 @@ Appendix B.  Example Test Vectors JSON Object
 
 
 
-
-Fussell                 Expires February 2, 2019                [Page 9]
+Fussell                 Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -514,6 +570,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "ansix9.63",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -556,8 +613,7 @@ Appendix C.  Example Test Results JSON Object
 
 
 
-
-Fussell                 Expires February 2, 2019               [Page 10]
+Fussell                 Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -613,4 +669,4 @@ Author's Address
 
 
 
-Fussell                 Expires February 2, 2019               [Page 11]
+Fussell                 Expires February 2, 2019               [Page 12]

--- a/artifacts/acvp_sub_kdf135_x963.txt
+++ b/artifacts/acvp_sub_kdf135_x963.txt
@@ -9,7 +9,7 @@ Expires: February 2, 2019
 
 
   ACVP ANS X9.63 Key Derivation Function Algorithm JSON Specification
-                 draft-ietf-acvp-subkdf135-ansx963-0.5
+                 draft-ietf-acvp-subkdf135-ansx963-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -421,12 +421,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-submac-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-8" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
 
@@ -455,7 +455,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">August 2018</td>
+<td class="right">August 1, 2018</td>
 </tr>
 
     	
@@ -469,12 +469,12 @@
 <p>This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification.</p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
 <p>This Internet-Draft will expire on February 2, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -724,6 +724,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 3.1</a> for examples </td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -853,6 +867,7 @@
                             
 {
   "algorithm": "CMAC-AES",
+  "revision": "1.0",
   "capabilities": [
     {
       "direction": "gen",
@@ -1010,6 +1025,16 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The algorithm used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -1187,6 +1212,7 @@
 {
 	"vsId": 1,
 	"algorithm": "CMAC-AES",
+	"revision": "1.0",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -1507,6 +1533,7 @@
 {
 	"vsId": 1,
     "algorithm": "CMAC",
+    "revision": "1.0",
     "testGroups": [{
 			"tgId": 4,
 			"tests": [{
@@ -1665,6 +1692,20 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">prereqVals</td>
 <td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 3.1</a> for examples </td>
 <td class="left">array of prereqAlgVal objects</td>
@@ -1793,6 +1834,7 @@
                             
 {
   "algorithm": "CMAC-TDES",
+  "revision": "1.0",
   "capabilities": [
     {
       "direction": "gen",
@@ -1890,6 +1932,16 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The algorithm used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -2067,6 +2119,7 @@
 {
 	"vsId": 1,
 	"algorithm": "CMAC-TDES",
+	"revision": "1.0",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -2473,6 +2526,7 @@
 {
     "vsId": 1,
 	"algorithm": "CMAC-TDES",
+	"revision": "1.0",
 	"testGroups": [{
 			"tgId": 4,
 			"tests": [{
@@ -2621,6 +2675,20 @@
 <td class="left">The MAC algorithm and mode to be validated.</td>
 <td class="left">value</td>
 <td class="left">See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">1.0</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -2828,6 +2896,7 @@
                             
 {
   "algorithm": "HMAC-SHA-1",
+  "revision": "1.0",
   "keyLen": [
     {
       "min": 8,
@@ -2883,6 +2952,16 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The algorithm and mode used for the test vectors. See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> for possible values. </td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -3042,6 +3121,7 @@
 {
     "vsId": 1,
 	"algorithm": "HMAC-SHA-1",
+	"revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -3229,6 +3309,7 @@
 {
 	"vsId": 1,
 	"algorithm": "HMAC-SHA-1",
+	"revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"tests": [{
@@ -3301,7 +3382,7 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.references.2">

--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -425,7 +425,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed. and R. Hammett, Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-submac-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-submac-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-08-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification." />
@@ -463,7 +463,7 @@
   </table>
 
   <p class="title">ACVP Message Authentication Algorithm JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-submac-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-submac-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using HMAC and CMAC algorithms with the ACVP specification.</p>

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -10,7 +10,7 @@ Expires: February 2, 2019                                       G2, Inc.
 
 
         ACVP Message Authentication Algorithm JSON Specification
-                       draft-ietf-acvp-submac-0.5
+                       draft-ietf-acvp-submac-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -6,7 +6,7 @@ TBD                                                      B. Fussell, Ed.
 Internet-Draft                                       Cisco Systems, Inc.
 Intended status: Informational                           R. Hammett, Ed.
 Expires: February 2, 2019                                       G2, Inc.
-                                                             August 2018
+                                                          August 1, 2018
 
 
         ACVP Message Authentication Algorithm JSON Specification
@@ -25,7 +25,7 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
@@ -41,7 +41,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -99,12 +99,12 @@ Table of Contents
      6.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  45
        6.4.1.  Example HMAC Test Vector Response JSON Object . . . .  46
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  47
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  47
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  48
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  48
    10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  48
      10.1.  Normative References . . . . . . . . . . . . . . . . . .  48
      10.2.  Informative References . . . . . . . . . . . . . . . . .  48
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  48
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  49
 
 
 
@@ -297,12 +297,17 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | algorithm to  |              |          |          |
    |              | be validated. |              |          |          |
    |              |               |              |          |          |
-   | prereqVals   | prerequistie  | array of     | See      | No       |
-   |              | algorithm     | prereqAlgVal | Section  |          |
-   |              | validations,  | objects      | 3.1      |          |
-   |              | See Section   |              |          |          |
-   |              | 3.1 for       |              |          |          |
-   |              | examples      |              |          |          |
+   | revision     | The algorithm | value        | "1.0"    | No       |
+   |              | testing       |              |          |          |
+   |              | revision to   |              |          |          |
+   |              | use.          |              |          |          |
+   |              |               |              |          |          |
+   | prereqVals   | prerequistie  | array of     | See Sect | No       |
+   |              | algorithm     | prereqAlgVal | ion 3.1  |          |
+   |              | validations,  | objects      |          |          |
+   |              | See           |              |          |          |
+   |              | Section 3.1   |              |          |          |
+   |              | for examples  |              |          |          |
    |              |               |              |          |          |
    | capabilities | The CMAC-AES  | array of     | See      | No       |
    |              | capabilities  | capability   | Table 3  |          |
@@ -314,11 +319,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    Each capability object describes a separate permutation of direction
    and key length.
-
-
-
-
-
 
 
 
@@ -396,6 +396,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    {
      "algorithm": "CMAC-AES",
+     "revision": "1.0",
      "capabilities": [
        {
          "direction": "gen",
@@ -441,7 +442,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
          "keyingOption": 0,
          "msgLen": [
            {
-             "min": 0,
 
 
 
@@ -450,6 +450,7 @@ Fussell & Hammett       Expires February 2, 2019                [Page 8]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+             "min": 0,
              "max": 65536,
              "increment": 8
            }
@@ -497,7 +498,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "min": 64,
              "max": 128,
              "increment": 8
-           }
 
 
 
@@ -506,6 +506,7 @@ Fussell & Hammett       Expires February 2, 2019                [Page 9]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+           }
          ]
        },
        {
@@ -556,7 +557,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell & Hammett       Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -572,6 +572,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | algorithm  | The algorithm used for the test vectors.    | value  |
+   |            |                                             |        |
+   | revision   | The algorithm testing revision to use.      | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 4.2.1                    |        |
@@ -589,8 +591,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    meta data that applies to all test vectors within the group.  The
    following table describes the secure HMAC and CMAC JSON elements of
    the Test Group JSON object.
-
-
 
 
 
@@ -698,6 +698,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 {
         "vsId": 1,
         "algorithm": "CMAC-AES",
+        "revision": "1.0",
         "testGroups": [{
                         "tgId": 4,
                         "testType": "AFT",
@@ -721,7 +722,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "message": "39A3DD0652483A26FB9D71F30A5E29D326627FE16E29E3A3BF8EDF68645B477B5DE88499EDB3CF9E036F3D0D316241EE7C569F74925AD0BD3DCBBA21E73D9638ABA2554C4CA62AC5D7113B3FE7216E79AFC7A6FB94F21EB234D0401879A6B03EAE242EA0DCF1B523513467B00C048E7DE333C8977C455DD943323D01C97CF93EC24843769E52AD785E2340F2CC61E571D2099472E47286F29BCDF28A69144692263312F176618777A6AD0A0338F8A636BCA6150F0E1F72D539BAD726C95425682678EA7297A118E819A2925747C0AD72F3BCDF8E7D6C0A11A6AA938E4AA119390451C4E56B99F29C34927C1830197FCD4921C7E38E29BAEA5E560C8A3D4D7B96BBC370C78EF794BA9F6DB737576867B334D1DCC537D4FD751952DDFF549109ECCAD38198CCB49F25E7FEB88B9FD33D3B56601B473946693C5C3D7B2D1C7BB857F9560B94A3BD145019150BA11159B39480F97B0DE90243D6"
                                 },
                                 {
-                                        "tcId": 28,
 
 
 
@@ -730,6 +730,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 13]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "tcId": 28,
                                         "key": "1E220113298DA3B30E14F1432C16FCE8",
                                         "message": "497E82B322B18B0295F3B4359AC0CFAF1D36B46F36C9E123B95B90985B06AC6AFAFB772E21CCA4665CEABFF9C1CE3D78F804BEBAC6F171C0ADA47FC718E7EC55EC7603D739C8B4DBF07B60A78A8EC83922A880485B99E0FED2B1F7D5A895E2BD9149888A085F21794C1953A6EF4471A47A285CFAA57E9F75000B375A4100F5432150ECFC3342627FA325C7FB0EE0090A0B39D69ED9030E7D46BBCC6ADFC49F14156187F94F7DDE50C736FEB3FCE530CC76171EE1150AA5A94A3B79119329B5A1D9C3E03EAC7F212A1AECA97EAD58B8BFCD5F94946578D8F5A0347970A7F93C70B4AB0BB5A4FE2B0AAC8459ED0045DDC3AC210ACF996A4DE478853CD88ACEAE73D9A9C48A1B64E0D82F2EFFB25C517BDD0C033E566C16197835271A85D65A38AB37B63E7B23E9C7EA7777E6B3E3820C930B1333C279E5291724E774E34F574F15E1E23568E486F03FC6B83B962E3E60A90A69DD26701A8D6C"
                                 },
@@ -777,7 +778,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 {
                                         "tcId": 75,
                                         "key": "5C185C01FBC57A40FC373F199374D1CC",
-                                        "message": "",
 
 
 
@@ -786,6 +786,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 14]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "message": "",
                                         "mac": "9507F00153543DE6"
                                 },
                                 {
@@ -833,7 +834,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 {
                                         "tcId": 83,
                                         "key": "23E9BEA8C4F14330B2836FDD0B6E803F",
-                                        "message": "",
 
 
 
@@ -842,6 +842,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 15]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "message": "",
                                         "mac": "F884E64E0CA4D34F"
                                 },
                                 {
@@ -889,7 +890,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 {
                                         "tcId": 91,
                                         "key": "E09B79F64B11F00B48081EEEA0482821",
-                                        "message": "",
 
 
 
@@ -898,6 +898,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 16]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "message": "",
                                         "mac": "4D927CED15907953"
                                 },
                                 {
@@ -939,7 +940,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    in a similar manner to how it receives vectors.  Several algorithms
    SHALL require the client to send back group level properties in their
    response.  This structure helps accommodate that.
-
 
 
 
@@ -998,10 +998,10 @@ Internet-Draft                Sym Alg JSON                   August 2018
    {
            "vsId": 1,
        "algorithm": "CMAC",
+       "revision": "1.0",
        "testGroups": [{
                            "tgId": 4,
                            "tests": [{
-                                           "tcId": 25,
 
 
 
@@ -1010,6 +1010,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 18]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                           "tcId": 25,
                                            "mac": "7AA2D56A0AE76620"
                                    },
                                    {
@@ -1057,7 +1058,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                            "testPassed": true
                                    },
                                    {
-                                           "tcId": 76,
 
 
 
@@ -1066,6 +1066,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 19]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                           "tcId": 76,
                                            "testPassed": true
                                    },
                                    {
@@ -1113,7 +1114,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                            "testPassed": true
                                    },
                                    {
-                                           "tcId": 88,
 
 
 
@@ -1122,6 +1122,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 20]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                           "tcId": 88,
                                            "testPassed": false
                                    },
                                    {
@@ -1172,7 +1173,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell & Hammett       Expires February 2, 2019               [Page 21]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -1187,26 +1187,26 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | be           |              |           |          |
    |              | validated.   |              |           |          |
    |              |              |              |           |          |
-   | prereqVals   | prerequistie | array of     | See       | No       |
-   |              | algorithm    | prereqAlgVal | Section   |          |
-   |              | validations, | objects      | 3.1       |          |
-   |              | See Section  |              |           |          |
-   |              | 3.1 for      |              |           |          |
-   |              | examples     |              |           |          |
+   | revision     | The          | value        | "1.0"     | No       |
+   |              | algorithm    |              |           |          |
+   |              | testing      |              |           |          |
+   |              | revision to  |              |           |          |
+   |              | use.         |              |           |          |
    |              |              |              |           |          |
-   | capabilities | The CMAC-    | array of     | See Table | No       |
-   |              | TDES         | capability   | 11        |          |
+   | prereqVals   | prerequistie | array of     | See Secti | No       |
+   |              | algorithm    | prereqAlgVal | on 3.1    |          |
+   |              | validations, | objects      |           |          |
+   |              | See          |              |           |          |
+   |              | Section 3.1  |              |           |          |
+   |              | for examples |              |           |          |
+   |              |              |              |           |          |
+   | capabilities | The CMAC-    | array of     | See       | No       |
+   |              | TDES         | capability   | Table 11  |          |
    |              | capabilities | objects      |           |          |
    |              |              |              |           |          |
    +--------------+--------------+--------------+-----------+----------+
 
           Table 10: CMAC-TDES Algorithm Capabilities JSON Values
-
-
-
-
-
-
 
 
 
@@ -1309,6 +1309,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    {
      "algorithm": "CMAC-TDES",
+     "revision": "1.0",
      "capabilities": [
        {
          "direction": "gen",
@@ -1337,7 +1338,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
              "max": 65536,
              "increment": 8
            }
-         ],
 
 
 
@@ -1346,6 +1346,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 24]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+         ],
          "macLen": [
            {
              "min": 32,
@@ -1396,7 +1397,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell & Hammett       Expires February 2, 2019               [Page 25]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -1412,6 +1412,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | algorithm  | The algorithm used for the test vectors.    | value  |
+   |            |                                             |        |
+   | revision   | The algorithm testing revision to use.      | value  |
    |            |                                             |        |
    | testGroups | Array of test group JSON objects, which are | array  |
    |            | defined in Section 5.2.1                    |        |
@@ -1429,8 +1431,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    meta data that applies to all test vectors within the group.  The
    following table describes the secure HMAC and CMAC JSON elements of
    the Test Group JSON object.
-
-
 
 
 
@@ -1541,6 +1541,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 {
         "vsId": 1,
         "algorithm": "CMAC-TDES",
+        "revision": "1.0",
         "testGroups": [{
                         "tgId": 4,
                         "testType": "AFT",
@@ -1561,7 +1562,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key": "82E572E29C84009E28390918155E4891A0D24C94C306FE56",
                                         "message": "7A70F3CE17598AC3553FBADA0CC562018FD40C6D25B098EC0B905B1BC9F67DFCBD797494E4B05E2C6C3C0F655F9E95FFFE16782E1454A5EE04D87E7586F7FF65A51979A1C46118080320C1CB9E9CC48A05E113C95C2316361B39F5FCB861",
                                         "key1": "82E572E29C84009E",
-                                        "key2": "28390918155E4891",
 
 
 
@@ -1570,6 +1570,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 28]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "key2": "28390918155E4891",
                                         "key3": "A0D24C94C306FE56"
                                 },
                                 {
@@ -1617,7 +1618,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key": "B10CCB821E63EF98928D1BC20D797C5E9149B32BFC090140",
                                         "message": "B19716D364D0680873D83F4991839465C169CADA64D5B57454ADDCDA64D1778219B204571593C5965E8F84C373CF0DBD10F4C8124D932FB6EF2B662966C698F79CB3199E40A45A8A7C186E948CA5A0BAD743A1FDC91336325145FC701D41",
                                         "key1": "B10CCB821E63EF98",
-                                        "key2": "928D1BC20D797C5E",
 
 
 
@@ -1626,6 +1626,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 29]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "key2": "928D1BC20D797C5E",
                                         "key3": "9149B32BFC090140"
                                 }
                         ],
@@ -1673,7 +1674,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key1": "4DB908F0A14A3959",
                                         "key2": "AC76D38D171114CA",
                                         "key3": "3651F7FF9C9B20B5"
-                                },
 
 
 
@@ -1682,6 +1682,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 30]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                },
                                 {
                                         "tcId": 77,
                                         "key": "670AB0529BCE3007BDC7706FED307419291C6BA004943806",
@@ -1729,7 +1730,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                 },
                                 {
                                         "tcId": 82,
-                                        "key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
 
 
 
@@ -1738,6 +1738,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 31]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "key": "97FBEF5ADADC68CCDD5BAFB50853589EDF4918593D29F5C0",
                                         "message": "",
                                         "mac": "317B4969",
                                         "key1": "97FBEF5ADADC68CC",
@@ -1785,7 +1786,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key": "C2A4D041516F0B7535D37F2B55FB38CFB75F24285D7BEF39",
                                         "message": "",
                                         "mac": "4A099862",
-                                        "key1": "C2A4D041516F0B75",
 
 
 
@@ -1794,6 +1794,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 32]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                        "key1": "C2A4D041516F0B75",
                                         "key2": "35D37F2B55FB38CF",
                                         "key3": "B75F24285D7BEF39"
                                 },
@@ -1841,7 +1842,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                         "key1": "1A29B0ED9040FD2D",
                                         "key2": "6A7D20A4DF50E290",
                                         "key3": "AB1D497EC1D211AA"
-                                }
 
 
 
@@ -1850,6 +1850,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 33]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                }
                         ],
                         "keyingOption": 1
                 }
@@ -1900,7 +1901,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell & Hammett       Expires February 2, 2019               [Page 34]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -1937,6 +1937,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    {
        "vsId": 1,
            "algorithm": "CMAC-TDES",
+           "revision": "1.0",
            "testGroups": [{
                            "tgId": 4,
                            "tests": [{
@@ -1953,7 +1954,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                    },
                                    {
                                            "tcId": 28,
-                                           "mac": "EC68CA91"
 
 
 
@@ -1962,6 +1962,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 35]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                           "mac": "EC68CA91"
                                    },
                                    {
                                            "tcId": 29,
@@ -2009,7 +2010,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                    },
                                    {
                                            "tcId": 79,
-                                           "testPassed": true
 
 
 
@@ -2018,6 +2018,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 36]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                           "testPassed": true
                                    },
                                    {
                                            "tcId": 80,
@@ -2065,7 +2066,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                                    },
                                    {
                                            "tcId": 91,
-                                           "testPassed": true
 
 
 
@@ -2074,6 +2074,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 37]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                           "testPassed": true
                                    },
                                    {
                                            "tcId": 92,
@@ -2124,7 +2125,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell & Hammett       Expires February 2, 2019               [Page 38]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -2134,14 +2134,19 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | JSON Value | Description     | JSON type    | Valid    | Optional |
    |            |                 |              | Values   |          |
    +------------+-----------------+--------------+----------+----------+
-   | algorithm  | The MAC         | value        | See      | No       |
-   |            | algorithm and   |              | Section  |          |
-   |            | mode to be      |              | 6.2      |          |
+   | algorithm  | The MAC         | value        | See Sect | No       |
+   |            | algorithm and   |              | ion 6.2  |          |
+   |            | mode to be      |              |          |          |
    |            | validated.      |              |          |          |
    |            |                 |              |          |          |
-   | prereqVals | prerequistie    | array of     | See      | No       |
-   |            | algorithm       | prereqAlgVal | Section  |          |
-   |            | validations,    | objects      | 3.1      |          |
+   | revision   | The algorithm   | value        | 1.0      | No       |
+   |            | testing         |              |          |          |
+   |            | revision to     |              |          |          |
+   |            | use.            |              |          |          |
+   |            |                 |              |          |          |
+   | prereqVals | prerequistie    | array of     | See Sect | No       |
+   |            | algorithm       | prereqAlgVal | ion 3.1  |          |
+   |            | validations,    | objects      |          |          |
    |            | See Section 3.1 |              |          |          |
    |            | for examples    |              |          |          |
    |            |                 |              |          |          |
@@ -2174,17 +2179,16 @@ Internet-Draft                Sym Alg JSON                   August 2018
    macLen for HMAC contains a Domain of values, the server may choose
    values defined by these rules:
 
-   o  The smallest HMAC length supported
-
-   o  A second HMAC length supported
-
-
 
 
 Fussell & Hammett       Expires February 2, 2019               [Page 39]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   o  The smallest HMAC length supported
+
+   o  A second HMAC length supported
 
    o  The largest HMAC length supported
 
@@ -2233,10 +2237,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-
-
 Fussell & Hammett       Expires February 2, 2019               [Page 40]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -2244,6 +2244,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    {
      "algorithm": "HMAC-SHA-1",
+     "revision": "1.0",
      "keyLen": [
        {
          "min": 8,
@@ -2292,7 +2293,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
 Fussell & Hammett       Expires February 2, 2019               [Page 41]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -2310,6 +2310,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | vectors. See Section 6.2 for possible        |       |
    |            | values.                                      |       |
    |            |                                              |       |
+   | revision   | The algorithm testing revision to use.       | value |
+   |            |                                              |       |
    | testGroups | Array of test group JSON objects, which are  | array |
    |            | defined in Section 6.3.1                     |       |
    +------------+----------------------------------------------+-------+
@@ -2326,8 +2328,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    meta data that applies to all test vectors within the group.  The
    following table describes the secure HMAC and CMAC JSON elements of
    the Test Group JSON object.
-
-
 
 
 
@@ -2418,6 +2418,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 {
     "vsId": 1,
         "algorithm": "HMAC-SHA-1",
+        "revision": "1.0",
         "testGroups": [{
                 "tgId": 1,
                 "testType": "AFT",
@@ -2457,7 +2458,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                         {
                                 "tcId": 7,
                                 "key": "E82C2306DADB20",
-                                "msg": "ABD9D90C4C912FC1F4208E8DC82C316A"
 
 
 
@@ -2466,6 +2466,7 @@ Fussell & Hammett       Expires February 2, 2019               [Page 44]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                "msg": "ABD9D90C4C912FC1F4208E8DC82C316A"
                         },
                         {
                                 "tcId": 8,
@@ -2512,8 +2513,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The testGroups section is used to organize the ACVP client response
    in a similar manner to how it receives vectors.  Several algorithms
-   SHALL require the client to send back group level properties in their
-   response.  This structure helps accommodate that.
+
 
 
 
@@ -2521,6 +2521,9 @@ Fussell & Hammett       Expires February 2, 2019               [Page 45]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   SHALL require the client to send back group level properties in their
+   response.  This structure helps accommodate that.
 
    +-----------+--------------------------------------------+----------+
    | JSON      | Description                                | JSON     |
@@ -2562,14 +2565,11 @@ Internet-Draft                Sym Alg JSON                   August 2018
    {
            "vsId": 1,
            "algorithm": "HMAC-SHA-1",
+           "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "tests": [{
                                    "tcId": 1,
-                                   "mac": "0970D053D6829C251070"
-                           },
-                           {
-                                   "tcId": 2,
 
 
 
@@ -2578,6 +2578,10 @@ Fussell & Hammett       Expires February 2, 2019               [Page 46]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                                   "mac": "0970D053D6829C251070"
+                           },
+                           {
+                                   "tcId": 2,
                                    "mac": "3A476E0407D7ADF14792"
                            },
                            {
@@ -2621,10 +2625,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    TBD...
 
-8.  IANA Considerations
-
-   This memo includes no request to IANA.
-
 
 
 
@@ -2633,6 +2633,10 @@ Fussell & Hammett       Expires February 2, 2019               [Page 47]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+8.  IANA Considerations
+
+   This memo includes no request to IANA.
 
 9.  Security Considerations
 
@@ -2646,8 +2650,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
 10.2.  Informative References
 
@@ -2674,10 +2678,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
               <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/
               NIST.SP.800-38b.pdf>.
 
-Authors' Addresses
-
-
-
 
 
 
@@ -2689,6 +2689,8 @@ Fussell & Hammett       Expires February 2, 2019               [Page 48]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+Authors' Addresses
 
    Barry Fussell (editor)
    Cisco Systems, Inc.
@@ -2706,8 +2708,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    USA
 
    Email: russ.hammett@g2-inc.com
-
-
 
 
 

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -429,14 +429,14 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.6.2 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-2" />
-  <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to " />
-  <meta name="description" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to " />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-02-01" />
+  <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  and  with the ACVP specification.  " />
+  <meta name="description" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  and  with the ACVP specification.  " />
 
 </head>
 
@@ -455,7 +455,7 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">February 2018</td>
+<td class="right">February 1, 2018</td>
 </tr>
 <tr>
 <td class="left">Expires: August 5, 2018</td>
@@ -473,12 +473,12 @@
 <p>This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to <a href="#FIPS186-4" class="xref">[FIPS186-4]</a> and <a href="#SP800-56B" class="xref">[SP800-56B]</a> with the ACVP specification.  </p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
 <p>This Internet-Draft will expire on August 5, 2018.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -790,6 +790,20 @@
 <td class="left">The RSA algorithm mode to be validated</td>
 <td class="left">value</td>
 <td class="left">"keyGen", "sigGen", "sigVer", "legacySigVer", "signaturePrimitive", "decryptionPrimitive"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -2019,12 +2033,12 @@
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC3447">[RFC3447]</b></td>
 <td class="top">
-<a>Jonsson, J.</a> and <a>B. Kaliski</a>, "<a href="http://tools.ietf.org/html/rfc3447">Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1</a>", RFC 3447, DOI 10.17487/RFC3447, February 2003.</td>
+<a>Jonsson, J.</a> and <a>B. Kaliski</a>, "<a href="https://tools.ietf.org/html/rfc3447">Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1</a>", RFC 3447, DOI 10.17487/RFC3447, February 2003.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP800-131A">[SP800-131A]</b></td>
@@ -2050,6 +2064,7 @@
    {
       "algorithm": "RSA",
       "mode": "keyGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
       "infoGeneratedByServer": false,
       "pubExpMode": "random",
@@ -2102,6 +2117,7 @@
    {
     "algorithm":"RSA",
     "mode":"keyGen",
+    "revision": "1.0",
     "prereqVals":[{"algorithm":"DRBG", "valValue":"123456"}, {"algorithm":"SHA", "valValue":"7890"}],
     "pubExpMode": "fixed",
     "fixedPubExp":"010001",
@@ -2157,6 +2173,7 @@
    {
       "algorithm": "RSA",
       "mode": "keyGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "pubExpMode" : "fixed",
       "fixedPubExp" : "010001",
@@ -2216,6 +2233,7 @@
    {
       "algorithm": "RSA",
       "mode": "sigGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "capabilities" : 
       [
@@ -2373,6 +2391,7 @@
    {
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "pubExpMode" : "random",
       "capabilities" : 
@@ -2531,6 +2550,7 @@
    {
       "algorithm": "RSA",
       "mode": "legacySigVer",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "capabilities" : 
       [
@@ -2583,6 +2603,7 @@
    {
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "keyFormat": "crt"
    }
 
@@ -2596,6 +2617,7 @@
    {
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "prereqVals": 
         [
             {"algorithm": "DRBG", "valValue": "123456"}, 
@@ -2620,6 +2642,7 @@
    { "vsId": 1133,
      "algorithm": "RSA",
      "mode": "keyGen",
+     "revision": "1.0",
      "infoGeneratedByServer": false,
      "pubExpMode" : "random",
      "keyFormat": "standard",
@@ -2835,6 +2858,7 @@
         "vsId" : 172,
         "algorithm" : "RSA",
         "mode" : "keyGen",
+        "revision": "1.0",
         "testGroups" : [
             {
                 "tgId": 1,
@@ -2902,6 +2926,7 @@
    { "vsId": 1163,
       "algorithm": "RSA",
       "mode": "sigGen",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2992,6 +3017,7 @@
    { "vsId": 1173,
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -3110,6 +3136,7 @@
    { "vsId": 1193,
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "keyFormat": "standard",
       "testGroups" : [
              {       
@@ -3145,6 +3172,7 @@
    { "vsId": 1194,
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -3183,6 +3211,7 @@
                 { "vsId": 1133,
                     "algorithm": "RSA",
                     "mode": keyGen,
+                    "revision": "1.0",
                     "testGroups": [
                     {
                       "tgId": 1,
@@ -3460,6 +3489,7 @@
                 { "vsId": 1163,
                   "algorithm": "RSA",
                   "mode": "sigGen",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -3528,6 +3558,7 @@
     { "vsId": 1173,
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
       "testGroups" : [
           {
             "tgId": 1,
@@ -3588,6 +3619,7 @@
     { "vsId": 47,
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "testGroups" : [
         {
           "tgId": 1,
@@ -3618,6 +3650,7 @@
     { "vsId": 48,
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "testGroups" : [
         {
           "tgId": 1,

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -433,7 +433,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Vassilev, A., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subrsa-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-02-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  and  with the ACVP specification.  " />
   <meta name="description" content="This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to  and  with the ACVP specification.  " />
@@ -467,7 +467,7 @@
   </table>
 
   <p class="title">ACVP RSA Algorithm Validation JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subrsa-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subrsa-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for testing RSA algorithm and component implementations for conformance to <a href="#FIPS186-4" class="xref">[FIPS186-4]</a> and <a href="#SP800-56B" class="xref">[SP800-56B]</a> with the ACVP specification.  </p>

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -9,7 +9,7 @@ Expires: August 5, 2018
 
 
             ACVP RSA Algorithm Validation JSON Specification
-                       draft-ietf-acvp-subrsa-0.5
+                       draft-ietf-acvp-subrsa-1.0
 
 Abstract
 

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -4,7 +4,7 @@
 
 TBD                                                     A. Vassilev, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                             February 2018
+Intended status: Informational                          February 1, 2018
 Expires: August 5, 2018
 
 
@@ -25,7 +25,7 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
@@ -41,7 +41,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -70,42 +70,42 @@ Table of Contents
    4.  Capabilities Registration . . . . . . . . . . . . . . . . . .   6
      4.1.  Required Prerequisite Algorithms for RSA Mode Validations   6
      4.2.  Supported RSA Capabilities  . . . . . . . . . . . . . . .   7
-     4.3.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   9
-       4.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   9
-         4.3.1.1.  keyGen Full Set Of Capabilities . . . . . . . . .   9
+     4.3.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   8
+       4.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   8
+         4.3.1.1.  keyGen Full Set Of Capabilities . . . . . . . . .   8
        4.3.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  12
          4.3.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  12
-       4.3.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  14
+       4.3.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  13
          4.3.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  14
-       4.3.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  16
-       4.3.5.  The signaturePrimitive Mode Capabilities  . . . . . .  18
+       4.3.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  15
+       4.3.5.  The signaturePrimitive Mode Capabilities  . . . . . .  17
        4.3.6.  The decryptionPrimitive Mode Capabilities . . . . . .  18
-   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  20
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  21
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  22
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  26
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  26
-   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  27
+   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  18
+     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  19
+     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  20
+   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  21
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  25
+   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  26
      A.1.  Example keyGen with Provable Primes and Provable Primes
-           with Conditions Capabilities JSON Objects . . . . . . . .  27
+           with Conditions Capabilities JSON Objects . . . . . . . .  26
        A.1.1.  Example keyGen with Probable Primes Capabilities JSON
-               Object  . . . . . . . . . . . . . . . . . . . . . . .  29
+               Object  . . . . . . . . . . . . . . . . . . . . . . .  28
        A.1.2.  Example keyGen with Provable Conditional Primes with
-               Probable Factors Capabilities JSON Object . . . . . .  31
-     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  32
-     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  35
-     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  38
-     A.5.  Example signaturePrimitive Capabilities JSON Objects  . .  40
-     A.6.  Example decryptionPrimitive Capabilities JSON Objects . .  40
-   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  40
-     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  40
+               Probable Factors Capabilities JSON Object . . . . . .  29
+     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  30
+     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  33
+     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  37
+     A.5.  Example signaturePrimitive Capabilities JSON Objects  . .  39
+     A.6.  Example decryptionPrimitive Capabilities JSON Objects . .  39
+   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  39
+     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  39
      B.2.  Example Test Vectors for keyGen when
-           infoGeneratedByServer is true . . . . . . . . . . . . . .  45
+           infoGeneratedByServer is true . . . . . . . . . . . . . .  44
      B.3.  Example Test Vectors for sigGen JSON Objects  . . . . . .  46
-     B.4.  Example Test Vectors for sigVer JSON Objects  . . . . . .  48
+     B.4.  Example Test Vectors for sigVer JSON Objects  . . . . . .  47
 
 
 
@@ -114,9 +114,9 @@ Vassilev                 Expires August 5, 2018                 [Page 2]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-     B.5.  Example Test Vectors for legacySigVer JSON Objects  . . .  51
-     B.6.  Example Test Vectors for signaturePrimitive JSON Objects   51
-     B.7.  Example Test Vectors for decryptionPrimitive JSON Objects  52
+     B.5.  Example Test Vectors for legacySigVer JSON Objects  . . .  50
+     B.6.  Example Test Vectors for signaturePrimitive JSON Objects   50
+     B.7.  Example Test Vectors for decryptionPrimitive JSON Objects  51
    Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  52
      C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  52
      C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  58
@@ -352,48 +352,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    object.  The following JSON values are used for RSA algorithm
    capabilities:
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                 [Page 7]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    +-----------+------------+------------+-------------------+---------+
    | JSON      | Descriptio | JSON type  | Valid Values      | Optiona |
    | Value     | n          |            |                   | l       |
@@ -411,18 +369,31 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |           |            |            | e", "decryptionPr |         |
    |           |            |            | imitive"          |         |
    |           |            |            |                   |         |
+   | revision  | The        | value      | "1.0"             | No      |
+   |           | algorithm  |            |                   |         |
+   |           | testing    |            |                   |         |
+   |           | revision   |            |                   |         |
+   |           | to use.    |            |                   |         |
+   |           |            |            |                   |         |
    | prereqVal | The prereq | array of p | array             | No      |
    | s         | uisite     | rereqAlgVa |                   |         |
    |           | algorithm  | l objects  |                   |         |
-   |           | validation | - see      |                   |         |
-   |           | s          | Section    |                   |         |
-   |           |            | 4.1        |                   |         |
+   |           | validation | - see Sect |                   |         |
+   |           | s          | ion 4.1    |                   |         |
    |           |            |            |                   |         |
    | capabilit | Array of   | array of   | See Table 1 and   | No      |
    | ies       | JSON       | JSON       | Section 4.3       |         |
    |           | objects    | objects,   |                   |         |
    |           |            | each with  |                   |         |
    |           |            | fields     |                   |         |
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 7]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |           |            | pertaining |                   |         |
    |           |            | to the     |                   |         |
    |           |            | global RSA |                   |         |
@@ -440,15 +411,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    +-----------+------------+------------+-------------------+---------+
 
               Table 3: RSA Algorithm Capabilities JSON Values
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                 [Page 8]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
 
 4.3.  Supported RSA Modes Capabilities
 
@@ -480,6 +442,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 8]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    +------------------+---------------+------+--------------+----------+
    | JSON Value       | Description   | JSON | Valid Values | Optional |
    |                  |               | type |              |          |
@@ -498,14 +468,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | (Appendix     |      |              |          |
    |                  | B.3.2);       |      |              |          |
    |                  | probable      |      |              |          |
-
-
-
-Vassilev                 Expires August 5, 2018                 [Page 9]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |                  | primes        |      |              |          |
    |                  | (Appendix     |      |              |          |
    |                  | B.3.3);       |      |              |          |
@@ -536,6 +498,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | Key           |      |              |          |
    |                  | Generation    |      |              |          |
    |                  | tests. This   |      |              |          |
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 9]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |                  | flag is not   |      |              |          |
    |                  | relevant to   |      |              |          |
    |                  | KeyGen mode   |      |              |          |
@@ -554,14 +524,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | the public    | e    |              |          |
    |                  | key exponent  |      |              |          |
    |                  | e in hex if   |      |              |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 10]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |                  | pubExpMode is |      |              |          |
    |                  | "fixed"       |      |              |          |
    |                  |               |      |              |          |
@@ -592,6 +554,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | components.   |      |              |          |
    |                  |               |      |              |          |
    | properties       | An array of   | arra |              | Yes      |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 10]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |                  | objects       | y    |              |          |
    |                  | containing    |      |              |          |
    |                  | properties    |      |              |          |
@@ -610,14 +580,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    | modulo           | supported RSA | valu | 2048, 3072   | Yes      |
    |                  | modulo for    | e    | or 4096      |          |
    |                  | the randPQ    |      |              |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 11]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |                  | mode - see    |      |              |          |
    |                  | [FIPS186-4],  |      |              |          |
    |                  | Appendix B.3  |      |              |          |
@@ -645,6 +607,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
                Table 4: RSA keyGen Capabilities JSON Values
 
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 11]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
 4.3.2.  The sigGen Mode Capabilities
 
    The RSA sigGen mode capabilities are advertised as JSON objects
@@ -665,14 +638,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
    The following RSA signature generation capabilities may be advertised
    by the ACVP compliant crypto module:
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 12]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
 
    +------------+-----------------+-------+-----------------+----------+
    | JSON value | Description     | JSON  | Valid values    | Optional |
@@ -701,6 +666,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |            |                 |       |                 |          |
    | hashPair   | supported hash  | array | an array of     | No       |
    |            | algorithms and  |       | objects         |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 12]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |            | optional salt   |       | containing a    |          |
    |            | length for      |       | hashAlg and an  |          |
    |            | signature       |       | optional        |          |
@@ -722,14 +695,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |            | Section 9       |       |                 |          |
    |            |                 |       |                 |          |
    | saltLen    | supported salt  | value | any integer     | Yes      |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 13]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |            | lengths in      |       | value subject   |          |
    |            | bytes for PSS   |       | to the          |          |
    |            | signature       |       | constraint in   |          |
@@ -757,6 +722,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    Each RSA sigVer mode capability is advertised as a self-contained
    JSON object consisting of the algorithm, mode, and capabilities
    array.  The capabilities array may contain multiple elements, each
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 13]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    pertaining to a sigType that is supported by the client for the RSA
    mode being advertised.
 
@@ -778,14 +751,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             | [FIPS186-4],   |       | "pss"}          |          |
    |             | Section 5      |       |                 |          |
    |             |                |       |                 |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 14]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    | properties  | properties     | array | a single modulo | No       |
    |             | supported for  |       | with an array   |          |
    |             | this sigType   |       | of at least one |          |
@@ -813,6 +778,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             | [SP800-131A],  |       |                 |          |
    |             | Section 9      |       |                 |          |
    |             |                |       |                 |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 14]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    | hashAlg     | supported hash | value | any value from  | No       |
    |             | algorithm for  |       | {"SHA-1",       |          |
    |             | signature      |       | "SHA2-224",     |          |
@@ -834,14 +807,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             | See also note  |       |                 |          |
    |             | below.         |       |                 |          |
    |             |                |       |                 |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 15]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    | pubExpMode  | type of public | value | "fixed" or      | Yes      |
    |             | exponent       |       | "random"        |          |
    |             |                |       |                 |          |
@@ -870,6 +835,13 @@ Internet-Draft                RSA Alg JSON                 February 2018
    'capability_exchange' element of the ACVP JSON registration message.
    See the ACVP specification for details on the registration message.
 
+
+
+Vassilev                 Expires August 5, 2018                [Page 15]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    Each RSA legacySigVer mode capability is advertised as a self-
    contained JSON object consisting of the algorithm, mode, and
    capabilities array.  The capabilities array may contain multiple
@@ -890,14 +862,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             | Section 5         |       |              |          |
    |             |                   |       |              |          |
    | properties  | RSA legacy        | array | modulo,      | No       |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 16]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |             | signature         |       | hashAlg, and |          |
    |             | verification      |       | saltLen      |          |
    |             | parameters  - see |       | (when        |          |
@@ -926,6 +890,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    | hashAlg     | supported hash    | array | any non-     | No       |
    |             | algorithms for    |       | empty subset |          |
    |             | this sigType and  |       | of {"SHA-1", |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 16]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |             | modulo - see      |       | "SHA2-224",  |          |
    |             | [SP800-131A],     |       | "SHA2-256",  |          |
    |             | Section 9         |       | "SHA2-384",  |          |
@@ -946,14 +918,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             |                   |       |              |          |
    | fixedPubExp | if pubExpMode is  | value | hex          | Yes      |
    |             | defined as        |       |              |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 17]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |             | "fixed", this is  |       |              |          |
    |             | the corresponding |       |              |          |
    |             | public exponent   |       |              |          |
@@ -982,6 +946,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    'd' is replaced with 'dmp1', 'dmq1', and 'iqmp'.  Only 2048-bit RSA
    keys are allowed for this capability.  There are no properties
    specified for this capability.  See Appendix B.6 for additional
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 17]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    details on constraints for 'msg' and 'n'.  See the ACVP specification
    for details on the registration message.
 
@@ -1002,14 +974,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    private key 'd', and calculates 's'.  If a client does not support
    decryption with a standard RSA private exponent 'd', the equivalent
    Chinese Remainder Theorem (CRT) private key values are allowed to be
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 18]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    used.  Only 2048-bit RSA keys are allowed for this capability.  See
    Appendix B.7 for additional details on constraints for 'cipherText'
    and 'n'.  The client provides the public exponent 'e', modulus 'n'
@@ -1041,27 +1005,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 19]
+Vassilev                 Expires August 5, 2018                [Page 18]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1086,8 +1030,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |            |                        |                             |
    | testGroups | Array of test group    | array                       |
    |            | JSON objects, which    |                             |
-   |            | are defined in Section |                             |
-   |            | 5.1                    |                             |
+   |            | are defined in         |                             |
+   |            | Section 5.1            |                             |
    +------------+------------------------+-----------------------------+
 
                       Table 8: Vector Set JSON Object
@@ -1117,7 +1061,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 20]
+Vassilev                 Expires August 5, 2018                [Page 19]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1173,7 +1117,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 21]
+Vassilev                 Expires August 5, 2018                [Page 20]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1229,7 +1173,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 22]
+Vassilev                 Expires August 5, 2018                [Page 21]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1285,7 +1229,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 23]
+Vassilev                 Expires August 5, 2018                [Page 22]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1341,7 +1285,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 24]
+Vassilev                 Expires August 5, 2018                [Page 23]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1397,7 +1341,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 25]
+Vassilev                 Expires August 5, 2018                [Page 24]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1441,8 +1385,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC3447]  Jonsson, J. and B. Kaliski, "Public-Key Cryptography
               Standards (PKCS) #1: RSA Cryptography Specifications
@@ -1453,7 +1397,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 26]
+Vassilev                 Expires August 5, 2018                [Page 25]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1509,7 +1453,7 @@ A.1.  Example keyGen with Provable Primes and Provable Primes with
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 27]
+Vassilev                 Expires August 5, 2018                [Page 26]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1517,6 +1461,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
    {
       "algorithm": "RSA",
       "mode": "keyGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
       "infoGeneratedByServer": false,
       "pubExpMode": "random",
@@ -1564,8 +1509,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-
-Vassilev                 Expires August 5, 2018                [Page 28]
+Vassilev                 Expires August 5, 2018                [Page 27]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1578,57 +1522,10 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
    Appendix B.3.6.  See also Section 4.3.1.1.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 29]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    {
     "algorithm":"RSA",
     "mode":"keyGen",
+    "revision": "1.0",
     "prereqVals":[{"algorithm":"DRBG", "valValue":"123456"}, {"algorithm":"SHA", "valValue":"7890"}],
     "pubExpMode": "fixed",
     "fixedPubExp":"010001",
@@ -1665,6 +1562,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
              {
                "modulo": 3072,
                "primeTest": [
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 28]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                  "tblC2",
                  "tblC3"
                ]
@@ -1673,13 +1578,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
          },
      ]
   }
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 30]
-
-Internet-Draft                RSA Alg JSON                 February 2018
 
 
 A.1.2.  Example keyGen with Provable Conditional Primes with Probable
@@ -1693,6 +1591,7 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
    {
       "algorithm": "RSA",
       "mode": "keyGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "pubExpMode" : "fixed",
       "fixedPubExp" : "010001",
@@ -1719,6 +1618,14 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
               {
                 "modulo" : 3072,
                 "hashAlg" : [
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 29]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                   "SHA-1",
                   "SHA2-224",
                   "SHA2-256",
@@ -1730,14 +1637,6 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
               },
               {
                 "modulo" : 4096,
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 31]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                 "hashAlg" : [
                   "SHA2-512"
                 ],
@@ -1760,6 +1659,7 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
    {
       "algorithm": "RSA",
       "mode": "sigGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "capabilities" :
       [
@@ -1774,6 +1674,14 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
                         {
                           "hashAlg" : "SHA2-256"
                         },
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 30]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                         {
                           "hashAlg" : "SHA2-512"
                         }
@@ -1786,14 +1694,6 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
                         },
                         {
                           "hashAlg" : "SHA2-256"
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 32]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                         },
                         {
                           "hashAlg" : "SHA2-512"
@@ -1830,6 +1730,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "hashAlg" : "SHA2-512"
                         }
                       ]
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 31]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                     }
                     { "modulo" : 3072,
                       "hashPair" : [
@@ -1842,14 +1750,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                         {
                           "hashAlg" : "SHA2-512"
                         }
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 33]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                       ]
                     }
                     { "modulo" : 4096,
@@ -1886,6 +1786,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                         }
                       ]
                     }
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 32]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                     { "modulo" : 3072,
                       "hashPair" : [
                         {
@@ -1898,14 +1806,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                         },
                         {
                           "hashAlg" : "SHA2-512",
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 34]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                           "saltLen" : 64
                         }
                       ]
@@ -1941,6 +1841,15 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
    {
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 33]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "pubExpMode" : "random",
       "capabilities" :
@@ -1954,14 +1863,6 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
                           "hashAlg" : "SHA2-224"
                         },
                         {
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 35]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                           "hashAlg" : "SHA2-256"
                         },
                         {
@@ -1997,6 +1898,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     }
                ]
          },
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 34]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
          {  "sigType" : "pkcs1v1.5",
             "properties" :
                 [
@@ -2010,14 +1919,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                         },
                         {
                           "hashAlg" : "SHA2-512"
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 36]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                         }
                       ]
                     }
@@ -2053,6 +1954,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
             "properties" :
                 [
                     { "modulo" : 2048,
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 35]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                       "hashPair" : [
                         {
                           "hashAlg" : "SHA2-224",
@@ -2066,14 +1975,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "hashAlg" : "SHA2-512",
                           "saltLen" : 64
                         }
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 37]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                       ]
                     }
                     { "modulo" : 3072,
@@ -2109,6 +2010,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       ]
                     }
                  ]
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 36]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
           }
       ]
    }
@@ -2125,7 +2034,42 @@ A.4.  Example RSA legacySigVer Capabilities JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 38]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 37]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2133,6 +2077,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
    {
       "algorithm": "RSA",
       "mode": "legacySigVer",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "capabilities" :
       [
@@ -2180,8 +2125,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-
-Vassilev                 Expires August 5, 2018                [Page 39]
+Vassilev                 Expires August 5, 2018                [Page 38]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2195,6 +2139,7 @@ A.5.  Example signaturePrimitive Capabilities JSON Objects
       {
          "algorithm": "RSA",
          "mode": "signaturePrimitive",
+         "revision": "1.0",
          "keyFormat": "crt"
       }
 
@@ -2208,6 +2153,7 @@ A.6.  Example decryptionPrimitive Capabilities JSON Objects
       {
          "algorithm": "RSA",
          "mode": "decryptionPrimitive",
+         "revision": "1.0",
          "prereqVals":
            [
                {"algorithm": "DRBG", "valValue": "123456"},
@@ -2231,17 +2177,18 @@ B.1.  Example Test Vectors for keyGen JSON Objects
    { "vsId": 1133,
      "algorithm": "RSA",
      "mode": "keyGen",
-     "infoGeneratedByServer": false,
-     "pubExpMode" : "random",
-     "keyFormat": "standard",
+     "revision": "1.0",
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 40]
+Vassilev                 Expires August 5, 2018                [Page 39]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+     "infoGeneratedByServer": false,
+     "pubExpMode" : "random",
+     "keyFormat": "standard",
      "testGroups" : [
              {
                  "tgId": 1,
@@ -2287,17 +2234,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1150
                     }
                  ]
-             },
-             {
-                "tgId": 4,
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 41]
+Vassilev                 Expires August 5, 2018                [Page 40]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+             },
+             {
+                "tgId": 4,
                 "randPQ": "B.3.4",
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
@@ -2343,17 +2290,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
               },
              {
                  "tgId": 7,
-                 "randPQ" : "B.3.6",
-                 "modulo" : 2048,
-                 "hashAlg" : "SHA2-256",
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 42]
+Vassilev                 Expires August 5, 2018                [Page 41]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                 "randPQ" : "B.3.6",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
                  "testType": "AFT",
                  "tests" : [
                     {
@@ -2399,17 +2346,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "qRand" : "ed1571a9e0cd4a42541284a9f98b54a6af67d399d55ef888b9fe9ef76a61e892c0bfbb87544e7b24a60535a65de422830252b45d2033819ca32b1a9c4413fa721f4a24ebb5510ddc9fd6f4c09dfc29cb9594650620ff551a62d53edc2f8ebf10beb86f483d463774e5801f3bb01c4d452acb86ecfade1c7df601cab68b065275"
 
                     }
-                 ]
-             },
-             {
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 43]
+Vassilev                 Expires August 5, 2018                [Page 42]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                 ]
+             },
+             {
                  "tgId": 10,
                  "randPQ" : "B.3.3",
                  "primeTest" : "tblC2",
@@ -2455,17 +2402,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "tests" : [
                     {
                       "tcId" : 1124,
-                      "e" : "535c97",
-                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
-                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 44]
+Vassilev                 Expires August 5, 2018                [Page 43]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                      "e" : "535c97",
+                      "pRand" : "b9c53dd71792a98fd35eaa569079dfc1f0f6dad9a4a50ca589cccdd80b7810c00c4c0b0a74d3c6ead42c2fa3478c5bfde09ffcad4cb793564fc83977ef1de96a11b16e5eb58590720715c10ac620b862cee5081934c5ddd3e3765fb848781af882558cc4f79663d7fff0263401adc832bc29d396a0c9916ed96005b79bf0dbead4158a3139c855f8d9ae83433410ef5fbdbbe9082ccb3b266c374a08ecca3a2d51bca0495766109ef471c9e07e098a809c9fdbdcada5aaeb11dfa36ca59991b5",
+                      "qRand" : "ed98c73529938fb891869c7ecc7de069af00abc5896e4ec1b32528feac69f29bfc93c707aec4921ac8191e7dde69272b97eebcd568641edf7dde60632ed075b93712870e4eccbeceefa06bade9d4fe2dc7c8ce6277371f3471f42d201831e9f95c8a6ac3d63dd47058e13b7d8e420d9790a17bc58470b5c130f84fdc39a7cfac3453f3706cc4118900710bed26deca871bfee3aa6c59263d314b969ef228b7d08ecec99acaba3466d25b99ecfa48388cc53b19ca74deefc6dfd3d1a80804f4c5"
                     }
                  ]
              }
@@ -2498,6 +2445,7 @@ B.2.  Example Test Vectors for keyGen when infoGeneratedByServer is true
         "vsId" : 172,
         "algorithm" : "RSA",
         "mode" : "keyGen",
+        "revision": "1.0",
         "testGroups" : [
             {
                 "tgId": 1,
@@ -2510,18 +2458,18 @@ B.2.  Example Test Vectors for keyGen when infoGeneratedByServer is true
                 "infoGeneratedByServer" : true,
                 "hashAlg" : "SHA2-256",
                 "tests" : [
-                    {
-                        "tcId" : 1,
-                        "bitlens" : [ 143, 160, 235, 249 ],
-                        "seed" : "3CE2DBBFFE28316F8E21BD73201E2D2B060EB14B53C4327627800E07"
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 45]
+Vassilev                 Expires August 5, 2018                [Page 44]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                    {
+                        "tcId" : 1,
+                        "bitlens" : [ 143, 160, 235, 249 ],
+                        "seed" : "3CE2DBBFFE28316F8E21BD73201E2D2B060EB14B53C4327627800E07"
                     }, {
                         "tcId" : 2,
                         "bitlens" : [ 169, 316, 277, 168 ],
@@ -2563,6 +2511,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
 ]
 
 
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 45]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
 B.3.  Example Test Vectors for sigGen JSON Objects
 
 
@@ -2570,15 +2529,8 @@ B.3.  Example Test Vectors for sigGen JSON Objects
    { "acvVersion": <acvp-version> },
    { "vsId": 1163,
       "algorithm": "RSA",
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 46]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
       "mode": "sigGen",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2618,6 +2570,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
              },
              {
                 "tgId": 4,
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 46]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
@@ -2626,14 +2586,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1168,
                       "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
                     }
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 47]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                  ]
              },
              {
@@ -2674,7 +2626,16 @@ B.4.  Example Test Vectors for sigVer JSON Objects
    { "acvVersion": <acvp-version> },
    { "vsId": 1173,
       "algorithm": "RSA",
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 47]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
       "mode": "sigVer",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2682,14 +2643,6 @@ B.4.  Example Test Vectors for sigVer JSON Objects
                  "hashAlg" : "SHA2-256",
                  "testType": "AFT",
                  "modulo" : 2048,
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 48]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
                  "tests" : [
@@ -2729,6 +2682,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1176,
                       "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
                       "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 48]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                     }
                  ]
              },
@@ -2738,14 +2699,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "modulo" : 3072,
                 "hashAlg" : "SHA2-256",
                 "testType": "AFT",
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 49]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
                 "tests" : [
@@ -2785,6 +2738,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1179,
                       "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
                       "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 49]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                     }
                  ]
              }
@@ -2792,14 +2753,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
       }
   ]
 
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 50]
-
-Internet-Draft                RSA Alg JSON                 February 2018
 
 
    Note: The ACVP server does retain additional context for each test
@@ -2816,11 +2769,45 @@ B.5.  Example Test Vectors for legacySigVer JSON Objects
 B.6.  Example Test Vectors for signaturePrimitive JSON Objects
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 50]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
  [
    { "acvVersion": <acvp-version> },
    { "vsId": 1193,
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "keyFormat": "standard",
       "testGroups" : [
              {
@@ -2849,6 +2836,19 @@ B.6.  Example Test Vectors for signaturePrimitive JSON Objects
    vector sent to the client in order to verify the results when
    submitted for validation.  These may include the public key 'n', the
    public exponent 'e', the private key 'd' for each test.  Note also
+   that each test for which 'msg' is not between '0' and 'n - 1' should
+   fail.
+
+B.7.  Example Test Vectors for decryptionPrimitive JSON Objects
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2858,17 +2858,12 @@ Vassilev                 Expires August 5, 2018                [Page 51]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   that each test for which 'msg' is not between '0' and 'n - 1' should
-   fail.
-
-B.7.  Example Test Vectors for decryptionPrimitive JSON Objects
-
-
  [
    { "acvVersion": <acvp-version> },
    { "vsId": 1194,
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2907,6 +2902,11 @@ C.1.  Example keyGen Test Results JSON Objects
    sent from the crypto module to the ACVP server.
 
 
+             [
+                { "acvVersion": <acvp-version> },
+                { "vsId": 1133,
+                    "algorithm": "RSA",
+
 
 
 Vassilev                 Expires August 5, 2018                [Page 52]
@@ -2914,11 +2914,8 @@ Vassilev                 Expires August 5, 2018                [Page 52]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-             [
-                { "acvVersion": <acvp-version> },
-                { "vsId": 1133,
-                    "algorithm": "RSA",
                     "mode": keyGen,
+                    "revision": "1.0",
                     "testGroups": [
                     {
                       "tgId": 1,
@@ -2962,6 +2959,9 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "tcId" : 1114,
                           "e" : "10000021",
                           "seed" : "6b6b99c71902a6e23cd941494876958fe816e8e2f587b4f05f24e8f674b9b10a",
+                          "bitlens" : [504, 238, 440, 185],
+                          "p" : "b6bbf5a62930f4a89153ff826347d7b49339a5af07d29fbb4120847c914f4a09c98c95070c70c5498520a2e799138cdaaca5c2fe1cd8ef6da799b26af0ac9785bbc790e6b52c32389ef26afd447cc05baf8e6c628832772bce91eb120309332aa8735ce7eb34c640863bb7efc59f70a3d3038359d57b8ba5b009ff7b119aa0c2db32a1edbac51f4bddc1c4dbd3f70e83d43b07c23a4d3859a91f51014e6aec589693e66928c20467fe3c568298b43cb98d8b0f2a7504c19b01759bd4de5c4fad",
+                          "q" : "c263d13aded6645ee10683efc4d216e6b51314684c7f3b84cbd59988c14134fd8327d5ee1b436cce2f8648a260f5fda5f9494dd2275ae475676439741aac62587fc2de745b68eb46c59eeee00cbf05f3d911752ba9223e5a0b88390023e79a60d94604b82ac6a51df27699c4b6672e17be555af0673bc2a5573c32ada7158272e08e02efd00d18932cdbd518b4e969b766fefd3f380f31f2180d55dbcbe55b3e6ffb755e07b03800537734c37e8644e66fe64cc7465a9a570e1ec03775cad1fb",
 
 
 
@@ -2970,9 +2970,6 @@ Vassilev                 Expires August 5, 2018                [Page 53]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                          "bitlens" : [504, 238, 440, 185],
-                          "p" : "b6bbf5a62930f4a89153ff826347d7b49339a5af07d29fbb4120847c914f4a09c98c95070c70c5498520a2e799138cdaaca5c2fe1cd8ef6da799b26af0ac9785bbc790e6b52c32389ef26afd447cc05baf8e6c628832772bce91eb120309332aa8735ce7eb34c640863bb7efc59f70a3d3038359d57b8ba5b009ff7b119aa0c2db32a1edbac51f4bddc1c4dbd3f70e83d43b07c23a4d3859a91f51014e6aec589693e66928c20467fe3c568298b43cb98d8b0f2a7504c19b01759bd4de5c4fad",
-                          "q" : "c263d13aded6645ee10683efc4d216e6b51314684c7f3b84cbd59988c14134fd8327d5ee1b436cce2f8648a260f5fda5f9494dd2275ae475676439741aac62587fc2de745b68eb46c59eeee00cbf05f3d911752ba9223e5a0b88390023e79a60d94604b82ac6a51df27699c4b6672e17be555af0673bc2a5573c32ada7158272e08e02efd00d18932cdbd518b4e969b766fefd3f380f31f2180d55dbcbe55b3e6ffb755e07b03800537734c37e8644e66fe64cc7465a9a570e1ec03775cad1fb",
                           "n" : "8ac1b03163ab5e673e5ebfa0328b694a322da0819fd97f7be54f94b805f58a8a2f7ff4e273c98440ba862e7959658ee1c0876a19232bbd4f85c9f20ebb92d031269cf19f0dd46ba28759a452678be7b9c35efb788f3739183b512a56e781bb6a9d42534399b8795e63705c01a742ede7862d6670ca02a02e5c117ac0a6548035be5cfad0da0174c1872d3da8523b3efbf98115d168e74bb4f327661131753593f45550edfda6486dd4dbf870e50367ca1c39e446f3be3b50f197f5f4b3137e950350542e3688330a4e6fd607286f57f5771255ef9f3816658c2ce981132b0303ad34c21208f3c15846f21dbb77daddd4adf5ddcc6d1b828a5a5a6f3c4f85a42f1b51085d2d913e1d105d5565c029efd80d2f8c42701f6e7d51e8bab650c03a98bad191e3f6508d42aff30e6db1ca81228bf044d13eff53bcf6d688b73a423503a8e36808b61ecf499df708c06aae3b441257d154bb5c483bb52f3b0990e47b06b6efdcaa73fb29de1897df0cf8ffb915a35e36ed1011a8a97ffd16ab51105b9f",
                           "d" : "cf02aaaca392f5d21e80ac8e954ccc3eb738155b9ca03d96c1c7506b6593e97954e0b97eed739e6cd0eff08fe66e1584926d8d6ab9d6c686f99f758fec24627071a0f9164096b93c2693e296d2707f392ada019d010459b0783918f8f104423e2dfdcd418194144bde4b9fbbc766dc892bf9154803d41e8a295e2fd280592e4388dd78d792f96654da3268421553fa101f5e334b5149a6bd6857705ae9b5fbe4f80f2334fffec4a168a63c47d927d54e33571590f4450e005adb54c4a290f52141a7a502007a3508c6fad932f04e5b469cbab7228f69c34e89b5b4e7378fc82a9f1dd2132bceceb447dfd8a14679dd9df39194e4190b6d5fa79e2abe140abc4cc6cd428ed04c1bdb14cf51bd9133119138b1cee3bb1649bedb2e86c810010006e611237a901e3e404ca78c551253979c587a92440e11c2b742e87bea09a93fa2b1ed6cbf66907d3005a572b20055cc4870bce35d78b51f7b22ba37ff7f8af05dc2d0d6c743d95ac0a5e0eabf5be061991bb2fb505555589c5c5a0cd3b575d15"
                         },
@@ -3018,6 +3015,9 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "xP" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e306705e39d2b621027353b4873898b36b3fe86ab203dee10260058ce77f13d315ea1dcc0b717ffe906bfb05f251f3e9d678c585917176e127ece648c788f28b05607d4f71e113842e289b0de45bed72b7e591ea55ae5750ebe86a8",
                           "p" : "e3422e7d39fbf3504174f0d8fb0422866756e23d4004e508e25c62f826c585c29df88ef7e8659e711dede3cb24697395b1af0acdfa80f48140420d4560303a699e21a307111382463322fe39e7b8e8e8e6ca4748725954d2acee20d3fffd2b56099407cb9e3092a9dfd7697a29e1c6952f0d71a7381d0bd64c4ac6102f54ae43b21f7d399583f86f6192717188b913ed16c1422d5fe5df0a407b1de9a05e178e4f47cdb3532866e2fcf36e57616f3473c5c967fa6703847d90ddfe0b822f24e9",
                           "xQ" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2dc5e9fe2c0077b65c79cb98bd4d7fced17121010598bbf410f3dd755df986b877e51058ef80649b486100c0d6eddf0825c69af34e3beace6e2810da3366c6f11520fd65b5ad7fbc7d33fa63a91f5ebb93b3d4b042478754ce89129e44add",
+                          "q" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2f82363823d9c7bb2f1f4e19cee9d524d96f478637e8a5054c34fbf73483134a40034a75c72d30ee9499ff2e899da5ff65733155eb0ad9217e7ca2c57af22b12991882ab7fa7ea6d8a5f60ae7a71842a4b286d618374f496efd642ffcaa0f",
+                          "n" : "a196d7142be535696b88a1f5b99e0872fdc653801d621d3f887173fb907ca4277f2caa063a1a1232e1823e7711d07423f60c5a96dd348384e7c23e504cf5e8c9d072e5d6c6d4b59a78773fa4257b5526a3a4b52118c587addbdf38646657fc8f78c13fd46878189f53f92f1c9edee80ca22415f05fbb9ba3fc080f72f2a15460520e2c9cce541f31a29aca658abda9528a766921e0d7376e522169bbcb34822c30f98262a1f9b7e77fca2593985165f84f52a46a363a7d4d3771b9fc884335f36b83acfb75928390d32f51728501a1d23950baa3dec46ec55f63dc950a4a740a3f3f30e221a5b7e303b5ea029b878423f157bb6335cabcc79f34977c9c89a02a050f68f7dceb31224f82f0d9391b46a79b0ced44bc68cbd82aff62be9e8ff2f25c840101ee640fe53dbb1c9827cf19fac1e2e7cdc110691501b34fec7df72bc847fda146c9e5dabe691a226ea2dbf4318a337851abf170696ef709b3aae977260f93ceaa003a45536f639a5706f7fb8a966ca2abcd8ff28fd6f305530ba1e3a7",
+                          "d" : "4abd536c3f299e3c7365e496caedc45561ddc2a97d2d52f8c9e3eb1e7be52117e952ad9ee9768df7380ed09750d6c9bedf7d5da8ebe36046cb17f16e4f7cd88ced6279cceda200b17faa16b77000b53360c9e50bd5da91329a309bf422c716b7127b7331163987810ad08ca15b0580a97fe63bec434c72213f8527d939b02b60bd0902e97da8068d81354eedfa5d62067201a2b5b64c021022becda98b175bb57f4216211f22f11b28b5ce0021e87361e5c0f4e363f8f15123b1e7eb76cea6ecd065549925425f68fc80c8846d399205edbdf417d6554bb3eeaa58ef0e68be51a447c80438dcdff548203813d13e50f792e2aa106537d39198fde0a305446dfaf16de93e670600ce20a48ddb16ae196c43b4d1049c7c1c130c510b780e37591bee3bcf6c3d716f9acd305f81ab54675c95b7bef042f4c11ecae895d18c4fe1a986410e947b150deba89cf123fe11874304ae8922b61cae5c6b298cf20ea65cce98e94cb4849c85b813de46554ad6e0f0f844b679060855c02ae69b1806e55e21"
 
 
 
@@ -3026,9 +3026,6 @@ Vassilev                 Expires August 5, 2018                [Page 54]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                          "q" : "b6068575e86ee559aac8292f99c8b33332a02066366837b1139c62f14b261b4b178154f1735392ccb925491b900dc1be408929dfc4909168b5f9918ce3f9c07403a426564bac8e2891eae2e51b899da8bb411d83797e66af9263635267da743d83e2f82363823d9c7bb2f1f4e19cee9d524d96f478637e8a5054c34fbf73483134a40034a75c72d30ee9499ff2e899da5ff65733155eb0ad9217e7ca2c57af22b12991882ab7fa7ea6d8a5f60ae7a71842a4b286d618374f496efd642ffcaa0f",
-                          "n" : "a196d7142be535696b88a1f5b99e0872fdc653801d621d3f887173fb907ca4277f2caa063a1a1232e1823e7711d07423f60c5a96dd348384e7c23e504cf5e8c9d072e5d6c6d4b59a78773fa4257b5526a3a4b52118c587addbdf38646657fc8f78c13fd46878189f53f92f1c9edee80ca22415f05fbb9ba3fc080f72f2a15460520e2c9cce541f31a29aca658abda9528a766921e0d7376e522169bbcb34822c30f98262a1f9b7e77fca2593985165f84f52a46a363a7d4d3771b9fc884335f36b83acfb75928390d32f51728501a1d23950baa3dec46ec55f63dc950a4a740a3f3f30e221a5b7e303b5ea029b878423f157bb6335cabcc79f34977c9c89a02a050f68f7dceb31224f82f0d9391b46a79b0ced44bc68cbd82aff62be9e8ff2f25c840101ee640fe53dbb1c9827cf19fac1e2e7cdc110691501b34fec7df72bc847fda146c9e5dabe691a226ea2dbf4318a337851abf170696ef709b3aae977260f93ceaa003a45536f639a5706f7fb8a966ca2abcd8ff28fd6f305530ba1e3a7",
-                          "d" : "4abd536c3f299e3c7365e496caedc45561ddc2a97d2d52f8c9e3eb1e7be52117e952ad9ee9768df7380ed09750d6c9bedf7d5da8ebe36046cb17f16e4f7cd88ced6279cceda200b17faa16b77000b53360c9e50bd5da91329a309bf422c716b7127b7331163987810ad08ca15b0580a97fe63bec434c72213f8527d939b02b60bd0902e97da8068d81354eedfa5d62067201a2b5b64c021022becda98b175bb57f4216211f22f11b28b5ce0021e87361e5c0f4e363f8f15123b1e7eb76cea6ecd065549925425f68fc80c8846d399205edbdf417d6554bb3eeaa58ef0e68be51a447c80438dcdff548203813d13e50f792e2aa106537d39198fde0a305446dfaf16de93e670600ce20a48ddb16ae196c43b4d1049c7c1c130c510b780e37591bee3bcf6c3d716f9acd305f81ab54675c95b7bef042f4c11ecae895d18c4fe1a986410e947b150deba89cf123fe11874304ae8922b61cae5c6b298cf20ea65cce98e94cb4849c85b813de46554ad6e0f0f844b679060855c02ae69b1806e55e21"
                         },
                         {
                           "tcId" : 1118,
@@ -3074,6 +3071,9 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "xQ2" : "19be84f228b1576165c13970c88939e7a027f29c3fc33542006dbead17a7e1e72d8bf9",
                           "xQ" : "e695e1de6811c9872ba9017fdde9a87969022882a295320cecd39f9a9bebae1e9edc0e42ff78cd17d05c58a93ec75ec09c3a75a8db24a19b073314f9d857fc43523291c58b23065660987ea793755ff238ffa5adfbd9ac26b53c6af016ebe9b646963ac139fa81b41534a0851a7e54ce3fe84af212452440f235701ec2dfd6b1b4980a67745b0144aed587ad04a692c86c0956bff44e263194efc4a26a7ef66dc056bc038d8d0aee995d8f71a3a68c4d2bc83042b96736663d1c34b13776b223",
                           "q" : "e695e1de6811c9872ba9017fdde9a87969022882a295320cecd39f9a9bebae1e9edc0e42ff78cd17d05c58a93ec75ec09c3a75a8db24a19b073314f9d857fc43523291c58b23065660987ea793755ff238ffa5adfbd9ac26b53c6af016ebe9b646963ac139fa81b41534a0851a7e54ce3fe84af2147d1c529ada626a4672b009324dbe5c76ca998a957d3c5d7dc1d59e55cccdb0b25f5076b3c475e623a98c5a52763b6d6fab10c4065e452c7d4e6644ddd2637b56d0ec47fdc990cb720f6fe1",
+                          "n" : "d83328a78e035fedf3f96aae5115232a3def973c4d74c6e8e92742b3b8ab1d2d9a869ce1d22aa1b17e31e0c95415d7295534aef9c206aaf4b90e797c20301a8c72de964ed51fae63a82a855ed672b6d6e438d581d5a3e9140977b8652b2ec8834e43964c9936fc1817f48d01d8d3a1924ae71ca99a6a7b4132ff25a2ddc1aec7e684d56882de162e6e8338883ea8b69f2bd0d6e2f37113b06a3384d51c8ae3270b402549178cc96ed473c9e740236cb36a07716c46c4e5b39337882dbde39ccc136bfa9e6a56bfe5d2cc28e062f53778c2f0ef64b9d7c37d312b265357bf0feedadb0816db40092e61989f6d32d3599d763e944f15fcfd1b675fd9c7f76b68ca822174c79f5d52d6b935d17122f0c628e16857c03d14799e86ca72f8b25f1069bf1cd90f0711dbdcd8aa49435e19658d6dd8f4e7b4072437ab8712576c91db016274c1bcf2edbc6c4ff52f1b077087ff80c92d1bda70771a78af7232705d39dd4015ef7b13fe443df70861c3d690a56b889824c44c121fde18fa55fd05c9b375",
+                          "d" : "8c377a2f9817c497507f74c2d4d37c2093e5a204fe0bc04299c0337af153bf86022c2ad9f88d156b67263d21e0fff1fce1cf8e9affbf52bd83e33f38d7223b6aae31667b029188d939453b5cff019c1fc6ed87296f7897c2b3328bb888e1dd3b082e5b11272f7f8fc62473d701b35b342e4ac4f757c4b17924912dba913f17800f2a5dec389436b8d7288e6c44035d2aad9bba5bd1cfb8550fc3bdfd01c317ec222ea6f0cb90342367fdaa5b61513cdc3bea7a12bb44f1f07811a2c193b99615e89627164482248f474e89985ac1655df1054d93ec91f93b08c5ef077fad256cd042ac375cd536837b65489d62833c48fff221cb1092509e82fea082f0022151dbd9d2104314d10cef26fd4ea710898f42f956be2aa46756e5c436174e181f95e54ac8b6477baa5a32044678b3686d16df88e457bda4e0dddd94a24dbdb3ced4827392780cc96287fd6a46e82a5fb1daa0d372953c06ff6c2e1236926e0c11a367218a4291e6288e5cd1be03408770c5a667da57652eb46a9367369f732eb41"
+                        },
 
 
 
@@ -3082,9 +3082,6 @@ Vassilev                 Expires August 5, 2018                [Page 55]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                          "n" : "d83328a78e035fedf3f96aae5115232a3def973c4d74c6e8e92742b3b8ab1d2d9a869ce1d22aa1b17e31e0c95415d7295534aef9c206aaf4b90e797c20301a8c72de964ed51fae63a82a855ed672b6d6e438d581d5a3e9140977b8652b2ec8834e43964c9936fc1817f48d01d8d3a1924ae71ca99a6a7b4132ff25a2ddc1aec7e684d56882de162e6e8338883ea8b69f2bd0d6e2f37113b06a3384d51c8ae3270b402549178cc96ed473c9e740236cb36a07716c46c4e5b39337882dbde39ccc136bfa9e6a56bfe5d2cc28e062f53778c2f0ef64b9d7c37d312b265357bf0feedadb0816db40092e61989f6d32d3599d763e944f15fcfd1b675fd9c7f76b68ca822174c79f5d52d6b935d17122f0c628e16857c03d14799e86ca72f8b25f1069bf1cd90f0711dbdcd8aa49435e19658d6dd8f4e7b4072437ab8712576c91db016274c1bcf2edbc6c4ff52f1b077087ff80c92d1bda70771a78af7232705d39dd4015ef7b13fe443df70861c3d690a56b889824c44c121fde18fa55fd05c9b375",
-                          "d" : "8c377a2f9817c497507f74c2d4d37c2093e5a204fe0bc04299c0337af153bf86022c2ad9f88d156b67263d21e0fff1fce1cf8e9affbf52bd83e33f38d7223b6aae31667b029188d939453b5cff019c1fc6ed87296f7897c2b3328bb888e1dd3b082e5b11272f7f8fc62473d701b35b342e4ac4f757c4b17924912dba913f17800f2a5dec389436b8d7288e6c44035d2aad9bba5bd1cfb8550fc3bdfd01c317ec222ea6f0cb90342367fdaa5b61513cdc3bea7a12bb44f1f07811a2c193b99615e89627164482248f474e89985ac1655df1054d93ec91f93b08c5ef077fad256cd042ac375cd536837b65489d62833c48fff221cb1092509e82fea082f0022151dbd9d2104314d10cef26fd4ea710898f42f956be2aa46756e5c436174e181f95e54ac8b6477baa5a32044678b3686d16df88e457bda4e0dddd94a24dbdb3ced4827392780cc96287fd6a46e82a5fb1daa0d372953c06ff6c2e1236926e0c11a367218a4291e6288e5cd1be03408770c5a667da57652eb46a9367369f732eb41"
-                        },
                       ]
                     },
                     {
@@ -3130,6 +3127,9 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "tcId" : 1121,
                           "testPassed": true
                         },
+                        {
+                          "tcId" : 1122,
+                          "testPassed": false
 
 
 
@@ -3138,9 +3138,6 @@ Vassilev                 Expires August 5, 2018                [Page 56]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                        {
-                          "tcId" : 1122,
-                          "testPassed": false
                         },
                       ]
                     },
@@ -3186,6 +3183,9 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "e" : "e66d81",
                           "p" : "fb61c111b038153b645cdd3103fc5eb3e9ab09b64d11de97a08662c569fb22456203fa5fc6b7e41a8e83fe995eeaea9cca670575a662447d39012aa093a051e781df6018c0ea8ab76d49353363074e92f070dfe3c3c8964acad4532da8bea7b0944ffd229f06da23abe7b050418abe4b44513777b988ab30ee696ef053e23ca5",
                           "q" : "c0ef0f196921eea05721308d4edca39afd20d0dbd6c6c446571f69d6c873838558c8bd2e3a5bee4b7d32de9819caf9f07d3807a16616081275263789adb5c1d092f9d0001486fde649998d15650b1e442e0076cacf5b276d6d52cbbe1ec713237ff0f59460967515914aed67eb806e92bc9a0affb27de9c5c74fa9aefa357627",
+                          "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
+                          "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
+                        },
 
 
 
@@ -3194,9 +3194,6 @@ Vassilev                 Expires August 5, 2018                [Page 57]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                          "n" : "bd740fe431c5e27255258afbde09db7e70de263c950206fd441a24c6bd41b955b8f83034eddef6558da9a924ad002530227cc7fe74e70c6b7ba9a438a5edf621e298251deb709d5c3737ab0759f6f4a2760e1c24243f2fbf1478f8adc7a5247961d5663727400b2928c9059d7d53226ce6cff76f409d253a500d8a837918defa087df338b88430dc5b547b09d7526ad364971eb12acbf3c812ca379a5f25924ade0d2719f5d6f53d05916bc8fa206618183456c69e1c78d5f5bc2b7915113985024e61bae4efb078e6fe275680a2830ba35225aac7af75cad2fbe00365957a184e5e8af4e8e1a4aca810056c82e558b52f00ecedfccf9b2aec981f7cbf944b23",
-                          "d" : "4f3dc0ac1211eeff7e21d296a69e27a7f785bb38346457ddddf109ff0c43bcf1e33bf9f0b37a505533a3e030d7f6fda72c1072e801084a71ea8b35b4e57c0a49ef92a7bd23979f7fb279cb22d8837a6b4eec40f918906fa2c33c1fb6344b12a851c37524e093c116ad971ff1674badca713491157bedabbb9049cf588b6b2f9899c65b99219f9ac9d2c870cdc8325532f8066a2eedc70d790971ff0416fcafc8a896b1619e2c382438eab73590958439a0e1a2bb85132896003df93def0fbeb98df886137f5762d4e24a040f7f7d5d35f4aca3d6b14daab758656ec0dea0d14d30457d7868885c8297da530c19180fb100a1cfbf7f0cd7262f970e44ec079895"
-                        },
                       ]
                     },
                     {
@@ -3236,12 +3233,15 @@ C.2.  Example sigGen Test Results JSON Objects
                 { "vsId": 1163,
                   "algorithm": "RSA",
                   "mode": "sigGen",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
                       "tests": [
                         {
                           "tcId" : 1165,
+                          "e" : "f3e7af",
+                          "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
 
 
 
@@ -3250,8 +3250,6 @@ Vassilev                 Expires August 5, 2018                [Page 58]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                          "e" : "f3e7af",
-                          "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
                           "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d"
                         },
                         {
@@ -3298,15 +3296,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     }
                  ]
              }
+           ]
+
 
 
 
 Vassilev                 Expires August 5, 2018                [Page 59]
 
 Internet-Draft                RSA Alg JSON                 February 2018
-
-
-           ]
 
 
 C.3.  Example sigVer Test Results JSON Objects
@@ -3320,6 +3317,7 @@ C.3.  Example sigVer Test Results JSON Objects
        { "vsId": 1173,
          "algorithm": "RSA",
          "mode": "sigVer",
+         "revision": "1.0",
          "testGroups" : [
              {
                "tgId": 1,
@@ -3354,6 +3352,8 @@ C.3.  Example sigVer Test Results JSON Objects
                      "tcId" : 1178,
                      "testPassed": false
                    },
+                   {
+                     "tcId" : 1179,
 
 
 
@@ -3362,8 +3362,6 @@ Vassilev                 Expires August 5, 2018                [Page 60]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-                   {
-                     "tcId" : 1179,
                      "testPassed": false
                    }
                  ]
@@ -3390,6 +3388,7 @@ C.5.  Example signaturePrimitive Test Results JSON Objects
     { "vsId": 47,
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "testGroups" : [
         {
           "tgId": 1,
@@ -3413,6 +3412,7 @@ C.5.  Example signaturePrimitive Test Results JSON Objects
 
 
 
+
 Vassilev                 Expires August 5, 2018                [Page 61]
 
 Internet-Draft                RSA Alg JSON                 February 2018
@@ -3429,6 +3429,7 @@ C.6.  Example decryptionPrimitive Test Results JSON Objects
     { "vsId": 48,
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "testGroups" : [
         {
           "tgId": 1,
@@ -3461,7 +3462,6 @@ Author's Address
    USA
 
    Email: apostol.vassilev@nist.gov
-
 
 
 

--- a/artifacts/draft-celi-acvp-block-ciph-00.html
+++ b/artifacts/draft-celi-acvp-block-ciph-00.html
@@ -426,7 +426,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-celi-block-ciph-00" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-celi-block-ciph-00-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2019-02-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using symmetric block cipher algorithms with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using symmetric block cipher algorithms with the ACVP specification." />
@@ -460,7 +460,7 @@
   </table>
 
   <p class="title">ACVP Symmetric Block Cipher Algorithm JSON Specification<br />
-  <span class="filename">draft-celi-block-ciph-00</span></p>
+  <span class="filename">draft-celi-block-ciph-00-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using symmetric block cipher algorithms with the ACVP specification.</p>

--- a/artifacts/draft-celi-acvp-block-ciph-00.html
+++ b/artifacts/draft-celi-acvp-block-ciph-00.html
@@ -422,7 +422,7 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.20.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
@@ -2241,7 +2241,7 @@ POST [
     "acvVersion": &lt;acvp-version&gt;
 },{
         "algorithm": "ACVP-AES-GCM",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "prereqVals" : 
             [{
                 "algorithm" : "ACVP-AES-ECB",
@@ -2280,7 +2280,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-ECB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2293,7 +2293,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CBC",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2306,7 +2306,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CFB8",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2322,7 +2322,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CFB128",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2335,7 +2335,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-OFB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2348,7 +2348,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-XPN",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "prereqVals" : 
         [{
             "algorithm" : "ACVP-AES-ECB", 
@@ -2385,7 +2385,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CTR",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2401,7 +2401,7 @@ POST [
         },
         {
         "algorithm": "ACVP-AES-CCM",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "prereqVals": [
             {
                 "algorithm": "ACVP-AES-ECB",
@@ -2434,7 +2434,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CFB1",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2447,7 +2447,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-KW",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2468,7 +2468,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-KWP",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2490,7 +2490,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-XTS",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2509,7 +2509,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-ECB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2523,7 +2523,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CBC",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2537,7 +2537,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CBCI",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2551,7 +2551,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-OFB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2565,7 +2565,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-OFBI",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2579,7 +2579,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFB64",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2593,7 +2593,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFB8",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2607,7 +2607,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFB1",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2621,7 +2621,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFBP64",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2635,7 +2635,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFBP8",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2649,7 +2649,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFBP1",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2663,7 +2663,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CTR",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2680,7 +2680,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-KW",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2707,7 +2707,7 @@ POST [
 },{
 	"vsId": 2055,
 	"algorithm": "ACVP-AES-GCM",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
             tgId": 1,
             "testType": "AFT",
@@ -2814,7 +2814,7 @@ POST [
 },{
 	"vsId": 2061,
 	"algorithm": "ACVP-AES-CCM",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -2902,7 +2902,7 @@ POST [
 },{
 	"vsId": 2057,
 	"algorithm": "ACVP-AES-CBC",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 			"tgId": 1,
 			"direction": "encrypt",
@@ -3040,7 +3040,7 @@ POST [
 },{
 	"vsId": 2056,
 	"algorithm": "ACVP-AES-ECB",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 			"tgId": 1,
             "testType": "AFT",
@@ -3180,7 +3180,7 @@ POST [
 },{
 	"vsId": 2060,
 	"algorithm": "ACVP-AES-OFB",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3316,7 +3316,7 @@ POST [
 },{
 	"vsId": 2062,
 	"algorithm": "ACVP-AES-CFB1",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3457,7 +3457,7 @@ POST [
 },{
 	"vsId": 2058,
 	"algorithm": "ACVP-AES-CFB8",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3593,7 +3593,7 @@ POST [
 },{
 	"vsId": 2059,
 	"algorithm": "ACVP-AES-CFB128",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3729,7 +3729,7 @@ POST [
 },{
 	"vsId": 2066,
 	"algorithm": "ACVP-AES-CTR",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3826,7 +3826,7 @@ POST [
   "acvVersion": &lt;acvp-version&gt;
 },{
   "algorithm": "ACVP-AES-XPN",
-  "revision": "1.0.0",
+  "revision": "1.0",
   "vsId": 1,
   "testGroups": [
     {
@@ -3895,7 +3895,7 @@ POST [
 },{
 	"vsId": 2065,
 	"algorithm": "ACVP-AES-XTS",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -3975,7 +3975,7 @@ POST [
 },{
 	"vsId": 2063,
 	"algorithm": "ACVP-AES-KW",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -4051,7 +4051,7 @@ POST [
 },{
 	"vsId": 2064,
 	"algorithm": "ACVP-AES-KWP",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -4130,7 +4130,7 @@ POST [
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-ECB",
-    "revision": "1.0.0",
+    "revision": "1.0",
     "testGroups": [{
         "tgId": 1,
         "direction": "encrypt",
@@ -4178,7 +4178,7 @@ POST [
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-CFB1",
-    "revision": "1.0.0",
+    "revision": "1.0",
     "testGroups": [{
             "tgId": 1,
             "direction": "encrypt",
@@ -4261,7 +4261,7 @@ POST [
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-ECB",
-    "revision": "1.0.0",
+    "revision": "1.0",
     "testGroups": [{
         "tgId": 1,
         "direction": "encrypt",

--- a/artifacts/draft-celi-acvp-block-ciph-00.txt
+++ b/artifacts/draft-celi-acvp-block-ciph-00.txt
@@ -1182,8 +1182,8 @@ Internet-Draft                Sym Alg JSON                 February 2019
    |                    | cipher text lengths in bits.  |              |
    |                    | This varies depending on the  |              |
    |                    | algorithm type, for           |              |
-   |                    | additional details see Table  |              |
-   |                    | 4 and Table 6                 |              |
+   |                    | additional details see        |              |
+   |                    | Table 4 and Table 6           |              |
    | ivLen              | The supported IV/Nonce        | domain       |
    |                    | lengths in bits, see Table 4  |              |
    | ivGen              | IV generation method for AES- | string       |
@@ -1532,8 +1532,8 @@ Internet-Draft                Sym Alg JSON                 February 2019
    | vsId       | Unique numeric identifier for the      | integer     |
    |            | vector set                             |             |
    | algorithm  | The block cipher algorithm and mode    | string      |
-   |            | used for the test vectors. See Section |             |
-   |            | 2 for possible values.                 |             |
+   |            | used for the test vectors. See         |             |
+   |            | Section 2 for possible values.         |             |
    | revision   | The version of the testing             | string      |
    |            | methodologies used in the vector set.  |             |
    | testGroups | Array of test group JSON objects,      | array of    |
@@ -1593,8 +1593,8 @@ Internet-Draft                Sym Alg JSON                 February 2019
    |              | information about what these tests do,  |          |
    |              | and how to implement them.              |          |
    | tests        | Array of individual test case JSON      | array of |
-   |              | objects, which are defined in Section   | testCase |
-   |              | 5.2                                     | objects  |
+   |              | objects, which are defined in           | testCase |
+   |              | Section 5.2                             | objects  |
    +--------------+-----------------------------------------+----------+
 
                       Table 8: Test Group JSON Object
@@ -2032,7 +2032,7 @@ Appendix A.  Example Capabilities JSON Object
        "acvVersion": <acvp-version>
    },{
            "algorithm": "ACVP-AES-GCM",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "prereqVals" :
                [{
                    "algorithm" : "ACVP-AES-ECB",
@@ -2079,7 +2079,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-ECB",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2092,7 +2092,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-CBC",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2105,7 +2105,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-CFB8",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2121,7 +2121,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-CFB128",
-           "revision": "1.0.0",
+           "revision": "1.0",
 
 
 
@@ -2142,7 +2142,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-OFB",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2155,7 +2155,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-XPN",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "prereqVals" :
            [{
                "algorithm" : "ACVP-AES-ECB",
@@ -2200,7 +2200,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-CTR",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2216,7 +2216,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
            },
            {
            "algorithm": "ACVP-AES-CCM",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "prereqVals": [
                {
                    "algorithm": "ACVP-AES-ECB",
@@ -2257,7 +2257,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-CFB1",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2270,7 +2270,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-KW",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2299,7 +2299,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
 
 
            "algorithm": "ACVP-AES-KWP",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2321,7 +2321,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-AES-XTS",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2340,7 +2340,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-ECB",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2362,7 +2362,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CBC",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2376,7 +2376,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CBCI",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2390,7 +2390,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-OFB",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2412,7 +2412,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
 
        {
            "algorithm": "ACVP-TDES-OFBI",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2426,7 +2426,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CFB64",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2440,7 +2440,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CFB8",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2454,7 +2454,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CFB1",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2476,7 +2476,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CFBP64",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2490,7 +2490,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CFBP8",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2504,7 +2504,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CFBP1",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2526,7 +2526,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-CTR",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2543,7 +2543,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
        },
        {
            "algorithm": "ACVP-TDES-KW",
-           "revision": "1.0.0",
+           "revision": "1.0",
            "direction": [
                "encrypt",
                "decrypt"
@@ -2581,7 +2581,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2055,
            "algorithm": "ACVP-AES-GCM",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                tgId": 1,
                "testType": "AFT",
@@ -2732,7 +2732,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2061,
            "algorithm": "ACVP-AES-CCM",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "direction": "encrypt",
@@ -2840,7 +2840,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2057,
            "algorithm": "ACVP-AES-CBC",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                            "tgId": 1,
                            "direction": "encrypt",
@@ -3002,7 +3002,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2056,
            "algorithm": "ACVP-AES-ECB",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                            "tgId": 1,
                "testType": "AFT",
@@ -3166,7 +3166,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2060,
            "algorithm": "ACVP-AES-OFB",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "direction": "encrypt",
@@ -3326,7 +3326,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2062,
            "algorithm": "ACVP-AES-CFB1",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "direction": "encrypt",
@@ -3491,7 +3491,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2058,
            "algorithm": "ACVP-AES-CFB8",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "direction": "encrypt",
@@ -3651,7 +3651,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2059,
            "algorithm": "ACVP-AES-CFB128",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "direction": "encrypt",
@@ -3811,7 +3811,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
 
 
            "algorithm": "ACVP-AES-CTR",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "direction": "encrypt",
@@ -3926,7 +3926,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
      "acvVersion": <acvp-version>
    },{
      "algorithm": "ACVP-AES-XPN",
-     "revision": "1.0.0",
+     "revision": "1.0",
      "vsId": 1,
      "testGroups": [
        {
@@ -4039,7 +4039,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2065,
            "algorithm": "ACVP-AES-XTS",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "testType": "AFT",
@@ -4151,7 +4151,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2063,
            "algorithm": "ACVP-AES-KW",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "testType": "AFT",
@@ -4263,7 +4263,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
            "vsId": 2064,
            "algorithm": "ACVP-AES-KWP",
-       "revision": "1.0.0",
+       "revision": "1.0",
            "testGroups": [{
                    "tgId": 1,
                    "testType": "AFT",
@@ -4375,7 +4375,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
        "vsId": 1564,
        "algorithm": "ACVP-TDES-ECB",
-       "revision": "1.0.0",
+       "revision": "1.0",
        "testGroups": [{
            "tgId": 1,
            "direction": "encrypt",
@@ -4435,7 +4435,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
        "vsId": 1564,
        "algorithm": "ACVP-TDES-CFB1",
-       "revision": "1.0.0",
+       "revision": "1.0",
        "testGroups": [{
                "tgId": 1,
                "direction": "encrypt",
@@ -4543,7 +4543,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    },{
        "vsId": 1564,
        "algorithm": "ACVP-TDES-ECB",
-       "revision": "1.0.0",
+       "revision": "1.0",
        "testGroups": [{
            "tgId": 1,
            "direction": "encrypt",

--- a/artifacts/draft-celi-acvp-block-ciph-00.txt
+++ b/artifacts/draft-celi-acvp-block-ciph-00.txt
@@ -9,7 +9,7 @@ Expires: August 5, 2019
 
 
         ACVP Symmetric Block Cipher Algorithm JSON Specification
-                        draft-celi-block-ciph-00
+                      draft-celi-block-ciph-00-1.0
 
 Abstract
 

--- a/artifacts/draft-celi-acvp-sha-00.html
+++ b/artifacts/draft-celi-acvp-sha-00.html
@@ -400,12 +400,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.8.2 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.5" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-11" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
 
@@ -426,7 +426,7 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">November 2018</td>
+<td class="right">November 1, 2018</td>
 </tr>
 <tr>
 <td class="left">Expires: May 5, 2019</td>
@@ -597,6 +597,11 @@ MD[0] = MD[1] = MD[2] = SEED
 <td class="left">string</td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">string</td>
+</tr>
+<tr>
 <td class="left">messageLength</td>
 <td class="left">The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</td>
 <td class="left">domain</td>
@@ -632,6 +637,11 @@ MD[0] = MD[1] = MD[2] = SEED
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The hash algorithm and mode used for the test vectors. See <a href="#supported_algs" class="xref">Section 2</a> for possible values.</td>
+<td class="left">string</td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">string</td>
 </tr>
 <tr>
@@ -841,6 +851,7 @@ MD[0] = MD[1] = MD[2] = SEED
 					
 {
 	"algorithm": "SHA2-256",
+	"revision": "1.0",
 	"messageLength": [{"min": 0, "max": 65535, "increment": 1}]
 }
 
@@ -855,6 +866,7 @@ MD[0] = MD[1] = MD[2] = SEED
       { "acvVersion": &lt;acvp-version&gt; },
       { "vsId": 1564,
   	"algorithm": "SHA2-512/224",
+		"revision": "1.0",
   	"testGroups": [
   	{
   		"testType": "AFT",
@@ -880,6 +892,7 @@ MD[0] = MD[1] = MD[2] = SEED
       { "acvVersion": &lt;acvp-version&gt; },
       { "vsId": 1564,
   	"algorithm": "SHA2-256",
+		"revision": "1.0",
   	"testGroups": [
     {
       	"testType": "AFT",
@@ -905,6 +918,7 @@ MD[0] = MD[1] = MD[2] = SEED
   { "acvVersion": &lt;acvp-version&gt; },
   { "vsId": 1564,
     "algorithm": "SHA-1",
+		"revision": "1.0",
     "testGroups": [
     {
         "testType": "MCT",

--- a/artifacts/draft-celi-acvp-sha-00.html
+++ b/artifacts/draft-celi-acvp-sha-00.html
@@ -404,7 +404,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
@@ -438,7 +438,7 @@
   </table>
 
   <p class="title">ACVP Secure Hash Algorithm (SHA) JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subsha-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subsha-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification.</p>

--- a/artifacts/draft-celi-acvp-sha-00.txt
+++ b/artifacts/draft-celi-acvp-sha-00.txt
@@ -4,7 +4,7 @@
 
 TBD                                                         C. Celi, Ed.
 Internet-Draft            National Institute of Standards and Technology
-Intended status: Informational                             November 2018
+Intended status: Informational                          November 1, 2018
 Expires: May 5, 2019
 
 
@@ -82,8 +82,8 @@ Table of Contents
      6.2.  Informative References  . . . . . . . . . . . . . . . . .   9
    Appendix A.  Example Secure Hash Capabilities JSON Object . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  10
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  11
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  12
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  12
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
 
 1.  Introduction
 
@@ -253,6 +253,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
    +---------------+------------------------------------------+--------+
    | algorithm     | The hash algorithm and mode to be        | string |
    |               | validated.                               |        |
+   | revision      | The algorithm testing revision to use.   | string |
    | messageLength | The message lengths in bits supported by | domain |
    |               | the IUT. Minimum allowed is 0, maximum   |        |
    |               | allowed is 65535.                        |        |
@@ -272,8 +273,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
    require the client to download and process multiple test vector sets.
    Each test vector set SHALL represent an individual cryptographic
    algorithm, such as SHA-1, SHA2-256, SHA2-512, etc.  This section
-   describes the JSON schema for a test vector set used with hash
-   algorithms.
+
 
 
 
@@ -281,6 +281,9 @@ Celi                       Expires May 5, 2019                  [Page 5]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
+
+   describes the JSON schema for a test vector set used with hash
+   algorithms.
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta-data for the entire vector set.  The test vector set
@@ -298,6 +301,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    | algorithm  | The hash algorithm and mode used for  | string       |
    |            | the test vectors. See Section 2 for   |              |
    |            | possible values.                      |              |
+   | revision   | The algorithm testing revision to     | string       |
+   |            | use.                                  |              |
    | testGroups | Array of test group JSON objects,     | array of     |
    |            | which are defined in Section 5.1      | testGroup    |
    |            |                                       | objects      |
@@ -315,11 +320,6 @@ Internet-Draft                Sym Alg JSON                 November 2018
    applies to all test cases within the group.  The following table
    describes the JSON elements that MAY appear from the server in the
    Test Group JSON object:
-
-
-
-
-
 
 
 
@@ -402,8 +402,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    |             | vector set                              |           |
    | testResults | Array of JSON objects that represent    | array of  |
    |             | each test vector result, which uses the | testGroup |
-   |             | same JSON schema as defined in Section  | objects   |
-   |             | 5.2                                     |           |
+   |             | same JSON schema as defined in          | objects   |
+   |             | Section 5.2                             |           |
    +-------------+-----------------------------------------+-----------+
 
                  Table 5: Vector Set Response JSON Object
@@ -517,6 +517,7 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
 
    {
            "algorithm": "SHA2-256",
+           "revision": "1.0",
            "messageLength": [{"min": 0, "max": 65535, "increment": 1}]
    }
 
@@ -534,6 +535,7 @@ Appendix B.  Example Test Vectors JSON Object
          { "acvVersion": <acvp-version> },
          { "vsId": 1564,
            "algorithm": "SHA2-512/224",
+                   "revision": "1.0",
            "testGroups": [
            {
                    "testType": "AFT",
@@ -552,8 +554,6 @@ Appendix B.  Example Test Vectors JSON Object
         }]
 
 
-   The following is another example JSON object for secure hash test
-   vectors sent from the ACVP server to the crypto module.
 
 
 
@@ -562,10 +562,15 @@ Celi                       Expires May 5, 2019                 [Page 10]
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   The following is another example JSON object for secure hash test
+   vectors sent from the ACVP server to the crypto module.
+
+
    [
       { "acvVersion": <acvp-version> },
       { "vsId": 1564,
         "algorithm": "SHA2-256",
+                "revision": "1.0",
         "testGroups": [
     {
         "testType": "AFT",
@@ -592,6 +597,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
      { "acvVersion": <acvp-version> },
      { "vsId": 1564,
        "algorithm": "SHA-1",
+                   "revision": "1.0",
        "testGroups": [
        {
            "testType": "MCT",
@@ -605,17 +611,17 @@ Internet-Draft                Sym Alg JSON                 November 2018
      }]
 
 
-Appendix C.  Example Test Results JSON Object
-
-   The following is a example JSON object for secure hash test results
-   sent from the crypto module to the ACVP server.
-
-
 
 
 Celi                       Expires May 5, 2019                 [Page 11]
 
 Internet-Draft                Sym Alg JSON                 November 2018
+
+
+Appendix C.  Example Test Results JSON Object
+
+   The following is a example JSON object for secure hash test results
+   sent from the crypto module to the ACVP server.
 
 
 [
@@ -661,18 +667,14 @@ Internet-Draft                Sym Alg JSON                 November 2018
   }
 
 
-Author's Address
-
-
-
-
-
 
 
 Celi                       Expires May 5, 2019                 [Page 12]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
+
+Author's Address
 
    Christopher Celi (editor)
    National Institute of Standards and Technology
@@ -681,8 +683,6 @@ Internet-Draft                Sym Alg JSON                 November 2018
    USA
 
    Email: christopher.celi@nist.gov
-
-
 
 
 

--- a/artifacts/draft-celi-acvp-sha-00.txt
+++ b/artifacts/draft-celi-acvp-sha-00.txt
@@ -9,7 +9,7 @@ Expires: May 5, 2019
 
 
           ACVP Secure Hash Algorithm (SHA) JSON Specification
-                       draft-ietf-acvp-subsha-0.5
+                       draft-ietf-acvp-subsha-1.0
 
 Abstract
 

--- a/artifacts/draft-celi-acvp-sha3-00.html
+++ b/artifacts/draft-celi-acvp-sha3-00.html
@@ -584,6 +584,11 @@
 <td class="left">string</td>
 </tr>
 <tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">string</td>
+</tr>
+<tr>
 <td class="left">inBit</td>
 <td class="left">Implementation does accept bit-oriented messages</td>
 <td class="left">boolean</td>
@@ -690,6 +695,11 @@
 <tr>
 <td class="left">algorithm</td>
 <td class="left">The hash algorithm and mode used for the test vectors.  See <a href="#supported_algs" class="xref">Section 2</a> for possible values.</td>
+<td class="left">string</td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
 <td class="left">string</td>
 </tr>
 <tr>
@@ -897,6 +907,7 @@
 					
 {
 	"algorithm": "SHA3-256",
+	"revision": "1.0",
 	"inBit": true,
 	"inEmpty": true
 }
@@ -907,6 +918,7 @@
 					
 {
 	"algorithm": "SHAKE-128",
+	"revision": "1.0",
 	"inBit": true,
 	"inEmpty": true,
 	"outBit": true,
@@ -929,6 +941,7 @@
     { 
         "vsId": 1564,
   	    "algorithm": "SHA3-512",
+        "revision": "1.0",
   	    "testGroups": [
   	    {
             "tgId": 1,
@@ -956,6 +969,7 @@
     { 
         "vsId": 1564,
         "algorithm": "SHA3-256",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 1,
@@ -983,6 +997,7 @@
     { 
         "vsId": 1564,
         "algorithm": "SHA3-384",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 2,
@@ -1060,6 +1075,7 @@
     { 
         "vsId": 1564,
         "algorithm": "SHAKE-128",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 1,

--- a/artifacts/draft-celi-acvp-sha3-00.html
+++ b/artifacts/draft-celi-acvp-sha3-00.html
@@ -405,7 +405,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha3-0.5" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha3-1.0" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA3 and SHAKE with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA3 and SHAKE with the ACVP specification." />
@@ -439,7 +439,7 @@
   </table>
 
   <p class="title">ACVP SHA3 and SHAKE JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subsha3-0.5</span></p>
+  <span class="filename">draft-ietf-acvp-subsha3-1.0</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SHA3 and SHAKE with the ACVP specification.</p>

--- a/artifacts/draft-celi-acvp-sha3-00.txt
+++ b/artifacts/draft-celi-acvp-sha3-00.txt
@@ -72,10 +72,10 @@ Table of Contents
      4.1.  SHA3 and SHAKE Algorithm Capabilities Registration  . . .   4
    5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   5
      5.1.  Test Groups . . . . . . . . . . . . . . . . . . . . . . .   6
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   6
+     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .   7
      5.3.  Test Vector Responses . . . . . . . . . . . . . . . . . .   7
      5.4.  Acknowledgements  . . . . . . . . . . . . . . . . . . . .   8
-     5.5.  IANA Considerations . . . . . . . . . . . . . . . . . . .   8
+     5.5.  IANA Considerations . . . . . . . . . . . . . . . . . . .   9
      5.6.  Security Considerations . . . . . . . . . . . . . . . . .   9
    6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
      6.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
@@ -206,6 +206,7 @@ Internet-Draft                  SHA3 JSON                  November 2018
    +--------------+------------------------------------------+---------+
    | algorithm    | The hash algorithm and mode to be        | string  |
    |              | validated.                               |         |
+   | revision     | The algorithm testing revision to use.   | string  |
    | inBit        | Implementation does accept bit-oriented  | boolean |
    |              | messages                                 |         |
    | inEmpty      | Implementation does accept null (zero-   | boolean |
@@ -215,7 +216,6 @@ Internet-Draft                  SHA3 JSON                  November 2018
    +--------------+------------------------------------------+---------+
 
         Table 1: SHA3 and SHAKE Algorithm Capabilities JSON Values
-
 
 
 
@@ -291,6 +291,7 @@ Internet-Draft                  SHA3 JSON                  November 2018
    | algorithm  | The hash algorithm and mode used for   | string      |
    |            | the test vectors.  See Section 2 for   |             |
    |            | possible values.                       |             |
+   | revision   | The algorithm testing revision to use. | string      |
    | testGroups | Array of test group JSON objects,      | array of    |
    |            | which are defined in Section 5.1       | testGroup   |
    |            |                                        | objects     |
@@ -325,10 +326,9 @@ Internet-Draft                  SHA3 JSON                  November 2018
 
                       Table 4: Test Group JSON Object
 
-5.2.  Test Case JSON Schema
 
-   Each test group SHALL contain an array of one or more test cases.
-   Each test case is a JSON object that represents a single case to be
+
+
 
 
 
@@ -338,6 +338,10 @@ Celi                       Expires May 5, 2019                  [Page 6]
 Internet-Draft                  SHA3 JSON                  November 2018
 
 
+5.2.  Test Case JSON Schema
+
+   Each test group SHALL contain an array of one or more test cases.
+   Each test case is a JSON object that represents a single case to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each test case.
 
@@ -381,10 +385,6 @@ Internet-Draft                  SHA3 JSON                  November 2018
 
                  Table 6: Vector Set Response JSON Object
 
-   The testGroup Response section is used to organize the ACVP client
-   response in a similar manner to how it receives vectors.  Several
-   algorithms SHALL require the client to send back group level
-   properties in its response.  This structure helps accommodate that.
 
 
 
@@ -393,6 +393,11 @@ Celi                       Expires May 5, 2019                  [Page 7]
 
 Internet-Draft                  SHA3 JSON                  November 2018
 
+
+   The testGroup Response section is used to organize the ACVP client
+   response in a similar manner to how it receives vectors.  Several
+   algorithms SHALL require the client to send back group level
+   properties in its response.  This structure helps accommodate that.
 
    +---------+------------------------------------+--------------------+
    | JSON    | Description                        | JSON type          |
@@ -434,11 +439,6 @@ Internet-Draft                  SHA3 JSON                  November 2018
 
    TBD...
 
-5.5.  IANA Considerations
-
-   This memo include requests to IANA to join draft XXX.
-
-
 
 
 
@@ -449,6 +449,10 @@ Celi                       Expires May 5, 2019                  [Page 8]
 
 Internet-Draft                  SHA3 JSON                  November 2018
 
+
+5.5.  IANA Considerations
+
+   This memo include requests to IANA to join draft XXX.
 
 5.6.  Security Considerations
 
@@ -478,6 +482,7 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
 
    {
            "algorithm": "SHA3-256",
+           "revision": "1.0",
            "inBit": true,
            "inEmpty": true
    }
@@ -496,11 +501,6 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
 
 
 
-
-
-
-
-
 Celi                       Expires May 5, 2019                  [Page 9]
 
 Internet-Draft                  SHA3 JSON                  November 2018
@@ -508,6 +508,7 @@ Internet-Draft                  SHA3 JSON                  November 2018
 
    {
            "algorithm": "SHAKE-128",
+           "revision": "1.0",
            "inBit": true,
            "inEmpty": true,
            "outBit": true,
@@ -533,6 +534,7 @@ Appendix B.  Example Test Vectors JSON Object
        {
            "vsId": 1564,
                "algorithm": "SHA3-512",
+           "revision": "1.0",
                "testGroups": [
                {
                "tgId": 1,
@@ -552,8 +554,6 @@ Appendix B.  Example Test Vectors JSON Object
        }
 
 
-   The following is another example JSON object for secure hash test
-   vectors sent from the ACVP server to the crypto module.
 
 
 
@@ -562,11 +562,16 @@ Celi                       Expires May 5, 2019                 [Page 10]
 Internet-Draft                  SHA3 JSON                  November 2018
 
 
+   The following is another example JSON object for secure hash test
+   vectors sent from the ACVP server to the crypto module.
+
+
 [
     { "acvVersion": <acvp-version> },
     {
         "vsId": 1564,
         "algorithm": "SHA3-256",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 1,
@@ -590,11 +595,35 @@ Internet-Draft                  SHA3 JSON                  November 2018
    Test test vectors sent from the ACVP server to the crypto module.
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 11]
+
+Internet-Draft                  SHA3 JSON                  November 2018
+
+
 [
     { "acvVersion": <acvp-version> },
     {
         "vsId": 1564,
         "algorithm": "SHA3-384",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 2,
@@ -607,15 +636,6 @@ Internet-Draft                  SHA3 JSON                  November 2018
             }]
         }]
     }
-
-
-
-
-
-
-Celi                       Expires May 5, 2019                 [Page 11]
-
-Internet-Draft                  SHA3 JSON                  November 2018
 
 
 Appendix C.  Example Test Results JSON Object
@@ -644,26 +664,6 @@ Appendix C.  Example Test Results JSON Object
    The following is a example JSON object for secure hash Monte Carlo
    Test results sent from the crypto module to the ACVP server.  Reduced
    to 2 iterations for brevity.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -735,6 +735,7 @@ Internet-Draft                  SHA3 JSON                  November 2018
        {
            "vsId": 1564,
            "algorithm": "SHAKE-128",
+           "revision": "1.0",
            "testGroups": [
            {
                "tgId": 1,
@@ -758,7 +759,6 @@ Internet-Draft                  SHA3 JSON                  November 2018
 
    The following is a example JSON object for the SHAKE Variable Output
    Test results sent from the crypto module to the ACVP server.
-
 
 
 

--- a/artifacts/draft-celi-acvp-sha3-00.txt
+++ b/artifacts/draft-celi-acvp-sha3-00.txt
@@ -9,7 +9,7 @@ Expires: May 5, 2019
 
 
                  ACVP SHA3 and SHAKE JSON Specification
-                      draft-ietf-acvp-subsha3-0.5
+                      draft-ietf-acvp-subsha3-1.0
 
 Abstract
 

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subdrbg-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subdrbg-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_drbg.xml
+++ b/src/acvp_sub_drbg.xml
@@ -591,6 +591,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>1.0</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>derFuncEnabled</c>
           <c>derivation function option, see the notes below            <xref target="caps_table"/>
  for more information.</c>
@@ -788,6 +798,13 @@
         <c/>
         <c/>
         <c/>
+
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c/>
+          <c/>
+          <c/>
 
         <c>testGroups</c>
         <c>Array of test group JSON objects, which are defined in          <xref target="tgjs"/>
@@ -1186,6 +1203,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
         <artwork><![CDATA[
 {
   "algorithm": "ctrDRBG",
+  "revision": "1.0",
   "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "TDES", "valValue": "5678"}],
   "predResistanceEnabled": [
     true,
@@ -1339,6 +1357,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
         <artwork><![CDATA[
         {
   "algorithm": "hashDRBG",
+  "revision": "1.0",
   "prereqVals": [{"algorithm": "AES", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
   "predResistanceEnabled": [
     true,
@@ -1479,6 +1498,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 { "vectorSetId": 1133,
                   "algorithm": "ctrDRBG",
                   "mode": "3KeyTDEA",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1535,6 +1555,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 { "vectorSetId": 1146,
                   "algorithm": "hmacDRBG",
                   "mode": "AES-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1589,6 +1610,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 { "vectorSetId": 1156,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1643,6 +1665,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 { "vectorSetId": 1157,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -1703,6 +1726,7 @@ the bit lengths the supported values shall be specified explicitly. </t>
                 { "vectorSetId": 1167,
                   "algorithm": "hashDRBG",
                   "mode": "SHA2-256",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -232,6 +232,11 @@
                     <c>value</c>
                     <c>"pqgGen", "pqgVer", "keyGen", "sigGen", "sigVer"</c>
                     <c>No</c>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
                     <c>prereqVals</c>
                     <c>prerequistie algorithm validations</c>
                     <c>array of prereqAlgVal objects</c>
@@ -442,6 +447,9 @@
                 <c>value</c>
                 <c>mode</c>
                 <c>The DSA mode used for the test vectors.</c>
+                <c>value</c>
+                <c>revision</c>
+                <c>The algorithm testing revision to use.</c>
                 <c>value</c>
                 <c>testGroups</c>
                 <c>Array of test group JSON objects, which are defined in                                                                               
@@ -724,6 +732,7 @@
 [{
 		"algorithm": "DSA",
 		"mode": "pqgGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -794,6 +803,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "pqgVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -885,6 +895,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "keyGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -911,6 +922,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "sigGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -964,6 +976,7 @@
 	{
 		"algorithm": "DSA",
 		"mode": "sigVer",
+        "revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -1046,6 +1059,7 @@
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "pqgGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -1186,6 +1200,8 @@
     {
         "vsId": 1564,
         "algorithm": "DSA",
+        "mode": "pqgVer",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,
@@ -1331,6 +1347,7 @@
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "keyGen",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,
@@ -1392,6 +1409,7 @@
         "vsId": 1564,
         "algorithm": "DSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,
@@ -1455,6 +1473,8 @@
     {
         "vsId": 1564,
         "algorithm": "DSA",
+        "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
           {
             "tgId": 1,

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -30,7 +30,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subdsa-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subdsa-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -29,7 +29,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subecdsa-0.3" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subecdsa-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -226,6 +226,11 @@
                     <c>value</c>
                     <c>"keyGen", "keyVer", "sigGen", or "sigVer"</c>
                     <c>No</c>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
                     <c>prereqVals</c>
                     <c>prerequistie algorithm validations</c>
                     <c>array of prereqAlgVal objects</c>
@@ -377,6 +382,9 @@
                 <c>value</c>
                 <c>mode</c>
                 <c>The ECDSA mode used for the test vectors</c>
+                <c>value</c>
+                <c>revision</c>
+                <c>The algorithm testing revision to use.</c>
                 <c>value</c>
                 <c>testGroups</c>
                 <c>Array of test group JSON objects, which are defined in 																																	
@@ -563,6 +571,7 @@
 [{
 		"algorithm": "ECDSA",
 		"mode": "keyGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -594,6 +603,7 @@
 	{
 		"algorithm": "ECDSA",
 		"mode": "keyVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -624,6 +634,7 @@
 	{
 		"algorithm": "ECDSA",
 		"mode": "sigGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -661,6 +672,7 @@
 	{
 		"algorithm": "ECDSA",
 		"mode": "sigVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -718,6 +730,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "keyGen",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -777,6 +790,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "keyVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -835,6 +849,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -896,6 +911,7 @@
         "vsId": 1564,
         "algorithm": "ECDSA",
         "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,

--- a/src/acvp_sub_eddsa.xml
+++ b/src/acvp_sub_eddsa.xml
@@ -208,6 +208,11 @@
                     <c>value</c>
                     <c>"keyGen", "keyVer", "sigGen", or "sigVer"</c>
                     <c>No</c>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
                     <c>prereqVals</c>
                     <c>prerequistie algorithm validations</c>
                     <c>array of prereqAlgVal objects</c>
@@ -357,6 +362,9 @@
                 <c>value</c>
                 <c>mode</c>
                 <c>The EDDSA mode used for the test vectors</c>
+                <c>value</c>
+                <c>revision</c>
+                <c>The algorithm testing revision to use.</c>
                 <c>value</c>
                 <c>testGroups</c>
                 <c>Array of test group JSON objects, which are defined in 																																	
@@ -527,6 +535,7 @@
 [{
 		"algorithm": "EDDSA",
 		"mode": "keyGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -548,6 +557,7 @@
 	{
 		"algorithm": "EDDSA",
 		"mode": "keyVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -565,6 +575,7 @@
 	{
 		"algorithm": "EDDSA",
 		"mode": "sigGen",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -584,6 +595,7 @@
 	{
 		"algorithm": "EDDSA",
 		"mode": "sigVer",
+		"revision": "1.0",
 		"prereqVals": [{
 				"algorithm": "SHA",
 				"valValue": "123456"
@@ -621,6 +633,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "keyGen",
+        "revision": "1.0",
         "testGroups": [
             {
                 "curve": "ED-25519",
@@ -679,6 +692,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "keyVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -737,6 +751,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "sigGen",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,
@@ -835,6 +850,7 @@
         "vsId": 1564,
         "algorithm": "EDDSA",
         "mode": "sigVer",
+        "revision": "1.0",
         "testGroups": [
             {
 				"tgId": 1,

--- a/src/acvp_sub_eddsa.xml
+++ b/src/acvp_sub_eddsa.xml
@@ -29,7 +29,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subeddsa-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subeddsa-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"
@@ -627,7 +627,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -657,7 +657,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -686,7 +686,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -717,7 +717,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -745,7 +745,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -797,7 +797,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -844,7 +844,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
@@ -878,7 +878,7 @@
                         <![CDATA[
 [
     {
-        "acvVersion": "0.5"
+        "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,

--- a/src/acvp_sub_kas_ecc.xml
+++ b/src/acvp_sub_kas_ecc.xml
@@ -28,7 +28,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkasecc-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkasecc-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kas_ecc.xml
+++ b/src/acvp_sub_kas_ecc.xml
@@ -352,6 +352,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>Prerequisite algorithm validations</c>
                     <c>array of prereqAlgVal objects</c>
@@ -946,6 +956,7 @@
 
 {
 	"algorithm": "KAS-ECC",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "ECDSA",
 			"valValue": "123456"
@@ -1013,6 +1024,7 @@
 {
 	"algorithm": "KAS-ECC",
 	"mode": "Component",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "ECDSA",
 			"valValue": "123456"
@@ -2368,6 +2380,12 @@
                 <c/>
                 <c/>
                 <c/>
+                <c>revision</c>
+                <c>The algorithm testing revision to use.</c>
+                <c>value</c>
+                <c/>
+                <c/>
+                <c/>
                 <c>type</c>
                 <c>Type of operation supported</c>
                 <c>value</c>
@@ -2840,6 +2858,7 @@
 	{
 		"vsId": 1564,
 		"algorithm": "KAS-ECC",
+		"revision": "1.0",
 		"testGroups": [
 			{
                 "tgId": 1,
@@ -2967,6 +2986,7 @@
 		"vsId": 1565,
 		"algorithm": "KAS-ECC",
 		"mode": "Component",
+		"revision": "1.0",
 		"testGroups": [{
                 "tgId": 1,
 				"scheme": "ephemeralUnified",
@@ -3236,6 +3256,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>Prerequisite algorithm validations</c>
                     <c>array of prereqAlgVal objects</c>
@@ -3270,6 +3300,7 @@
 {
 	"algorithm": "KAS-ECC",
 	"mode": "CDH-Component",
+	"revision": "1.0",
 	"prereqVals": [{
 		"algorithm": "ECDSA",
 		"valValue": "123456"
@@ -3305,6 +3336,16 @@
                     <c>The algorithm mode under test</c>
                     <c>value</c>
                     <c>CDH-Component</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
                     <c>No</c>
                     <c/>
                     <c/>
@@ -3439,6 +3480,7 @@
 		"vsId": 1750,
 		"algorithm": "KAS-ECC",
 		"mode": "CDH-Component",
+		"revision": "1.0",
 		"testGroups": [{
 				"tgId": 1,
 				"testType": "AFT",

--- a/src/acvp_sub_kas_ffc.xml
+++ b/src/acvp_sub_kas_ffc.xml
@@ -353,6 +353,16 @@
 					<c/>
 					<c/>
 					<c/>
+					<c>revision</c>
+					<c>The algorithm testing revision to use.</c>
+					<c>value</c>
+					<c>"1.0"</c>
+					<c>No</c>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
+					<c/>
 					<c>prereqVals</c>
 					<c>Prerequisite algorithm validations</c>
 					<c>array of prereqAlgVal objects</c>
@@ -868,6 +878,7 @@
 
 {
 	"algorithm": "KAS-FFC",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "DSA",
 			"valValue": "123456"
@@ -995,6 +1006,7 @@
 {
 	"algorithm": "KAS-FFC",
 	"mode": "Component",
+	"revision": "1.0",
 	"prereqVals": [{
 			"algorithm": "DSA",
 			"valValue": "123456"
@@ -2359,6 +2371,12 @@
 				<c/>
 				<c/>
 				<c/>
+				<c>revision</c>
+				<c>The algorithm testing revision to use.</c>
+				<c>value</c>
+				<c/>
+				<c/>
+				<c/>
 				<c>type</c>
 				<c>Type of operation supported</c>
 				<c>value</c>
@@ -2815,6 +2833,7 @@
 	{
 		"vsId": 1564,
 		"algorithm": "KAS-FFC",
+		"revision": "1.0",
 		"testGroups": [
 			{
 				"tgId": 1,
@@ -3489,6 +3508,7 @@
 		"vsId": 1564,
 		"algorithm": "KAS-FFC",
 		"mode": "Component",
+		"revision": "1.0",
 		"testGroups": [{
 				"tgId": 1,
 				"scheme": "dhEphem",

--- a/src/acvp_sub_kas_ffc.xml
+++ b/src/acvp_sub_kas_ffc.xml
@@ -28,7 +28,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkasffc-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkasffc-1.0" ipr="trust200902">
 	<!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf108.xml
+++ b/src/acvp_sub_kdf108.xml
@@ -154,6 +154,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>prerequistie algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -299,6 +309,12 @@
         <c>See                               
           <xref target="supported_algs" />
         </c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>The algorithm testing revision to use.</c>
         <c>value</c>
         <c/>
         <c/>
@@ -542,6 +558,7 @@
           <![CDATA[
 {
     "algorithm": "KDF",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -673,6 +690,7 @@
 	{
 		"vsId": 1564,
 		"algorithm": "counterMode",
+		"revision": "1.0",
 		"testGroups": [{
 			"tgId": 1,
 			"kdfMode": "counter",

--- a/src/acvp_sub_kdf108.xml
+++ b/src/acvp_sub_kdf108.xml
@@ -28,7 +28,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf108-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf108-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_ikev1.xml
+++ b/src/acvp_sub_kdf135_ikev1.xml
@@ -163,6 +163,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>Prerequisite algorithm validations</c>
                     <c>array of prereqAlgVal objects</c>
@@ -282,6 +292,12 @@
                 <c/>
                 <c>mode</c>
                 <c>"ikev1"</c>
+                <c>value</c>
+                <c/>
+                <c/>
+                <c/>
+                <c>revision</c>
+                <c>"1.0"</c>
                 <c>value</c>
                 <c/>
                 <c/>
@@ -556,6 +572,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ikev1",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -683,7 +700,9 @@
 	},
 	{
 		"vsId": 1564,
-		"algorithm": "IKEv1",
+		"algorithm": "kdf-components",
+		"mode": "ikev1",
+		"revision": "1.0",
 		"testGroups": [{
 				"tgId": 1,
 				"authenticationMethod": "dsa",

--- a/src/acvp_sub_kdf135_ikev1.xml
+++ b/src/acvp_sub_kdf135_ikev1.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-ikev1-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-ikev1-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_ikev2.xml
+++ b/src/acvp_sub_kdf135_ikev2.xml
@@ -28,7 +28,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-ikev2-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-ikev2-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_ikev2.xml
+++ b/src/acvp_sub_kdf135_ikev2.xml
@@ -164,6 +164,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -273,6 +283,12 @@
         <c/>
         <c>mode</c>
         <c>"ikev2"</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -558,6 +574,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ikev2",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -621,7 +638,9 @@
     },
     {
         "vsId": 1564,
-        "algorithm": "IKEv2",
+        "algorithm": "kdf-components",
+        "mode": "ikev2",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/src/acvp_sub_kdf135_snmp.xml
+++ b/src/acvp_sub_kdf135_snmp.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-snmp-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-snmp-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_snmp.xml
+++ b/src/acvp_sub_kdf135_snmp.xml
@@ -164,6 +164,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -222,6 +232,12 @@
         <c/>
         <c>mode</c>
         <c>"snmp"</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -417,6 +433,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "snmp",
+    "revision" "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -452,6 +469,7 @@
 		"vsId": 1564,
 		"algorithm": "kdf-components",
 		"mode": "snmp",
+    "revision": "1.0",
 		"testGroups": [{
 			"tgId": 1,
 			"engineId": "12345678912345678900",

--- a/src/acvp_sub_kdf135_srtp.xml
+++ b/src/acvp_sub_kdf135_srtp.xml
@@ -164,6 +164,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -232,6 +242,12 @@
         <c/>
         <c>mode</c>
         <c>"srtp"</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -486,6 +502,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "srtp",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "AES",
@@ -540,7 +557,9 @@
     },
     {
         "vsId": 1564,
-        "algorithm": "SRTP",
+        "algorithm": "kdf-components",
+        "mode": "srtp",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/src/acvp_sub_kdf135_srtp.xml
+++ b/src/acvp_sub_kdf135_srtp.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-srtp-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-srtp-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_ssh.xml
+++ b/src/acvp_sub_kdf135_ssh.xml
@@ -163,6 +163,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -221,6 +231,12 @@
         <c/>
         <c>mode</c>
         <c>"ssh"</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -466,6 +482,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ssh",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm":"TDES",
@@ -511,6 +528,7 @@
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "ssh",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/src/acvp_sub_kdf135_ssh.xml
+++ b/src/acvp_sub_kdf135_ssh.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-ssh-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-ssh-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_tls.xml
+++ b/src/acvp_sub_kdf135_tls.xml
@@ -164,6 +164,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -222,6 +232,12 @@
         <c/>
         <c>mode</c>
         <c>"tls"</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -474,6 +490,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "tls",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "HMAC",
@@ -511,6 +528,7 @@
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "tls",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/src/acvp_sub_kdf135_tls.xml
+++ b/src/acvp_sub_kdf135_tls.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135--tls-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135--tls-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_tpm.xml
+++ b/src/acvp_sub_kdf135_tpm.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-tpm-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-tpm-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_kdf135_tpm.xml
+++ b/src/acvp_sub_kdf135_tpm.xml
@@ -189,6 +189,17 @@
           <ttcol align="left">Optional</ttcol>
 
           <c>algorithm</c>
+          <c>The algorithm to be validated</c>
+          <c>value</c>
+          <c>kdf-components</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+
+          <c>algorithm</c>
           <c>The KDF to be validated</c>
           <c>value</c>
           <c>See            <xref target="supported_algs" />
@@ -260,7 +271,21 @@
         <c/>
 
         <c>algorithm</c>
-        <c>TPM</c>
+        <c>kdf-components</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+
+        <c>mode</c>
+        <c>tpm</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -483,7 +508,9 @@
 
 
             {
-                "algorithm": "TPM",
+                "algorithm": "kdf-components",
+                "mode": "tpm",
+                "revision": "1.0",
                 "prereqVals" : [{"algorithm" : "HMAC", "valValue" : "123456"},
 		                {"algorithm" : "SHA", "valValue" : "123456"}]
             }
@@ -499,7 +526,9 @@
 	},
 	{
 		"vsId": 1564,
-		"algorithm": "TPM",
+		"algorithm": "kdf-components",
+		"mode": "tpm",
+		"revision": "1.0",
 		"testGroups": [{
 			"tgId": 1,
 			"tests": [{

--- a/src/acvp_sub_kdf135_x963.xml
+++ b/src/acvp_sub_kdf135_x963.xml
@@ -164,6 +164,16 @@
           <c/>
           <c/>
           <c/>
+          <c>revision</c>
+          <c>The algorithm testing revision to use.</c>
+          <c>value</c>
+          <c>"1.0"</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
           <c>prereqVals</c>
           <c>Prerequisite algorithm validations</c>
           <c>array of prereqAlgVal objects</c>
@@ -242,6 +252,12 @@
         <c/>
         <c>mode</c>
         <c>"ansix9.63"</c>
+        <c>value</c>
+        <c/>
+        <c/>
+        <c/>
+        <c>revision</c>
+        <c>"1.0"</c>
         <c>value</c>
         <c/>
         <c/>
@@ -463,6 +479,7 @@
 {
     "algorithm": "kdf-components",
     "mode": "ansix9.63",
+    "revision": "1.0",
     "prereqVals": [
         {
             "algorithm": "SHA",
@@ -505,6 +522,7 @@
         "vsId": 1564,
         "algorithm": "kdf-components",
         "mode": "ansix9.63",
+        "revision": "1.0",
         "testGroups": [
             {
                 "tgId": 1,

--- a/src/acvp_sub_kdf135_x963.xml
+++ b/src/acvp_sub_kdf135_x963.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subkdf135-ansx963-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subkdf135-ansx963-1.0" ipr="trust200902">
   <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -275,6 +275,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
                         examples </c>
@@ -376,6 +386,7 @@
                             <![CDATA[
 {
   "algorithm": "CMAC-AES",
+  "revision": "1.0",
   "capabilities": [
     {
       "direction": "gen",
@@ -533,6 +544,12 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>testGroups</c>
                     <c>Array of test group JSON objects, which are defined in <xref
                             target="cmac_aes_tgjs"/>
@@ -659,6 +676,7 @@
 {
 	"vsId": 1,
 	"algorithm": "CMAC-AES",
+	"revision": "1.0",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -942,6 +960,7 @@
 {
 	"vsId": 1,
     "algorithm": "CMAC",
+    "revision": "1.0",
     "testGroups": [{
 			"tgId": 4,
 			"tests": [{
@@ -1092,6 +1111,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
                         examples </c>
@@ -1196,6 +1225,7 @@
                             <![CDATA[
 {
   "algorithm": "CMAC-TDES",
+  "revision": "1.0",
   "capabilities": [
     {
       "direction": "gen",
@@ -1288,6 +1318,12 @@
                     <c/>
                     <c>algorithm</c>
                     <c>The algorithm used for the test vectors.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
                     <c>value</c>
                     <c/>
                     <c/>
@@ -1420,6 +1456,7 @@
 {
 	"vsId": 1,
 	"algorithm": "CMAC-TDES",
+	"revision": "1.0",
 	"testGroups": [{
 			"tgId": 4,
 			"testType": "AFT",
@@ -1789,6 +1826,7 @@
 {
     "vsId": 1,
 	"algorithm": "CMAC-TDES",
+	"revision": "1.0",
 	"testGroups": [{
 			"tgId": 4,
 			"tests": [{
@@ -1938,6 +1976,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>1.0</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
                         examples </c>
@@ -2075,6 +2123,7 @@
                             <![CDATA[
 {
   "algorithm": "HMAC-SHA-1",
+  "revision": "1.0",
   "keyLen": [
     {
       "min": 8,
@@ -2126,6 +2175,12 @@
                     <c>algorithm</c>
                     <c>The algorithm and mode used for the test vectors. See <xref
                             target="hmac_supported_algs"/> for possible values. </c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
                     <c>value</c>
                     <c/>
                     <c/>
@@ -2243,6 +2298,7 @@
 {
     "vsId": 1,
 	"algorithm": "HMAC-SHA-1",
+	"revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -2394,6 +2450,7 @@
 {
 	"vsId": 1,
 	"algorithm": "HMAC-SHA-1",
+	"revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"tests": [{

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -28,7 +28,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-submac-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-submac-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -29,7 +29,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subrsa-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subrsa-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -301,6 +301,16 @@
                     <c/>
                     <c/>
                     <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
                     <c>prereqVals</c>
                     <c>The prerequisite algorithm validations</c>
                     <c>array of prereqAlgVal objects - see 
@@ -1325,6 +1335,7 @@
    {
       "algorithm": "RSA",
       "mode": "keyGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "1234"}, {"algorithm": "SHA", "valValue": "5678"}],
       "infoGeneratedByServer": false,
       "pubExpMode": "random",
@@ -1381,6 +1392,7 @@
    {
     "algorithm":"RSA",
     "mode":"keyGen",
+    "revision": "1.0",
     "prereqVals":[{"algorithm":"DRBG", "valValue":"123456"}, {"algorithm":"SHA", "valValue":"7890"}],
     "pubExpMode": "fixed",
     "fixedPubExp":"010001",
@@ -1440,6 +1452,7 @@
    {
       "algorithm": "RSA",
       "mode": "keyGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "pubExpMode" : "fixed",
       "fixedPubExp" : "010001",
@@ -1503,6 +1516,7 @@
    {
       "algorithm": "RSA",
       "mode": "sigGen",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "same"}, {"algorithm": "SHA", "valValue": "same"}],
       "capabilities" : 
       [
@@ -1663,6 +1677,7 @@
    {
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "pubExpMode" : "random",
       "capabilities" : 
@@ -1824,6 +1839,7 @@
    {
       "algorithm": "RSA",
       "mode": "legacySigVer",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "capabilities" : 
       [
@@ -1879,6 +1895,7 @@
    {
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "keyFormat": "crt"
    }
 ]]>
@@ -1895,6 +1912,7 @@
    {
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "prereqVals": 
         [
             {"algorithm": "DRBG", "valValue": "123456"}, 
@@ -1919,6 +1937,7 @@
    { "vsId": 1133,
      "algorithm": "RSA",
      "mode": "keyGen",
+     "revision": "1.0",
      "infoGeneratedByServer": false,
      "pubExpMode" : "random",
      "keyFormat": "standard",
@@ -2142,6 +2161,7 @@
         "vsId" : 172,
         "algorithm" : "RSA",
         "mode" : "keyGen",
+        "revision": "1.0",
         "testGroups" : [
             {
                 "tgId": 1,
@@ -2210,6 +2230,7 @@
    { "vsId": 1163,
       "algorithm": "RSA",
       "mode": "sigGen",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2301,6 +2322,7 @@
    { "vsId": 1173,
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2420,6 +2442,7 @@
    { "vsId": 1193,
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "keyFormat": "standard",
       "testGroups" : [
              {       
@@ -2457,6 +2480,7 @@
    { "vsId": 1194,
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "testGroups" : [
              {
                  "tgId": 1,
@@ -2496,6 +2520,7 @@
                 { "vsId": 1133,
                     "algorithm": "RSA",
                     "mode": keyGen,
+                    "revision": "1.0",
                     "testGroups": [
                     {
                       "tgId": 1,
@@ -2774,6 +2799,7 @@
                 { "vsId": 1163,
                   "algorithm": "RSA",
                   "mode": "sigGen",
+                  "revision": "1.0",
                   "testGroups": [
                     {
                       "tgId": 1,
@@ -2843,6 +2869,7 @@
     { "vsId": 1173,
       "algorithm": "RSA",
       "mode": "sigVer",
+      "revision": "1.0",
       "testGroups" : [
           {
             "tgId": 1,
@@ -2903,6 +2930,7 @@
     { "vsId": 47,
       "algorithm": "RSA",
       "mode": "signaturePrimitive",
+      "revision": "1.0",
       "testGroups" : [
         {
           "tgId": 1,
@@ -2934,6 +2962,7 @@
     { "vsId": 48,
       "algorithm": "RSA",
       "mode": "decryptionPrimitive",
+      "revision": "1.0",
       "testGroups" : [
         {
           "tgId": 1,

--- a/src/draft-celi-acvp-block-ciph-00.xml
+++ b/src/draft-celi-acvp-block-ciph-00.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-celi-block-ciph-00" ipr="trust200902">
+<rfc category="info" docName="draft-celi-block-ciph-00-1.0" ipr="trust200902">
     <!-- category values: std, bcp, info, exp, and historic
      ipr values: full3667, noModification3667, noDerivatives3667
      you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/draft-celi-acvp-block-ciph-00.xml
+++ b/src/draft-celi-acvp-block-ciph-00.xml
@@ -1653,7 +1653,7 @@ POST [
     "acvVersion": <acvp-version>
 },{
         "algorithm": "ACVP-AES-GCM",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "prereqVals" : 
             [{
                 "algorithm" : "ACVP-AES-ECB",
@@ -1692,7 +1692,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-ECB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1705,7 +1705,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CBC",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1718,7 +1718,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CFB8",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1734,7 +1734,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CFB128",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1747,7 +1747,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-OFB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1760,7 +1760,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-XPN",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "prereqVals" : 
         [{
             "algorithm" : "ACVP-AES-ECB", 
@@ -1797,7 +1797,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CTR",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1813,7 +1813,7 @@ POST [
         },
         {
         "algorithm": "ACVP-AES-CCM",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "prereqVals": [
             {
                 "algorithm": "ACVP-AES-ECB",
@@ -1846,7 +1846,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-CFB1",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1859,7 +1859,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-KW",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1880,7 +1880,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-KWP",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1902,7 +1902,7 @@ POST [
     },
     {
         "algorithm": "ACVP-AES-XTS",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1921,7 +1921,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-ECB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1935,7 +1935,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CBC",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1949,7 +1949,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CBCI",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1963,7 +1963,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-OFB",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1977,7 +1977,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-OFBI",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -1991,7 +1991,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFB64",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2005,7 +2005,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFB8",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2019,7 +2019,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFB1",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2033,7 +2033,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFBP64",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2047,7 +2047,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFBP8",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2061,7 +2061,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CFBP1",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2075,7 +2075,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-CTR",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2092,7 +2092,7 @@ POST [
     },
     {
         "algorithm": "ACVP-TDES-KW",
-        "revision": "1.0.0",
+        "revision": "1.0",
         "direction": [
             "encrypt",
             "decrypt"
@@ -2122,7 +2122,7 @@ POST [
 },{
 	"vsId": 2055,
 	"algorithm": "ACVP-AES-GCM",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
             tgId": 1,
             "testType": "AFT",
@@ -2235,7 +2235,7 @@ POST [
 },{
 	"vsId": 2061,
 	"algorithm": "ACVP-AES-CCM",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -2329,7 +2329,7 @@ POST [
 },{
 	"vsId": 2057,
 	"algorithm": "ACVP-AES-CBC",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 			"tgId": 1,
 			"direction": "encrypt",
@@ -2474,7 +2474,7 @@ POST [
 },{
 	"vsId": 2056,
 	"algorithm": "ACVP-AES-ECB",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 			"tgId": 1,
             "testType": "AFT",
@@ -2620,7 +2620,7 @@ POST [
 },{
 	"vsId": 2060,
 	"algorithm": "ACVP-AES-OFB",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -2762,7 +2762,7 @@ POST [
 },{
 	"vsId": 2062,
 	"algorithm": "ACVP-AES-CFB1",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -2910,7 +2910,7 @@ POST [
 },{
 	"vsId": 2058,
 	"algorithm": "ACVP-AES-CFB8",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3053,7 +3053,7 @@ POST [
 },{
 	"vsId": 2059,
 	"algorithm": "ACVP-AES-CFB128",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3195,7 +3195,7 @@ POST [
 },{
 	"vsId": 2066,
 	"algorithm": "ACVP-AES-CTR",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"direction": "encrypt",
@@ -3297,7 +3297,7 @@ POST [
   "acvVersion": <acvp-version>
 },{
   "algorithm": "ACVP-AES-XPN",
-  "revision": "1.0.0",
+  "revision": "1.0",
   "vsId": 1,
   "testGroups": [
     {
@@ -3372,7 +3372,7 @@ POST [
 },{
 	"vsId": 2065,
 	"algorithm": "ACVP-AES-XTS",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -3458,7 +3458,7 @@ POST [
 },{
 	"vsId": 2063,
 	"algorithm": "ACVP-AES-KW",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -3540,7 +3540,7 @@ POST [
 },{
 	"vsId": 2064,
 	"algorithm": "ACVP-AES-KWP",
-    "revision": "1.0.0",
+    "revision": "1.0",
 	"testGroups": [{
 		"tgId": 1,
 		"testType": "AFT",
@@ -3626,7 +3626,7 @@ POST [
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-ECB",
-    "revision": "1.0.0",
+    "revision": "1.0",
     "testGroups": [{
         "tgId": 1,
         "direction": "encrypt",
@@ -3683,7 +3683,7 @@ POST [
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-CFB1",
-    "revision": "1.0.0",
+    "revision": "1.0",
     "testGroups": [{
             "tgId": 1,
             "direction": "encrypt",
@@ -3773,7 +3773,7 @@ POST [
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-ECB",
-    "revision": "1.0.0",
+    "revision": "1.0",
     "testGroups": [{
         "tgId": 1,
         "direction": "encrypt",

--- a/src/draft-celi-acvp-sha-00.xml
+++ b/src/draft-celi-acvp-sha-00.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subsha-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subsha-1.0" ipr="trust200902">
 	<!-- category values: std, bcp, info, exp, and historic
     	 ipr values: full3667, noModification3667, noDerivatives3667
     	 you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/draft-celi-acvp-sha-00.xml
+++ b/src/draft-celi-acvp-sha-00.xml
@@ -233,6 +233,10 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>The hash algorithm and mode to be validated.</c>
 					<c>string</c>
 
+					<c>revision</c>
+					<c>The algorithm testing revision to use.</c>
+					<c>string</c>
+
 					<c>messageLength</c>
 					<c>The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535.</c>
 					<c>domain</c>
@@ -272,6 +276,10 @@ MD[0] = MD[1] = MD[2] = SEED
 				<c>algorithm</c>
 				<c>The hash algorithm and mode used for the test vectors. See <xref target="supported_algs"/> for possible values.</c>
 				<c>string</c>
+
+        <c>revision</c>
+        <c>The algorithm testing revision to use.</c>
+        <c>string</c>
 
 				<c>testGroups</c>
 				<c>Array of test group JSON objects, which are defined in <xref target="tgjs"/></c>
@@ -465,6 +473,7 @@ MD[0] = MD[1] = MD[2] = SEED
 					<![CDATA[
 {
 	"algorithm": "SHA2-256",
+	"revision": "1.0",
 	"messageLength": [{"min": 0, "max": 65535, "increment": 1}]
 }
 ]]>
@@ -484,6 +493,7 @@ MD[0] = MD[1] = MD[2] = SEED
       { "acvVersion": <acvp-version> },
       { "vsId": 1564,
   	"algorithm": "SHA2-512/224",
+		"revision": "1.0",
   	"testGroups": [
   	{
   		"testType": "AFT",
@@ -512,6 +522,7 @@ MD[0] = MD[1] = MD[2] = SEED
       { "acvVersion": <acvp-version> },
       { "vsId": 1564,
   	"algorithm": "SHA2-256",
+		"revision": "1.0",
   	"testGroups": [
     {
       	"testType": "AFT",
@@ -540,6 +551,7 @@ MD[0] = MD[1] = MD[2] = SEED
   { "acvVersion": <acvp-version> },
   { "vsId": 1564,
     "algorithm": "SHA-1",
+		"revision": "1.0",
     "testGroups": [
     {
         "testType": "MCT",

--- a/src/draft-celi-acvp-sha3-00.xml
+++ b/src/draft-celi-acvp-sha3-00.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subsha3-0.5" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subsha3-1.0" ipr="trust200902">
 	<!-- category values: std, bcp, info, exp, and historic
     	 ipr values: full3667, noModification3667, noDerivatives3667
     	 you can add the attributes updates="NNNN" and obsoletes="NNNN"

--- a/src/draft-celi-acvp-sha3-00.xml
+++ b/src/draft-celi-acvp-sha3-00.xml
@@ -203,6 +203,10 @@
 					<c>The hash algorithm and mode to be validated.</c>
 					<c>string</c>
 
+					<c>revision</c>
+					<c>The algorithm testing revision to use.</c>
+					<c>string</c>
+
 					<c>inBit</c>
 					<c>Implementation does accept bit-oriented messages</c>
 					<c>boolean</c>
@@ -263,6 +267,10 @@
 
 				<c>algorithm</c>
 				<c>The hash algorithm and mode used for the test vectors.  See <xref target="supported_algs"/> for possible values.</c>
+				<c>string</c>
+
+				<c>revision</c>
+				<c>The algorithm testing revision to use.</c>
 				<c>string</c>
 
 				<c>testGroups</c>
@@ -450,6 +458,7 @@
 					<![CDATA[
 {
 	"algorithm": "SHA3-256",
+	"revision": "1.0",
 	"inBit": true,
 	"inEmpty": true
 }
@@ -462,6 +471,7 @@
 					<![CDATA[
 {
 	"algorithm": "SHAKE-128",
+	"revision": "1.0",
 	"inBit": true,
 	"inEmpty": true,
 	"outBit": true,
@@ -488,6 +498,7 @@
     { 
         "vsId": 1564,
   	    "algorithm": "SHA3-512",
+        "revision": "1.0",
   	    "testGroups": [
   	    {
             "tgId": 1,
@@ -517,6 +528,7 @@
     { 
         "vsId": 1564,
         "algorithm": "SHA3-256",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 1,
@@ -546,6 +558,7 @@
     { 
         "vsId": 1564,
         "algorithm": "SHA3-384",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 2,
@@ -629,6 +642,7 @@
     { 
         "vsId": 1564,
         "algorithm": "SHAKE-128",
+        "revision": "1.0",
         "testGroups": [
         {
             "tgId": 1,


### PR DESCRIPTION
A new capability registration property for each algorithm that controls which "testing revision" the vector generation/validation should utilize.

As a starting point, all algorithms will be at testing revision "1.0", but as time goes on, as testing changes, those testing revisions will theoretically change independent of the ACVP protocol.

This `revision` property will be incremented on a per algorithm basis - so "AES-GCM" could be at testing revision "1.5", while "SHA2" remains at "1.0", while still being separate from the ACVP protocol version of "2.0".