### PR TITLE
Removal of `msg` from MCT responses for sha1, sha2, sha3, and shake.

### DIFF
--- a/src/draft-celi-acvp-sha-00.xml
+++ b/src/draft-celi-acvp-sha-00.xml
@@ -405,7 +405,7 @@ MD[0] = MD[1] = MD[2] = SEED
 
 					<c>resultsArray</c>
 					<c>Array of JSON objects that represent each iteration of an MCT. Each iteration will contain the msg and md</c>
-					<c>array of objects containing msg and md</c>
+					<c>array of objects containing the md</c>
 				</texttable>
 				<t>
 					Note: The tcId MUST be included in every test case object sent between the client and the server.
@@ -603,15 +603,12 @@ MD[0] = MD[1] = MD[2] = SEED
 		"tcId": 10246,
 		"resultsArray": [
 		{
-			"msg": "4e971d7d4bb5a67b2fb51e1b6026f9e561b05779ad4783daa999812260f7623f4e971d7d4bb5a67b2fb51e1b6026f9e561b05779ad4783daa999812260f7623f4e971d7d4bb5a67b2fb51e1b6026f9e561b05779ad4783daa999812260f7623f",
 			"md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
 		},
 		{
-			"msg": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7",
 			"md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
 		},
 		{
-			"msg": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf95eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf95eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9",
 			"md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
 		}]
     }]

--- a/src/draft-celi-acvp-sha3-00.xml
+++ b/src/draft-celi-acvp-sha3-00.xml
@@ -397,7 +397,7 @@
 
                     <c>resultsArray</c>
                     <c>Array of JSON objects that represent each iteration of a Monte Carlo Test. Each iteration will contain the msg and md (and outLen for SHAKE-128 and SHAKE-256)</c>
-                    <c>array of objects containing msg, md (and potentially outLen)</c>
+                    <c>array of objects containing the md (and potentially outLen)</c>
                 </texttable>
                 <t>
                     Note: The tcId MUST be included in every test case object sent between the client and the server.
@@ -615,11 +615,9 @@
                     "tcId": 1254,
                     "resultsArray": [
                         {
-                            "msg": "DAE0367015D3019BE3B2A35B9699D22D4D0B81D453EFD32724C149EE",
                             "md": "CE2372967F76F2A6A41C3BF115BEBF6ECA3F63269579F6FC25861B64"
                         },
                         {
-                            "msg": "CE2372967F76F2A6A41C3BF115BEBF6ECA3F63269579F6FC25861B64",
                             "md": "A811B806FE4811B9CC822D7149F7BAC76EF3FA6A40863A865440E244"
                         }
                     ]


### PR DESCRIPTION
PR addresses the removal of `msg` from MCT response files within the specification.

#564, #622