### PR TITLE
Feature/sp800-106

### DIFF
--- a/artifacts/acvp_sub_dsa.html
+++ b/artifacts/acvp_sub_dsa.html
@@ -986,7 +986,7 @@
 </tr></thead>
 <tbody><tr>
 <td class="left">SP800-106</td>
-<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</td>
+<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of `"conformance": "SP800-106"`.</td>
 <td class="left">SigGen, SigVer</td>
 <td class="left">Yes</td>
 </tr></tbody>
@@ -1115,9 +1115,9 @@
 <td class="left">No</td>
 </tr>
 <tr>
-<td class="left">isMessageRandomized</td>
+<td class="left">Conformance</td>
 <td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
-<td class="left">boolean</td>
+<td class="left">"SP800-106"</td>
 <td class="left">Yes</td>
 </tr>
 <tr>
@@ -2144,7 +2144,7 @@
                 "l": 2048,
                 "n": 224,
                 "sha": "SHA-1",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,
@@ -2238,7 +2238,7 @@
             "q": "1F855467465A653D2245B7E31C910A18EF79...",
             "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
             "hashAlg": "SHA-1",
-            "isMessageRandomized": true,
+            "conformance": "SP800-106",
             "tests": [
               {
                 "tcId": 2,

--- a/artifacts/acvp_sub_dsa.html
+++ b/artifacts/acvp_sub_dsa.html
@@ -395,14 +395,15 @@
 <link href="#rfc.section.4.3.4.1" rel="Chapter" title="4.3.4.1 sigGen Full Set of Capabilities">
 <link href="#rfc.section.4.3.5" rel="Chapter" title="4.3.5 The sigVer Mode Capabilities">
 <link href="#rfc.section.4.3.5.1" rel="Chapter" title="4.3.5.1 sigVer Full Set of Capabilities">
-<link href="#rfc.section.5" rel="Chapter" title="5 Test Vectors">
-<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Test Groups JSON Schema">
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Test Case JSON Schema">
-<link href="#rfc.section.6" rel="Chapter" title="6 Test Vector Responses">
-<link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
-<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
-<link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="10 Normative References">
+<link href="#rfc.section.5" rel="Chapter" title="5 Supported DSA Conformances">
+<link href="#rfc.section.6" rel="Chapter" title="6 Test Vectors">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Test Groups JSON Schema">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Test Case JSON Schema">
+<link href="#rfc.section.7" rel="Chapter" title="7 Test Vector Responses">
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgements">
+<link href="#rfc.section.9" rel="Chapter" title="9 IANA Considerations">
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="11 Normative References">
 <link href="#rfc.appendix.A" rel="Chapter" title="A Example Capabilities JSON Object">
 <link href="#rfc.appendix.B" rel="Chapter" title="B Example Vector Set Request/Responses JSON Object">
 <link href="#rfc.appendix.B.1" rel="Chapter" title="B.1 Example Test DSA PQGGen JSON Object">
@@ -511,21 +512,23 @@
 </li>
 <ul><li>4.3.5.1.   <a href="#rfc.section.4.3.5.1">sigVer Full Set of Capabilities</a>
 </li>
-</ul></ul></ul><li>5.   <a href="#rfc.section.5">Test Vectors</a>
+</ul></ul></ul><li>5.   <a href="#rfc.section.5">Supported DSA Conformances</a>
 </li>
-<ul><li>5.1.   <a href="#rfc.section.5.1">Test Groups JSON Schema</a>
+<li>6.   <a href="#rfc.section.6">Test Vectors</a>
 </li>
-<li>5.2.   <a href="#rfc.section.5.2">Test Case JSON Schema</a>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Test Groups JSON Schema</a>
 </li>
-</ul><li>6.   <a href="#rfc.section.6">Test Vector Responses</a>
+<li>6.2.   <a href="#rfc.section.6.2">Test Case JSON Schema</a>
 </li>
-<li>7.   <a href="#rfc.section.7">Acknowledgements</a>
+</ul><li>7.   <a href="#rfc.section.7">Test Vector Responses</a>
 </li>
-<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+<li>8.   <a href="#rfc.section.8">Acknowledgements</a>
 </li>
-<li>9.   <a href="#rfc.section.9">Security Considerations</a>
+<li>9.   <a href="#rfc.section.9">IANA Considerations</a>
 </li>
-<li>10.   <a href="#rfc.references">Normative References</a>
+<li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<li>11.   <a href="#rfc.references">Normative References</a>
 </li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Example Capabilities JSON Object</a>
 </li>
@@ -594,6 +597,7 @@
 <ul class="empty">
 <li>FIPS.186-4 - 3 General Discussion. Domain parameter generation, key generation, signature generation, and signature validation are all within scope of ACVP server testing.  </li>
 <li>FIPS.186-4 - 4 The Digital Signature Algorithm (DSA). The ACVP server provides a means of the generation and validation of domain parameters. The ACVP server is SHALL support a variety of parameter sizes/hash function for creation and delivery to/from the IUT.  The ACVP server SHALL allow for the testing of the validity of domain parameters.  Key pair generation testing SHALL be provided by the ACVP server. Both Signature Generation and Validation testing mechanmisms SHALL be provided by the ACVP server.  </li>
+<li>SP800-106 - (3) Randomized Hashing and (4) Digital Signatures Using Randomized Hashing.  The IUT SHALL be provided or provide a random value that should be used to "randomize" a message prior to signing and/or verifying an original message.  </li>
 </ul>
 
 <p> </p>
@@ -605,6 +609,7 @@
 <ul class="empty">
 <li>FIPS.186-4 - 3 General Discussion. Assurances of private key secrecy and ownership SHALL NOT be within scope of ACVP testing.  </li>
 <li>FIPS.186-4 - 4 The Digital Signature Algorithm (DSA). The IUT's selection of parameter sizes and hash functions SHALL NOT be within scope of ACVP server testing.  Though the ACVP server SHALL support a variety of parameter sizes/hash functions, the IUT's selection of these is out of scope of testing.  The ACVP server MAY provide testing for the validity of domain parameters, but testing SHALL NOT provide assurances the IUT has validated a set of domain parameters prior to their use.  Domain parameter and key pair management SHALL NOT be within scope of ACVP testing.  </li>
+<li>SP800-106 - 3.3 The Random Value. DSA, ECDSA, and RSA have random values generated as per their signing process, this random value can be used as the input to the message randomization function, doing so however is out of scope of this testing.  </li>
 </ul>
 
 <p> </p>
@@ -709,6 +714,13 @@
 <td class="left">Array of JSON objects</td>
 <td class="left">See <a href="#supported_modes" class="xref">Section 4.3</a> </td>
 <td class="left">No</td>
+</tr>
+<tr>
+<td class="left">conformances</td>
+<td class="left">Used to denote the conformances that can apply to specific modes of DSA.</td>
+<td class="left">Array of strings</td>
+<td class="left">See <a href="#supported_conformances" class="xref">Section 5</a> </td>
+<td class="left">Yes</td>
 </tr>
 </tbody>
 </table>
@@ -959,11 +971,32 @@
 </tbody>
 </table>
 <h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+<a href="#rfc.section.5">5.</a> <a href="#supported_conformances" id="supported_conformances">Supported DSA Conformances</a>
 </h1>
-<p id="rfc.section.5.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual DSA function. This section describes the JSON schema for a test vector set used with DSA algorithms.</p>
-<p id="rfc.section.5.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy. </p>
+<p id="rfc.section.5.p.1">Conformances MAY be used to test additional features of certain algorithms.</p>
 <div id="rfc.table.8"></div>
+<div id="conformances_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>DSA Conformances</caption>
+<thead><tr>
+<th class="left">String Value</th>
+<th class="left">Description</th>
+<th class="left">Valid algorithm modes</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody><tr>
+<td class="left">SP800-106</td>
+<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</td>
+<td class="left">SigGen, SigVer</td>
+<td class="left">Yes</td>
+</tr></tbody>
+</table>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+</h1>
+<p id="rfc.section.6.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual DSA function. This section describes the JSON schema for a test vector set used with DSA algorithms.</p>
+<p id="rfc.section.6.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy. </p>
+<div id="rfc.table.9"></div>
 <div id="vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set JSON Object</caption>
@@ -1000,17 +1033,17 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 5.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 6.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.1">
-<a href="#rfc.section.5.1">5.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.5.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test  groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
-<p id="rfc.section.5.1.p.2">The test group for DSA is as follows:</p>
-<div id="rfc.table.9"></div>
+<p id="rfc.section.6.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test  groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.6.1.p.2">The test group for DSA is as follows:</p>
+<div id="rfc.table.10"></div>
 <div id="vs_tg_table5"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Group JSON Object</caption>
@@ -1082,18 +1115,22 @@
 <td class="left">No</td>
 </tr>
 <tr>
+<td class="left">isMessageRandomized</td>
+<td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 5.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 6.2</a> </td>
+</tr>
+<tr>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.2">
-<a href="#rfc.section.5.2">5.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.5.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DSA test vector.</p>
-<div id="rfc.table.10"></div>
+<p id="rfc.section.6.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DSA test vector.</p>
+<div id="rfc.table.11"></div>
 <div id="vs_tc_table5"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Test Case JSON Object</caption>
@@ -1206,13 +1243,25 @@
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
+<tr>
+<td class="left">randomValue</td>
+<td class="left">The random value to be used as an input into the message randomization function as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left">randomValueLen</td>
+<td class="left">The random value's bit length.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
 </h1>
-<p id="rfc.section.6.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.11"></div>
+<p id="rfc.section.7.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.12"></div>
 <div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1239,8 +1288,8 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.p.2">The following table describes the JSON object that represents a vector set response for DSA.</p>
-<div id="rfc.table.12"></div>
+<p id="rfc.section.7.p.2">The following table describes the JSON object that represents a vector set response for DSA.</p>
+<div id="rfc.table.13"></div>
 <div id="vr_top_table5"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1330,6 +1379,18 @@
 <td class="left">Yes</td>
 </tr>
 <tr>
+<td class="left">randomValue</td>
+<td class="left">The random value to be used as an input into the message randomization function as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left">randomValueLen</td>
+<td class="left">The random value's bit length.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
 <td class="left">testPassed</td>
 <td class="left">The pass or fail result of the verify</td>
 <td class="left">boolean</td>
@@ -1337,20 +1398,20 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
-</h1>
-<p id="rfc.section.7.p.1">TBD...</p>
 <h1 id="rfc.section.8">
-<a href="#rfc.section.8">8.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+<a href="#rfc.section.8">8.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
-<p id="rfc.section.8.p.1">This memo includes no request to IANA.</p>
+<p id="rfc.section.8.p.1">TBD...</p>
 <h1 id="rfc.section.9">
-<a href="#rfc.section.9">9.</a> <a href="#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.9">9.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.9.p.1">Security considerations are addressed by the ACVP specification.</p>
+<p id="rfc.section.9.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.10.p.1">Security considerations are addressed by the ACVP specification.</p>
 <h1 id="rfc.references">
-<a href="#rfc.references">10.</a> Normative References</h1>
+<a href="#rfc.references">11.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
@@ -1366,6 +1427,11 @@
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
 <a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SP.800-106">[SP.800-106]</b></td>
+<td class="top">
+<a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf">Randomized Hashing for Digital Signatures</a>", February 2009.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP.800-89">[SP.800-89]</b></td>
@@ -1621,6 +1687,9 @@
 					"SHA2-512/256"
 				]
 			}
+		],
+		"conformances": [
+			"SP800-106"
 		]
 	},
 	{
@@ -1688,6 +1757,9 @@
 					"SHA2-512/256"
 				]
 			}
+		]
+		"conformances": [
+			"SP800-106"
 		]
 	}
 ]
@@ -2064,6 +2136,19 @@
                         "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
                     }
                 ]
+            },
+            {
+                "tgId": 2,
+                "l": 2048,
+                "n": 224,
+                "sha": "SHA-1",
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
+                    }
+                ]
             }
         ]
     }
@@ -2073,28 +2158,38 @@
 <p id="rfc.section.B.4.p.2">The following is a example JSON object for DSA SigGen test results sent from the crypto module to the ACVP server.</p>
 <pre>
                         
-[
-    {
-        "acvVersion": &lt;acvp-version&gt;
+[{
+        "acvVersion": ""
     },
     {
         "vsId": 1564,
-        "testGroups": [
-        {
-          "tgId": 1,
-          "p": "C8DC6C77CC31ADAE68F3221D59C75538F6956517FF915B96939D0355D3AE7D00789EDDFF13C6707CFAC855EE79FC5A25F7243FF8D6FAD5E89CC799FB275ADB2A6F573FDF69FBF3C3C358C51E229B7799D78416F33F2F20420F35BDABB967435C78EFE843BADF4D93A65538B54723BBF1489D20482A295224CA870EE7F65BC7A17611221D58DB4B51D9C32A359D93032DD97942E8042EC4458D1E78B97D783D14243AEFDE455ED9AEC1925FE49E4B2A9B2160D710CCBEA6BC679E2A2A5307F5CD6B7C8E1078E83DF39A636ACE7E6EED18FBDC56ED89AC21B2ED133566D4696609E0AD0C95DC776893AB71AC9E223CE318CE26FBAE29B812075975F6B73DAF3529",
-          "q": "B1B7BCF2467F8CC46FCDD2A41327C2698D9E0A3F36682E17546EAE5B",
-          "g": "6C07130A6F6D05AAC9350936EE06B1303035FE460CEBF21DDA00CC08CD5E8A788D8C3F6B4B0A567A82DBF373CE36A40ADCF77D0CB6CA9AB93D1C0051E354AEB27BBC808A4950E91E2BFFFEF7427DBEA5E05BC9A3C003F6796C0A3EF3CF7D30378657A0966AE952BDC038645199F3C2FBBFD0B4E6E489E97D6DF8A9AD4356B34A3CD289DF9BA53F95A62E110B2BA84D668D7F72EA6CA471B6624F0F2E5CB54C9E96367CD4659BC64EC731B7F60CE0F08B58CFB29090DBDE6BDD7EC16689A9CC3913F3F009E03280342150C0899814532F471594C883B3941ADA81EB95274BB0B8900C492D92AD5686141DBB302DD2C2B4EEA8C2C7AD9B616DF0A520B9CCF7074F",
-          "y": "79143F63ECCC06B3D35C61DA2FB8ED359F8FBF014D699C3B6E150E60443BA461C256498F52262AD3850FECDA5F01F4702F5411BF25F0D9A4CF21F9B84B8FEF8C5E83563A1AE35C253D07011E5492106F46C7DF2624948E3662DAC129E5A094A6180F24480D3FFBD2F223156E68EBD6378ECBA010DF0CB6B3DD12045D8015E66160821AF5A12C8FE239AB331EBCDE6B906A40197769A74780700420C40428A81FBDEB94B9FE37183E9401167AFF6AEAE9968A6FBD11AFB3EB60ED076627CC2873EA2034BAEF2427C1BABF858D4E783B0FE3C51B39661EFBD9518F93A554E5E37428AFC62CF0C61A3B9248B56BBA0282E9BB7A8A6FB14D2CA4AAA9DC3245722525",
-          "tests": [
-            {
-              "tcId": 1,
-              "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
-              "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314"
+        "testGroups": [{
+                "tgId": 1,
+                "p": "C8DC6C77CC31ADAE68F3221D59C75538F6956517FF915B96939D0355D3AE7D00789EDDFF13C6707CFAC855EE79FC5A25F7243FF8D6FAD5E89CC799FB275ADB2A6F573FDF69FBF3C3C358C51E229B7799D78416F33F2F20420F35BDABB967435C78EFE843BADF4D93A65538B54723BBF1489D20482A295224CA870EE7F65BC7A17611221D58DB4B51D9C32A359D93032DD97942E8042EC4458D1E78B97D783D14243AEFDE455ED9AEC1925FE49E4B2A9B2160D710CCBEA6BC679E2A2A5307F5CD6B7C8E1078E83DF39A636ACE7E6EED18FBDC56ED89AC21B2ED133566D4696609E0AD0C95DC776893AB71AC9E223CE318CE26FBAE29B812075975F6B73DAF3529",
+                "q": "B1B7BCF2467F8CC46FCDD2A41327C2698D9E0A3F36682E17546EAE5B",
+                "g": "6C07130A6F6D05AAC9350936EE06B1303035FE460CEBF21DDA00CC08CD5E8A788D8C3F6B4B0A567A82DBF373CE36A40ADCF77D0CB6CA9AB93D1C0051E354AEB27BBC808A4950E91E2BFFFEF7427DBEA5E05BC9A3C003F6796C0A3EF3CF7D30378657A0966AE952BDC038645199F3C2FBBFD0B4E6E489E97D6DF8A9AD4356B34A3CD289DF9BA53F95A62E110B2BA84D668D7F72EA6CA471B6624F0F2E5CB54C9E96367CD4659BC64EC731B7F60CE0F08B58CFB29090DBDE6BDD7EC16689A9CC3913F3F009E03280342150C0899814532F471594C883B3941ADA81EB95274BB0B8900C492D92AD5686141DBB302DD2C2B4EEA8C2C7AD9B616DF0A520B9CCF7074F",
+                "y": "79143F63ECCC06B3D35C61DA2FB8ED359F8FBF014D699C3B6E150E60443BA461C256498F52262AD3850FECDA5F01F4702F5411BF25F0D9A4CF21F9B84B8FEF8C5E83563A1AE35C253D07011E5492106F46C7DF2624948E3662DAC129E5A094A6180F24480D3FFBD2F223156E68EBD6378ECBA010DF0CB6B3DD12045D8015E66160821AF5A12C8FE239AB331EBCDE6B906A40197769A74780700420C40428A81FBDEB94B9FE37183E9401167AFF6AEAE9968A6FBD11AFB3EB60ED076627CC2873EA2034BAEF2427C1BABF858D4E783B0FE3C51B39661EFBD9518F93A554E5E37428AFC62CF0C61A3B9248B56BBA0282E9BB7A8A6FB14D2CA4AAA9DC3245722525",
+                "tests": [{
+                    "tcId": 1,
+                    "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
+                    "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314"
+                }]
             },
-          ]
+            {
+                "tgId": 2,
+                "p": "77CC31ADAE68F3221D59C75538F6...",
+                "q": "82E17546E564816AFB54987C879A...",
+                "g": "B1303035FE460CEBF21DDA00CC08...",
+                "y": "D699C3B6E150E60443BA461C2564...",
+                "tests": [{
+                    "tcId": 1,
+                    "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
+                    "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314",
+                    "randomValue": "23678643ACB7283497...",
+                    "randomValueLen": 1024
+                }]
+            }
         ]
-      }
     }
 ]
           
@@ -2123,6 +2218,7 @@
             "q": "D3C53E62338D4231E42FA9683175C404FBF52759",
             "g": "7BDDD6B8E9B4667397B278F98F446C418EF1A502068B3082F9CE1D639F5FAA67048ACD4F50E1F855467465A653D2245B7E31C910A18EF79F098ACF73BFC43B1B5E7BFB065FB7A89583C5C23105018D0525AFA9C40B6C343E69CFC2B6B2A87FB4265FDE13D6F19A7BF7A1302AA14EDFA56FD1526241316D1BA182683B8E306CDA",
             "hashAlg": "SHA-1",
+            "isMessageRandomized": true,
             "tests": [
               {
                 "tcId": 1,
@@ -2130,6 +2226,26 @@
                 "y": "A3A2F1AFC3091204B7D7ED3617A80E0FD57221BE67E852A1558CA08984CB56F3A0EF37749B5EA4D2EC824ED5E7EDB0D25A72C8DEFA0F409909E31C2C23BB7A24B8103F11F9781A0F0A15FE6F6DAEFD42CD5FA7444221CB545BB0CDB95DC9D76E0DB9AF193E6832934537B0B05D177BA8F7DA48D9DD84D27B8AFE9481BE520B",
                 "r": "C390851DE10669399308D9F401B0286AA1F4189D",
                 "s": "26BE6EFDCD2ED6946BFCFE2D396AB3A2E84B2FF8"
+              },
+            ]
+          },
+          {
+            "tgId": 2,
+            "l": 1024,
+            "n": 160,
+            "p": "66F108D370A2A9E87DBD49BC09A27017621A...",
+            "q": "1F855467465A653D2245B7E31C910A18EF79...",
+            "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
+            "hashAlg": "SHA-1",
+            "tests": [
+              {
+                "tcId": 1,
+                "message": "A0F409909E31C2C23BB7A24B8103F11F...",
+                "randomValue": "DB0D25A72C8DEFA0F409909E31C2..."
+                "randomValueLen": 1024,
+                "y": "A3A284CB56F3A0EF37749B5EA4D2EC824ED5E7EAD481BE520B...",
+                "r": "15FE6F6DAEFD42CD5FA7444221CB545BB0CDB95DC9D76E0...",
+                "s": "B9AF193E6832934537B0B05D177BA8F7DA48D9DD84D27B8AFE9..."
               },
             ]
           }

--- a/artifacts/acvp_sub_dsa.html
+++ b/artifacts/acvp_sub_dsa.html
@@ -1117,10 +1117,12 @@
 <tr>
 <td class="left">isMessageRandomized</td>
 <td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
-<td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 6.2</a> </td>
+<td class="left">boolean</td>
+<td class="left">Yes</td>
 </tr>
 <tr>
+<td class="left">tests</td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 6.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
@@ -1757,7 +1759,7 @@
 					"SHA2-512/256"
 				]
 			}
-		]
+		],
 		"conformances": [
 			"SP800-106"
 		]
@@ -2145,7 +2147,7 @@
                 "isMessageRandomized": true,
                 "tests": [
                     {
-                        "tcId": 1,
+                        "tcId": 2,
                         "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
                     }
                 ]
@@ -2182,7 +2184,7 @@
                 "g": "B1303035FE460CEBF21DDA00CC08...",
                 "y": "D699C3B6E150E60443BA461C2564...",
                 "tests": [{
-                    "tcId": 1,
+                    "tcId": 2,
                     "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
                     "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314",
                     "randomValue": "23678643ACB7283497...",
@@ -2218,7 +2220,6 @@
             "q": "D3C53E62338D4231E42FA9683175C404FBF52759",
             "g": "7BDDD6B8E9B4667397B278F98F446C418EF1A502068B3082F9CE1D639F5FAA67048ACD4F50E1F855467465A653D2245B7E31C910A18EF79F098ACF73BFC43B1B5E7BFB065FB7A89583C5C23105018D0525AFA9C40B6C343E69CFC2B6B2A87FB4265FDE13D6F19A7BF7A1302AA14EDFA56FD1526241316D1BA182683B8E306CDA",
             "hashAlg": "SHA-1",
-            "isMessageRandomized": true,
             "tests": [
               {
                 "tcId": 1,
@@ -2237,9 +2238,10 @@
             "q": "1F855467465A653D2245B7E31C910A18EF79...",
             "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
             "hashAlg": "SHA-1",
+            "isMessageRandomized": true,
             "tests": [
               {
-                "tcId": 1,
+                "tcId": 2,
                 "message": "A0F409909E31C2C23BB7A24B8103F11F...",
                 "randomValue": "DB0D25A72C8DEFA0F409909E31C2..."
                 "randomValueLen": 1024,
@@ -2269,6 +2271,10 @@
               "tests": [
                 {
                   "tcId": 1,
+                  "testPassed": true
+                },
+                {
+                  "tcId": 2,
                   "testPassed": true
                 }
               ]

--- a/artifacts/acvp_sub_dsa.txt
+++ b/artifacts/acvp_sub_dsa.txt
@@ -842,39 +842,38 @@ Fussell                 Expires December 3, 2016               [Page 15]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +---------------------+--------------------+-------+----------------+
-   | JSON Value          | Description        | JSON  | Optional       |
-   |                     |                    | type  |                |
-   +---------------------+--------------------+-------+----------------+
-   | l                   | Length in bits of  | value | No             |
-   |                     | prime modulus p    |       |                |
-   | n                   | Length in bits of  | value | No             |
-   |                     | prime divisor q    |       |                |
-   | p                   | Domain parameter P | value | Yes            |
-   | q                   | Domain parameter Q | value | Yes            |
-   | g                   | Domain parameter G | value | Yes            |
-   | x                   | Private key X      | value | Yes            |
-   | y                   | Public key Y       | value | Yes            |
-   | hashAlg             | The hash algorithm | value | No             |
-   |                     | used in the test   |       |                |
-   |                     | group              |       |                |
-   | pqMode              | The specific pq    | value | No             |
-   |                     | generation mode    |       |                |
-   |                     | used in the test   |       |                |
-   |                     | group              |       |                |
-   | gMode               | The specific g     | value | No             |
-   |                     | generation mode    |       |                |
-   |                     | used in the test   |       |                |
-   |                     | group              |       |                |
-   | isMessageRandomized | Signifies all test | tests | Array of       |
-   |                     | cases within the   |       | individual     |
-   |                     | group should       |       | test vector    |
-   |                     | utilize random     |       | JSON objects,  |
-   |                     | message hashing as |       | which are      |
-   |                     | described in       |       | defined in     |
-   |                     | [SP.800-106].      |       | Section 6.2    |
-   | array               | No                 |
-   +---------------------+--------------------+-------+----------------+
+   +---------------------+------------------------+---------+----------+
+   | JSON Value          | Description            | JSON    | Optional |
+   |                     |                        | type    |          |
+   +---------------------+------------------------+---------+----------+
+   | l                   | Length in bits of      | value   | No       |
+   |                     | prime modulus p        |         |          |
+   | n                   | Length in bits of      | value   | No       |
+   |                     | prime divisor q        |         |          |
+   | p                   | Domain parameter P     | value   | Yes      |
+   | q                   | Domain parameter Q     | value   | Yes      |
+   | g                   | Domain parameter G     | value   | Yes      |
+   | x                   | Private key X          | value   | Yes      |
+   | y                   | Public key Y           | value   | Yes      |
+   | hashAlg             | The hash algorithm     | value   | No       |
+   |                     | used in the test group |         |          |
+   | pqMode              | The specific pq        | value   | No       |
+   |                     | generation mode used   |         |          |
+   |                     | in the test group      |         |          |
+   | gMode               | The specific g         | value   | No       |
+   |                     | generation mode used   |         |          |
+   |                     | in the test group      |         |          |
+   | isMessageRandomized | Signifies all test     | boolean | Yes      |
+   |                     | cases within the group |         |          |
+   |                     | should utilize random  |         |          |
+   |                     | message hashing as     |         |          |
+   |                     | described in           |         |          |
+   |                     | [SP.800-106].          |         |          |
+   | tests               | Array of individual    | array   | No       |
+   |                     | test vector JSON       |         |          |
+   |                     | objects, which are     |         |          |
+   |                     | defined in Section 6.2 |         |          |
+   +---------------------+------------------------+---------+----------+
 
                     Table 10: Vector Group JSON Object
 
@@ -890,6 +889,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |                |                             | type    |          |
    +----------------+-----------------------------+---------+----------+
    | tcId           | Numeric identifier for the  | value   | No       |
+   |                | test case, unique across    |         |          |
 
 
 
@@ -898,7 +898,6 @@ Fussell                 Expires December 3, 2016               [Page 16]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |                | test case, unique across    |         |          |
    |                | the entire vector set.      |         |          |
    | p              | The prime modulus           | value   | Yes      |
    | q              | The prime divisor of p - 1  | value   | Yes      |
@@ -942,6 +941,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
    +----------------+-----------------------------+---------+----------+
 
                       Table 11: Test Case JSON Object
+
 
 
 
@@ -1475,7 +1475,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "SHA2-512/256"
                                    ]
                            }
-                   ]
+                   ],
                    "conformances": [
                            "SP800-106"
                    ]
@@ -1992,7 +1992,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "isMessageRandomized": true,
                 "tests": [
                     {
-                        "tcId": 1,
+                        "tcId": 2,
                         "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
                     }
                 ]
@@ -2042,7 +2042,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "g": "B1303035FE460CEBF21DDA00CC08...",
                 "y": "D699C3B6E150E60443BA461C2564...",
                 "tests": [{
-                    "tcId": 1,
+                    "tcId": 2,
                     "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
                     "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314",
                     "randomValue": "23678643ACB7283497...",
@@ -2086,7 +2086,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
             "q": "D3C53E62338D4231E42FA9683175C404FBF52759",
             "g": "7BDDD6B8E9B4667397B278F98F446C418EF1A502068B3082F9CE1D639F5FAA67048ACD4F50E1F855467465A653D2245B7E31C910A18EF79F098ACF73BFC43B1B5E7BFB065FB7A89583C5C23105018D0525AFA9C40B6C343E69CFC2B6B2A87FB4265FDE13D6F19A7BF7A1302AA14EDFA56FD1526241316D1BA182683B8E306CDA",
             "hashAlg": "SHA-1",
-            "isMessageRandomized": true,
             "tests": [
               {
                 "tcId": 1,
@@ -2105,9 +2104,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
             "q": "1F855467465A653D2245B7E31C910A18EF79...",
             "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
             "hashAlg": "SHA-1",
+            "isMessageRandomized": true,
             "tests": [
               {
-                "tcId": 1,
+                "tcId": 2,
                 "message": "A0F409909E31C2C23BB7A24B8103F11F...",
                 "randomValue": "DB0D25A72C8DEFA0F409909E31C2..."
                 "randomValueLen": 1024,
@@ -2147,6 +2147,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
                    {
                      "tcId": 1,
                      "testPassed": true
+                   },
+                   {
+                     "tcId": 2,
+                     "testPassed": true
                    }
                  ]
                }
@@ -2164,10 +2168,6 @@ Author's Address
    USA
 
    Email: bfussell@cisco.com
-
-
-
-
 
 
 

--- a/artifacts/acvp_sub_dsa.txt
+++ b/artifacts/acvp_sub_dsa.txt
@@ -85,7 +85,7 @@ Table of Contents
    6.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  14
      6.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  15
      6.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  16
-   7.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  18
+   7.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  17
    8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  19
    9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
    10. Security Considerations . . . . . . . . . . . . . . . . . . .  20
@@ -743,8 +743,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |           | conformance SHALL generate     |           |          |
    |           | additional test groups,        |           |          |
    |           | denoted with a group level     |           |          |
-   |           | property of                    |           |          |
-   |           | "isMessageRandomized".         |           |          |
+   |           | property of `"conformance":    |           |          |
+   |           | "SP800-106"`.                  |           |          |
    +-----------+--------------------------------+-----------+----------+
 
                          Table 8: DSA Conformances
@@ -842,38 +842,35 @@ Fussell                 Expires December 3, 2016               [Page 15]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +---------------------+------------------------+---------+----------+
-   | JSON Value          | Description            | JSON    | Optional |
-   |                     |                        | type    |          |
-   +---------------------+------------------------+---------+----------+
-   | l                   | Length in bits of      | value   | No       |
-   |                     | prime modulus p        |         |          |
-   | n                   | Length in bits of      | value   | No       |
-   |                     | prime divisor q        |         |          |
-   | p                   | Domain parameter P     | value   | Yes      |
-   | q                   | Domain parameter Q     | value   | Yes      |
-   | g                   | Domain parameter G     | value   | Yes      |
-   | x                   | Private key X          | value   | Yes      |
-   | y                   | Public key Y           | value   | Yes      |
-   | hashAlg             | The hash algorithm     | value   | No       |
-   |                     | used in the test group |         |          |
-   | pqMode              | The specific pq        | value   | No       |
-   |                     | generation mode used   |         |          |
-   |                     | in the test group      |         |          |
-   | gMode               | The specific g         | value   | No       |
-   |                     | generation mode used   |         |          |
-   |                     | in the test group      |         |          |
-   | isMessageRandomized | Signifies all test     | boolean | Yes      |
-   |                     | cases within the group |         |          |
-   |                     | should utilize random  |         |          |
-   |                     | message hashing as     |         |          |
-   |                     | described in           |         |          |
-   |                     | [SP.800-106].          |         |          |
-   | tests               | Array of individual    | array   | No       |
-   |                     | test vector JSON       |         |          |
-   |                     | objects, which are     |         |          |
-   |                     | defined in Section 6.2 |         |          |
-   +---------------------+------------------------+---------+----------+
+   +-------------+----------------------------+-------------+----------+
+   | JSON Value  | Description                | JSON type   | Optional |
+   +-------------+----------------------------+-------------+----------+
+   | l           | Length in bits of prime    | value       | No       |
+   |             | modulus p                  |             |          |
+   | n           | Length in bits of prime    | value       | No       |
+   |             | divisor q                  |             |          |
+   | p           | Domain parameter P         | value       | Yes      |
+   | q           | Domain parameter Q         | value       | Yes      |
+   | g           | Domain parameter G         | value       | Yes      |
+   | x           | Private key X              | value       | Yes      |
+   | y           | Public key Y               | value       | Yes      |
+   | hashAlg     | The hash algorithm used in | value       | No       |
+   |             | the test group             |             |          |
+   | pqMode      | The specific pq generation | value       | No       |
+   |             | mode used in the test      |             |          |
+   |             | group                      |             |          |
+   | gMode       | The specific g generation  | value       | No       |
+   |             | mode used in the test      |             |          |
+   |             | group                      |             |          |
+   | Conformance | Signifies all test cases   | "SP800-106" | Yes      |
+   |             | within the group should    |             |          |
+   |             | utilize random message     |             |          |
+   |             | hashing as described in    |             |          |
+   |             | [SP.800-106].              |             |          |
+   | tests       | Array of individual test   | array       | No       |
+   |             | vector JSON objects, which |             |          |
+   |             | are defined in Section 6.2 |             |          |
+   +-------------+----------------------------+-------------+----------+
 
                     Table 10: Vector Group JSON Object
 
@@ -890,6 +887,9 @@ Internet-Draft                Sym Alg JSON                     June 2016
    +----------------+-----------------------------+---------+----------+
    | tcId           | Numeric identifier for the  | value   | No       |
    |                | test case, unique across    |         |          |
+   |                | the entire vector set.      |         |          |
+   | p              | The prime modulus           | value   | Yes      |
+   | q              | The prime divisor of p - 1  | value   | Yes      |
 
 
 
@@ -898,9 +898,6 @@ Fussell                 Expires December 3, 2016               [Page 16]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   |                | the entire vector set.      |         |          |
-   | p              | The prime modulus           | value   | Yes      |
-   | q              | The prime divisor of p - 1  | value   | Yes      |
    | domainSeed     | The seed used to generate p | value   | Yes      |
    |                | and q in the probable       |         |          |
    |                | method                      |         |          |
@@ -942,9 +939,12 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
                       Table 11: Test Case JSON Object
 
+7.  Test Vector Responses
 
-
-
+   After the ACVP client downloads and processes a vector set, it must
+   send the response vectors back to the ACVP server.  The following
+   table describes the JSON object that represents a vector set
+   response.
 
 
 
@@ -953,13 +953,6 @@ Fussell                 Expires December 3, 2016               [Page 17]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
-
-7.  Test Vector Responses
-
-   After the ACVP client downloads and processes a vector set, it must
-   send the response vectors back to the ACVP server.  The following
-   table describes the JSON object that represents a vector set
-   response.
 
    +-------------+---------------------------------------------+-------+
    | JSON Value  | Description                                 | JSON  |
@@ -977,6 +970,13 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The following table describes the JSON object that represents a
    vector set response for DSA.
+
+
+
+
+
+
+
 
 
 
@@ -1989,7 +1989,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "l": 2048,
                 "n": 224,
                 "sha": "SHA-1",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,
@@ -2104,7 +2104,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
             "q": "1F855467465A653D2245B7E31C910A18EF79...",
             "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
             "hashAlg": "SHA-1",
-            "isMessageRandomized": true,
+            "conformance": "SP800-106",
             "tests": [
               {
                 "tcId": 2,

--- a/artifacts/acvp_sub_dsa.txt
+++ b/artifacts/acvp_sub_dsa.txt
@@ -72,31 +72,32 @@ Table of Contents
      4.2.  DSA Algorithm Capabilities Registration . . . . . . . . .   6
      4.3.  Supported DSA Modes Capabilities  . . . . . . . . . . . .   7
        4.3.1.  The pqgGen Mode Capabilities  . . . . . . . . . . . .   7
-         4.3.1.1.  pqgGen Full Set of Capabilities . . . . . . . . .   7
-       4.3.2.  The pqgVer Mode Capabilities  . . . . . . . . . . . .   8
+         4.3.1.1.  pqgGen Full Set of Capabilities . . . . . . . . .   8
+       4.3.2.  The pqgVer Mode Capabilities  . . . . . . . . . . . .   9
          4.3.2.1.  pqgVer Full Set of Capabilities . . . . . . . . .   9
        4.3.3.  The keyGen Mode Capabilities  . . . . . . . . . . . .  10
-         4.3.3.1.  keyGen Full Set of Capabilities . . . . . . . . .  10
-       4.3.4.  The sigGen Mode Capabilities  . . . . . . . . . . . .  10
-         4.3.4.1.  sigGen Full Set of Capabilities . . . . . . . . .  10
-       4.3.5.  The sigVer Mode Capabilities  . . . . . . . . . . . .  11
-         4.3.5.1.  sigVer Full Set of Capabilities . . . . . . . . .  11
-   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  12
-     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  13
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  14
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  15
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  17
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  17
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  17
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  17
-   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  17
-   Appendix B.  Example Vector Set Request/Responses JSON Object . .  24
-     B.1.  Example Test DSA PQGGen JSON Object . . . . . . . . . . .  24
-     B.2.  Example Test DSA PQGVer JSON Object . . . . . . . . . . .  27
-     B.3.  Example Test DSA KeyGen JSON Object . . . . . . . . . . .  31
-     B.4.  Example Test DSA SigGen JSON Object . . . . . . . . . . .  32
-     B.5.  Example Test DSA SigVer JSON Object . . . . . . . . . . .  34
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  36
+         4.3.3.1.  keyGen Full Set of Capabilities . . . . . . . . .  11
+       4.3.4.  The sigGen Mode Capabilities  . . . . . . . . . . . .  11
+         4.3.4.1.  sigGen Full Set of Capabilities . . . . . . . . .  11
+       4.3.5.  The sigVer Mode Capabilities  . . . . . . . . . . . .  12
+         4.3.5.1.  sigVer Full Set of Capabilities . . . . . . . . .  12
+   5.  Supported DSA Conformances  . . . . . . . . . . . . . . . . .  13
+   6.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  14
+     6.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  15
+     6.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  16
+   7.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  18
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  19
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  20
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  20
+   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  20
+   Appendix B.  Example Vector Set Request/Responses JSON Object . .  27
+     B.1.  Example Test DSA PQGGen JSON Object . . . . . . . . . . .  27
+     B.2.  Example Test DSA PQGVer JSON Object . . . . . . . . . . .  30
+     B.3.  Example Test DSA KeyGen JSON Object . . . . . . . . . . .  34
+     B.4.  Example Test DSA SigGen JSON Object . . . . . . . . . . .  35
+     B.5.  Example Test DSA SigVer JSON Object . . . . . . . . . . .  37
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  39
 
 1.  Introduction
 
@@ -105,7 +106,6 @@ Table of Contents
    software or hardware crypto module.  The ACVP specification defines
    how a crypto module communicates with an ACVP server, including
    crypto capabilities negotiation, session management, authentication,
-   vector processing and more.  The ACVP specification does not define
 
 
 
@@ -114,6 +114,7 @@ Fussell                 Expires December 3, 2016                [Page 2]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+   vector processing and more.  The ACVP specification does not define
    algorithm specific JSON constructs for performing the crypto
    validation.  A series of ACVP sub-specifications define the
    constructs for testing individual crypto algorithms.  Each sub-
@@ -160,8 +161,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
       mode is REQUIRED to generate PQ or G as a response to the ACVP
       provided test vector set.
 
-      DSA / pqgVer "GDT" - Generated Data Test.  In this test mode, the
-      ACVP server is REQUIRED to generate domain parameters for
+
 
 
 
@@ -170,6 +170,8 @@ Fussell                 Expires December 3, 2016                [Page 3]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+      DSA / pqgVer "GDT" - Generated Data Test.  In this test mode, the
+      ACVP server is REQUIRED to generate domain parameters for
       transmission to the IUT.  The IUT is expected to evaluate the
       validity of the domain parameters.
 
@@ -204,6 +206,11 @@ Internet-Draft                Sym Alg JSON                     June 2016
       Validation testing mechanmisms SHALL be provided by the ACVP
       server.
 
+      SP800-106 - (3) Randomized Hashing and (4) Digital Signatures
+      Using Randomized Hashing.  The IUT SHALL be provided or provide a
+      random value that should be used to "randomize" a message prior to
+      signing and/or verifying an original message.
+
 3.1.2.  Requirements Not Covered
 
       FIPS.186-4 - 3 General Discussion.  Assurances of private key
@@ -211,6 +218,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
       FIPS.186-4 - 4 The Digital Signature Algorithm (DSA).  The IUT's
       selection of parameter sizes and hash functions SHALL NOT be
+
+
+
+Fussell                 Expires December 3, 2016                [Page 4]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
       within scope of ACVP server testing.  Though the ACVP server SHALL
       support a variety of parameter sizes/hash functions, the IUT's
       selection of these is out of scope of testing.  The ACVP server
@@ -219,12 +234,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
       of domain parameters prior to their use.  Domain parameter and key
       pair management SHALL NOT be within scope of ACVP testing.
 
-
-
-Fussell                 Expires December 3, 2016                [Page 4]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
+      SP800-106 - 3.3 The Random Value.  DSA, ECDSA, and RSA have random
+      values generated as per their signing process, this random value
+      can be used as the input to the message randomization function,
+      doing so however is out of scope of this testing.
 
 4.  Capabilities Registration
 
@@ -251,6 +264,24 @@ Internet-Draft                Sym Alg JSON                     June 2016
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 5]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    +--------------+--------------+---------------+----------+----------+
    | JSON Value   | Description  | JSON type     | Valid    | Optional |
    |              |              |               | Values   |          |
@@ -272,15 +303,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    +--------------+--------------+---------------+----------+----------+
 
          Table 1: Required DSA Prerequisite Algorithms JSON Values
-
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 5]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
 4.2.  DSA Algorithm Capabilities Registration
 
@@ -308,6 +330,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |              | algorithm    | prereqAlgVal | on 4.1    |          |
    |              | validations  | objects      |           |          |
    | capabilities | array of     | Array of     | See Secti | No       |
+
+
+
+Fussell                 Expires December 3, 2016                [Page 6]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    |              | JSON         | JSON objects | on 4.3    |          |
    |              | objects,     |              |           |          |
    |              | each with    |              |           |          |
@@ -326,17 +356,17 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |              | "mode" and   |              |           |          |
    |              | indicated    |              |           |          |
    |              | properties   |              |           |          |
+   | conformances | Used to      | Array of     | See       | Yes      |
+   |              | denote the   | strings      | Section 5 |          |
+   |              | conformances |              |           |          |
+   |              | that can     |              |           |          |
+   |              | apply to     |              |           |          |
+   |              | specific     |              |           |          |
+   |              | modes of     |              |           |          |
+   |              | DSA.         |              |           |          |
    +--------------+--------------+--------------+-----------+----------+
 
               Table 2: DSA Algorithm Capabilities JSON Values
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 6]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
 4.3.  Supported DSA Modes Capabilities
 
@@ -357,6 +387,13 @@ Internet-Draft                Sym Alg JSON                     June 2016
    registration message.  See the ACVP specification for details on the
    registration message.
 
+
+
+Fussell                 Expires December 3, 2016                [Page 7]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    Each DSA pqgGen mode capability set is advertised as a self-contained
    JSON object.
 
@@ -364,35 +401,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of DSA pqg generation capabilities may be
    advertised by the ACVP compliant crypto module:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 7]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
    +---------+-------------+-------+------------------------+----------+
    | JSON    | Description | JSON  | Valid Values           | Optional |
@@ -434,14 +442,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
                Table 3: DSA pqgGen Capabilities JSON Values
 
-4.3.2.  The pqgVer Mode Capabilities
-
-   The DSA pqgVer mode capabilities are advertised as JSON objects,
-   which are elements of the 'capabilities' array in the ACVP
-   registration message.  See the ACVP specification for details on the
-   registration message.
-
-
 
 
 
@@ -450,6 +450,13 @@ Fussell                 Expires December 3, 2016                [Page 8]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+4.3.2.  The pqgVer Mode Capabilities
+
+   The DSA pqgVer mode capabilities are advertised as JSON objects,
+   which are elements of the 'capabilities' array in the ACVP
+   registration message.  See the ACVP specification for details on the
+   registration message.
+
    Each DSA pqgVer mode capability set is advertised as a self-contained
    JSON object.
 
@@ -457,6 +464,47 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of DSA pqg verification capabilities may be
    advertised by the ACVP compliant crypto module:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 9]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    +---------+-------------+-------+------------------------+----------+
    | JSON    | Description | JSON  | Valid Values           | Optional |
@@ -499,19 +547,20 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
                Table 4: DSA pqgVer Capabilities JSON Values
 
-
-
-Fussell                 Expires December 3, 2016                [Page 9]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
 4.3.3.  The keyGen Mode Capabilities
 
    The DSA keyGen mode capabilities are advertised as JSON objects,
    which are elements of the 'capabilities' array in the ACVP
    registration message.  See the ACVP specification for details on the
    registration message.
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 10]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    Each DSA keyGen mode capability set is advertised as a self-contained
    JSON object.
@@ -557,7 +606,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 10]
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 11]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -613,7 +669,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 11]
+Fussell                 Expires December 3, 2016               [Page 12]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -646,7 +702,54 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
                Table 7: DSA sigVer Capabilities JSON Values
 
-5.  Test Vectors
+5.  Supported DSA Conformances
+
+   Conformances MAY be used to test additional features of certain
+   algorithms.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 13]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   +-----------+--------------------------------+-----------+----------+
+   | String    | Description                    | Valid     | Optional |
+   | Value     |                                | algorithm |          |
+   |           |                                | modes     |          |
+   +-----------+--------------------------------+-----------+----------+
+   | SP800-106 | This conformance signifies the | SigGen,   | Yes      |
+   |           | SigGen and/or SigVer modes     | SigVer    |          |
+   |           | support randomized message     |           |          |
+   |           | hashing as described in        |           |          |
+   |           | [SP.800-106]. Utilizing this   |           |          |
+   |           | conformance SHALL generate     |           |          |
+   |           | additional test groups,        |           |          |
+   |           | denoted with a group level     |           |          |
+   |           | property of                    |           |          |
+   |           | "isMessageRandomized".         |           |          |
+   +-----------+--------------------------------+-----------+----------+
+
+                         Table 8: DSA Conformances
+
+6.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -669,7 +772,16 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 12]
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 14]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -685,12 +797,12 @@ Internet-Draft                Sym Alg JSON                     June 2016
    | mode       | The DSA mode used for the test vectors.     | value  |
    | revision   | The algorithm testing revision to use.      | value  |
    | testGroups | Array of test group JSON objects, which are | array  |
-   |            | defined in Section 5.1                      |        |
+   |            | defined in Section 6.1                      |        |
    +------------+---------------------------------------------+--------+
 
-                      Table 8: Vector Set JSON Object
+                      Table 9: Vector Set JSON Object
 
-5.1.  Test Groups JSON Schema
+6.1.  Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -725,122 +837,129 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 13]
+Fussell                 Expires December 3, 2016               [Page 15]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +---------+--------------------------------------+-------+----------+
-   | JSON    | Description                          | JSON  | Optional |
-   | Value   |                                      | type  |          |
-   +---------+--------------------------------------+-------+----------+
-   | l       | Length in bits of prime modulus p    | value | No       |
-   | n       | Length in bits of prime divisor q    | value | No       |
-   | p       | Domain parameter P                   | value | Yes      |
-   | q       | Domain parameter Q                   | value | Yes      |
-   | g       | Domain parameter G                   | value | Yes      |
-   | x       | Private key X                        | value | Yes      |
-   | y       | Public key Y                         | value | Yes      |
-   | hashAlg | The hash algorithm used in the test  | value | No       |
-   |         | group                                |       |          |
-   | pqMode  | The specific pq generation mode used | value | No       |
-   |         | in the test group                    |       |          |
-   | gMode   | The specific g generation mode used  | value | No       |
-   |         | in the test group                    |       |          |
-   | tests   | Array of individual test vector JSON | array | No       |
-   |         | objects, which are defined in        |       |          |
-   |         | Section 5.2                          |       |          |
-   +---------+--------------------------------------+-------+----------+
+   +---------------------+--------------------+-------+----------------+
+   | JSON Value          | Description        | JSON  | Optional       |
+   |                     |                    | type  |                |
+   +---------------------+--------------------+-------+----------------+
+   | l                   | Length in bits of  | value | No             |
+   |                     | prime modulus p    |       |                |
+   | n                   | Length in bits of  | value | No             |
+   |                     | prime divisor q    |       |                |
+   | p                   | Domain parameter P | value | Yes            |
+   | q                   | Domain parameter Q | value | Yes            |
+   | g                   | Domain parameter G | value | Yes            |
+   | x                   | Private key X      | value | Yes            |
+   | y                   | Public key Y       | value | Yes            |
+   | hashAlg             | The hash algorithm | value | No             |
+   |                     | used in the test   |       |                |
+   |                     | group              |       |                |
+   | pqMode              | The specific pq    | value | No             |
+   |                     | generation mode    |       |                |
+   |                     | used in the test   |       |                |
+   |                     | group              |       |                |
+   | gMode               | The specific g     | value | No             |
+   |                     | generation mode    |       |                |
+   |                     | used in the test   |       |                |
+   |                     | group              |       |                |
+   | isMessageRandomized | Signifies all test | tests | Array of       |
+   |                     | cases within the   |       | individual     |
+   |                     | group should       |       | test vector    |
+   |                     | utilize random     |       | JSON objects,  |
+   |                     | message hashing as |       | which are      |
+   |                     | described in       |       | defined in     |
+   |                     | [SP.800-106].      |       | Section 6.2    |
+   | array               | No                 |
+   +---------------------+--------------------+-------+----------------+
 
-                     Table 9: Vector Group JSON Object
+                    Table 10: Vector Group JSON Object
 
-5.2.  Test Case JSON Schema
+6.2.  Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each DSA test vector.
 
+   +----------------+-----------------------------+---------+----------+
+   | JSON Value     | Description                 | JSON    | Optional |
+   |                |                             | type    |          |
+   +----------------+-----------------------------+---------+----------+
+   | tcId           | Numeric identifier for the  | value   | No       |
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 14]
+Fussell                 Expires December 3, 2016               [Page 16]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +------------+---------------------------------+---------+----------+
-   | JSON Value | Description                     | JSON    | Optional |
-   |            |                                 | type    |          |
-   +------------+---------------------------------+---------+----------+
-   | tcId       | Numeric identifier for the test | value   | No       |
-   |            | case, unique across the entire  |         |          |
-   |            | vector set.                     |         |          |
-   | p          | The prime modulus               | value   | Yes      |
-   | q          | The prime divisor of p - 1      | value   | Yes      |
-   | domainSeed | The seed used to generate p and | value   | Yes      |
-   |            | q in the probable method        |         |          |
-   | counter    | The counter used to generate p  | value - | Yes      |
-   |            | and q in the probable method    | integer |          |
-   | pSeed      | The seed used to generate p in  | value   | Yes      |
-   |            | the provable method             |         |          |
-   | qSeed      | The seed used to generate q in  | value   | Yes      |
-   |            | the provable method             |         |          |
-   | pCounter   | The counter used to generate p  | value - | Yes      |
-   |            | in the provable method          | integer |          |
-   | qCounter   | The counter used to generate q  | value - | Yes      |
-   |            | in the provable method          | integer |          |
-   | g          | The generator                   | value   | Yes      |
-   | h          | The index value provided to the | value   | Yes      |
-   |            | g generator in the unverifiable |         |          |
-   |            | method                          |         |          |
-   | index      | The index value provided to the | value   | Yes      |
-   |            | g generator in the canonical    |         |          |
-   |            | method                          |         |          |
-   | r          | The signature component R       | value   | Yes      |
-   | s          | The signature component S       | value   | Yes      |
-   | x          | The private key component X     | value   | Yes      |
-   | y          | The public key component Y      | value   | Yes      |
-   | message    | The message used to generate    | value   | Yes      |
-   |            | signature or verify signature   |         |          |
-   +------------+---------------------------------+---------+----------+
+   |                | test case, unique across    |         |          |
+   |                | the entire vector set.      |         |          |
+   | p              | The prime modulus           | value   | Yes      |
+   | q              | The prime divisor of p - 1  | value   | Yes      |
+   | domainSeed     | The seed used to generate p | value   | Yes      |
+   |                | and q in the probable       |         |          |
+   |                | method                      |         |          |
+   | counter        | The counter used to         | value - | Yes      |
+   |                | generate p and q in the     | integer |          |
+   |                | probable method             |         |          |
+   | pSeed          | The seed used to generate p | value   | Yes      |
+   |                | in the provable method      |         |          |
+   | qSeed          | The seed used to generate q | value   | Yes      |
+   |                | in the provable method      |         |          |
+   | pCounter       | The counter used to         | value - | Yes      |
+   |                | generate p in the provable  | integer |          |
+   |                | method                      |         |          |
+   | qCounter       | The counter used to         | value - | Yes      |
+   |                | generate q in the provable  | integer |          |
+   |                | method                      |         |          |
+   | g              | The generator               | value   | Yes      |
+   | h              | The index value provided to | value   | Yes      |
+   |                | the g generator in the      |         |          |
+   |                | unverifiable method         |         |          |
+   | index          | The index value provided to | value   | Yes      |
+   |                | the g generator in the      |         |          |
+   |                | canonical method            |         |          |
+   | r              | The signature component R   | value   | Yes      |
+   | s              | The signature component S   | value   | Yes      |
+   | x              | The private key component X | value   | Yes      |
+   | y              | The public key component Y  | value   | Yes      |
+   | message        | The message used to         | value   | Yes      |
+   |                | generate signature or       |         |          |
+   |                | verify signature            |         |          |
+   | randomValue    | The random value to be used | value   | Yes      |
+   |                | as an input into the        |         |          |
+   |                | message randomization       |         |          |
+   |                | function as described in    |         |          |
+   |                | [SP.800-106].               |         |          |
+   | randomValueLen | The random value's bit      | value   | Yes      |
+   |                | length.                     |         |          |
+   +----------------+-----------------------------+---------+----------+
 
-                      Table 10: Test Case JSON Object
+                      Table 11: Test Case JSON Object
 
-6.  Test Vector Responses
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 17]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+7.  Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
    table describes the JSON object that represents a vector set
    response.
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 15]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
    +-------------+---------------------------------------------+-------+
    | JSON Value  | Description                                 | JSON  |
@@ -854,63 +973,108 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |             | tables below                                |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 11: Vector Set Response JSON Object
+                 Table 12: Vector Set Response JSON Object
 
    The following table describes the JSON object that represents a
    vector set response for DSA.
 
-   +------------+--------------------------------+----------+----------+
-   | JSON Value | Description                    | JSON     | Optional |
-   |            |                                | type     |          |
-   +------------+--------------------------------+----------+----------+
-   | p          | The prime modulus              | value    | Yes      |
-   | q          | The prime divisor of p - 1     | value    | Yes      |
-   | g          | The generator                  | value    | Yes      |
-   | x          | The private key component X    | value    | Yes      |
-   | y          | The public key component Y     | value    | Yes      |
-   | r          | The signature component R      | value    | Yes      |
-   | s          | The signature component S      | value    | Yes      |
-   | domainSeed | The seed used to generate p    | value    | Yes      |
-   |            | and q in the probable method   |          |          |
-   | counter    | The counter used to generate p | value -  | Yes      |
-   |            | and q in the probable method   | integer  |          |
-   | pSeed      | The seed used to generate p in | value    | Yes      |
-   |            | the provable method            |          |          |
-   | qSeed      | The seed used to generate q in | value    | Yes      |
-   |            | the provable method            |          |          |
-   | pCounter   | The counter used to generate p | value -  | Yes      |
-   |            | in the provable method         | integer  |          |
-   | qCounter   | The counter used to generate q | value -  | Yes      |
-   |            | in the provable method         | integer  |          |
-   | testPassed | The pass or fail result of the | boolean  | Yes      |
-   |            | verify                         |          |          |
-   +------------+--------------------------------+----------+----------+
-
-                 Table 12: Vector Set Response JSON Object
 
 
 
 
 
 
-Fussell                 Expires December 3, 2016               [Page 16]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 18]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-7.  Acknowledgements
+   +----------------+-----------------------------+---------+----------+
+   | JSON Value     | Description                 | JSON    | Optional |
+   |                |                             | type    |          |
+   +----------------+-----------------------------+---------+----------+
+   | p              | The prime modulus           | value   | Yes      |
+   | q              | The prime divisor of p - 1  | value   | Yes      |
+   | g              | The generator               | value   | Yes      |
+   | x              | The private key component X | value   | Yes      |
+   | y              | The public key component Y  | value   | Yes      |
+   | r              | The signature component R   | value   | Yes      |
+   | s              | The signature component S   | value   | Yes      |
+   | domainSeed     | The seed used to generate p | value   | Yes      |
+   |                | and q in the probable       |         |          |
+   |                | method                      |         |          |
+   | counter        | The counter used to         | value - | Yes      |
+   |                | generate p and q in the     | integer |          |
+   |                | probable method             |         |          |
+   | pSeed          | The seed used to generate p | value   | Yes      |
+   |                | in the provable method      |         |          |
+   | qSeed          | The seed used to generate q | value   | Yes      |
+   |                | in the provable method      |         |          |
+   | pCounter       | The counter used to         | value - | Yes      |
+   |                | generate p in the provable  | integer |          |
+   |                | method                      |         |          |
+   | qCounter       | The counter used to         | value - | Yes      |
+   |                | generate q in the provable  | integer |          |
+   |                | method                      |         |          |
+   | randomValue    | The random value to be used | value   | Yes      |
+   |                | as an input into the        |         |          |
+   |                | message randomization       |         |          |
+   |                | function as described in    |         |          |
+   |                | [SP.800-106].               |         |          |
+   | randomValueLen | The random value's bit      | value   | Yes      |
+   |                | length.                     |         |          |
+   | testPassed     | The pass or fail result of  | boolean | Yes      |
+   |                | the verify                  |         |          |
+   +----------------+-----------------------------+---------+----------+
+
+                 Table 13: Vector Set Response JSON Object
+
+8.  Acknowledgements
 
    TBD...
 
-8.  IANA Considerations
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 19]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+9.  IANA Considerations
 
    This memo includes no request to IANA.
 
-9.  Security Considerations
+10.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
 
-10.  Normative References
+11.  Normative References
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
 
@@ -923,6 +1087,12 @@ Internet-Draft                Sym Alg JSON                     June 2016
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
+
+   [SP.800-106]
+              NIST, "Randomized Hashing for Digital Signatures",
+              February 2009,
+              <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/
+              nistspecialpublication800-106.pdf>.
 
    [SP.800-89]
               NIST, "Recommendation for Obtaining Assurances for Digital
@@ -944,16 +1114,16 @@ Appendix A.  Example Capabilities JSON Object
                    "prereqVals": [{
                                    "algorithm": "SHA",
                                    "valValue": "123456"
-                           },
-                           {
 
 
 
-Fussell                 Expires December 3, 2016               [Page 17]
+Fussell                 Expires December 3, 2016               [Page 20]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                           },
+                           {
                                    "algorithm": "DRBG",
                                    "valValue": "123456"
                            }
@@ -1000,16 +1170,16 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "pqGen": [
                                            "probable",
                                            "provable"
-                                   ],
-                                   "gGen": [
 
 
 
-Fussell                 Expires December 3, 2016               [Page 18]
+Fussell                 Expires December 3, 2016               [Page 21]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   ],
+                                   "gGen": [
                                            "unverifiable",
                                            "canonical"
                                    ],
@@ -1056,16 +1226,16 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "SHA2-512",
                                            "SHA2-512/224",
                                            "SHA2-512/256"
-                                   ]
-                           },
 
 
 
-Fussell                 Expires December 3, 2016               [Page 19]
+Fussell                 Expires December 3, 2016               [Page 22]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   ]
+                           },
                            {
                                    "pqGen": [
                                            "probable",
@@ -1112,16 +1282,16 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "gGen": [
                                            "unverifiable",
                                            "canonical"
-                                   ],
-                                   "l": 3072,
 
 
 
-Fussell                 Expires December 3, 2016               [Page 20]
+Fussell                 Expires December 3, 2016               [Page 23]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   ],
+                                   "l": 3072,
                                    "n": 256,
                                    "hashAlg": [
                                            "SHA2-256",
@@ -1168,16 +1338,16 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "valValue": "123456"
                            },
                            {
-                                   "algorithm": "DRBG",
-                                   "valValue": "123456"
 
 
 
-Fussell                 Expires December 3, 2016               [Page 21]
+Fussell                 Expires December 3, 2016               [Page 24]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+                                   "algorithm": "DRBG",
+                                   "valValue": "123456"
                            }
                    ],
                    "capabilities": [{
@@ -1219,21 +1389,24 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "SHA2-512/256"
                                    ]
                            }
+                   ],
+                   "conformances": [
+                           "SP800-106"
                    ]
            },
+
+
+
+Fussell                 Expires December 3, 2016               [Page 25]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
            {
                    "algorithm": "DSA",
                    "mode": "sigVer",
            "revision": "1.0",
                    "prereqVals": [{
-
-
-
-Fussell                 Expires December 3, 2016               [Page 22]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                                    "algorithm": "SHA",
                                    "valValue": "123456"
                            },
@@ -1277,19 +1450,19 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "SHA2-256",
                                            "SHA2-384",
                                            "SHA2-512",
+
+
+
+Fussell                 Expires December 3, 2016               [Page 26]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                                            "SHA2-512/224",
                                            "SHA2-512/256"
                                    ]
                            },
                            {
-
-
-
-Fussell                 Expires December 3, 2016               [Page 23]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                                    "n": 256,
                                    "l": 3072,
                                    "hashAlg": [
@@ -1302,6 +1475,9 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                            "SHA2-512/256"
                                    ]
                            }
+                   ]
+                   "conformances": [
+                           "SP800-106"
                    ]
            }
    ]
@@ -1330,6 +1506,14 @@ B.1.  Example Test DSA PQGGen JSON Object
                 "l": 2048,
                 "n": 224,
                 "hashAlg": "SHA2-224",
+
+
+
+Fussell                 Expires December 3, 2016               [Page 27]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                 "pqMode": "probable",
                 "testType": "GDT",
                 "tests": [
@@ -1338,14 +1522,6 @@ B.1.  Example Test DSA PQGGen JSON Object
                     }
                 ]
             },
-
-
-
-Fussell                 Expires December 3, 2016               [Page 24]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
             {
                 "tgId": 2,
                 "l": 2048,
@@ -1386,6 +1562,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
                       "tcId": 4,
                       "p": "CACDDA5F26C38B7EF49E8AC524AB8798FAF1328D7B64DCFC8DCEC1A129C7153D81D086FF9EE82A78ACBE4672EB4415C96FD7889BD22CFB9CDD6637D246607655E60EB927F56C115D56D4B4EB124FA0CB2EF9CED3FAF539EF6F78564267AB7E0D1506D3554D191C21ADA02177D2F87ABC5ECD00A570ECEE2E3E9AF2A044D76C6DE7CDC319FB36DE181521F92DB5DC6C89D71B6D9B192C1AA56060144BAE4202C904758560409EE87788793AFFFC1AB2B608841772CE13A782EC8CDE91838CB77F32CC8F31FF345AEB54BC6FC1DB29DDBA83E5BD5E879CC025ADBC198D7568D88F4E815AC2246D8BEF381AA1579F04EE653C125742F18E4090B983B8025AD531E5",
                       "q": "A4D538BAE42A3531663DD60DD8ACA2F0415C483DE36EF62EB4B2CEA3",
+
+
+
+Fussell                 Expires December 3, 2016               [Page 28]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                       "domainSeed": "E8A171F4CDF1674093EA6771EE3DC6737018834C9A346097B49119F8",
                       "index": "AD"
                     },
@@ -1394,12 +1578,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
         ]
     }
 ]
-
-
-
-Fussell                 Expires December 3, 2016               [Page 25]
-
-Internet-Draft                Sym Alg JSON                     June 2016
 
 
    The following is a example JSON object for DSA PQGGen test results
@@ -1440,6 +1618,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 }
               ]
             },
+
+
+
+Fussell                 Expires December 3, 2016               [Page 29]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
             {
               "tgId": 3,
               "tests": [
@@ -1450,14 +1636,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
               ]
             },
             {
-
-
-
-Fussell                 Expires December 3, 2016               [Page 26]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
               "tgId": 4,
               "tests": [
                 {
@@ -1496,6 +1674,14 @@ B.2.  Example Test DSA PQGVer JSON Object
             "pqMode": "probable",
             "tests": [
               {
+
+
+
+Fussell                 Expires December 3, 2016               [Page 30]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                 "tcId": 1,
                 "p": "9D9269AC94DB5003355DF597CD4136A049EEE19F0843A8B90E75E9CC37261713F53120EC3BDF10DECACFB369B6CED7FFC05DF938FB001C2DE8929524E36DFB9B8741503E23F471862D2C963152FD907441E5532B7E401765BB35AB7B0AB90DC5C13936E0CB5B46261F5F2DF944BBE2EC24AD37AB427CC52B20FBB95A38DCA267",
                 "q": "C5C97FD66D441234E781EA5E94C4448BCB040B1F",
@@ -1506,14 +1692,6 @@ B.2.  Example Test DSA PQGVer JSON Object
           },
           {
             "tgId": 2,
-
-
-
-Fussell                 Expires December 3, 2016               [Page 27]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
             "l": 1024,
             "n": 160,
             "hashAlg": "SHA-1",
@@ -1552,6 +1730,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
           {
             "tgId": 4,
             "l": 1024,
+
+
+
+Fussell                 Expires December 3, 2016               [Page 31]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
             "n": 160,
             "hashAlg": "SHA-1",
             "testType": "GDT",
@@ -1562,14 +1748,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "p": "9A1B46A4498962D12FDE300EB25B65E06DB00ED31D3AB653D5244894A243A149034FF193EC603C2872287F2B14E628C1B9C9391A56B544DA0906103BB308BC1196CA0BF92C7BFE4CA3C593243CB695C1EFC727557D85B9E0B0A07599636C6692DCD8895C87F66797CC9F61B3AE06FA94A2301D40A0D280E60DE40F66310244C9",
                 "q": "B70E07662CADF2A4191470948B040BE39BD56671",
                 "g": "45659A0B48B5B581E5CA68C8B81731DEE8381619A0F6EF421E20FB26CB0F78DE3571C73C98441BAE2E2C7B1201E95A32E4BD28D347AC5DFEA5848E9AD48C579D17756AF49E4E620B85E9EE4FFE1C4F8B111F161FA2FF292529FAF97776877B34C3B35950C0A1A27FBEC78164B1D48AD6E0F8D58E09EA2E5ACE96C3F8C0250678",
-
-
-
-Fussell                 Expires December 3, 2016               [Page 28]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                 "index": "45"
               },
             ]
@@ -1611,17 +1789,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 29]
+Fussell                 Expires December 3, 2016               [Page 32]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1677,7 +1845,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 30]
+Fussell                 Expires December 3, 2016               [Page 33]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1733,7 +1901,7 @@ B.3.  Example Test DSA KeyGen JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 31]
+Fussell                 Expires December 3, 2016               [Page 34]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1789,7 +1957,7 @@ B.4.  Example Test DSA SigGen JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 32]
+Fussell                 Expires December 3, 2016               [Page 35]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1815,6 +1983,19 @@ Internet-Draft                Sym Alg JSON                     June 2016
                         "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
                     }
                 ]
+            },
+            {
+                "tgId": 2,
+                "l": 2048,
+                "n": 224,
+                "sha": "SHA-1",
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
+                    }
+                ]
             }
         ]
     }
@@ -1832,46 +2013,43 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 33]
+Fussell                 Expires December 3, 2016               [Page 36]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-[
-    {
-        "acvVersion": <acvp-version>
+[{
+        "acvVersion": ""
     },
     {
         "vsId": 1564,
-        "testGroups": [
-        {
-          "tgId": 1,
-          "p": "C8DC6C77CC31ADAE68F3221D59C75538F6956517FF915B96939D0355D3AE7D00789EDDFF13C6707CFAC855EE79FC5A25F7243FF8D6FAD5E89CC799FB275ADB2A6F573FDF69FBF3C3C358C51E229B7799D78416F33F2F20420F35BDABB967435C78EFE843BADF4D93A65538B54723BBF1489D20482A295224CA870EE7F65BC7A17611221D58DB4B51D9C32A359D93032DD97942E8042EC4458D1E78B97D783D14243AEFDE455ED9AEC1925FE49E4B2A9B2160D710CCBEA6BC679E2A2A5307F5CD6B7C8E1078E83DF39A636ACE7E6EED18FBDC56ED89AC21B2ED133566D4696609E0AD0C95DC776893AB71AC9E223CE318CE26FBAE29B812075975F6B73DAF3529",
-          "q": "B1B7BCF2467F8CC46FCDD2A41327C2698D9E0A3F36682E17546EAE5B",
-          "g": "6C07130A6F6D05AAC9350936EE06B1303035FE460CEBF21DDA00CC08CD5E8A788D8C3F6B4B0A567A82DBF373CE36A40ADCF77D0CB6CA9AB93D1C0051E354AEB27BBC808A4950E91E2BFFFEF7427DBEA5E05BC9A3C003F6796C0A3EF3CF7D30378657A0966AE952BDC038645199F3C2FBBFD0B4E6E489E97D6DF8A9AD4356B34A3CD289DF9BA53F95A62E110B2BA84D668D7F72EA6CA471B6624F0F2E5CB54C9E96367CD4659BC64EC731B7F60CE0F08B58CFB29090DBDE6BDD7EC16689A9CC3913F3F009E03280342150C0899814532F471594C883B3941ADA81EB95274BB0B8900C492D92AD5686141DBB302DD2C2B4EEA8C2C7AD9B616DF0A520B9CCF7074F",
-          "y": "79143F63ECCC06B3D35C61DA2FB8ED359F8FBF014D699C3B6E150E60443BA461C256498F52262AD3850FECDA5F01F4702F5411BF25F0D9A4CF21F9B84B8FEF8C5E83563A1AE35C253D07011E5492106F46C7DF2624948E3662DAC129E5A094A6180F24480D3FFBD2F223156E68EBD6378ECBA010DF0CB6B3DD12045D8015E66160821AF5A12C8FE239AB331EBCDE6B906A40197769A74780700420C40428A81FBDEB94B9FE37183E9401167AFF6AEAE9968A6FBD11AFB3EB60ED076627CC2873EA2034BAEF2427C1BABF858D4E783B0FE3C51B39661EFBD9518F93A554E5E37428AFC62CF0C61A3B9248B56BBA0282E9BB7A8A6FB14D2CA4AAA9DC3245722525",
-          "tests": [
-            {
-              "tcId": 1,
-              "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
-              "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314"
+        "testGroups": [{
+                "tgId": 1,
+                "p": "C8DC6C77CC31ADAE68F3221D59C75538F6956517FF915B96939D0355D3AE7D00789EDDFF13C6707CFAC855EE79FC5A25F7243FF8D6FAD5E89CC799FB275ADB2A6F573FDF69FBF3C3C358C51E229B7799D78416F33F2F20420F35BDABB967435C78EFE843BADF4D93A65538B54723BBF1489D20482A295224CA870EE7F65BC7A17611221D58DB4B51D9C32A359D93032DD97942E8042EC4458D1E78B97D783D14243AEFDE455ED9AEC1925FE49E4B2A9B2160D710CCBEA6BC679E2A2A5307F5CD6B7C8E1078E83DF39A636ACE7E6EED18FBDC56ED89AC21B2ED133566D4696609E0AD0C95DC776893AB71AC9E223CE318CE26FBAE29B812075975F6B73DAF3529",
+                "q": "B1B7BCF2467F8CC46FCDD2A41327C2698D9E0A3F36682E17546EAE5B",
+                "g": "6C07130A6F6D05AAC9350936EE06B1303035FE460CEBF21DDA00CC08CD5E8A788D8C3F6B4B0A567A82DBF373CE36A40ADCF77D0CB6CA9AB93D1C0051E354AEB27BBC808A4950E91E2BFFFEF7427DBEA5E05BC9A3C003F6796C0A3EF3CF7D30378657A0966AE952BDC038645199F3C2FBBFD0B4E6E489E97D6DF8A9AD4356B34A3CD289DF9BA53F95A62E110B2BA84D668D7F72EA6CA471B6624F0F2E5CB54C9E96367CD4659BC64EC731B7F60CE0F08B58CFB29090DBDE6BDD7EC16689A9CC3913F3F009E03280342150C0899814532F471594C883B3941ADA81EB95274BB0B8900C492D92AD5686141DBB302DD2C2B4EEA8C2C7AD9B616DF0A520B9CCF7074F",
+                "y": "79143F63ECCC06B3D35C61DA2FB8ED359F8FBF014D699C3B6E150E60443BA461C256498F52262AD3850FECDA5F01F4702F5411BF25F0D9A4CF21F9B84B8FEF8C5E83563A1AE35C253D07011E5492106F46C7DF2624948E3662DAC129E5A094A6180F24480D3FFBD2F223156E68EBD6378ECBA010DF0CB6B3DD12045D8015E66160821AF5A12C8FE239AB331EBCDE6B906A40197769A74780700420C40428A81FBDEB94B9FE37183E9401167AFF6AEAE9968A6FBD11AFB3EB60ED076627CC2873EA2034BAEF2427C1BABF858D4E783B0FE3C51B39661EFBD9518F93A554E5E37428AFC62CF0C61A3B9248B56BBA0282E9BB7A8A6FB14D2CA4AAA9DC3245722525",
+                "tests": [{
+                    "tcId": 1,
+                    "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
+                    "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314"
+                }]
             },
-          ]
+            {
+                "tgId": 2,
+                "p": "77CC31ADAE68F3221D59C75538F6...",
+                "q": "82E17546E564816AFB54987C879A...",
+                "g": "B1303035FE460CEBF21DDA00CC08...",
+                "y": "D699C3B6E150E60443BA461C2564...",
+                "tests": [{
+                    "tcId": 1,
+                    "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
+                    "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314",
+                    "randomValue": "23678643ACB7283497...",
+                    "randomValueLen": 1024
+                }]
+            }
         ]
-      }
     }
 ]
 
@@ -1882,36 +2060,20 @@ B.5.  Example Test DSA SigVer JSON Object
    sent from the ACVP server to the crypto module and the response.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 34]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
 [
     {
         "acvVersion": <acvp-version>
     },
     {
         "vsId": 1564,
+
+
+
+Fussell                 Expires December 3, 2016               [Page 37]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
         "algorithm": "DSA",
         "mode": "sigVer",
         "revision": "1.0",
@@ -1924,6 +2086,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
             "q": "D3C53E62338D4231E42FA9683175C404FBF52759",
             "g": "7BDDD6B8E9B4667397B278F98F446C418EF1A502068B3082F9CE1D639F5FAA67048ACD4F50E1F855467465A653D2245B7E31C910A18EF79F098ACF73BFC43B1B5E7BFB065FB7A89583C5C23105018D0525AFA9C40B6C343E69CFC2B6B2A87FB4265FDE13D6F19A7BF7A1302AA14EDFA56FD1526241316D1BA182683B8E306CDA",
             "hashAlg": "SHA-1",
+            "isMessageRandomized": true,
             "tests": [
               {
                 "tcId": 1,
@@ -1933,33 +2096,42 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "s": "26BE6EFDCD2ED6946BFCFE2D396AB3A2E84B2FF8"
               },
             ]
+          },
+          {
+            "tgId": 2,
+            "l": 1024,
+            "n": 160,
+            "p": "66F108D370A2A9E87DBD49BC09A27017621A...",
+            "q": "1F855467465A653D2245B7E31C910A18EF79...",
+            "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
+            "hashAlg": "SHA-1",
+            "tests": [
+              {
+                "tcId": 1,
+                "message": "A0F409909E31C2C23BB7A24B8103F11F...",
+                "randomValue": "DB0D25A72C8DEFA0F409909E31C2..."
+                "randomValueLen": 1024,
+                "y": "A3A284CB56F3A0EF37749B5EA4D2EC824ED5E7EAD481BE520B...",
+                "r": "15FE6F6DAEFD42CD5FA7444221CB545BB0CDB95DC9D76E0...",
+                "s": "B9AF193E6832934537B0B05D177BA8F7DA48D9DD84D27B8AFE9..."
+              },
+            ]
           }
         ]
     }
 ]
 
 
-   The following is a example JSON object for DSA generation test
-   results sent from the crypto module to the ACVP server.
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 35]
+Fussell                 Expires December 3, 2016               [Page 38]
 
 Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   The following is a example JSON object for DSA generation test
+   results sent from the crypto module to the ACVP server.
 
 
    [
@@ -2009,8 +2181,4 @@ Author's Address
 
 
 
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 36]
+Fussell                 Expires December 3, 2016               [Page 39]

--- a/artifacts/acvp_sub_ecdsa.html
+++ b/artifacts/acvp_sub_ecdsa.html
@@ -393,14 +393,15 @@
 <link href="#rfc.section.4.3.3.1" rel="Chapter" title="4.3.3.1 sigGen Full Set of Capabilities">
 <link href="#rfc.section.4.3.4" rel="Chapter" title="4.3.4 The sigVer Mode Capabilities">
 <link href="#rfc.section.4.3.4.1" rel="Chapter" title="4.3.4.1 sigVer Full Set of Capabilities">
-<link href="#rfc.section.5" rel="Chapter" title="5 Test Vectors">
-<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Test Groups JSON Schema">
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Test Case JSON Schema">
-<link href="#rfc.section.6" rel="Chapter" title="6 Test Vector Responses">
-<link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
-<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
-<link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="10 Normative References">
+<link href="#rfc.section.5" rel="Chapter" title="5 Supported DSA Conformances">
+<link href="#rfc.section.6" rel="Chapter" title="6 Test Vectors">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Test Groups JSON Schema">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Test Case JSON Schema">
+<link href="#rfc.section.7" rel="Chapter" title="7 Test Vector Responses">
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgements">
+<link href="#rfc.section.9" rel="Chapter" title="9 IANA Considerations">
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="11 Normative References">
 <link href="#rfc.appendix.A" rel="Chapter" title="A Example Capabilities JSON Object">
 <link href="#rfc.appendix.B" rel="Chapter" title="B Example Vector Set Request/Responses JSON Object">
 <link href="#rfc.appendix.B.1" rel="Chapter" title="B.1 Example Test ECDSA KeyGen JSON Object">
@@ -504,21 +505,23 @@
 </li>
 <ul><li>4.3.4.1.   <a href="#rfc.section.4.3.4.1">sigVer Full Set of Capabilities</a>
 </li>
-</ul></ul></ul><li>5.   <a href="#rfc.section.5">Test Vectors</a>
+</ul></ul></ul><li>5.   <a href="#rfc.section.5">Supported DSA Conformances</a>
 </li>
-<ul><li>5.1.   <a href="#rfc.section.5.1">Test Groups JSON Schema</a>
+<li>6.   <a href="#rfc.section.6">Test Vectors</a>
 </li>
-<li>5.2.   <a href="#rfc.section.5.2">Test Case JSON Schema</a>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Test Groups JSON Schema</a>
 </li>
-</ul><li>6.   <a href="#rfc.section.6">Test Vector Responses</a>
+<li>6.2.   <a href="#rfc.section.6.2">Test Case JSON Schema</a>
 </li>
-<li>7.   <a href="#rfc.section.7">Acknowledgements</a>
+</ul><li>7.   <a href="#rfc.section.7">Test Vector Responses</a>
 </li>
-<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+<li>8.   <a href="#rfc.section.8">Acknowledgements</a>
 </li>
-<li>9.   <a href="#rfc.section.9">Security Considerations</a>
+<li>9.   <a href="#rfc.section.9">IANA Considerations</a>
 </li>
-<li>10.   <a href="#rfc.references">Normative References</a>
+<li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<li>11.   <a href="#rfc.references">Normative References</a>
 </li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Example Capabilities JSON Object</a>
 </li>
@@ -583,6 +586,7 @@
 <ul class="empty">
 <li>FIPS.186-4 - 3 General Discussion. Domain parameter generation, key generation, signature generation, and signature validation are all within scope of ACVP server testing.  </li>
 <li>FIPS.186-4 - 6 The Eliliptic Curve Digital Signature Algorithm (ECDSA). The ACVP server SHALL allow testing with the recommended NIST curves.  The ACVP server SHALL support a variety of curves/hash function for creation and delivery to/from the IUT.  Key pair generation/verification testing SHALL be provided by the ACVP server. Both Signature Generation and Validation testing mechanmisms SHALL be provided by the ACVP server.  </li>
+<li>SP800-106 - (3) Randomized Hashing and (4) Digital Signatures Using Randomized Hashing.  The IUT SHALL be provided or provide a random value that should be used to "randomize" a message prior to signing and/or verifying an original message.  </li>
 </ul>
 
 <p> </p>
@@ -594,6 +598,7 @@
 <ul class="empty">
 <li>FIPS.186-4 - 3 General Discussion. Assurances of private key secrecy and ownership SHALL NOT be within scope of ACVP testing.  </li>
 <li>FIPS.186-4 - 6 The Eliliptic Curve Digital Signature Algorithm (ECDSA). Though the ACVP server SHALL support a variety of parameter sizes/hash functions, the IUT's selection of these is out of scope of testing.  The ACVP server SHALL NOT provide testing for the validity of domain parameters as testing is (currently) limited to approved NIST curves.  Testing SHALL NOT provide assurances the IUT has validated a set of domain parameters prior to their use.  Domain parameter and key pair management SHALL NOT be within scope of ACVP testing.  </li>
+<li>SP800-106 - 3.3 The Random Value. DSA, ECDSA, and RSA have random values generated as per their signing process, this random value can be used as the input to the message randomization function, doing so however is out of scope of this testing.  </li>
 </ul>
 
 <p> </p>
@@ -697,6 +702,13 @@
 <td class="left">array of JSON objects, each with fields pertaining to the global ECDSA mode indicated above and identified uniquely by the combination of the ECDSA "mode" and indicated properties</td>
 <td class="left">Array of JSON objects</td>
 <td class="left">See <a href="#supported_modes" class="xref">Section 4.3</a> </td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left">conformances</td>
+<td class="left">Used to denote the conformances that can apply to specific modes of DSA.</td>
+<td class="left">Array of strings</td>
+<td class="left">See <a href="#supported_conformances" class="xref">Section 5</a> </td>
 <td class="left">Yes</td>
 </tr>
 </tbody>
@@ -860,11 +872,32 @@
 </tbody>
 </table>
 <h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+<a href="#rfc.section.5">5.</a> <a href="#supported_conformances" id="supported_conformances">Supported DSA Conformances</a>
 </h1>
-<p id="rfc.section.5.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual ECDSA function. This section describes the JSON schema for a test vector set used with ECDSA algorithms.</p>
-<p id="rfc.section.5.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy.</p>
+<p id="rfc.section.5.p.1">Conformances MAY be used to test additional features of certain algorithms.</p>
 <div id="rfc.table.7"></div>
+<div id="conformances_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>DSA Conformances</caption>
+<thead><tr>
+<th class="left">String Value</th>
+<th class="left">Description</th>
+<th class="left">Valid algorithm modes</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody><tr>
+<td class="left">SP800-106</td>
+<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</td>
+<td class="left">SigGen, SigVer</td>
+<td class="left">Yes</td>
+</tr></tbody>
+</table>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+</h1>
+<p id="rfc.section.6.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual ECDSA function. This section describes the JSON schema for a test vector set used with ECDSA algorithms.</p>
+<p id="rfc.section.6.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy.</p>
+<div id="rfc.table.8"></div>
 <div id="vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set JSON Object</caption>
@@ -901,17 +934,17 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 5.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 6.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.1">
-<a href="#rfc.section.5.1">5.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.5.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted	in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
-<p id="rfc.section.5.1.p.2">The test group for ECDSA is as follows:</p>
-<div id="rfc.table.8"></div>
+<p id="rfc.section.6.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted	in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.</p>
+<p id="rfc.section.6.1.p.2">The test group for ECDSA is as follows:</p>
+<div id="rfc.table.9"></div>
 <div id="vs_tg_table5"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Group JSON Object</caption>
@@ -953,18 +986,24 @@
 <td class="left">Yes</td>
 </tr>
 <tr>
+<td class="left">isMessageRandomized</td>
+<td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">boolean</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 5.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#tvjs" class="xref">Section 6.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.2">
-<a href="#rfc.section.5.2">5.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.5.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object	that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ECDSA test vector.</p>
-<div id="rfc.table.9"></div>
+<p id="rfc.section.6.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object	that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ECDSA test vector.</p>
+<div id="rfc.table.10"></div>
 <div id="vs_tc_table5"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Test Case JSON Object</caption>
@@ -1011,13 +1050,25 @@
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
+<tr>
+<td class="left">randomValue</td>
+<td class="left">The random value to be used as an input into the message randomization function as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left">randomValueLen</td>
+<td class="left">The random value's bit length.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
 </h1>
-<p id="rfc.section.6.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.10"></div>
+<p id="rfc.section.7.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.11"></div>
 <div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1044,8 +1095,8 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.p.2">The following table describes the JSON object that represents a vector set response for ECDSA.</p>
-<div id="rfc.table.11"></div>
+<p id="rfc.section.7.p.2">The following table describes the JSON object that represents a vector set response for ECDSA.</p>
+<div id="rfc.table.12"></div>
 <div id="vr_top_table5"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1087,6 +1138,18 @@
 <td class="left">Yes</td>
 </tr>
 <tr>
+<td class="left">randomValue</td>
+<td class="left">The random value to be used as an input into the message randomization function as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left">randomValueLen</td>
+<td class="left">The random value's bit length.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
 <td class="left">testPassed</td>
 <td class="left">The Pass or Fail result of the verify or validation</td>
 <td class="left">boolean</td>
@@ -1094,20 +1157,20 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
-</h1>
-<p id="rfc.section.7.p.1">TBD...</p>
 <h1 id="rfc.section.8">
-<a href="#rfc.section.8">8.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+<a href="#rfc.section.8">8.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
-<p id="rfc.section.8.p.1">This memo includes no request to IANA.</p>
+<p id="rfc.section.8.p.1">TBD...</p>
 <h1 id="rfc.section.9">
-<a href="#rfc.section.9">9.</a> <a href="#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.9">9.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.9.p.1">Security considerations are addressed by the ACVP specification.</p>
+<p id="rfc.section.9.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.10.p.1">Security considerations are addressed by the ACVP specification.</p>
 <h1 id="rfc.references">
-<a href="#rfc.references">10.</a> Normative References</h1>
+<a href="#rfc.references">11.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
@@ -1123,6 +1186,11 @@
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
 <a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SP.800-106">[SP.800-106]</b></td>
+<td class="top">
+<a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf">Randomized Hashing for Digital Signatures</a>", February 2009.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP.800-89">[SP.800-89]</b></td>
@@ -1235,7 +1303,10 @@
 				"SHA2-512/224",
 				"SHA2-512/256"
 			]
-		}]
+		}],
+		"conformances": [
+			"SP800-106"
+		]
 	},
 	{
 		"algorithm": "ECDSA",
@@ -1277,7 +1348,10 @@
 				"SHA2-512/224",
 				"SHA2-512/256"
 			]
-		}]
+		}],
+		"conformances": [
+			"SP800-106"
+		]
 	}
 ]
             
@@ -1415,13 +1489,25 @@
         "revision": "1.0",
         "testGroups": [
             {
-				"tgId": 1,
+                "tgId": 1,
                 "curve": "P-224",
                 "hashAlg": "SHA2-224",
                 "tests": [
                     {
                         "tcId": 1,
                         "message": "AB6F57713A3BD323B4AFDCFBE202EE00A9CF5C787D19FD9094323C57FEA8B7FBE31559EC1CAC6D29C3229A58811CF2BAE2B78183DFDABD055B741EA86496454F085D17D5BCD1B82B533B533A1E5804B2DAA0ED43F8BF59FBEB16BDD4D7C065165CB9B085CECD5BCFFA794339D5A81B1949F569CAACA208B9E3E6A217A1B3A596"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "curve": "P-224",
+                "hashAlg": "SHA2-224",
+                "isMessageRandomized": true
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "message": "23B4AFDCFBE202EE00A9CF5C787D19FD90..."
                     }
                 ]
             }
@@ -1441,16 +1527,30 @@
         "vsId": 1564,
         "testGroups": [
             {
-				"tgId": 1,
-				"qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
+                "tgId": 1,
+                "qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
                 "qy": "E56F7B7C9E6355E573B7B3B6C0E1ECD70E4ABDF1554EAD8A68ABA1A4",
-				"tests": [
-					{
-						"tcId": 1,
-						"r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
-						"s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
-					}
-				]
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                        "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "qx": "A1304693BDBA632CB93A3B8BA632CB93A3...",
+                "qy": "ECD70E4ABBA632CB93A3BA632CB93A3DF1...",
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                        "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A",
+                        "randomValue": "0A0E11C4C6D6F8F3C51..."
+                        "randomValueLen": 1024
+                    }
+                ]
             }
         ]
     }
@@ -1474,7 +1574,7 @@
         "revision": "1.0",
         "testGroups": [
             {
-				"tgId": 1,
+                "tgId": 1,
                 "curve": "P-192",
                 "hashAlg": "SHA-1",
                 "tests": [
@@ -1485,6 +1585,24 @@
                         "qy": "55847857E5E48025BE9053952E0E1ECFB1D883CF9F085386",
                         "r": "E31121E544D476DC3FA79B4DCB0A7252B6E80468BBF22843",
                         "s": "6E3F47F2327E36AD936E0F4BE245C05F264BA9300E9E7DD9"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "curve": "P-192",
+                "hashAlg": "SHA-1",
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "message": "D38A81D04A06A8C4760AC15DB266B17B48B...",
+                        "randomValue": "1527E0FE37FD1162F5DD0D975E83C0D...",
+                        "randomValueLen": 1024
+                        "qx": "D1E896486D9D986A464D3469941F93FC65556E2CB...",
+                        "qy": "ADCB8D50375DC76907195B6AF6C06F...",
+                        "r": "6D9D986A464D3469941F93FC65556E2CB8AB5F113...",
+                        "s": "8E713EB6106EF0E19E241DB4B4831E06437E5C..."
                     }
                 ]
             }
@@ -1504,13 +1622,20 @@
         "vsId": 1564,
         "testGroups": [
             {
-				"tgId": 1,
-				"tests": [
-					{
-						"tcId": 1,
-						"testPassed": false
-					}
-				]
+                "tgId": 1,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "testPassed": false
+                    }
+                ],
+                "tgId": 2,
+                "tests" [
+                    {
+                        "tcId": 2,
+                        "testPassed": true
+                    }
+                ]
             }
         ]
     }

--- a/artifacts/acvp_sub_ecdsa.html
+++ b/artifacts/acvp_sub_ecdsa.html
@@ -887,7 +887,7 @@
 </tr></thead>
 <tbody><tr>
 <td class="left">SP800-106</td>
-<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</td>
+<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of `"conformance": "SP800-106"`.</td>
 <td class="left">SigGen, SigVer</td>
 <td class="left">Yes</td>
 </tr></tbody>
@@ -986,9 +986,9 @@
 <td class="left">Yes</td>
 </tr>
 <tr>
-<td class="left">isMessageRandomized</td>
+<td class="left">conformance</td>
 <td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
-<td class="left">boolean</td>
+<td class="left">"SP800-106"</td>
 <td class="left">Yes</td>
 </tr>
 <tr>
@@ -1503,7 +1503,7 @@
                 "tgId": 2,
                 "curve": "P-224",
                 "hashAlg": "SHA2-224",
-                "isMessageRandomized": true
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,
@@ -1592,7 +1592,7 @@
                 "tgId": 2,
                 "curve": "P-192",
                 "hashAlg": "SHA-1",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,

--- a/artifacts/acvp_sub_ecdsa.txt
+++ b/artifacts/acvp_sub_ecdsa.txt
@@ -636,8 +636,8 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |           | conformance SHALL generate     |           |          |
    |           | additional test groups,        |           |          |
    |           | denoted with a group level     |           |          |
-   |           | property of                    |           |          |
-   |           | "isMessageRandomized".         |           |          |
+   |           | property of `"conformance":    |           |          |
+   |           | "SP800-106"`.                  |           |          |
    +-----------+--------------------------------+-----------+----------+
 
                          Table 7: DSA Conformances
@@ -730,34 +730,36 @@ Fussell                 Expires December 3, 2016               [Page 13]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +----------------------+-----------------------+---------+----------+
-   | JSON Value           | Description           | JSON    | Optional |
-   |                      |                       | type    |          |
-   +----------------------+-----------------------+---------+----------+
-   | curve                | The curve type used   | value   | No       |
-   |                      | for the test vectors. |         |          |
-   | secretGenerationMode | The method of         | value   | Yes      |
-   |                      | generating a secret   |         |          |
-   |                      | used for key          |         |          |
-   |                      | generation in the     |         |          |
-   |                      | test vectors.         |         |          |
-   | hashAlg              | SHA version used      | value   | Yes      |
-   | qx                   | The public key curve  | value   | Yes      |
-   |                      | point x               |         |          |
-   | qy                   | The public key curve  | value   | Yes      |
-   |                      | point y               |         |          |
-   | isMessageRandomized  | Signifies all test    | boolean | Yes      |
-   |                      | cases within the      |         |          |
-   |                      | group should utilize  |         |          |
-   |                      | random message        |         |          |
-   |                      | hashing as described  |         |          |
-   |                      | in [SP.800-106].      |         |          |
-   | tests                | Array of individual   | array   | No       |
-   |                      | test vector JSON      |         |          |
-   |                      | objects, which are    |         |          |
-   |                      | defined in            |         |          |
-   |                      | Section 6.2           |         |          |
-   +----------------------+-----------------------+---------+----------+
+   +----------------------+-------------------+-------------+----------+
+   | JSON Value           | Description       | JSON type   | Optional |
+   +----------------------+-------------------+-------------+----------+
+   | curve                | The curve type    | value       | No       |
+   |                      | used for the test |             |          |
+   |                      | vectors.          |             |          |
+   | secretGenerationMode | The method of     | value       | Yes      |
+   |                      | generating a      |             |          |
+   |                      | secret used for   |             |          |
+   |                      | key generation in |             |          |
+   |                      | the test vectors. |             |          |
+   | hashAlg              | SHA version used  | value       | Yes      |
+   | qx                   | The public key    | value       | Yes      |
+   |                      | curve point x     |             |          |
+   | qy                   | The public key    | value       | Yes      |
+   |                      | curve point y     |             |          |
+   | conformance          | Signifies all     | "SP800-106" | Yes      |
+   |                      | test cases within |             |          |
+   |                      | the group should  |             |          |
+   |                      | utilize random    |             |          |
+   |                      | message hashing   |             |          |
+   |                      | as described in   |             |          |
+   |                      | [SP.800-106].     |             |          |
+   | tests                | Array of          | array       | No       |
+   |                      | individual test   |             |          |
+   |                      | vector JSON       |             |          |
+   |                      | objects, which    |             |          |
+   |                      | are defined in    |             |          |
+   |                      | Section 6.2       |             |          |
+   +----------------------+-------------------+-------------+----------+
 
                      Table 9: Vector Group JSON Object
 
@@ -767,8 +769,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each ECDSA test vector.
-
-
 
 
 
@@ -1371,7 +1371,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "tgId": 2,
                 "curve": "P-224",
                 "hashAlg": "SHA2-224",
-                "isMessageRandomized": true
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,
@@ -1487,7 +1487,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
                 "tgId": 2,
                 "curve": "P-192",
                 "hashAlg": "SHA-1",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,

--- a/artifacts/acvp_sub_ecdsa.txt
+++ b/artifacts/acvp_sub_ecdsa.txt
@@ -67,33 +67,34 @@ Table of Contents
      3.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .   4
        3.1.1.  Requirements Covered  . . . . . . . . . . . . . . . .   4
        3.1.2.  Requirements Not Covered  . . . . . . . . . . . . . .   4
-   4.  Capabilities Registration . . . . . . . . . . . . . . . . . .   4
+   4.  Capabilities Registration . . . . . . . . . . . . . . . . . .   5
      4.1.  Required Prerequisite Algorithms for ECDSA Validations  .   5
-     4.2.  ECDSA Algorithm Capabilities Registration . . . . . . . .   5
-     4.3.  Supported ECDSA Modes Capabilities  . . . . . . . . . . .   6
+     4.2.  ECDSA Algorithm Capabilities Registration . . . . . . . .   6
+     4.3.  Supported ECDSA Modes Capabilities  . . . . . . . . . . .   7
        4.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   7
-         4.3.1.1.  keyGen Full Set of Capabilities . . . . . . . . .   7
+         4.3.1.1.  keyGen Full Set of Capabilities . . . . . . . . .   8
        4.3.2.  The keyVer Mode Capabilities  . . . . . . . . . . . .   8
-         4.3.2.1.  keyVer Full Set of Capabilities . . . . . . . . .   8
+         4.3.2.1.  keyVer Full Set of Capabilities . . . . . . . . .   9
        4.3.3.  The sigGen Mode Capabilities  . . . . . . . . . . . .   9
          4.3.3.1.  sigGen Full Set of Capabilities . . . . . . . . .   9
        4.3.4.  The sigVer Mode Capabilities  . . . . . . . . . . . .  10
          4.3.4.1.  sigVer Full Set of Capabilities . . . . . . . . .  11
-   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  12
-     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  12
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  13
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  14
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  15
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  15
-   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  15
-   Appendix B.  Example Vector Set Request/Responses JSON Object . .  18
-     B.1.  Example Test ECDSA KeyGen JSON Object . . . . . . . . . .  18
-     B.2.  Example Test ECDSA KeyVer JSON Object . . . . . . . . . .  20
-     B.3.  Example Test ECDSA Signature Generation JSON Object . . .  22
-     B.4.  Example Test ECDSA SigVer JSON Object . . . . . . . . . .  24
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  26
+   5.  Supported DSA Conformances  . . . . . . . . . . . . . . . . .  12
+   6.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     6.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  13
+     6.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  14
+   7.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  15
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  16
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  16
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  16
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  16
+   Appendix A.  Example Capabilities JSON Object . . . . . . . . . .  17
+   Appendix B.  Example Vector Set Request/Responses JSON Object . .  20
+     B.1.  Example Test ECDSA KeyGen JSON Object . . . . . . . . . .  20
+     B.2.  Example Test ECDSA KeyVer JSON Object . . . . . . . . . .  22
+     B.3.  Example Test ECDSA Signature Generation JSON Object . . .  24
+     B.4.  Example Test ECDSA SigVer JSON Object . . . . . . . . . .  26
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  28
 
 1.  Introduction
 
@@ -105,7 +106,6 @@ Table of Contents
    vector processing and more.  The ACVP specification does not define
    algorithm specific JSON constructs for performing the crypto
    validation.  A series of ACVP sub-specifications define the
-   constructs for testing individual crypto algorithms.  Each sub-
 
 
 
@@ -114,6 +114,7 @@ Fussell                 Expires December 3, 2016                [Page 2]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+   constructs for testing individual crypto algorithms.  Each sub-
    specification addresses a specific class of crypto algorithms.  This
    sub-specification defines the JSON constructs for testing ECDSA
    algorithms using ACVP.
@@ -164,7 +165,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
 Fussell                 Expires December 3, 2016                [Page 3]
 
 Internet-Draft                Sym Alg JSON                     June 2016
@@ -197,6 +197,11 @@ Internet-Draft                Sym Alg JSON                     June 2016
       server.  Both Signature Generation and Validation testing
       mechanmisms SHALL be provided by the ACVP server.
 
+      SP800-106 - (3) Randomized Hashing and (4) Digital Signatures
+      Using Randomized Hashing.  The IUT SHALL be provided or provide a
+      random value that should be used to "randomize" a message prior to
+      signing and/or verifying an original message.
+
 3.1.2.  Requirements Not Covered
 
       FIPS.186-4 - 3 General Discussion.  Assurances of private key
@@ -212,12 +217,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
       parameters prior to their use.  Domain parameter and key pair
       management SHALL NOT be within scope of ACVP testing.
 
-4.  Capabilities Registration
 
-   ACVP requires crypto modules to register their capabilities.  This
-   allows the crypto module to advertise support for specific
-   algorithms, notifying the ACVP server which algorithms need test
-   vectors generated for the validation process.  This section describes
 
 
 
@@ -226,6 +226,17 @@ Fussell                 Expires December 3, 2016                [Page 4]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
+      SP800-106 - 3.3 The Random Value.  DSA, ECDSA, and RSA have random
+      values generated as per their signing process, this random value
+      can be used as the input to the message randomization function,
+      doing so however is out of scope of this testing.
+
+4.  Capabilities Registration
+
+   ACVP requires crypto modules to register their capabilities.  This
+   allows the crypto module to advertise support for specific
+   algorithms, notifying the ACVP server which algorithms need test
+   vectors generated for the validation process.  This section describes
    the constructs for advertising support of ECDSA algorithms to the
    ACVP server.
 
@@ -244,6 +255,32 @@ Internet-Draft                Sym Alg JSON                     June 2016
    underlying algorithm primitives must be validated, either separately
    or as part of the same submission.  ACVP provides a mechanism for
    specifying the required prerequisites:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 5]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
 
    +-------------+--------------+--------------+------------+----------+
    | JSON Value  | Description  | JSON type    | Valid      | Optional |
@@ -273,15 +310,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    Each algorithm capability advertised is a self-contained JSON object
    using the following values
 
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 5]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
    +--------------+--------------+--------------+-----------+----------+
    | JSON Value   | Description  | JSON type    | Valid     | Optional |
    |              |              |              | Values    |          |
@@ -302,6 +330,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
    | prereqVals   | prerequistie | array of     | See Secti | No       |
    |              | algorithm    | prereqAlgVal | on 4.1    |          |
    |              | validations  | objects      |           |          |
+
+
+
+Fussell                 Expires December 3, 2016                [Page 6]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    | capabilities | array of     | Array of     | See Secti | Yes      |
    |              | JSON         | JSON objects | on 4.3    |          |
    |              | objects,     |              |           |          |
@@ -321,6 +357,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |              | "mode" and   |              |           |          |
    |              | indicated    |              |           |          |
    |              | properties   |              |           |          |
+   | conformances | Used to      | Array of     | See       | Yes      |
+   |              | denote the   | strings      | Section 5 |          |
+   |              | conformances |              |           |          |
+   |              | that can     |              |           |          |
+   |              | apply to     |              |           |          |
+   |              | specific     |              |           |          |
+   |              | modes of     |              |           |          |
+   |              | DSA.         |              |           |          |
    +--------------+--------------+--------------+-----------+----------+
 
              Table 2: ECDSA Algorithm Capabilities JSON Values
@@ -330,14 +374,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    The ECDSA mode capabilities are advertised as JSON objects within the
    'capabilities' value of the ACVP registration message - see Table 2 .
    The 'capabilities' value is an array, where each array element is a
-
-
-
-Fussell                 Expires December 3, 2016                [Page 6]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
    JSON object corresponding to a particular ECDSA mode defined in this
    section.  The 'capabilities' value is part of the
    'capability_exchange' element of the ACVP JSON registration message.
@@ -349,6 +385,15 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The ECDSA keyGen mode capabilities are advertised as JSON objects,
    which are elements of the 'capabilities' array in the ACVP
+
+
+
+
+Fussell                 Expires December 3, 2016                [Page 7]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    registration message.  See the ACVP specification for details on the
    registration message.
 
@@ -359,40 +404,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of ECDSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016                [Page 7]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
 
    +--------------------+------------+-------+--------------+----------+
    | JSON Value         | Descriptio | JSON  | Valid Values | Optional |
@@ -431,17 +442,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
    registration message.  See the ACVP specification for details on the
    registration message.
 
-   Each ECDSA keyVer mode capability set is advertised as a self-
-   contained JSON object.
-
-4.3.2.1.  keyVer Full Set of Capabilities
-
-   The complete list of ECDSA key verification capabilities may be
-   advertised by the ACVP compliant crypto module:
-
-
-
-
 
 
 
@@ -449,6 +449,14 @@ Fussell                 Expires December 3, 2016                [Page 8]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
+
+   Each ECDSA keyVer mode capability set is advertised as a self-
+   contained JSON object.
+
+4.3.2.1.  keyVer Full Set of Capabilities
+
+   The complete list of ECDSA key verification capabilities may be
+   advertised by the ACVP compliant crypto module:
 
    +-------+-------------+-------+--------------------------+----------+
    | JSON  | Description | JSON  | Valid Values             | Optional |
@@ -481,14 +489,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
    The complete list of ECDSA signature generation capabilities may be
    advertised by the ACVP compliant crypto module:
-
-
-
-
-
-
-
-
 
 
 
@@ -618,7 +618,31 @@ Fussell                 Expires December 3, 2016               [Page 11]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-5.  Test Vectors
+5.  Supported DSA Conformances
+
+   Conformances MAY be used to test additional features of certain
+   algorithms.
+
+   +-----------+--------------------------------+-----------+----------+
+   | String    | Description                    | Valid     | Optional |
+   | Value     |                                | algorithm |          |
+   |           |                                | modes     |          |
+   +-----------+--------------------------------+-----------+----------+
+   | SP800-106 | This conformance signifies the | SigGen,   | Yes      |
+   |           | SigGen and/or SigVer modes     | SigVer    |          |
+   |           | support randomized message     |           |          |
+   |           | hashing as described in        |           |          |
+   |           | [SP.800-106]. Utilizing this   |           |          |
+   |           | conformance SHALL generate     |           |          |
+   |           | additional test groups,        |           |          |
+   |           | denoted with a group level     |           |          |
+   |           | property of                    |           |          |
+   |           | "isMessageRandomized".         |           |          |
+   +-----------+--------------------------------+-----------+----------+
+
+                         Table 7: DSA Conformances
+
+6.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -633,6 +657,23 @@ Internet-Draft                Sym Alg JSON                     June 2016
    test vectors to be processed by the ACVP client.The following table
    describes the JSON elements at the top level of the hierarchy.
 
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 12]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
    |            |                                             | type   |
@@ -644,12 +685,12 @@ Internet-Draft                Sym Alg JSON                     June 2016
    | mode       | The ECDSA mode used for the test vectors    | value  |
    | revision   | The algorithm testing revision to use.      | value  |
    | testGroups | Array of test group JSON objects, which are | array  |
-   |            | defined in Section 5.1                      |        |
+   |            | defined in Section 6.1                      |        |
    +------------+---------------------------------------------+--------+
 
-                      Table 7: Vector Set JSON Object
+                      Table 8: Vector Set JSON Object
 
-5.1.  Test Groups JSON Schema
+6.1.  Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -669,57 +710,16 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 12]
-
-Internet-Draft                Sym Alg JSON                     June 2016
 
 
-   +----------------------+-------------------------+-------+----------+
-   | JSON Value           | Description             | JSON  | Optional |
-   |                      |                         | type  |          |
-   +----------------------+-------------------------+-------+----------+
-   | curve                | The curve type used for | value | No       |
-   |                      | the test vectors.       |       |          |
-   | secretGenerationMode | The method of           | value | Yes      |
-   |                      | generating a secret     |       |          |
-   |                      | used for key generation |       |          |
-   |                      | in the test vectors.    |       |          |
-   | hashAlg              | SHA version used        | value | Yes      |
-   | qx                   | The public key curve    | value | Yes      |
-   |                      | point x                 |       |          |
-   | qy                   | The public key curve    | value | Yes      |
-   |                      | point y                 |       |          |
-   | tests                | Array of individual     | array | No       |
-   |                      | test vector JSON        |       |          |
-   |                      | objects, which are      |       |          |
-   |                      | defined in Section 5.2  |       |          |
-   +----------------------+-------------------------+-------+----------+
 
-                     Table 8: Vector Group JSON Object
 
-5.2.  Test Case JSON Schema
 
-   Each test group contains an array of one or more test cases.  Each
-   test case is a JSON object that represents a single test vector to be
-   processed by the ACVP client.  The following table describes the JSON
-   elements for each ECDSA test vector.
 
-   +---------+--------------------------------------+-------+----------+
-   | JSON    | Description                          | JSON  | Optional |
-   | Value   |                                      | type  |          |
-   +---------+--------------------------------------+-------+----------+
-   | tcId    | Numeric identifier for the test      | value | No       |
-   |         | case, unique across the entire       |       |          |
-   |         | vector set.                          |       |          |
-   | qx      | The public key curve point x         | value | Yes      |
-   | qy      | The public key curve point y         | value | Yes      |
-   | r       | The signature component R            | value | Yes      |
-   | s       | The signature component S            | value | Yes      |
-   | message | The message used to generate         | value | Yes      |
-   |         | signature or verify signature        |       |          |
-   +---------+--------------------------------------+-------+----------+
 
-                      Table 9: Test Case JSON Object
+
+
+
 
 
 
@@ -730,7 +730,86 @@ Fussell                 Expires December 3, 2016               [Page 13]
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-6.  Test Vector Responses
+   +----------------------+-----------------------+---------+----------+
+   | JSON Value           | Description           | JSON    | Optional |
+   |                      |                       | type    |          |
+   +----------------------+-----------------------+---------+----------+
+   | curve                | The curve type used   | value   | No       |
+   |                      | for the test vectors. |         |          |
+   | secretGenerationMode | The method of         | value   | Yes      |
+   |                      | generating a secret   |         |          |
+   |                      | used for key          |         |          |
+   |                      | generation in the     |         |          |
+   |                      | test vectors.         |         |          |
+   | hashAlg              | SHA version used      | value   | Yes      |
+   | qx                   | The public key curve  | value   | Yes      |
+   |                      | point x               |         |          |
+   | qy                   | The public key curve  | value   | Yes      |
+   |                      | point y               |         |          |
+   | isMessageRandomized  | Signifies all test    | boolean | Yes      |
+   |                      | cases within the      |         |          |
+   |                      | group should utilize  |         |          |
+   |                      | random message        |         |          |
+   |                      | hashing as described  |         |          |
+   |                      | in [SP.800-106].      |         |          |
+   | tests                | Array of individual   | array   | No       |
+   |                      | test vector JSON      |         |          |
+   |                      | objects, which are    |         |          |
+   |                      | defined in            |         |          |
+   |                      | Section 6.2           |         |          |
+   +----------------------+-----------------------+---------+----------+
+
+                     Table 9: Vector Group JSON Object
+
+6.2.  Test Case JSON Schema
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each ECDSA test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 14]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   +----------------+-------------------------------+-------+----------+
+   | JSON Value     | Description                   | JSON  | Optional |
+   |                |                               | type  |          |
+   +----------------+-------------------------------+-------+----------+
+   | tcId           | Numeric identifier for the    | value | No       |
+   |                | test case, unique across the  |       |          |
+   |                | entire vector set.            |       |          |
+   | qx             | The public key curve point x  | value | Yes      |
+   | qy             | The public key curve point y  | value | Yes      |
+   | r              | The signature component R     | value | Yes      |
+   | s              | The signature component S     | value | Yes      |
+   | message        | The message used to generate  | value | Yes      |
+   |                | signature or verify signature |       |          |
+   | randomValue    | The random value to be used   | value | Yes      |
+   |                | as an input into the message  |       |          |
+   |                | randomization function as     |       |          |
+   |                | described in [SP.800-106].    |       |          |
+   | randomValueLen | The random value's bit        | value | Yes      |
+   |                | length.                       |       |          |
+   +----------------+-------------------------------+-------+----------+
+
+                      Table 10: Test Case JSON Object
+
+7.  Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
@@ -749,48 +828,57 @@ Internet-Draft                Sym Alg JSON                     June 2016
    |             | tables below                                |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 10: Vector Set Response JSON Object
+                 Table 11: Vector Set Response JSON Object
 
    The following table describes the JSON object that represents a
    vector set response for ECDSA.
 
-   +------------+---------------------------------+---------+----------+
-   | JSON Value | Description                     | JSON    | Optional |
-   |            |                                 | type    |          |
-   +------------+---------------------------------+---------+----------+
-   | d          | The private key                 | value   | Yes      |
-   | qx         | The public key curve point x    | value   | Yes      |
-   | qy         | The public key curve point y    | value   | Yes      |
-   | r          | The signature component R       | value   | Yes      |
-   | s          | The signature component S       | value   | Yes      |
-   | testPassed | The Pass or Fail result of the  | boolean | Yes      |
-   |            | verify or validation            |         |          |
-   +------------+---------------------------------+---------+----------+
-
-                 Table 11: Vector Set Response JSON Object
-
-7.  Acknowledgements
-
-   TBD...
-
-8.  IANA Considerations
-
-   This memo includes no request to IANA.
 
 
 
 
-
-Fussell                 Expires December 3, 2016               [Page 14]
+Fussell                 Expires December 3, 2016               [Page 15]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
 
-9.  Security Considerations
+   +----------------+-----------------------------+---------+----------+
+   | JSON Value     | Description                 | JSON    | Optional |
+   |                |                             | type    |          |
+   +----------------+-----------------------------+---------+----------+
+   | d              | The private key             | value   | Yes      |
+   | qx             | The public key curve point  | value   | Yes      |
+   |                | x                           |         |          |
+   | qy             | The public key curve point  | value   | Yes      |
+   |                | y                           |         |          |
+   | r              | The signature component R   | value   | Yes      |
+   | s              | The signature component S   | value   | Yes      |
+   | randomValue    | The random value to be used | value   | Yes      |
+   |                | as an input into the        |         |          |
+   |                | message randomization       |         |          |
+   |                | function as described in    |         |          |
+   |                | [SP.800-106].               |         |          |
+   | randomValueLen | The random value's bit      | value   | Yes      |
+   |                | length.                     |         |          |
+   | testPassed     | The Pass or Fail result of  | boolean | Yes      |
+   |                | the verify or validation    |         |          |
+   +----------------+-----------------------------+---------+----------+
+
+                 Table 12: Vector Set Response JSON Object
+
+8.  Acknowledgements
+
+   TBD...
+
+9.  IANA Considerations
+
+   This memo includes no request to IANA.
+
+10.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
 
-10.  Normative References
+11.  Normative References
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
 
@@ -799,10 +887,27 @@ Internet-Draft                Sym Alg JSON                     June 2016
               <https://nvlpubs.nist.gov/nistpubs/FIPS/
               NIST.FIPS.186-4.pdf>.
 
+
+
+
+
+
+
+Fussell                 Expires December 3, 2016               [Page 16]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
+
+   [SP.800-106]
+              NIST, "Randomized Hashing for Digital Signatures",
+              February 2009,
+              <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/
+              nistspecialpublication800-106.pdf>.
 
    [SP.800-89]
               NIST, "Recommendation for Obtaining Assurances for Digital
@@ -834,14 +939,6 @@ Appendix A.  Example Capabilities JSON Object
                            "P-224",
                            "P-256",
                            "P-384",
-
-
-
-Fussell                 Expires December 3, 2016               [Page 15]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                            "P-521",
                            "B-233",
                            "B-283",
@@ -849,6 +946,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
                            "B-571",
                            "K-233",
                            "K-283",
+
+
+
+Fussell                 Expires December 3, 2016               [Page 17]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                            "K-409",
                            "K-571"
                    ],
@@ -890,14 +995,6 @@ Internet-Draft                Sym Alg JSON                     June 2016
            },
            {
                    "algorithm": "ECDSA",
-
-
-
-Fussell                 Expires December 3, 2016               [Page 16]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                    "mode": "sigGen",
                    "revision": "1.0",
                    "prereqVals": [{
@@ -905,6 +1002,14 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "valValue": "123456"
                            },
                            {
+
+
+
+Fussell                 Expires December 3, 2016               [Page 18]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                                    "algorithm": "DRBG",
                                    "valValue": "123456"
                            }
@@ -932,7 +1037,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "SHA2-512/224",
                                    "SHA2-512/256"
                            ]
-                   }]
+                   }],
+                   "conformances": [
+                           "SP800-106"
+                   ]
            },
            {
                    "algorithm": "ECDSA",
@@ -946,18 +1054,18 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "algorithm": "DRBG",
                                    "valValue": "123456"
                            }
-
-
-
-Fussell                 Expires December 3, 2016               [Page 17]
-
-Internet-Draft                Sym Alg JSON                     June 2016
-
-
                    ],
                    "capabilities": [{
                            "curve": [
                                    "P-192",
+
+
+
+Fussell                 Expires December 3, 2016               [Page 19]
+
+Internet-Draft                Sym Alg JSON                     June 2016
+
+
                                    "P-224",
                                    "P-256",
                                    "P-384",
@@ -982,7 +1090,10 @@ Internet-Draft                Sym Alg JSON                     June 2016
                                    "SHA2-512/224",
                                    "SHA2-512/256"
                            ]
-                   }]
+                   }],
+                   "conformances": [
+                           "SP800-106"
+                   ]
            }
    ]
 
@@ -1005,7 +1116,8 @@ B.1.  Example Test ECDSA KeyGen JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 18]
+
+Fussell                 Expires December 3, 2016               [Page 20]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1061,7 +1173,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 19]
+Fussell                 Expires December 3, 2016               [Page 21]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1117,7 +1229,7 @@ B.2.  Example Test ECDSA KeyVer JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 20]
+Fussell                 Expires December 3, 2016               [Page 22]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1173,7 +1285,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-Fussell                 Expires December 3, 2016               [Page 21]
+Fussell                 Expires December 3, 2016               [Page 23]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1229,7 +1341,7 @@ B.3.  Example Test ECDSA Signature Generation JSON Object
 
 
 
-Fussell                 Expires December 3, 2016               [Page 22]
+Fussell                 Expires December 3, 2016               [Page 24]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1245,13 +1357,25 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "revision": "1.0",
         "testGroups": [
             {
-                                "tgId": 1,
+                "tgId": 1,
                 "curve": "P-224",
                 "hashAlg": "SHA2-224",
                 "tests": [
                     {
                         "tcId": 1,
                         "message": "AB6F57713A3BD323B4AFDCFBE202EE00A9CF5C787D19FD9094323C57FEA8B7FBE31559EC1CAC6D29C3229A58811CF2BAE2B78183DFDABD055B741EA86496454F085D17D5BCD1B82B533B533A1E5804B2DAA0ED43F8BF59FBEB16BDD4D7C065165CB9B085CECD5BCFFA794339D5A81B1949F569CAACA208B9E3E6A217A1B3A596"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "curve": "P-224",
+                "hashAlg": "SHA2-224",
+                "isMessageRandomized": true
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "message": "23B4AFDCFBE202EE00A9CF5C787D19FD90..."
                     }
                 ]
             }
@@ -1273,19 +1397,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 23]
+Fussell                 Expires December 3, 2016               [Page 25]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1298,16 +1410,30 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "vsId": 1564,
         "testGroups": [
             {
-                                "tgId": 1,
-                                "qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
+                "tgId": 1,
+                "qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
                 "qy": "E56F7B7C9E6355E573B7B3B6C0E1ECD70E4ABDF1554EAD8A68ABA1A4",
-                                "tests": [
-                                        {
-                                                "tcId": 1,
-                                                "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
-                                                "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
-                                        }
-                                ]
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                        "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "qx": "A1304693BDBA632CB93A3B8BA632CB93A3...",
+                "qy": "ECD70E4ABBA632CB93A3BA632CB93A3DF1...",
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                        "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A",
+                        "randomValue": "0A0E11C4C6D6F8F3C51..."
+                        "randomValueLen": 1024
+                    }
+                ]
             }
         ]
     }
@@ -1327,21 +1453,7 @@ B.4.  Example Test ECDSA SigVer JSON Object
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 24]
+Fussell                 Expires December 3, 2016               [Page 26]
 
 Internet-Draft                Sym Alg JSON                     June 2016
 
@@ -1357,7 +1469,7 @@ Internet-Draft                Sym Alg JSON                     June 2016
         "revision": "1.0",
         "testGroups": [
             {
-                                "tgId": 1,
+                "tgId": 1,
                 "curve": "P-192",
                 "hashAlg": "SHA-1",
                 "tests": [
@@ -1370,36 +1482,40 @@ Internet-Draft                Sym Alg JSON                     June 2016
                         "s": "6E3F47F2327E36AD936E0F4BE245C05F264BA9300E9E7DD9"
                     }
                 ]
+            },
+            {
+                "tgId": 2,
+                "curve": "P-192",
+                "hashAlg": "SHA-1",
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "message": "D38A81D04A06A8C4760AC15DB266B17B48B...",
+                        "randomValue": "1527E0FE37FD1162F5DD0D975E83C0D...",
+                        "randomValueLen": 1024
+                        "qx": "D1E896486D9D986A464D3469941F93FC65556E2CB...",
+                        "qy": "ADCB8D50375DC76907195B6AF6C06F...",
+                        "r": "6D9D986A464D3469941F93FC65556E2CB8AB5F113...",
+                        "s": "8E713EB6106EF0E19E241DB4B4831E06437E5C..."
+                    }
+                ]
             }
         ]
     }
 ]
 
 
-   The following is a example JSON object for ECDSA generation test
-   results sent from the crypto module to the ACVP server.
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 25]
+Fussell                 Expires December 3, 2016               [Page 27]
 
 Internet-Draft                Sym Alg JSON                     June 2016
+
+
+   The following is a example JSON object for ECDSA generation test
+   results sent from the crypto module to the ACVP server.
 
 
    [
@@ -1410,13 +1526,20 @@ Internet-Draft                Sym Alg JSON                     June 2016
            "vsId": 1564,
            "testGroups": [
                {
-                                   "tgId": 1,
-                                   "tests": [
-                                           {
-                                                   "tcId": 1,
-                                                   "testPassed": false
-                                           }
-                                   ]
+                   "tgId": 1,
+                   "tests": [
+                       {
+                           "tcId": 1,
+                           "testPassed": false
+                       }
+                   ],
+                   "tgId": 2,
+                   "tests" [
+                       {
+                           "tcId": 2,
+                           "testPassed": true
+                       }
+                   ]
                }
            ]
        }
@@ -1442,15 +1565,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-Fussell                 Expires December 3, 2016               [Page 26]
+Fussell                 Expires December 3, 2016               [Page 28]

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -394,14 +394,15 @@
 <link href="#rfc.section.4.3.4" rel="Chapter" title="4.3.4 The legacySigVer Mode Capabilities">
 <link href="#rfc.section.4.3.5" rel="Chapter" title="4.3.5 The signaturePrimitive Mode Capabilities">
 <link href="#rfc.section.4.3.6" rel="Chapter" title="4.3.6 The decryptionPrimitive Mode Capabilities">
-<link href="#rfc.section.5" rel="Chapter" title="5 Test Vectors">
-<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Test Groups JSON Schema">
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Test Case JSON Schema">
-<link href="#rfc.section.6" rel="Chapter" title="6 Test Vector Responses">
-<link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
-<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
-<link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="10 Normative References">
+<link href="#rfc.section.5" rel="Chapter" title="5 Supported DSA Conformances">
+<link href="#rfc.section.6" rel="Chapter" title="6 Test Vectors">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Test Groups JSON Schema">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Test Case JSON Schema">
+<link href="#rfc.section.7" rel="Chapter" title="7 Test Vector Responses">
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgements">
+<link href="#rfc.section.9" rel="Chapter" title="9 IANA Considerations">
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="11 Normative References">
 <link href="#rfc.appendix.A" rel="Chapter" title="A Example RSA Capabilities JSON Objects">
 <link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 Example keyGen with Provable Primes and Provable Primes with Conditions Capabilities JSON Objects">
 <link href="#rfc.appendix.A.1.1" rel="Chapter" title="A.1.1 Example keyGen with Probable Primes Capabilities JSON Object">
@@ -525,21 +526,23 @@
 </li>
 <li>4.3.6.   <a href="#rfc.section.4.3.6">The decryptionPrimitive Mode Capabilities</a>
 </li>
-</ul></ul><li>5.   <a href="#rfc.section.5">Test Vectors</a>
+</ul></ul><li>5.   <a href="#rfc.section.5">Supported DSA Conformances</a>
 </li>
-<ul><li>5.1.   <a href="#rfc.section.5.1">Test Groups JSON Schema</a>
+<li>6.   <a href="#rfc.section.6">Test Vectors</a>
 </li>
-<li>5.2.   <a href="#rfc.section.5.2">Test Case JSON Schema</a>
+<ul><li>6.1.   <a href="#rfc.section.6.1">Test Groups JSON Schema</a>
 </li>
-</ul><li>6.   <a href="#rfc.section.6">Test Vector Responses</a>
+<li>6.2.   <a href="#rfc.section.6.2">Test Case JSON Schema</a>
 </li>
-<li>7.   <a href="#rfc.section.7">Acknowledgements</a>
+</ul><li>7.   <a href="#rfc.section.7">Test Vector Responses</a>
 </li>
-<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+<li>8.   <a href="#rfc.section.8">Acknowledgements</a>
 </li>
-<li>9.   <a href="#rfc.section.9">Security Considerations</a>
+<li>9.   <a href="#rfc.section.9">IANA Considerations</a>
 </li>
-<li>10.   <a href="#rfc.references">Normative References</a>
+<li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<li>11.   <a href="#rfc.references">Normative References</a>
 </li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Example RSA Capabilities JSON Objects</a>
 </li>
@@ -669,6 +672,7 @@
 <li>FIPS.186-4 - 3 General Discussion. Key generation, signature generation, and signature validation are all within scope of ACVP server testing.  </li>
 <li>FIPS.186-4 - 5 The RSA Digital Signature Algorithm. The ACVP server provides a means of testing the generation of RSA keys.  The ACVP server SHALL support a variety of RSA capabilities functionS for the creation and delivery of tests to/from the IUT.  Key pair generation testing SHALL be provided by the ACVP server.  Both Signature Generation and Validation testing mechanmisms SHALL be provided by the ACVP server.  </li>
 <li>FIPS.186-2.  The ACVP server MAY provide a means of testing legacy RSA functions such as RSA.sigVer.  This testing is provided to ensure an IUT is capable of verifying a signature that is no longer approved for generation, given the same capabilities.  </li>
+<li>SP800-106 - (3) Randomized Hashing and (4) Digital Signatures Using Randomized Hashing.  The IUT SHALL be provided or provide a random value that should be used to "randomize" a message prior to signing and/or verifying an original message.  </li>
 </ul>
 
 <p> </p>
@@ -680,6 +684,7 @@
 <ul class="empty">
 <li>FIPS.186-4 - 3 General Discussion. Assurances of private key secrecy and ownership SHALL NOT be within scope of ACVP testing.  </li>
 <li>FIPS.186-4 - 5 The RSA Digital Signature Algorithm. Though the ACVP server SHALL support a variety of parameter sizes/hash functions, the IUT's selection of these is out of scope of testing.  Key pair management SHALL NOT be within scope of ACVP testing.  </li>
+<li>SP800-106 - 3.3 The Random Value. DSA, ECDSA, and RSA have random values generated as per their signing process, this random value can be used as the input to the message randomization function, doing so however is out of scope of this testing.  </li>
 </ul>
 
 <p> </p>
@@ -833,6 +838,13 @@
 <td class="left">array of JSON objects, each with fields pertaining to the global RSA mode indicated above and identified uniquely by the combination of the RSA "mode" and indicated properties</td>
 <td class="left">See <a href="#algs_table" class="xref">Table 1</a> and <a href="#supported_modes" class="xref">Section 4.3</a> </td>
 <td class="left">No</td>
+</tr>
+<tr>
+<td class="left">conformances</td>
+<td class="left">Used to denote the conformances that can apply to specific modes of DSA.</td>
+<td class="left">Array of strings</td>
+<td class="left">See <a href="#supported_conformances" class="xref">Section 5</a> </td>
+<td class="left">Yes</td>
 </tr>
 </tbody>
 </table>
@@ -1352,11 +1364,32 @@
 <p id="rfc.section.4.3.6.p.1">The RSA decryptionPrimitive mode capabilities are advertised as JSON objects within the array of 'capabilities' as part of the 'capability_exchange' element of the ACVP JSON registration message. A single property is allowed in the registration, 'modulo' with the only approved value of 2048. In this mode, the only tested capability is the correct exponentiation 's = cipherText^d mod n', where 'cipherText' is a cipherText to be decrypted, 'd' is the private exponent and 'n' is the modulus. See <a href="#SP800-56B" class="xref">[SP800-56B]</a>, Section 7.1.2 for details.  </p>
 <p id="rfc.section.4.3.6.p.2">In testing, only 'cipherText' is supplied by the ACVP server.  The client is responsible for generating RSA key pairs of modulus 'n', private key 'd', and calculates 's'. If a client does not support decryption with a standard RSA private exponent 'd', the equivalent Chinese Remainder Theorem (CRT) private key values are allowed to be used.  Only 2048-bit RSA keys are allowed for this capability. See <a href="#app-testdecryptionPrimitive-ex" class="xref">Appendix B.7</a> for additional details on constraints for 'cipherText' and 'n'. The client provides the public exponent 'e', modulus 'n' and the computed result 's' in its response to the ACVP - see <a href="#app-componentdec-results-ex" class="xref">Appendix C.6</a> .  The client must first check if  '0 &lt; cipherText &lt; n-1' and return an error if this is not the case. The client returns a value 's' only when 'cipherText' is in the proper range for the size of the selected modulus 'n'. See the ACVP specification for details on the registration message.  </p>
 <h1 id="rfc.section.5">
-<a href="#rfc.section.5">5.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+<a href="#rfc.section.5">5.</a> <a href="#supported_conformances" id="supported_conformances">Supported DSA Conformances</a>
 </h1>
-<p id="rfc.section.5.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed by the client and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm and mode, such as {"algorithm": "RSA, "mode": "sigGen"}, etc.  This section describes the JSON schema for test vector sets used with the RSA algorithm and modes.</p>
-<p id="rfc.section.5.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
+<p id="rfc.section.5.p.1">Conformances MAY be used to test additional features of certain algorithms.</p>
 <div id="rfc.table.8"></div>
+<div id="conformances_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>DSA Conformances</caption>
+<thead><tr>
+<th class="left">String Value</th>
+<th class="left">Description</th>
+<th class="left">Valid algorithm modes</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody><tr>
+<td class="left">SP800-106</td>
+<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</td>
+<td class="left">SigGen, SigVer</td>
+<td class="left">Yes</td>
+</tr></tbody>
+</table>
+<h1 id="rfc.section.6">
+<a href="#rfc.section.6">6.</a> <a href="#test_vectors" id="test_vectors">Test Vectors</a>
+</h1>
+<p id="rfc.section.6.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed by the client and returned to the ACVP server for validation.  A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client.  Each test vector set represents an individual algorithm and mode, such as {"algorithm": "RSA, "mode": "sigGen"}, etc.  This section describes the JSON schema for test vector sets used with the RSA algorithm and modes.</p>
+<p id="rfc.section.6.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.  The following table describes the JSON elements at the top level of the hierarchy.  </p>
+<div id="rfc.table.9"></div>
 <div id="vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set JSON Object</caption>
@@ -1408,16 +1441,16 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 5.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#tgjs" class="xref">Section 6.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.1">
-<a href="#rfc.section.5.1">5.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
+<h1 id="rfc.section.6.1">
+<a href="#rfc.section.6.1">6.1.</a> <a href="#tgjs" id="tgjs">Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.5.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. The Test Group JSON object contains meta data that applies to all test vectors within the group.  The following table describes the RSA JSON elements of the Test Group JSON object.</p>
-<div id="rfc.table.9"></div>
+<p id="rfc.section.6.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups.  Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. The Test Group JSON object contains meta data that applies to all test vectors within the group.  The following table describes the RSA JSON elements of the Test Group JSON object.</p>
+<div id="rfc.table.10"></div>
 <div id="vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Test Group JSON Object</caption>
@@ -1554,13 +1587,25 @@
 <td class="left">value</td>
 <td class="left">Yes</td>
 </tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">isMessageRandomized</td>
+<td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">boolean</td>
+<td class="left">Yes</td>
+</tr>
 </tbody>
 </table>
-<h1 id="rfc.section.5.2">
-<a href="#rfc.section.5.2">5.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#tvjs" id="tvjs">Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.5.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each RSA test vector.</p>
-<div id="rfc.table.10"></div>
+<p id="rfc.section.6.2.p.1">Each test group contains an array of one or more test cases.  Each test case is a JSON object that represents a single test vector to be processed by the ACVP client.  The following table describes the JSON elements for each RSA test vector.</p>
+<div id="rfc.table.11"></div>
 <div id="vs_tc_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>RSA Test Case JSON Object</caption>
@@ -1656,6 +1701,30 @@
 <td class="left"></td>
 </tr>
 <tr>
+<td class="left">randomValue</td>
+<td class="left">The random value to be used as an input into the message randomization function as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">randomValueLen</td>
+<td class="left">The random value's bit length.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
 <td class="left">signature</td>
 <td class="left">the signature to be verified</td>
 <td class="left">hex value</td>
@@ -1699,11 +1768,11 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#vector_responses" id="vector_responses">Test Vector Responses</a>
 </h1>
-<p id="rfc.section.6.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.11"></div>
+<p id="rfc.section.7.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server.  The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.12"></div>
 <div id="vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Vector Set Response JSON Object</caption>
@@ -1735,13 +1804,13 @@
 </tr>
 <tr>
 <td class="left">testResults</td>
-<td class="left">Array of JSON objects that represent each test vector result, which uses the same JSON schema as defined in <a href="#tvjs" class="xref">Section 5.2</a> </td>
+<td class="left">Array of JSON objects that represent each test vector result, which uses the same JSON schema as defined in <a href="#tvjs" class="xref">Section 6.2</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.p.2">The following table describes the JSON elements for the response to a RSA test vector.</p>
-<div id="rfc.table.12"></div>
+<p id="rfc.section.7.p.2">The following table describes the JSON elements for the response to a RSA test vector.</p>
+<div id="rfc.table.13"></div>
 <div id="vs_tr_keyGen_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>RSA Test Case Results JSON Object</caption>
@@ -1998,22 +2067,46 @@
 <td class="left">hex value</td>
 <td class="left">Yes</td>
 </tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">randomValue</td>
+<td class="left">The random value to be used as an input into the message randomization function as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">randomValueLen</td>
+<td class="left">The random value's bit length.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
 </tbody>
 </table>
-<h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
-</h1>
-<p id="rfc.section.7.p.1">TBD...</p>
 <h1 id="rfc.section.8">
-<a href="#rfc.section.8">8.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+<a href="#rfc.section.8">8.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
-<p id="rfc.section.8.p.1">This memo includes no request to IANA.</p>
+<p id="rfc.section.8.p.1">TBD...</p>
 <h1 id="rfc.section.9">
-<a href="#rfc.section.9">9.</a> <a href="#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.9">9.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.9.p.1">Security considerations are addressed by the ACVP specification.</p>
+<p id="rfc.section.9.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.10.p.1">Security considerations are addressed by the ACVP specification.</p>
 <h1 id="rfc.references">
-<a href="#rfc.references">10.</a> Normative References</h1>
+<a href="#rfc.references">11.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
@@ -2039,6 +2132,11 @@
 <td class="reference"><b id="RFC3447">[RFC3447]</b></td>
 <td class="top">
 <a>Jonsson, J.</a> and <a>B. Kaliski</a>, "<a href="https://tools.ietf.org/html/rfc3447">Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1</a>", RFC 3447, DOI 10.17487/RFC3447, February 2003.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SP.800-106">[SP.800-106]</b></td>
+<td class="top">
+<a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf">Randomized Hashing for Digital Signatures</a>", February 2009.</td>
 </tr>
 <tr>
 <td class="reference"><b id="SP800-131A">[SP800-131A]</b></td>
@@ -2378,6 +2476,9 @@
                     }
                 ]
          }
+      ],
+      "conformances": [
+        "SP800-106"
       ]
    }
 
@@ -2537,6 +2638,9 @@
                     }
                  ]
           }
+      ],
+      "conformances": [
+        "SP800-106"
       ]
    }
 
@@ -2846,7 +2950,7 @@
    ]
 
                     </pre>
-<p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table" class="xref">Table 12</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4" class="xref">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the server validates that this pair matches the requirements. Below is an example set of test vectors that would come from the server when the registration includes "infoGeneratedByServer" set to true.  </p>
+<p id="rfc.section.B.1.p.1">Note that this example has "infoGeneratedByServer" set to false. This means the client is responsible for providing the details by running an instance of the appropriate Key Generation method for each test. The information returned should match all applicable data in <a href="#vs_tr_keyGen_table" class="xref">Table 13</a>. For Key Generation method 2 (Appendix B.3.3 <a href="#FIPS186-4" class="xref">[FIPS186-4]</a>) if the public exponent is random, there are two test types. One is a known answer test (KAT) provided by the server resulting in a "pass"/"fail" response determining if the input forms a valid key pair. The other, which exists for a fixed public exponent as well, asks the client to generate 10 key pairs ('e', 'p', 'q', 'n', and 'd') and the server validates that this pair matches the requirements. Below is an example set of test vectors that would come from the server when the registration includes "infoGeneratedByServer" set to true.  </p>
 <h1 id="rfc.appendix.B.2">
 <a href="#rfc.appendix.B.2">B.2.</a> <a href="#app-testVectorsKeygenB34-ex" id="app-testVectorsKeygenB34-ex">Example Test Vectors for keyGen when infoGeneratedByServer is true</a>
 </h1>
@@ -3001,7 +3105,88 @@
                       "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
                     }
                  ]
-             }
+             },
+
+             {
+                 "tgId": 7,
+                 "sigType" : "ansx9.31",
+                 "hashAlg" : "SHA2-256",
+                 "modulo" : 2048,
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11165,
+                      "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
+                    }
+                 ]
+             },
+             {
+                "tgId": 8,
+                "sigType": "ansx9.31",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                      "tcId" : 11166,
+                      "message" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
+                    }
+                 ]
+             },
+             {
+                "tgId": 9,
+                "sigType" : "pkcs1v1.5",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 2048,
+                "isMessageRandomized": true,
+                "tests" : [
+                   {
+                     "tcId" : 11167,
+                     "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
+                   }
+                ]
+             },
+             {
+                "tgId": 10,
+                "sigType" : "pkcs1v1.5",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11168,
+                      "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
+                    }
+                 ]
+             },
+             {
+                "tgId": 11,
+                "sigType" : "pss",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 2048,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11169,
+                      "saltLen" : 20,
+                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
+                    }
+                 ]
+             },
+             {
+                "tgId": 12,
+                "sigType" : "pss",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11170,
+                      "saltLen" : 20,
+                      "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
+                    }
+                 ]
+             }             
        ]
     }
   ]
@@ -3114,7 +3299,122 @@
                       "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
                     }
                  ]
-             }
+             },
+
+             {
+                 "tgId": 7,
+                 "sigType" : "ansx9.31",
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "modulo" : 2048,
+                 "e" : "166f67",
+                 "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11174,
+                      "message" : "ff17e5e88ad5cd0dc463ae0b286273b3905271939c60ed70577edef018b9f596a7c7dbf3a1e0ba1b1ed0fe5790495d19ef7d143513ec744d617b9e8da9c78b994fb84fc4a9599e83a9e78f21bc28a0b4f1fdfa4f5e3bf779c0b7e2de61a0fe453f12c9c26ae7812daed1e8d272a6456ae0faab4b46f37ddbbc59324a08ed5681", 
+                      "randomValue": "ab676ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 8,
+                 "sigType" : "ansx9.31",
+                 "modulo" : 3072,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "89ca09",
+                 "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11175,
+                      "message" : "7cdcd58f9f290bd550c46b61f15b7fe082b8741cba8acedb57685a04b213640496fb2b70520592ec0d8c184b5aa60af80da8f8944cec65e0e9d1c2deef049e337afe17d0ccce94d19e19b6a5b45f8b70b47f05ad387eab1822848fcb302780a7d0ec80f5350b794daa732bb7260e6911214685b1a7c8094bab88a7149d057327", 
+                      "randomValue": "ab61bc76ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "1c3d10d8b876e2cae5e8210fd2dd53d9b1245b961e69f6fd7759cd27e7a88dd7fc59f517972f4e6a0b480c837bd7d768292f5784ac5f1df692a9699e32d976ebd1a4282af727a5605cbc5b28d8dae834bdcad391282e6bef543bd11a3d72ef984195236043b655217c8cd8bd3247f29afe17ad0af20dc703df5d7ad49af1ff4bb247717dc6335c45e5845d92772c4e4eef5e2efb4a1c45cb2ffe296cecc4474ab81ec17401b4d3c5129a59a40da2ba8c8fa548a0ae8bbe43b1f1f1dbe029e28dc61a762ed2665ac1bbd6eb6aeecf1bca4b450e8df7bed087f7d390733fa477823eaaf59d0bf7a0c7a8150850b413a05237bd253350d5091a12219a35a58a0ef6fc15024f24b9ef2bd7b27ace7bedc30c9f9ecd1e828966cec760e555d019507560c2ba68dc562300460453f937abca74ca25a7de5fa66e4f28fdefb3030126c0f93b8304717c5a28d07ef095069ca9b6925f6e5ad11497b03a2b2c6660485e0e99b13c334084b038a4d81556c5b7c9ed766fd3fb30bf6931e22e94f647f619d4"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 9,
+                 "sigType" : "pkcs1v1.5",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "49d2a1",
+                 "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",  
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11176,
+                      "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
+                      "randomValue": "ab676ab761abca76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
+                    }
+                 ]
+             },
+             {
+                "tgId": 10,
+                "sigType" : "pkcs1v1.5",
+                "modulo" : 3072,
+                "hashAlg" : "SHA2-256",
+                "testType": "AFT",
+                "e" : "ac6db1",
+                "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11177,
+                      "message" : "921961e184a5d9657697e3e65ceb1ed10204ec56e739df0e4f906ee194c9ed27bd9fbc0d514abe3a6e480cb3155debfcc8d9fc815719b334f7500a769488773b68e31b69cd273c824f79f58306692c0c232fc5c0c83415ef1dd59a73a063e9d7bc6ee7bf9e433c8344b3051ed616c9473a90afdde393ee88e9a5849e5f642b43",
+                      "randomValue": "ab676abab6283676a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "55362a6854a7846c4d105dc8a358fd4c02931f117631968457f422939d266682fd705e2091bfd5d1bfb52b4bfad684914489ecdad9038b75c65916a9e967630b16c76656b58404ec11ac46d8684b3e72d4392fb6e7e6c929e43ad4fb6ce6198f241b39e8bcbbc058792dde31b195b91bb14236dcb82c28a5c24d633dd847d1548dd403b3a70149371f46432db1767a00c462758c2298fe9f1f04c2ff4b96858d084ffe5a624cb85c1f9be2a60fed40133b7c571c6c467f46a0f1e48ee6e2e6d65424bf8196b0d927e0fd4141264aa5df4129d52d2fb57b8dac9386a84ecd34ecb1feac3a2b99d055eda977ddf8027f1178348a30e4cb4ecef2291d7f520794018b39f5251fd46d97282ac21f6bce6539d19aa1c21c3c220a2ddb6feed262eceebd753eaf5e0eb98cb3eb7d324a3dac0a415a18b7f36170676e8b9d3e421a6f77046bee6d9591c93f7ef0242f464f15b63132a0aee80949709429b1e76d40d60f79b2a6ab362f12e2cdd0bc66868c80278043e179a36f2815e7916378b0fbdb8e"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 11,
+                 "sigType" : "pss",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "10e43f",
+                 "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",  
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11178,
+                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
+                      "randomValue": "ab67a6786b876c6ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
+                    }
+                 ]
+             },
+             {
+                "tgId": 12,
+                "sigType" : "pss",
+                "modulo" : 3072,
+                "hashAlg" : "SHA2-512",
+                "testType": "AFT",
+                "e" : "fe3079",
+                "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11179,
+                      "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
+                      "randomValue": "ab6a9b8b6a75ba76ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
+                    }
+                 ]
+             }             
           ]
       }
   ]
@@ -3541,7 +3841,70 @@
                           "signature" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
                         }
                       ]
-                    }
+                    },
+                    {
+                      "tgId": 7,
+                      "tests": [
+                        {
+                          "tcId" : 11165,
+                          "e" : "f3e7af",
+                          "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
+                          "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d",
+                          "randomValue": "ab67a6b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11166,
+                          "e" : "ebda09",
+                          "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
+                          "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c",
+                          "randomValue": "ab67a6b67a86ab87687667b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                      ]
+                    },
+                    {
+                      "tgId": 8,
+                      "tests": [       
+                        {
+                          "tcId" : 11167,
+                          "e" : "260445",
+                          "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
+                          "signature" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
+                          "randomValue": "ab67ab7a897ba897a6b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11168,
+                          "e" : "eaf05d",
+                          "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
+                          "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82",
+                          "randomValue": "ab67a6b7a6b5ab67aa768b6a87b65...",
+                          "randomValueLen": 1024
+                        },
+                      ]
+                    },
+                    {
+                      "tgId": 9,
+                      "tests": [
+                        {
+                          "tcId" : 11169,
+                          "e" : "86c94f",
+                          "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
+                          "signature" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc",
+                          "randomValue": "ab67a6b7a6b5ab67aa768b6a87ba67ba6b6a754a3265...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11170,
+                          "e" : "1415a7",
+                          "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
+                          "signature" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e",
+                          "randomValue": "ab67a6ab67ab4ab23b7a6b5ab67aa768b6a87b65...",
+                          "randomValueLen": 1024
+                        }
+                      ]
+                    }                    
                  ]
              }
            ]
@@ -3595,6 +3958,45 @@
                 },
                 {
                   "tcId" : 1179,
+                  "testPassed": false
+                }
+              ]
+          }
+          {
+            "tgId": 7,
+            "tests": [
+                {
+                  "tcId" : 11174,
+                  "testPassed": false
+                },
+                {
+                  "tcId" : 11175,
+                  "testPassed": false
+                }
+              ]
+          },
+          {
+            "tgId": 8,
+            "tests": [
+                {
+                  "tcId" : 11176,
+                  "testPassed": true
+                },
+                {
+                  "tcId" : 11177,
+                  "testPassed": false
+                }
+              ]
+          },
+          {
+            "tgId": 9,
+            "tests": [
+                {
+                  "tcId" : 11178,
+                  "testPassed": true
+                },
+                {
+                  "tcId" : 11179,
                   "testPassed": false
                 }
               ]

--- a/artifacts/acvp_sub_rsa.html
+++ b/artifacts/acvp_sub_rsa.html
@@ -1379,7 +1379,7 @@
 </tr></thead>
 <tbody><tr>
 <td class="left">SP800-106</td>
-<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</td>
+<td class="left">This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of `"conformance": "SP800-106"`.</td>
 <td class="left">SigGen, SigVer</td>
 <td class="left">Yes</td>
 </tr></tbody>
@@ -1594,9 +1594,9 @@
 <td class="left"></td>
 </tr>
 <tr>
-<td class="left">isMessageRandomized</td>
+<td class="left">conformance</td>
 <td class="left">Signifies all test cases within the group should utilize random message hashing as described in <a href="#SP.800-106" class="xref">[SP.800-106]</a>.</td>
-<td class="left">boolean</td>
+<td class="left">"SP800-106"</td>
 <td class="left">Yes</td>
 </tr>
 </tbody>
@@ -3112,7 +3112,7 @@
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
                  "modulo" : 2048,
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11165,
@@ -3125,7 +3125,7 @@
                 "sigType": "ansx9.31",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                       "tcId" : 11166,
@@ -3138,7 +3138,7 @@
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 2048,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                    {
                      "tcId" : 11167,
@@ -3151,7 +3151,7 @@
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11168,
@@ -3164,7 +3164,7 @@
                 "sigType" : "pss",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 2048,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11169,
@@ -3178,7 +3178,7 @@
                 "sigType" : "pss",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11170,
@@ -3309,7 +3309,7 @@
                  "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11174,
@@ -3328,7 +3328,7 @@
                  "testType": "AFT",
                  "e" : "89ca09",
                  "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11175,
@@ -3347,7 +3347,7 @@
                  "testType": "AFT",
                  "e" : "49d2a1",
                  "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",  
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11176,
@@ -3366,7 +3366,7 @@
                 "testType": "AFT",
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11177,
@@ -3385,7 +3385,7 @@
                  "testType": "AFT",
                  "e" : "10e43f",
                  "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",  
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11178,
@@ -3404,7 +3404,7 @@
                 "testType": "AFT",
                 "e" : "fe3079",
                 "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11179,

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -1043,8 +1043,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |           | conformance SHALL generate     |           |          |
    |           | additional test groups,        |           |          |
    |           | denoted with a group level     |           |          |
-   |           | property of                    |           |          |
-   |           | "isMessageRandomized".         |           |          |
+   |           | property of `"conformance":    |           |          |
+   |           | "SP800-106"`.                  |           |          |
    +-----------+--------------------------------+-----------+----------+
 
                          Table 8: DSA Conformances
@@ -1109,11 +1109,11 @@ Internet-Draft                RSA Alg JSON                 February 2018
    applies to all test vectors within the group.  The following table
    describes the RSA JSON elements of the Test Group JSON object.
 
-   +---------------------+-------------------+--------------+----------+
-   | JSON Value          | Description       | JSON type    | Optional |
-   +---------------------+-------------------+--------------+----------+
-   | modulo              | RSA modulus       | value        | No       |
-   |                     |                   |              |          |
+
+
+
+
+
 
 
 
@@ -1122,53 +1122,53 @@ Vassilev                 Expires August 5, 2018                [Page 20]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   | hashAlg             | the hash          | value        | Yes      |
-   |                     | algorithm         |              |          |
-   |                     |                   |              |          |
-   | primeTest           | Miller-Rabin      | value        | Yes      |
-   |                     | constraint from   |              |          |
-   |                     | Table C.2 or C.3  |              |          |
-   |                     |                   |              |          |
-   | pubExpMode          | Fixed or random   | "fixed" or   | Yes      |
-   |                     | public exponent   | "random"     |          |
-   |                     |                   |              |          |
-   | randPQ              | KeyGen mode used  | "B.3.2",     | Yes      |
-   |                     |                   | "B.3.3",     |          |
-   |                     |                   | "B.3.4",     |          |
-   |                     |                   | "B.3.5",     |          |
-   |                     |                   | "B.3.6"      |          |
-   |                     |                   |              |          |
-   | fixedPubExp         | Fixed public      | hex value    | Yes      |
-   |                     | exponent value if |              |          |
-   |                     | pubExpMode is     |              |          |
-   |                     | defined as        |              |          |
-   |                     | "fixed"           |              |          |
-   |                     |                   |              |          |
-   | n                   | Public modulus    | hex value    | Yes      |
-   |                     | value n           |              |          |
-   |                     |                   |              |          |
-   | e                   | Public exponent   | hex value    | Yes      |
-   |                     | value e           |              |          |
-   |                     |                   |              |          |
-   | pubExpMode          | Fixed or random   | "fixed" or   | Yes      |
-   |                     | public exponent   | "random"     |          |
-   |                     |                   |              |          |
-   | sigType             | Type of signature | "ansx9.31",  | Yes      |
-   |                     | used in the group | "pkcs1v1.5", |          |
-   |                     |                   | "pss"        |          |
-   |                     |                   |              |          |
-   | saltLen             | The salt length   | value        | Yes      |
-   |                     | for the group in  |              |          |
-   |                     | bytes             |              |          |
-   |                     |                   |              |          |
-   | isMessageRandomized | Signifies all     | boolean      | Yes      |
-   |                     | test cases within |              |          |
-   |                     | the group should  |              |          |
-   |                     | utilize random    |              |          |
-   |                     | message hashing   |              |          |
-   |                     | as described in   |              |          |
-   |                     | [SP.800-106].     |              |          |
-   +---------------------+-------------------+--------------+----------+
+   +-------------+---------------------------+--------------+----------+
+   | JSON Value  | Description               | JSON type    | Optional |
+   +-------------+---------------------------+--------------+----------+
+   | modulo      | RSA modulus               | value        | No       |
+   |             |                           |              |          |
+   | hashAlg     | the hash algorithm        | value        | Yes      |
+   |             |                           |              |          |
+   | primeTest   | Miller-Rabin constraint   | value        | Yes      |
+   |             | from Table C.2 or C.3     |              |          |
+   |             |                           |              |          |
+   | pubExpMode  | Fixed or random public    | "fixed" or   | Yes      |
+   |             | exponent                  | "random"     |          |
+   |             |                           |              |          |
+   | randPQ      | KeyGen mode used          | "B.3.2",     | Yes      |
+   |             |                           | "B.3.3",     |          |
+   |             |                           | "B.3.4",     |          |
+   |             |                           | "B.3.5",     |          |
+   |             |                           | "B.3.6"      |          |
+   |             |                           |              |          |
+   | fixedPubExp | Fixed public exponent     | hex value    | Yes      |
+   |             | value if pubExpMode is    |              |          |
+   |             | defined as "fixed"        |              |          |
+   |             |                           |              |          |
+   | n           | Public modulus value n    | hex value    | Yes      |
+   |             |                           |              |          |
+   | e           | Public exponent value e   | hex value    | Yes      |
+   |             |                           |              |          |
+   | pubExpMode  | Fixed or random public    | "fixed" or   | Yes      |
+   |             | exponent                  | "random"     |          |
+   |             |                           |              |          |
+   | sigType     | Type of signature used in | "ansx9.31",  | Yes      |
+   |             | the group                 | "pkcs1v1.5", |          |
+   |             |                           | "pss"        |          |
+   |             |                           |              |          |
+   | saltLen     | The salt length for the   | value        | Yes      |
+   |             | group in bytes            |              |          |
+   |             |                           |              |          |
+   | conformance | Signifies all test cases  | "SP800-106"  | Yes      |
+   |             | within the group should   |              |          |
+   |             | utilize random message    |              |          |
+   |             | hashing as described in   |              |          |
+   |             | [SP.800-106].             |              |          |
+   +-------------+---------------------------+--------------+----------+
+
+                     Table 10: Test Group JSON Object
+
+
 
 
 
@@ -1177,8 +1177,6 @@ Vassilev                 Expires August 5, 2018                [Page 21]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
-
-                     Table 10: Test Group JSON Object
 
 6.2.  Test Case JSON Schema
 
@@ -1226,6 +1224,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                |                               |       |          |
    | signature      | the signature to be verified  | hex   | Yes      |
    |                |                               | value |          |
+   |                |                               |       |          |
+   | cipherText     | the cipherText to be          | hex   | Yes      |
 
 
 
@@ -1234,8 +1234,6 @@ Vassilev                 Expires August 5, 2018                [Page 22]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   |                |                               |       |          |
-   | cipherText     | the cipherText to be          | hex   | Yes      |
    |                | decrypted                     | value |          |
    |                |                               |       |          |
    | cipherText     | the cipherText to be          | hex   | Yes      |
@@ -1282,6 +1280,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                | unique across the |                   |          |
    |                | entire vector     |                   |          |
    |                | set.              |                   |          |
+   |                |                   |                   |          |
+   | e              | the public        | hex value         | Yes      |
 
 
 
@@ -1290,8 +1290,6 @@ Vassilev                 Expires August 5, 2018                [Page 23]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   |                |                   |                   |          |
-   | e              | the public        | hex value         | Yes      |
    |                | exponent          |                   |          |
    |                |                   |                   |          |
    | pRand          | the random for P, | hex value         | Yes      |
@@ -1338,6 +1336,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                | [FIPS186-4],      |                   |          |
    |                | Appendix B.3.2,   |                   |          |
    |                | B.3.4, B.3.5 or   |                   |          |
+   |                | the length of     |                   |          |
+   |                | xP1, xP2, xQ1,    |                   |          |
 
 
 
@@ -1346,8 +1346,6 @@ Vassilev                 Expires August 5, 2018                [Page 24]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   |                | the length of     |                   |          |
-   |                | xP1, xP2, xQ1,    |                   |          |
    |                | and xQ2 for B.3.6 |                   |          |
    |                |                   |                   |          |
    | xP1            | the prime factor  | hex value         | Yes      |
@@ -1394,6 +1392,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                | B.3.4, or B.3.5,  |                   |          |
    |                | if applicable     |                   |          |
    |                |                   |                   |          |
+   | xQ             | the random number | hex value         | Yes      |
+   |                | used in Step 3 of |                   |          |
 
 
 
@@ -1402,8 +1402,6 @@ Vassilev                 Expires August 5, 2018                [Page 25]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   | xQ             | the random number | hex value         | Yes      |
-   |                | used in Step 3 of |                   |          |
    |                | the algorithm in  |                   |          |
    |                | [FIPS186-4],      |                   |          |
    |                | Appendix C.9 to   |                   |          |
@@ -1450,6 +1448,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                | message           |                   |          |
    |                | randomization     |                   |          |
    |                | function as       |                   |          |
+   |                | described in      |                   |          |
+   |                | [SP.800-106].     |                   |          |
 
 
 
@@ -1458,8 +1458,6 @@ Vassilev                 Expires August 5, 2018                [Page 26]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   |                | described in      |                   |          |
-   |                | [SP.800-106].     |                   |          |
    |                |                   |                   |          |
    | randomValueLen | The random        | value             | Yes      |
    |                | value's bit       |                   |          |
@@ -1504,6 +1502,8 @@ Internet-Draft                RSA Alg JSON                 February 2018
               Standards (PKCS) #1: RSA Cryptography Specifications
               Version 2.1", RFC 3447, DOI 10.17487/RFC3447, February
               2003, <https://www.rfc-editor.org/info/rfc3447>.
+
+
 
 
 
@@ -2732,7 +2732,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
                  "modulo" : 2048,
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11165,
@@ -2753,7 +2753,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType": "ansx9.31",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                       "tcId" : 11166,
@@ -2766,7 +2766,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 2048,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                    {
                      "tcId" : 11167,
@@ -2779,7 +2779,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11168,
@@ -2792,7 +2792,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pss",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 2048,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
 
 
@@ -2814,7 +2814,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "sigType" : "pss",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11170,
@@ -2959,7 +2959,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
 
@@ -2986,7 +2986,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "testType": "AFT",
                  "e" : "89ca09",
                  "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11175,
@@ -3005,7 +3005,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "testType": "AFT",
                  "e" : "49d2a1",
                  "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11176,
@@ -3032,7 +3032,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "testType": "AFT",
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11177,
@@ -3051,7 +3051,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                  "testType": "AFT",
                  "e" : "10e43f",
                  "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11178,
@@ -3070,7 +3070,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 "testType": "AFT",
                 "e" : "fe3079",
                 "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11179,

--- a/artifacts/acvp_sub_rsa.txt
+++ b/artifacts/acvp_sub_rsa.txt
@@ -70,42 +70,42 @@ Table of Contents
    4.  Capabilities Registration . . . . . . . . . . . . . . . . . .   6
      4.1.  Required Prerequisite Algorithms for RSA Mode Validations   6
      4.2.  Supported RSA Capabilities  . . . . . . . . . . . . . . .   7
-     4.3.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   8
-       4.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   8
-         4.3.1.1.  keyGen Full Set Of Capabilities . . . . . . . . .   8
+     4.3.  Supported RSA Modes Capabilities  . . . . . . . . . . . .   9
+       4.3.1.  The keyGen Mode Capabilities  . . . . . . . . . . . .   9
+         4.3.1.1.  keyGen Full Set Of Capabilities . . . . . . . . .   9
        4.3.2.  The sigGen Mode Capabilities  . . . . . . . . . . . .  12
-         4.3.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  12
-       4.3.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  13
+         4.3.2.1.  sigGen Capabilities . . . . . . . . . . . . . . .  13
+       4.3.3.  The sigVer Mode Capabilities  . . . . . . . . . . . .  14
          4.3.3.1.  sigVer Capabilities . . . . . . . . . . . . . . .  14
-       4.3.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  15
-       4.3.5.  The signaturePrimitive Mode Capabilities  . . . . . .  17
+       4.3.4.  The legacySigVer Mode Capabilities  . . . . . . . . .  16
+       4.3.5.  The signaturePrimitive Mode Capabilities  . . . . . .  18
        4.3.6.  The decryptionPrimitive Mode Capabilities . . . . . .  18
-   5.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  18
-     5.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  19
-     5.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  20
-   6.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  21
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  25
-   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  26
+   5.  Supported DSA Conformances  . . . . . . . . . . . . . . . . .  19
+   6.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .  19
+     6.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .  20
+     6.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  22
+   7.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  23
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  27
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  27
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  27
+   Appendix A.  Example RSA Capabilities JSON Objects  . . . . . . .  28
      A.1.  Example keyGen with Provable Primes and Provable Primes
-           with Conditions Capabilities JSON Objects . . . . . . . .  26
+           with Conditions Capabilities JSON Objects . . . . . . . .  28
        A.1.1.  Example keyGen with Probable Primes Capabilities JSON
-               Object  . . . . . . . . . . . . . . . . . . . . . . .  28
+               Object  . . . . . . . . . . . . . . . . . . . . . . .  30
        A.1.2.  Example keyGen with Provable Conditional Primes with
-               Probable Factors Capabilities JSON Object . . . . . .  29
-     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  30
-     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  33
-     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  37
-     A.5.  Example signaturePrimitive Capabilities JSON Objects  . .  39
-     A.6.  Example decryptionPrimitive Capabilities JSON Objects . .  39
-   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  39
-     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  39
+               Probable Factors Capabilities JSON Object . . . . . .  31
+     A.2.  Example RSA sigGen Capabilities JSON Objects  . . . . . .  32
+     A.3.  Example RSA sigVer Capabilities JSON Objects  . . . . . .  35
+     A.4.  Example RSA legacySigVer Capabilities JSON Objects  . . .  39
+     A.5.  Example signaturePrimitive Capabilities JSON Objects  . .  41
+     A.6.  Example decryptionPrimitive Capabilities JSON Objects . .  41
+   Appendix B.  Example Test Vectors JSON Objects  . . . . . . . . .  41
+     B.1.  Example Test Vectors for keyGen JSON Objects  . . . . . .  41
      B.2.  Example Test Vectors for keyGen when
-           infoGeneratedByServer is true . . . . . . . . . . . . . .  44
-     B.3.  Example Test Vectors for sigGen JSON Objects  . . . . . .  46
-     B.4.  Example Test Vectors for sigVer JSON Objects  . . . . . .  47
+           infoGeneratedByServer is true . . . . . . . . . . . . . .  46
+     B.3.  Example Test Vectors for sigGen JSON Objects  . . . . . .  48
 
 
 
@@ -114,17 +114,18 @@ Vassilev                 Expires August 5, 2018                 [Page 2]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-     B.5.  Example Test Vectors for legacySigVer JSON Objects  . . .  50
-     B.6.  Example Test Vectors for signaturePrimitive JSON Objects   50
-     B.7.  Example Test Vectors for decryptionPrimitive JSON Objects  51
-   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  52
-     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  52
-     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  58
-     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  60
-     C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  61
-     C.5.  Example signaturePrimitive Test Results JSON Objects  . .  61
-     C.6.  Example decryptionPrimitive Test Results JSON Objects . .  62
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  62
+     B.4.  Example Test Vectors for sigVer JSON Objects  . . . . . .  51
+     B.5.  Example Test Vectors for legacySigVer JSON Objects  . . .  56
+     B.6.  Example Test Vectors for signaturePrimitive JSON Objects   56
+     B.7.  Example Test Vectors for decryptionPrimitive JSON Objects  57
+   Appendix C.  Example Test Results JSON Objects  . . . . . . . . .  58
+     C.1.  Example keyGen Test Results JSON Objects  . . . . . . . .  58
+     C.2.  Example sigGen Test Results JSON Objects  . . . . . . . .  64
+     C.3.  Example sigVer Test Results JSON Objects  . . . . . . . .  67
+     C.4.  Example legacySigVer Test Results JSON Objects  . . . . .  69
+     C.5.  Example signaturePrimitive Test Results JSON Objects  . .  69
+     C.6.  Example decryptionPrimitive Test Results JSON Objects . .  70
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  71
 
 1.  Introduction
 
@@ -152,7 +153,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
    The following RSA algorithm modes may be advertised by the ACVP
    compliant crypto module:
-
 
 
 
@@ -262,6 +262,11 @@ Internet-Draft                RSA Alg JSON                 February 2018
       ensure an IUT is capable of verifying a signature that is no
       longer approved for generation, given the same capabilities.
 
+      SP800-106 - (3) Randomized Hashing and (4) Digital Signatures
+      Using Randomized Hashing.  The IUT SHALL be provided or provide a
+      random value that should be used to "randomize" a message prior to
+      signing and/or verifying an original message.
+
 3.1.2.  Requirements Not Covered
 
       FIPS.186-4 - 3 General Discussion.  Assurances of private key
@@ -269,11 +274,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
       FIPS.186-4 - 5 The RSA Digital Signature Algorithm.  Though the
       ACVP server SHALL support a variety of parameter sizes/hash
-      functions, the IUT's selection of these is out of scope of
-      testing.  Key pair management SHALL NOT be within scope of ACVP
-      testing.
-
-
 
 
 
@@ -281,6 +281,15 @@ Vassilev                 Expires August 5, 2018                 [Page 5]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
+
+      functions, the IUT's selection of these is out of scope of
+      testing.  Key pair management SHALL NOT be within scope of ACVP
+      testing.
+
+      SP800-106 - 3.3 The Random Value.  DSA, ECDSA, and RSA have random
+      values generated as per their signing process, this random value
+      can be used as the input to the message randomization function,
+      doing so however is out of scope of this testing.
 
 4.  Capabilities Registration
 
@@ -304,6 +313,30 @@ Internet-Draft                RSA Alg JSON                 February 2018
    primitives must be validated, either separately or as part of the
    same submission.  ACVP provides a mechanism for specifying the
    required prerequisites:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 6]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
 
    +--------------+--------------+--------------+-----------+----------+
    | JSON Value   | Description  | JSON type    | Valid     | Optional |
@@ -331,13 +364,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
       Table 2: Required RSA Modes Prerequisite Algorithms JSON Values
 
-
-
-Vassilev                 Expires August 5, 2018                 [Page 6]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
 4.2.  Supported RSA Capabilities
 
    The algorithm capabilities are advertised as JSON objects within the
@@ -360,6 +386,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |           | algorithm  |            |                   |         |
    |           | to be      |            |                   |         |
    |           | validated  |            |                   |         |
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 7]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |           |            |            |                   |         |
    | mode      | The RSA    | value      | "keyGen",         | No      |
    |           | algorithm  |            | "sigGen",         |         |
@@ -386,14 +420,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |           | objects    | objects,   |                   |         |
    |           |            | each with  |                   |         |
    |           |            | fields     |                   |         |
-
-
-
-Vassilev                 Expires August 5, 2018                 [Page 7]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |           |            | pertaining |                   |         |
    |           |            | to the     |                   |         |
    |           |            | global RSA |                   |         |
@@ -408,6 +434,23 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |           |            | "mode" and |                   |         |
    |           |            | indicated  |                   |         |
    |           |            | properties |                   |         |
+   | conforman | Used to    | Array of   | See Section 5     | Yes     |
+   | ces       | denote the | strings    |                   |         |
+   |           | conformanc |            |                   |         |
+   |           | es that    |            |                   |         |
+   |           | can apply  |            |                   |         |
+   |           | to         |            |                   |         |
+   |           | specific   |            |                   |         |
+   |           | modes of   |            |                   |         |
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 8]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+   |           | DSA.       |            |                   |         |
    +-----------+------------+------------+-------------------+---------+
 
               Table 3: RSA Algorithm Capabilities JSON Values
@@ -442,14 +485,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    The complete list of RSA key generation capabilities may be
    advertised by the ACVP compliant crypto module:
 
-
-
-
-Vassilev                 Expires August 5, 2018                 [Page 8]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    +------------------+---------------+------+--------------+----------+
    | JSON Value       | Description   | JSON | Valid Values | Optional |
    |                  |               | type |              |          |
@@ -463,6 +498,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | generated as  |      |              |          |
    |                  | (see          |      |              |          |
    |                  | [FIPS186-4]): |      |              |          |
+
+
+
+Vassilev                 Expires August 5, 2018                 [Page 9]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |                  | provable      |      |              |          |
    |                  | primes        |      |              |          |
    |                  | (Appendix     |      |              |          |
@@ -498,14 +541,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | Key           |      |              |          |
    |                  | Generation    |      |              |          |
    |                  | tests. This   |      |              |          |
-
-
-
-Vassilev                 Expires August 5, 2018                 [Page 9]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |                  | flag is not   |      |              |          |
    |                  | relevant to   |      |              |          |
    |                  | KeyGen mode   |      |              |          |
@@ -519,6 +554,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | random public |      |              |          |
    |                  | key exponent  |      |              |          |
    |                  | e             |      |              |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 10]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |                  |               |      |              |          |
    | fixedPubExp      | The value of  | valu | hex          | Yes      |
    |                  | the public    | e    |              |          |
@@ -554,14 +597,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | components.   |      |              |          |
    |                  |               |      |              |          |
    | properties       | An array of   | arra |              | Yes      |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 10]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |                  | objects       | y    |              |          |
    |                  | containing    |      |              |          |
    |                  | properties    |      |              |          |
@@ -575,6 +610,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |                  | for a single  |      |              |          |
    |                  | key           |      |              |          |
    |                  | generation    |      |              |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 11]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |                  | mode          |      |              |          |
    |                  |               |      |              |          |
    | modulo           | supported RSA | valu | 2048, 3072   | Yes      |
@@ -607,17 +650,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
                Table 4: RSA keyGen Capabilities JSON Values
 
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 11]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
 4.3.2.  The sigGen Mode Capabilities
 
    The RSA sigGen mode capabilities are advertised as JSON objects
@@ -633,6 +665,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
    The following subsections define the capabilities that may be
    advertised by the ACVP compliant crypto modules.
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 12]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
 
 4.3.2.1.  sigGen Capabilities
 
@@ -666,14 +706,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |            |                 |       |                 |          |
    | hashPair   | supported hash  | array | an array of     | No       |
    |            | algorithms and  |       | objects         |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 12]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |            | optional salt   |       | containing a    |          |
    |            | length for      |       | hashAlg and an  |          |
    |            | signature       |       | optional        |          |
@@ -690,6 +722,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |            | generation for  |       | "SHA2-384",     |          |
    |            | this sigType    |       | "SHA2-512",     |          |
    |            | and modulo -    |       | "SHA2-512/224", |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 13]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |            | see             |       | "SHA2-512/256"} |          |
    |            | [SP800-131A],   |       |                 |          |
    |            | Section 9       |       |                 |          |
@@ -722,14 +762,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    Each RSA sigVer mode capability is advertised as a self-contained
    JSON object consisting of the algorithm, mode, and capabilities
    array.  The capabilities array may contain multiple elements, each
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 13]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    pertaining to a sigType that is supported by the client for the RSA
    mode being advertised.
 
@@ -746,6 +778,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             |                | type  |                 |          |
    +-------------+----------------+-------+-----------------+----------+
    | sigType     | supported RSA  | value | one of          | No       |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 14]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |             | signature      |       | {"ansx9.31",    |          |
    |             | types  - see   |       | "pkcs1v1.5",    |          |
    |             | [FIPS186-4],   |       | "pss"}          |          |
@@ -778,14 +818,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             | [SP800-131A],  |       |                 |          |
    |             | Section 9      |       |                 |          |
    |             |                |       |                 |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 14]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    | hashAlg     | supported hash | value | any value from  | No       |
    |             | algorithm for  |       | {"SHA-1",       |          |
    |             | signature      |       | "SHA2-224",     |          |
@@ -802,6 +834,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             | signature      |       | constraint in   |          |
    |             | verification - |       | the note below. |          |
    |             | see            |       |                 |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 15]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |             | [FIPS186-4],   |       |                 |          |
    |             | Section 5.5.   |       |                 |          |
    |             | See also note  |       |                 |          |
@@ -835,13 +875,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    'capability_exchange' element of the ACVP JSON registration message.
    See the ACVP specification for details on the registration message.
 
-
-
-Vassilev                 Expires August 5, 2018                [Page 15]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    Each RSA legacySigVer mode capability is advertised as a self-
    contained JSON object consisting of the algorithm, mode, and
    capabilities array.  The capabilities array may contain multiple
@@ -857,6 +890,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    +-------------+-------------------+-------+--------------+----------+
    | sigType     | supported RSA     | value | one of       | No       |
    |             | legacy signature  |       | {"ansx9.31", |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 16]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    |             | types  - see      |       | "pkcs1v1.5", |          |
    |             | [FIPS186-4],      |       | "pss"}       |          |
    |             | Section 5         |       |              |          |
@@ -890,14 +931,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    | hashAlg     | supported hash    | array | any non-     | No       |
    |             | algorithms for    |       | empty subset |          |
    |             | this sigType and  |       | of {"SHA-1", |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 16]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    |             | modulo - see      |       | "SHA2-224",  |          |
    |             | [SP800-131A],     |       | "SHA2-256",  |          |
    |             | Section 9         |       | "SHA2-384",  |          |
@@ -913,6 +946,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             |                   |       | in the note  |          |
    |             |                   |       | below.       |          |
    |             |                   |       |              |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 17]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    | pubExpMode  | type of public    | value | "fixed" or   | Yes      |
    |             | exponent          |       | "random"     |          |
    |             |                   |       |              |          |
@@ -946,14 +987,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    'd' is replaced with 'dmp1', 'dmq1', and 'iqmp'.  Only 2048-bit RSA
    keys are allowed for this capability.  There are no properties
    specified for this capability.  See Appendix B.6 for additional
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 17]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
    details on constraints for 'msg' and 'n'.  See the ACVP specification
    for details on the registration message.
 
@@ -968,6 +1001,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
    where 'cipherText' is a cipherText to be decrypted, 'd' is the
    private exponent and 'n' is the modulus.  See [SP800-56B],
    Section 7.1.2 for details.
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 18]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
 
    In testing, only 'cipherText' is supplied by the ACVP server.  The
    client is responsible for generating RSA key pairs of modulus 'n',
@@ -984,7 +1025,31 @@ Internet-Draft                RSA Alg JSON                 February 2018
    of the selected modulus 'n'.  See the ACVP specification for details
    on the registration message.
 
-5.  Test Vectors
+5.  Supported DSA Conformances
+
+   Conformances MAY be used to test additional features of certain
+   algorithms.
+
+   +-----------+--------------------------------+-----------+----------+
+   | String    | Description                    | Valid     | Optional |
+   | Value     |                                | algorithm |          |
+   |           |                                | modes     |          |
+   +-----------+--------------------------------+-----------+----------+
+   | SP800-106 | This conformance signifies the | SigGen,   | Yes      |
+   |           | SigGen and/or SigVer modes     | SigVer    |          |
+   |           | support randomized message     |           |          |
+   |           | hashing as described in        |           |          |
+   |           | [SP.800-106]. Utilizing this   |           |          |
+   |           | conformance SHALL generate     |           |          |
+   |           | additional test groups,        |           |          |
+   |           | denoted with a group level     |           |          |
+   |           | property of                    |           |          |
+   |           | "isMessageRandomized".         |           |          |
+   +-----------+--------------------------------+-----------+----------+
+
+                         Table 8: DSA Conformances
+
+6.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed by the client and returned to the ACVP server for
@@ -992,6 +1057,15 @@ Internet-Draft                RSA Alg JSON                 February 2018
    test vector sets to be downloaded and processed by the ACVP client.
    Each test vector set represents an individual algorithm and mode,
    such as {"algorithm": "RSA, "mode": "sigGen"}, etc.  This section
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 19]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
    describes the JSON schema for test vector sets used with the RSA
    algorithm and modes.
 
@@ -999,16 +1073,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
    contains meta data for the entire vector set as well as individual
    test vectors to be processed by the ACVP client.  The following table
    describes the JSON elements at the top level of the hierarchy.
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 18]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
 
    +------------+------------------------+-----------------------------+
    | JSON Value | Description            | JSON type                   |
@@ -1031,12 +1095,12 @@ Internet-Draft                RSA Alg JSON                 February 2018
    | testGroups | Array of test group    | array                       |
    |            | JSON objects, which    |                             |
    |            | are defined in         |                             |
-   |            | Section 5.1            |                             |
+   |            | Section 6.1            |                             |
    +------------+------------------------+-----------------------------+
 
-                      Table 8: Vector Set JSON Object
+                      Table 9: Vector Set JSON Object
 
-5.1.  Test Groups JSON Schema
+6.1.  Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -1045,75 +1109,11 @@ Internet-Draft                RSA Alg JSON                 February 2018
    applies to all test vectors within the group.  The following table
    describes the RSA JSON elements of the Test Group JSON object.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 19]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
-   +-------------+-----------------------+------------------+----------+
-   | JSON Value  | Description           | JSON type        | Optional |
-   +-------------+-----------------------+------------------+----------+
-   | modulo      | RSA modulus           | value            | No       |
-   |             |                       |                  |          |
-   | hashAlg     | the hash algorithm    | value            | Yes      |
-   |             |                       |                  |          |
-   | primeTest   | Miller-Rabin          | value            | Yes      |
-   |             | constraint from Table |                  |          |
-   |             | C.2 or C.3            |                  |          |
-   |             |                       |                  |          |
-   | pubExpMode  | Fixed or random       | "fixed" or       | Yes      |
-   |             | public exponent       | "random"         |          |
-   |             |                       |                  |          |
-   | randPQ      | KeyGen mode used      | "B.3.2",         | Yes      |
-   |             |                       | "B.3.3",         |          |
-   |             |                       | "B.3.4",         |          |
-   |             |                       | "B.3.5", "B.3.6" |          |
-   |             |                       |                  |          |
-   | fixedPubExp | Fixed public exponent | hex value        | Yes      |
-   |             | value if pubExpMode   |                  |          |
-   |             | is defined as "fixed" |                  |          |
-   |             |                       |                  |          |
-   | n           | Public modulus value  | hex value        | Yes      |
-   |             | n                     |                  |          |
-   |             |                       |                  |          |
-   | e           | Public exponent value | hex value        | Yes      |
-   |             | e                     |                  |          |
-   |             |                       |                  |          |
-   | pubExpMode  | Fixed or random       | "fixed" or       | Yes      |
-   |             | public exponent       | "random"         |          |
-   |             |                       |                  |          |
-   | sigType     | Type of signature     | "ansx9.31",      | Yes      |
-   |             | used in the group     | "pkcs1v1.5",     |          |
-   |             |                       | "pss"            |          |
-   |             |                       |                  |          |
-   | saltLen     | The salt length for   | value            | Yes      |
-   |             | the group in bytes    |                  |          |
-   +-------------+-----------------------+------------------+----------+
-
-                      Table 9: Test Group JSON Object
-
-5.2.  Test Case JSON Schema
-
-   Each test group contains an array of one or more test cases.  Each
-   test case is a JSON object that represents a single test vector to be
-   processed by the ACVP client.  The following table describes the JSON
-   elements for each RSA test vector.
+   +---------------------+-------------------+--------------+----------+
+   | JSON Value          | Description       | JSON type    | Optional |
+   +---------------------+-------------------+--------------+----------+
+   | modulo              | RSA modulus       | value        | No       |
+   |                     |                   |              |          |
 
 
 
@@ -1122,53 +1122,53 @@ Vassilev                 Expires August 5, 2018                [Page 20]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   +------------+-----------------------------------+-------+----------+
-   | JSON Value | Description                       | JSON  | Optional |
-   |            |                                   | type  |          |
-   +------------+-----------------------------------+-------+----------+
-   | tcId       | Numeric identifier for the test   | value | No       |
-   |            | case, unique across the entire    |       |          |
-   |            | vector set.                       |       |          |
-   |            |                                   |       |          |
-   | e          | the public exponent               | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | d          | the private exponent              | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | n          | the public modulus                | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | pRand      | the random for P, testing         | hex   | Yes      |
-   |            | probable primes according to      | value |          |
-   |            | [FIPS186-4], Appendix B.3.3       |       |          |
-   |            |                                   |       |          |
-   | qRand      | the random for Q, if applicable,  | hex   | Yes      |
-   |            | testing probable primes according | value |          |
-   |            | to [FIPS186-4], Appendix B.3.3    |       |          |
-   |            |                                   |       |          |
-   | message    | the message to be signed          | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | signature  | the signature to be verified      | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | cipherText | the cipherText to be decrypted    | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | cipherText | the cipherText to be decrypted    | hex   | Yes      |
-   |            |                                   | value |          |
-   |            |                                   |       |          |
-   | salt       | the salt value used to sign the   | hex   | Yes      |
-   |            | message                           | value |          |
-   +------------+-----------------------------------+-------+----------+
-
-                    Table 10: RSA Test Case JSON Object
-
-6.  Test Vector Responses
-
-   After the ACVP client downloads and processes a vector set, it must
-   send the response vectors back to the ACVP server.  The following
+   | hashAlg             | the hash          | value        | Yes      |
+   |                     | algorithm         |              |          |
+   |                     |                   |              |          |
+   | primeTest           | Miller-Rabin      | value        | Yes      |
+   |                     | constraint from   |              |          |
+   |                     | Table C.2 or C.3  |              |          |
+   |                     |                   |              |          |
+   | pubExpMode          | Fixed or random   | "fixed" or   | Yes      |
+   |                     | public exponent   | "random"     |          |
+   |                     |                   |              |          |
+   | randPQ              | KeyGen mode used  | "B.3.2",     | Yes      |
+   |                     |                   | "B.3.3",     |          |
+   |                     |                   | "B.3.4",     |          |
+   |                     |                   | "B.3.5",     |          |
+   |                     |                   | "B.3.6"      |          |
+   |                     |                   |              |          |
+   | fixedPubExp         | Fixed public      | hex value    | Yes      |
+   |                     | exponent value if |              |          |
+   |                     | pubExpMode is     |              |          |
+   |                     | defined as        |              |          |
+   |                     | "fixed"           |              |          |
+   |                     |                   |              |          |
+   | n                   | Public modulus    | hex value    | Yes      |
+   |                     | value n           |              |          |
+   |                     |                   |              |          |
+   | e                   | Public exponent   | hex value    | Yes      |
+   |                     | value e           |              |          |
+   |                     |                   |              |          |
+   | pubExpMode          | Fixed or random   | "fixed" or   | Yes      |
+   |                     | public exponent   | "random"     |          |
+   |                     |                   |              |          |
+   | sigType             | Type of signature | "ansx9.31",  | Yes      |
+   |                     | used in the group | "pkcs1v1.5", |          |
+   |                     |                   | "pss"        |          |
+   |                     |                   |              |          |
+   | saltLen             | The salt length   | value        | Yes      |
+   |                     | for the group in  |              |          |
+   |                     | bytes             |              |          |
+   |                     |                   |              |          |
+   | isMessageRandomized | Signifies all     | boolean      | Yes      |
+   |                     | test cases within |              |          |
+   |                     | the group should  |              |          |
+   |                     | utilize random    |              |          |
+   |                     | message hashing   |              |          |
+   |                     | as described in   |              |          |
+   |                     | [SP.800-106].     |              |          |
+   +---------------------+-------------------+--------------+----------+
 
 
 
@@ -1178,6 +1178,79 @@ Vassilev                 Expires August 5, 2018                [Page 21]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                     Table 10: Test Group JSON Object
+
+6.2.  Test Case JSON Schema
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each RSA test vector.
+
+   +----------------+-------------------------------+-------+----------+
+   | JSON Value     | Description                   | JSON  | Optional |
+   |                |                               | type  |          |
+   +----------------+-------------------------------+-------+----------+
+   | tcId           | Numeric identifier for the    | value | No       |
+   |                | test case, unique across the  |       |          |
+   |                | entire vector set.            |       |          |
+   |                |                               |       |          |
+   | e              | the public exponent           | hex   | Yes      |
+   |                |                               | value |          |
+   |                |                               |       |          |
+   | d              | the private exponent          | hex   | Yes      |
+   |                |                               | value |          |
+   |                |                               |       |          |
+   | n              | the public modulus            | hex   | Yes      |
+   |                |                               | value |          |
+   |                |                               |       |          |
+   | pRand          | the random for P, testing     | hex   | Yes      |
+   |                | probable primes according to  | value |          |
+   |                | [FIPS186-4], Appendix B.3.3   |       |          |
+   |                |                               |       |          |
+   | qRand          | the random for Q, if          | hex   | Yes      |
+   |                | applicable, testing probable  | value |          |
+   |                | primes according to           |       |          |
+   |                | [FIPS186-4], Appendix B.3.3   |       |          |
+   |                |                               |       |          |
+   | message        | the message to be signed      | hex   | Yes      |
+   |                |                               | value |          |
+   |                |                               |       |          |
+   | randomValue    | The random value to be used   | value | Yes      |
+   |                | as an input into the message  |       |          |
+   |                | randomization function as     |       |          |
+   |                | described in [SP.800-106].    |       |          |
+   |                |                               |       |          |
+   | randomValueLen | The random value's bit        | value | Yes      |
+   |                | length.                       |       |          |
+   |                |                               |       |          |
+   | signature      | the signature to be verified  | hex   | Yes      |
+   |                |                               | value |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 22]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+   |                |                               |       |          |
+   | cipherText     | the cipherText to be          | hex   | Yes      |
+   |                | decrypted                     | value |          |
+   |                |                               |       |          |
+   | cipherText     | the cipherText to be          | hex   | Yes      |
+   |                | decrypted                     | value |          |
+   |                |                               |       |          |
+   | salt           | the salt value used to sign   | hex   | Yes      |
+   |                | the message                   | value |          |
+   +----------------+-------------------------------+-------+----------+
+
+                    Table 11: RSA Test Case JSON Object
+
+7.  Test Vector Responses
+
+   After the ACVP client downloads and processes a vector set, it must
+   send the response vectors back to the ACVP server.  The following
    table describes the JSON object that represents a vector set
    response.
 
@@ -1192,96 +1265,23 @@ Internet-Draft                RSA Alg JSON                 February 2018
    |             |                                             |       |
    | testResults | Array of JSON objects that represent each   | array |
    |             | test vector result, which uses the same     |       |
-   |             | JSON schema as defined in Section 5.2       |       |
+   |             | JSON schema as defined in Section 6.2       |       |
    +-------------+---------------------------------------------+-------+
 
-                 Table 11: Vector Set Response JSON Object
+                 Table 12: Vector Set Response JSON Object
 
    The following table describes the JSON elements for the response to a
    RSA test vector.
 
-   +------------+-----------------------+-------------------+----------+
-   | JSON Value | Description           | JSON type         | Optional |
-   +------------+-----------------------+-------------------+----------+
-   | tcId       | Numeric identifier    | value             | No       |
-   |            | for the test case,    |                   |          |
-   |            | unique across the     |                   |          |
-   |            | entire vector set.    |                   |          |
-   |            |                       |                   |          |
-   | e          | the public exponent   | hex value         | Yes      |
-   |            |                       |                   |          |
-   | pRand      | the random for P,     | hex value         | Yes      |
-   |            | testing probable      |                   |          |
-   |            | primes according to   |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3                 |                   |          |
-   |            |                       |                   |          |
-   | qRand      | the random for Q, if  | hex value         | Yes      |
-   |            | applicable, testing   |                   |          |
-   |            | probable primes       |                   |          |
-   |            | according to          |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3                 |                   |          |
-   |            |                       |                   |          |
-   | testPassed | the verdict on the    | "passed"/"failed" | Yes      |
-   |            | prime generation,     |                   |          |
-   |            | signature             |                   |          |
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 22]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
-   |            | verification,         |                   |          |
-   |            | signature primitice,  |                   |          |
-   |            | decryption primitive  |                   |          |
-   |            | process, testing for  |                   |          |
-   |            | the supplied          |                   |          |
-   |            | pRand/qRand           |                   |          |
-   |            | combination, see      |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3.                |                   |          |
-   |            |                       |                   |          |
-   | seed       | the seed used in      | hex value         | Yes      |
-   |            | prime generation      |                   |          |
-   |            | according to          |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.2, B.3.4, or      |                   |          |
-   |            | B.3.5                 |                   |          |
-   |            |                       |                   |          |
-   | bitlens    | the length of p1, p2, | array of ints     | Yes      |
-   |            | q1, and q2 for prime  |                   |          |
-   |            | generation according  |                   |          |
-   |            | to [FIPS186-4],       |                   |          |
-   |            | Appendix B.3.2,       |                   |          |
-   |            | B.3.4, B.3.5 or the   |                   |          |
-   |            | length of xP1, xP2,   |                   |          |
-   |            | xQ1, and xQ2 for      |                   |          |
-   |            | B.3.6                 |                   |          |
-   |            |                       |                   |          |
-   | xP1        | the prime factor p1   | hex value         | Yes      |
-   |            | for Primes with       |                   |          |
-   |            | Conditions - see      |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3, B.3.4, or      |                   |          |
-   |            | B.3.5, if applicable  |                   |          |
-   |            |                       |                   |          |
-   | xP2        | the prime factor p2   | hex value         | Yes      |
-   |            | for Primes with       |                   |          |
-   |            | Conditions - see      |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3, B.3.4, or      |                   |          |
-   |            | B.3.5, if applicable  |                   |          |
-   |            |                       |                   |          |
-   | xP         | the random number     | hex value         | Yes      |
-   |            | used in Step 3 of the |                   |          |
-   |            | algorithm in          |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | C.9 to generate the   |                   |          |
-   |            | prime P, if           |                   |          |
-   |            | applicable            |                   |          |
+   +----------------+-------------------+-------------------+----------+
+   | JSON Value     | Description       | JSON type         | Optional |
+   +----------------+-------------------+-------------------+----------+
+   | tcId           | Numeric           | value             | No       |
+   |                | identifier for    |                   |          |
+   |                | the test case,    |                   |          |
+   |                | unique across the |                   |          |
+   |                | entire vector     |                   |          |
+   |                | set.              |                   |          |
 
 
 
@@ -1290,54 +1290,54 @@ Vassilev                 Expires August 5, 2018                [Page 23]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   |            |                       |                   |          |
-   | p          | the private prime     | hex value         | Yes      |
-   |            | factor p              |                   |          |
-   |            |                       |                   |          |
-   | xQ1        | the prime factor q1   | hex value         | Yes      |
-   |            | for Primes with       |                   |          |
-   |            | Conditions - see      |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3, B.3.4, or      |                   |          |
-   |            | B.3.5, if applicable  |                   |          |
-   |            |                       |                   |          |
-   | xQ2        | the prime factor q2   | hex value         | Yes      |
-   |            | for Primes with       |                   |          |
-   |            | Conditions - see      |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | B.3.3, B.3.4, or      |                   |          |
-   |            | B.3.5, if applicable  |                   |          |
-   |            |                       |                   |          |
-   | xQ         | the random number     | hex value         | Yes      |
-   |            | used in Step 3 of the |                   |          |
-   |            | algorithm in          |                   |          |
-   |            | [FIPS186-4], Appendix |                   |          |
-   |            | C.9 to generate the   |                   |          |
-   |            | prime Q, if           |                   |          |
-   |            | applicable            |                   |          |
-   |            |                       |                   |          |
-   | q          | the private prime     | hex value         | Yes      |
-   |            | factor q              |                   |          |
-   |            |                       |                   |          |
-   | n          | the modulus           | hex value         | Yes      |
-   |            |                       |                   |          |
-   | d          | the private exponent  | hex value         | Yes      |
-   |            | d                     |                   |          |
-   |            |                       |                   |          |
-   | dmp1       | the private exponent  | hex value         | Yes      |
-   |            | d modulo (p - 1) used |                   |          |
-   |            | in a Chinese          |                   |          |
-   |            | Remainder Theorem     |                   |          |
-   |            | private key           |                   |          |
-   |            |                       |                   |          |
-   | dmq1       | the private exponent  | hex value         | Yes      |
-   |            | d modulo (q - 1) used |                   |          |
-   |            | in a Chinese          |                   |          |
-   |            | Remainder Theorem     |                   |          |
-   |            | private key           |                   |          |
-   |            |                       |                   |          |
-   | iqmp       | the multiplicative    | hex value         | Yes      |
-   |            | inverse of q modulo p |                   |          |
+   |                |                   |                   |          |
+   | e              | the public        | hex value         | Yes      |
+   |                | exponent          |                   |          |
+   |                |                   |                   |          |
+   | pRand          | the random for P, | hex value         | Yes      |
+   |                | testing probable  |                   |          |
+   |                | primes according  |                   |          |
+   |                | to [FIPS186-4],   |                   |          |
+   |                | Appendix B.3.3    |                   |          |
+   |                |                   |                   |          |
+   | qRand          | the random for Q, | hex value         | Yes      |
+   |                | if applicable,    |                   |          |
+   |                | testing probable  |                   |          |
+   |                | primes according  |                   |          |
+   |                | to [FIPS186-4],   |                   |          |
+   |                | Appendix B.3.3    |                   |          |
+   |                |                   |                   |          |
+   | testPassed     | the verdict on    | "passed"/"failed" | Yes      |
+   |                | the prime         |                   |          |
+   |                | generation,       |                   |          |
+   |                | signature         |                   |          |
+   |                | verification,     |                   |          |
+   |                | signature         |                   |          |
+   |                | primitice,        |                   |          |
+   |                | decryption        |                   |          |
+   |                | primitive         |                   |          |
+   |                | process, testing  |                   |          |
+   |                | for the supplied  |                   |          |
+   |                | pRand/qRand       |                   |          |
+   |                | combination, see  |                   |          |
+   |                | [FIPS186-4],      |                   |          |
+   |                | Appendix B.3.3.   |                   |          |
+   |                |                   |                   |          |
+   | seed           | the seed used in  | hex value         | Yes      |
+   |                | prime generation  |                   |          |
+   |                | according to      |                   |          |
+   |                | [FIPS186-4],      |                   |          |
+   |                | Appendix B.3.2,   |                   |          |
+   |                | B.3.4, or B.3.5   |                   |          |
+   |                |                   |                   |          |
+   | bitlens        | the length of p1, | array of ints     | Yes      |
+   |                | p2, q1, and q2    |                   |          |
+   |                | for prime         |                   |          |
+   |                | generation        |                   |          |
+   |                | according to      |                   |          |
+   |                | [FIPS186-4],      |                   |          |
+   |                | Appendix B.3.2,   |                   |          |
+   |                | B.3.4, B.3.5 or   |                   |          |
 
 
 
@@ -1346,29 +1346,141 @@ Vassilev                 Expires August 5, 2018                [Page 24]
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
-   |            | used in a Chinese     |                   |          |
-   |            | Remainder Theorem     |                   |          |
-   |            | private key           |                   |          |
-   |            |                       |                   |          |
-   | signature  | the digital signature | hex value         | Yes      |
-   |            | value                 |                   |          |
-   +------------+-----------------------+-------------------+----------+
+   |                | the length of     |                   |          |
+   |                | xP1, xP2, xQ1,    |                   |          |
+   |                | and xQ2 for B.3.6 |                   |          |
+   |                |                   |                   |          |
+   | xP1            | the prime factor  | hex value         | Yes      |
+   |                | p1 for Primes     |                   |          |
+   |                | with Conditions - |                   |          |
+   |                | see [FIPS186-4],  |                   |          |
+   |                | Appendix B.3.3,   |                   |          |
+   |                | B.3.4, or B.3.5,  |                   |          |
+   |                | if applicable     |                   |          |
+   |                |                   |                   |          |
+   | xP2            | the prime factor  | hex value         | Yes      |
+   |                | p2 for Primes     |                   |          |
+   |                | with Conditions - |                   |          |
+   |                | see [FIPS186-4],  |                   |          |
+   |                | Appendix B.3.3,   |                   |          |
+   |                | B.3.4, or B.3.5,  |                   |          |
+   |                | if applicable     |                   |          |
+   |                |                   |                   |          |
+   | xP             | the random number | hex value         | Yes      |
+   |                | used in Step 3 of |                   |          |
+   |                | the algorithm in  |                   |          |
+   |                | [FIPS186-4],      |                   |          |
+   |                | Appendix C.9 to   |                   |          |
+   |                | generate the      |                   |          |
+   |                | prime P, if       |                   |          |
+   |                | applicable        |                   |          |
+   |                |                   |                   |          |
+   | p              | the private prime | hex value         | Yes      |
+   |                | factor p          |                   |          |
+   |                |                   |                   |          |
+   | xQ1            | the prime factor  | hex value         | Yes      |
+   |                | q1 for Primes     |                   |          |
+   |                | with Conditions - |                   |          |
+   |                | see [FIPS186-4],  |                   |          |
+   |                | Appendix B.3.3,   |                   |          |
+   |                | B.3.4, or B.3.5,  |                   |          |
+   |                | if applicable     |                   |          |
+   |                |                   |                   |          |
+   | xQ2            | the prime factor  | hex value         | Yes      |
+   |                | q2 for Primes     |                   |          |
+   |                | with Conditions - |                   |          |
+   |                | see [FIPS186-4],  |                   |          |
+   |                | Appendix B.3.3,   |                   |          |
+   |                | B.3.4, or B.3.5,  |                   |          |
+   |                | if applicable     |                   |          |
+   |                |                   |                   |          |
 
-                Table 12: RSA Test Case Results JSON Object
 
-7.  Acknowledgements
+
+Vassilev                 Expires August 5, 2018                [Page 25]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+   | xQ             | the random number | hex value         | Yes      |
+   |                | used in Step 3 of |                   |          |
+   |                | the algorithm in  |                   |          |
+   |                | [FIPS186-4],      |                   |          |
+   |                | Appendix C.9 to   |                   |          |
+   |                | generate the      |                   |          |
+   |                | prime Q, if       |                   |          |
+   |                | applicable        |                   |          |
+   |                |                   |                   |          |
+   | q              | the private prime | hex value         | Yes      |
+   |                | factor q          |                   |          |
+   |                |                   |                   |          |
+   | n              | the modulus       | hex value         | Yes      |
+   |                |                   |                   |          |
+   | d              | the private       | hex value         | Yes      |
+   |                | exponent d        |                   |          |
+   |                |                   |                   |          |
+   | dmp1           | the private       | hex value         | Yes      |
+   |                | exponent d modulo |                   |          |
+   |                | (p - 1) used in a |                   |          |
+   |                | Chinese Remainder |                   |          |
+   |                | Theorem private   |                   |          |
+   |                | key               |                   |          |
+   |                |                   |                   |          |
+   | dmq1           | the private       | hex value         | Yes      |
+   |                | exponent d modulo |                   |          |
+   |                | (q - 1) used in a |                   |          |
+   |                | Chinese Remainder |                   |          |
+   |                | Theorem private   |                   |          |
+   |                | key               |                   |          |
+   |                |                   |                   |          |
+   | iqmp           | the               | hex value         | Yes      |
+   |                | multiplicative    |                   |          |
+   |                | inverse of q      |                   |          |
+   |                | modulo p used in  |                   |          |
+   |                | a Chinese         |                   |          |
+   |                | Remainder Theorem |                   |          |
+   |                | private key       |                   |          |
+   |                |                   |                   |          |
+   | signature      | the digital       | hex value         | Yes      |
+   |                | signature value   |                   |          |
+   |                |                   |                   |          |
+   | randomValue    | The random value  | value             | Yes      |
+   |                | to be used as an  |                   |          |
+   |                | input into the    |                   |          |
+   |                | message           |                   |          |
+   |                | randomization     |                   |          |
+   |                | function as       |                   |          |
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 26]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+   |                | described in      |                   |          |
+   |                | [SP.800-106].     |                   |          |
+   |                |                   |                   |          |
+   | randomValueLen | The random        | value             | Yes      |
+   |                | value's bit       |                   |          |
+   |                | length.           |                   |          |
+   +----------------+-------------------+-------------------+----------+
+
+                Table 13: RSA Test Case Results JSON Object
+
+8.  Acknowledgements
 
    TBD...
 
-8.  IANA Considerations
+9.  IANA Considerations
 
    This memo includes no request to IANA.
 
-9.  Security Considerations
+10.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
 
-10.  Normative References
+11.  Normative References
 
    [ACVP]     NIST, "ACVP Specification", 2016.
 
@@ -1397,10 +1509,16 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 25]
+Vassilev                 Expires August 5, 2018                [Page 27]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
+
+   [SP.800-106]
+              NIST, "Randomized Hashing for Digital Signatures",
+              February 2009,
+              <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/
+              nistspecialpublication800-106.pdf>.
 
    [SP800-131A]
               Barker, E. and A. Roginsky, "Transitions: Recommendation
@@ -1447,13 +1565,7 @@ A.1.  Example keyGen with Provable Primes and Provable Primes with
 
 
 
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 26]
+Vassilev                 Expires August 5, 2018                [Page 28]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1509,7 +1621,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 27]
+Vassilev                 Expires August 5, 2018                [Page 29]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1565,7 +1677,7 @@ A.1.1.  Example keyGen with Probable Primes Capabilities JSON Object
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 28]
+Vassilev                 Expires August 5, 2018                [Page 30]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1621,7 +1733,7 @@ A.1.2.  Example keyGen with Provable Conditional Primes with Probable
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 29]
+Vassilev                 Expires August 5, 2018                [Page 31]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1677,7 +1789,7 @@ A.2.  Example RSA sigGen Capabilities JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 30]
+Vassilev                 Expires August 5, 2018                [Page 32]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1733,7 +1845,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 31]
+Vassilev                 Expires August 5, 2018                [Page 33]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1789,7 +1901,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 32]
+Vassilev                 Expires August 5, 2018                [Page 34]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -1828,6 +1940,9 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     }
                 ]
          }
+      ],
+      "conformances": [
+        "SP800-106"
       ]
    }
 
@@ -1839,17 +1954,17 @@ A.3.  Example RSA sigVer Capabilities JSON Objects
 
 
    {
-      "algorithm": "RSA",
-      "mode": "sigVer",
-      "revision": "1.0",
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 33]
+Vassilev                 Expires August 5, 2018                [Page 35]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+      "algorithm": "RSA",
+      "mode": "sigVer",
+      "revision": "1.0",
       "prereqVals": [{"algorithm": "DRBG", "valValue": "123456"}, {"algorithm": "DRBG", "valValue": "654321"}, {"algorithm": "SHA", "valValue": "7890"}],
       "pubExpMode" : "random",
       "capabilities" :
@@ -1895,17 +2010,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "hashAlg" : "SHA2-512"
                         }
                       ]
-                    }
-               ]
-         },
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 34]
+Vassilev                 Expires August 5, 2018                [Page 36]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                    }
+               ]
+         },
          {  "sigType" : "pkcs1v1.5",
             "properties" :
                 [
@@ -1951,17 +2066,17 @@ Internet-Draft                RSA Alg JSON                 February 2018
                 ]
          },
          {  "sigType" : "pss",
-            "properties" :
-                [
-                    { "modulo" : 2048,
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 35]
+Vassilev                 Expires August 5, 2018                [Page 37]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+            "properties" :
+                [
+                    { "modulo" : 2048,
                       "hashPair" : [
                         {
                           "hashAlg" : "SHA2-224",
@@ -2007,18 +2122,21 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "hashAlg" : "SHA2-512",
                           "saltLen" : 64
                         }
-                      ]
-                    }
-                 ]
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 36]
+Vassilev                 Expires August 5, 2018                [Page 38]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                      ]
+                    }
+                 ]
           }
+      ],
+      "conformances": [
+        "SP800-106"
       ]
    }
 
@@ -2063,13 +2181,7 @@ A.4.  Example RSA legacySigVer Capabilities JSON Objects
 
 
 
-
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 37]
+Vassilev                 Expires August 5, 2018                [Page 39]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2125,7 +2237,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 38]
+Vassilev                 Expires August 5, 2018                [Page 40]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2181,7 +2293,7 @@ B.1.  Example Test Vectors for keyGen JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 39]
+Vassilev                 Expires August 5, 2018                [Page 41]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2237,7 +2349,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 40]
+Vassilev                 Expires August 5, 2018                [Page 42]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2293,7 +2405,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 41]
+Vassilev                 Expires August 5, 2018                [Page 43]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2349,7 +2461,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 42]
+Vassilev                 Expires August 5, 2018                [Page 44]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2405,7 +2517,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 43]
+Vassilev                 Expires August 5, 2018                [Page 45]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2425,7 +2537,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
    This means the client is responsible for providing the details by
    running an instance of the appropriate Key Generation method for each
    test.  The information returned should match all applicable data in
-   Table 12.  For Key Generation method 2 (Appendix B.3.3 [FIPS186-4])
+   Table 13.  For Key Generation method 2 (Appendix B.3.3 [FIPS186-4])
    if the public exponent is random, there are two test types.  One is a
    known answer test (KAT) provided by the server resulting in a
    "pass"/"fail" response determining if the input forms a valid key
@@ -2461,7 +2573,7 @@ B.2.  Example Test Vectors for keyGen when infoGeneratedByServer is true
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 44]
+Vassilev                 Expires August 5, 2018                [Page 46]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2517,7 +2629,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 45]
+Vassilev                 Expires August 5, 2018                [Page 47]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2573,7 +2685,7 @@ B.3.  Example Test Vectors for sigGen JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 46]
+Vassilev                 Expires August 5, 2018                [Page 48]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2613,6 +2725,103 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
                     }
                  ]
+             },
+
+             {
+                 "tgId": 7,
+                 "sigType" : "ansx9.31",
+                 "hashAlg" : "SHA2-256",
+                 "modulo" : 2048,
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11165,
+                      "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
+                    }
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 49]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+                 ]
+             },
+             {
+                "tgId": 8,
+                "sigType": "ansx9.31",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                      "tcId" : 11166,
+                      "message" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
+                    }
+                 ]
+             },
+             {
+                "tgId": 9,
+                "sigType" : "pkcs1v1.5",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 2048,
+                "isMessageRandomized": true,
+                "tests" : [
+                   {
+                     "tcId" : 11167,
+                     "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
+                   }
+                ]
+             },
+             {
+                "tgId": 10,
+                "sigType" : "pkcs1v1.5",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11168,
+                      "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
+                    }
+                 ]
+             },
+             {
+                "tgId": 11,
+                "sigType" : "pss",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 2048,
+                "isMessageRandomized": true,
+                "tests" : [
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 50]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+                    {
+                      "tcId" : 11169,
+                      "saltLen" : 20,
+                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
+                    }
+                 ]
+             },
+             {
+                "tgId": 12,
+                "sigType" : "pss",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11170,
+                      "saltLen" : 20,
+                      "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
+                    }
+                 ]
              }
        ]
     }
@@ -2626,14 +2835,6 @@ B.4.  Example Test Vectors for sigVer JSON Objects
    { "acvVersion": <acvp-version> },
    { "vsId": 1173,
       "algorithm": "RSA",
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 47]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
       "mode": "sigVer",
       "revision": "1.0",
       "testGroups" : [
@@ -2649,6 +2850,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     {
                       "tcId" : 1174,
                       "message" : "ff17e5e88ad5cd0dc463ae0b286273b3905271939c60ed70577edef018b9f596a7c7dbf3a1e0ba1b1ed0fe5790495d19ef7d143513ec744d617b9e8da9c78b994fb84fc4a9599e83a9e78f21bc28a0b4f1fdfa4f5e3bf779c0b7e2de61a0fe453f12c9c26ae7812daed1e8d272a6456ae0faab4b46f37ddbbc59324a08ed5681",
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 51]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                       "signature" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
                     }
                  ]
@@ -2682,14 +2891,6 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1176,
                       "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
                       "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 48]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
                     }
                  ]
              },
@@ -2705,6 +2906,14 @@ Internet-Draft                RSA Alg JSON                 February 2018
                     {
                       "tcId" : 1177,
                       "message" : "921961e184a5d9657697e3e65ceb1ed10204ec56e739df0e4f906ee194c9ed27bd9fbc0d514abe3a6e480cb3155debfcc8d9fc815719b334f7500a769488773b68e31b69cd273c824f79f58306692c0c232fc5c0c83415ef1dd59a73a063e9d7bc6ee7bf9e433c8344b3051ed616c9473a90afdde393ee88e9a5849e5f642b43",
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 52]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                       "signature" : "55362a6854a7846c4d105dc8a358fd4c02931f117631968457f422939d266682fd705e2091bfd5d1bfb52b4bfad684914489ecdad9038b75c65916a9e967630b16c76656b58404ec11ac46d8684b3e72d4392fb6e7e6c929e43ad4fb6ce6198f241b39e8bcbbc058792dde31b195b91bb14236dcb82c28a5c24d633dd847d1548dd403b3a70149371f46432db1767a00c462758c2298fe9f1f04c2ff4b96858d084ffe5a624cb85c1f9be2a60fed40133b7c571c6c467f46a0f1e48ee6e2e6d65424bf8196b0d927e0fd4141264aa5df4129d52d2fb57b8dac9386a84ecd34ecb1feac3a2b99d055eda977ddf8027f1178348a30e4cb4ecef2291d7f520794018b39f5251fd46d97282ac21f6bce6539d19aa1c21c3c220a2ddb6feed262eceebd753eaf5e0eb98cb3eb7d324a3dac0a415a18b7f36170676e8b9d3e421a6f77046bee6d9591c93f7ef0242f464f15b63132a0aee80949709429b1e76d40d60f79b2a6ab362f12e2cdd0bc66868c80278043e179a36f2815e7916378b0fbdb8e"
                     }
                  ]
@@ -2738,14 +2947,145 @@ Internet-Draft                RSA Alg JSON                 February 2018
                       "tcId" : 1179,
                       "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
                       "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
+                    }
+                 ]
+             },
+
+             {
+                 "tgId": 7,
+                 "sigType" : "ansx9.31",
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "modulo" : 2048,
+                 "e" : "166f67",
+                 "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 49]
+Vassilev                 Expires August 5, 2018                [Page 53]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+                      "tcId" : 11174,
+                      "message" : "ff17e5e88ad5cd0dc463ae0b286273b3905271939c60ed70577edef018b9f596a7c7dbf3a1e0ba1b1ed0fe5790495d19ef7d143513ec744d617b9e8da9c78b994fb84fc4a9599e83a9e78f21bc28a0b4f1fdfa4f5e3bf779c0b7e2de61a0fe453f12c9c26ae7812daed1e8d272a6456ae0faab4b46f37ddbbc59324a08ed5681",
+                      "randomValue": "ab676ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 8,
+                 "sigType" : "ansx9.31",
+                 "modulo" : 3072,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "89ca09",
+                 "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11175,
+                      "message" : "7cdcd58f9f290bd550c46b61f15b7fe082b8741cba8acedb57685a04b213640496fb2b70520592ec0d8c184b5aa60af80da8f8944cec65e0e9d1c2deef049e337afe17d0ccce94d19e19b6a5b45f8b70b47f05ad387eab1822848fcb302780a7d0ec80f5350b794daa732bb7260e6911214685b1a7c8094bab88a7149d057327",
+                      "randomValue": "ab61bc76ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "1c3d10d8b876e2cae5e8210fd2dd53d9b1245b961e69f6fd7759cd27e7a88dd7fc59f517972f4e6a0b480c837bd7d768292f5784ac5f1df692a9699e32d976ebd1a4282af727a5605cbc5b28d8dae834bdcad391282e6bef543bd11a3d72ef984195236043b655217c8cd8bd3247f29afe17ad0af20dc703df5d7ad49af1ff4bb247717dc6335c45e5845d92772c4e4eef5e2efb4a1c45cb2ffe296cecc4474ab81ec17401b4d3c5129a59a40da2ba8c8fa548a0ae8bbe43b1f1f1dbe029e28dc61a762ed2665ac1bbd6eb6aeecf1bca4b450e8df7bed087f7d390733fa477823eaaf59d0bf7a0c7a8150850b413a05237bd253350d5091a12219a35a58a0ef6fc15024f24b9ef2bd7b27ace7bedc30c9f9ecd1e828966cec760e555d019507560c2ba68dc562300460453f937abca74ca25a7de5fa66e4f28fdefb3030126c0f93b8304717c5a28d07ef095069ca9b6925f6e5ad11497b03a2b2c6660485e0e99b13c334084b038a4d81556c5b7c9ed766fd3fb30bf6931e22e94f647f619d4"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 9,
+                 "sigType" : "pkcs1v1.5",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "49d2a1",
+                 "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11176,
+                      "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
+                      "randomValue": "ab676ab761abca76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
+                    }
+                 ]
+             },
+             {
+                "tgId": 10,
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 54]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+                "sigType" : "pkcs1v1.5",
+                "modulo" : 3072,
+                "hashAlg" : "SHA2-256",
+                "testType": "AFT",
+                "e" : "ac6db1",
+                "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11177,
+                      "message" : "921961e184a5d9657697e3e65ceb1ed10204ec56e739df0e4f906ee194c9ed27bd9fbc0d514abe3a6e480cb3155debfcc8d9fc815719b334f7500a769488773b68e31b69cd273c824f79f58306692c0c232fc5c0c83415ef1dd59a73a063e9d7bc6ee7bf9e433c8344b3051ed616c9473a90afdde393ee88e9a5849e5f642b43",
+                      "randomValue": "ab676abab6283676a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "55362a6854a7846c4d105dc8a358fd4c02931f117631968457f422939d266682fd705e2091bfd5d1bfb52b4bfad684914489ecdad9038b75c65916a9e967630b16c76656b58404ec11ac46d8684b3e72d4392fb6e7e6c929e43ad4fb6ce6198f241b39e8bcbbc058792dde31b195b91bb14236dcb82c28a5c24d633dd847d1548dd403b3a70149371f46432db1767a00c462758c2298fe9f1f04c2ff4b96858d084ffe5a624cb85c1f9be2a60fed40133b7c571c6c467f46a0f1e48ee6e2e6d65424bf8196b0d927e0fd4141264aa5df4129d52d2fb57b8dac9386a84ecd34ecb1feac3a2b99d055eda977ddf8027f1178348a30e4cb4ecef2291d7f520794018b39f5251fd46d97282ac21f6bce6539d19aa1c21c3c220a2ddb6feed262eceebd753eaf5e0eb98cb3eb7d324a3dac0a415a18b7f36170676e8b9d3e421a6f77046bee6d9591c93f7ef0242f464f15b63132a0aee80949709429b1e76d40d60f79b2a6ab362f12e2cdd0bc66868c80278043e179a36f2815e7916378b0fbdb8e"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 11,
+                 "sigType" : "pss",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "10e43f",
+                 "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11178,
+                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
+                      "randomValue": "ab67a6786b876c6ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
+                    }
+                 ]
+             },
+             {
+                "tgId": 12,
+                "sigType" : "pss",
+                "modulo" : 3072,
+                "hashAlg" : "SHA2-512",
+                "testType": "AFT",
+                "e" : "fe3079",
+                "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11179,
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 55]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+                      "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
+                      "randomValue": "ab6a9b8b6a75ba76ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
                     }
                  ]
              }
@@ -2793,11 +3133,7 @@ B.6.  Example Test Vectors for signaturePrimitive JSON Objects
 
 
 
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 50]
+Vassilev                 Expires August 5, 2018                [Page 56]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2853,7 +3189,7 @@ B.7.  Example Test Vectors for decryptionPrimitive JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 51]
+Vassilev                 Expires August 5, 2018                [Page 57]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2909,7 +3245,7 @@ C.1.  Example keyGen Test Results JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 52]
+Vassilev                 Expires August 5, 2018                [Page 58]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -2965,7 +3301,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 53]
+Vassilev                 Expires August 5, 2018                [Page 59]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -3021,7 +3357,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 54]
+Vassilev                 Expires August 5, 2018                [Page 60]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -3077,7 +3413,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 55]
+Vassilev                 Expires August 5, 2018                [Page 61]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -3133,7 +3469,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 56]
+Vassilev                 Expires August 5, 2018                [Page 62]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -3189,7 +3525,7 @@ Internet-Draft                RSA Alg JSON                 February 2018
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 57]
+Vassilev                 Expires August 5, 2018                [Page 63]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -3245,7 +3581,7 @@ C.2.  Example sigGen Test Results JSON Objects
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 58]
+Vassilev                 Expires August 5, 2018                [Page 64]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
@@ -3293,17 +3629,89 @@ Internet-Draft                RSA Alg JSON                 February 2018
                           "signature" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
                         }
                       ]
+                    },
+                    {
+                      "tgId": 7,
+                      "tests": [
+                        {
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 65]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+                          "tcId" : 11165,
+                          "e" : "f3e7af",
+                          "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
+                          "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d",
+                          "randomValue": "ab67a6b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11166,
+                          "e" : "ebda09",
+                          "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
+                          "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c",
+                          "randomValue": "ab67a6b67a86ab87687667b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                      ]
+                    },
+                    {
+                      "tgId": 8,
+                      "tests": [
+                        {
+                          "tcId" : 11167,
+                          "e" : "260445",
+                          "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
+                          "signature" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
+                          "randomValue": "ab67ab7a897ba897a6b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11168,
+                          "e" : "eaf05d",
+                          "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
+                          "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82",
+                          "randomValue": "ab67a6b7a6b5ab67aa768b6a87b65...",
+                          "randomValueLen": 1024
+                        },
+                      ]
+                    },
+                    {
+                      "tgId": 9,
+                      "tests": [
+                        {
+                          "tcId" : 11169,
+                          "e" : "86c94f",
+                          "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
+                          "signature" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc",
+                          "randomValue": "ab67a6b7a6b5ab67aa768b6a87ba67ba6b6a754a3265...",
+                          "randomValueLen": 1024
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 66]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
+                        },
+                        {
+                          "tcId" : 11170,
+                          "e" : "1415a7",
+                          "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
+                          "signature" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e",
+                          "randomValue": "ab67a6ab67ab4ab23b7a6b5ab67aa768b6a87b65...",
+                          "randomValueLen": 1024
+                        }
+                      ]
                     }
                  ]
              }
            ]
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 59]
-
-Internet-Draft                RSA Alg JSON                 February 2018
 
 
 C.3.  Example sigVer Test Results JSON Objects
@@ -3338,6 +3746,14 @@ C.3.  Example sigVer Test Results JSON Objects
                    {
                      "tcId" : 1176,
                      "testPassed": true
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 67]
+
+Internet-Draft                RSA Alg JSON                 February 2018
+
+
                    },
                    {
                      "tcId" : 1177,
@@ -3354,14 +3770,53 @@ C.3.  Example sigVer Test Results JSON Objects
                    },
                    {
                      "tcId" : 1179,
+                     "testPassed": false
+                   }
+                 ]
+             }
+             {
+               "tgId": 7,
+               "tests": [
+                   {
+                     "tcId" : 11174,
+                     "testPassed": false
+                   },
+                   {
+                     "tcId" : 11175,
+                     "testPassed": false
+                   }
+                 ]
+             },
+             {
+               "tgId": 8,
+               "tests": [
+                   {
+                     "tcId" : 11176,
+                     "testPassed": true
+                   },
+                   {
+                     "tcId" : 11177,
+                     "testPassed": false
+                   }
+                 ]
+             },
+             {
+               "tgId": 9,
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 60]
+Vassilev                 Expires August 5, 2018                [Page 68]
 
 Internet-Draft                RSA Alg JSON                 February 2018
 
 
+               "tests": [
+                   {
+                     "tcId" : 11178,
+                     "testPassed": true
+                   },
+                   {
+                     "tcId" : 11179,
                      "testPassed": false
                    }
                  ]
@@ -3381,6 +3836,34 @@ C.5.  Example signaturePrimitive Test Results JSON Objects
 
    The following is a example JSON object for RSA signaturePrimitive
    test results sent from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 69]
+
+Internet-Draft                RSA Alg JSON                 February 2018
 
 
 [
@@ -3408,20 +3891,35 @@ C.5.  Example signaturePrimitive Test Results JSON Objects
 ]
 
 
-
-
-
-
-
-Vassilev                 Expires August 5, 2018                [Page 61]
-
-Internet-Draft                RSA Alg JSON                 February 2018
-
-
 C.6.  Example decryptionPrimitive Test Results JSON Objects
 
    The following is a example JSON object for RSA decryptionPrimitive
    test results sent from the crypto module to the ACVP server.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 70]
+
+Internet-Draft                RSA Alg JSON                 February 2018
 
 
 [
@@ -3469,4 +3967,10 @@ Author's Address
 
 
 
-Vassilev                 Expires August 5, 2018                [Page 62]
+
+
+
+
+
+
+Vassilev                 Expires August 5, 2018                [Page 71]

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -452,7 +452,7 @@
                             <ttcol align="left">Valid algorithm modes</ttcol>
                             <ttcol align="left">Optional</ttcol>
                             <c>SP800-106</c>
-                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</c>
+                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of `"conformance": "SP800-106"`.</c>
                             <c>SigGen, SigVer</c>
                             <c>Yes</c>
                         </texttable>
@@ -535,9 +535,9 @@
                     <c>The specific g generation mode used in the test group</c>
                     <c>value</c>
                     <c>No</c>
-                    <c>isMessageRandomized</c>
+                    <c>Conformance</c>
                     <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
-                    <c>boolean</c>
+                    <c>"SP800-106"</c>
                     <c>Yes</c>
                     <c>tests</c>
                     <c>Array of individual test vector JSON objects, which are defined in                                                                                             
@@ -1492,7 +1492,7 @@
                 "l": 2048,
                 "n": 224,
                 "sha": "SHA-1",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,
@@ -1589,7 +1589,7 @@
             "q": "1F855467465A653D2245B7E31C910A18EF79...",
             "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
             "hashAlg": "SHA-1",
-            "isMessageRandomized": true,
+            "conformance": "SP800-106",
             "tests": [
               {
                 "tcId": 2,

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -537,6 +537,8 @@
                     <c>No</c>
                     <c>isMessageRandomized</c>
                     <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
+                    <c>boolean</c>
+                    <c>Yes</c>
                     <c>tests</c>
                     <c>Array of individual test vector JSON objects, which are defined in                                                                                             
               
@@ -1097,7 +1099,7 @@
 					"SHA2-512/256"
 				]
 			}
-		]
+		],
 		"conformances": [
 			"SP800-106"
 		]
@@ -1493,7 +1495,7 @@
                 "isMessageRandomized": true,
                 "tests": [
                     {
-                        "tcId": 1,
+                        "tcId": 2,
                         "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
                     }
                 ]
@@ -1532,7 +1534,7 @@
                 "g": "B1303035FE460CEBF21DDA00CC08...",
                 "y": "D699C3B6E150E60443BA461C2564...",
                 "tests": [{
-                    "tcId": 1,
+                    "tcId": 2,
                     "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
                     "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314",
                     "randomValue": "23678643ACB7283497...",
@@ -1569,7 +1571,6 @@
             "q": "D3C53E62338D4231E42FA9683175C404FBF52759",
             "g": "7BDDD6B8E9B4667397B278F98F446C418EF1A502068B3082F9CE1D639F5FAA67048ACD4F50E1F855467465A653D2245B7E31C910A18EF79F098ACF73BFC43B1B5E7BFB065FB7A89583C5C23105018D0525AFA9C40B6C343E69CFC2B6B2A87FB4265FDE13D6F19A7BF7A1302AA14EDFA56FD1526241316D1BA182683B8E306CDA",
             "hashAlg": "SHA-1",
-            "isMessageRandomized": true,
             "tests": [
               {
                 "tcId": 1,
@@ -1588,9 +1589,10 @@
             "q": "1F855467465A653D2245B7E31C910A18EF79...",
             "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
             "hashAlg": "SHA-1",
+            "isMessageRandomized": true,
             "tests": [
               {
-                "tcId": 1,
+                "tcId": 2,
                 "message": "A0F409909E31C2C23BB7A24B8103F11F...",
                 "randomValue": "DB0D25A72C8DEFA0F409909E31C2..."
                 "randomValueLen": 1024,
@@ -1622,6 +1624,10 @@
               "tests": [
                 {
                   "tcId": 1,
+                  "testPassed": true
+                },
+                {
+                  "tcId": 2,
                   "testPassed": true
                 }
               ]

--- a/src/acvp_sub_dsa.xml
+++ b/src/acvp_sub_dsa.xml
@@ -160,6 +160,9 @@
                             The ACVP server SHALL allow for the testing of the validity of domain parameters.  Key pair generation testing SHALL be provided by
                             the ACVP server. Both Signature Generation and Validation testing mechanmisms SHALL be provided by the ACVP server.
                           </t>
+                          <t>
+                            SP800-106 - (3) Randomized Hashing and (4) Digital Signatures Using Randomized Hashing.  The IUT SHALL be provided or provide a random value that should be used to "randomize" a message prior to signing and/or verifying an original message.
+                          </t>
                         </list>
                     </t>
                 </section>
@@ -175,6 +178,9 @@
                             of ACVP server testing.  Though the ACVP server SHALL support a variety of parameter sizes/hash functions, the IUT's selection of these is out of scope of testing.
                             The ACVP server MAY provide testing for the validity of domain parameters, but testing SHALL NOT provide assurances the IUT has validated a set of domain parameters prior to their use.
                             Domain parameter and key pair management SHALL NOT be within scope of ACVP testing.
+                          </t>
+                          <t>
+                          SP800-106 - 3.3 The Random Value. DSA, ECDSA, and RSA have random values generated as per their signing process, this random value can be used as the input to the message randomization function, doing so however is out of scope of this testing.
                           </t>
                         </list>
                     </t>
@@ -255,6 +261,15 @@
                         <xref target="supported_modes" />
                     </c>
                     <c>No</c>
+                    <c>conformances</c>
+                    <c>Used to denote the conformances that can apply to specific modes of DSA.</c>
+                    <c>Array of strings</c>
+                    <c>See                                                                                     
+
+                        
+                        <xref target="supported_conformances" />
+                    </c>
+                    <c>Yes</c>
                 </texttable>
             </section>
             <section anchor="supported_modes" title="Supported DSA Modes Capabilities">
@@ -429,6 +444,19 @@
                 </section>
             </section>
         </section>
+        <section anchor="supported_conformances" title="Supported DSA Conformances">
+            <t>Conformances MAY be used to test additional features of certain algorithms.</t>
+            <texttable anchor="conformances_table" title="DSA Conformances">
+                            <ttcol align="left">String Value</ttcol>
+                            <ttcol align="left">Description</ttcol>
+                            <ttcol align="left">Valid algorithm modes</ttcol>
+                            <ttcol align="left">Optional</ttcol>
+                            <c>SP800-106</c>
+                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</c>
+                            <c>SigGen, SigVer</c>
+                            <c>Yes</c>
+                        </texttable>
+        </section>
         <section anchor="test_vectors" title="Test Vectors">
             <t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual DSA function. This section describes the JSON schema for a test vector set used with DSA algorithms.</t>
             <t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy. </t>
@@ -507,6 +535,8 @@
                     <c>The specific g generation mode used in the test group</c>
                     <c>value</c>
                     <c>No</c>
+                    <c>isMessageRandomized</c>
+                    <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
                     <c>tests</c>
                     <c>Array of individual test vector JSON objects, which are defined in                                                                                             
               
@@ -592,6 +622,14 @@
                     <c>The message used to generate signature or verify signature</c>
                     <c>value</c>
                     <c>Yes</c>
+                    <c>randomValue</c>
+                    <c>The random value to be used as an input into the message randomization function as described in <xref target="SP.800-106" />.</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c>randomValueLen</c>
+                    <c>The random value's bit length.</c>
+                    <c>value</c>
+                    <c>Yes</c>
                 </texttable>
             </section>
         </section>
@@ -669,6 +707,14 @@
                 <c>The counter used to generate q in the provable method</c>
                 <c>value - integer</c>
                 <c>Yes</c>
+                <c>randomValue</c>
+                <c>The random value to be used as an input into the message randomization function as described in <xref target="SP.800-106" />.</c>
+                <c>value</c>
+                <c>Yes</c>
+                <c>randomValueLen</c>
+                <c>The random value's bit length.</c>
+                <c>value</c>
+                <c>Yes</c>
                 <c>testPassed</c>
                 <c>The pass or fail result of the verify</c>
                 <c>boolean</c>
@@ -721,6 +767,16 @@
                         <organization>NIST</organization>
                     </author>
                     <date month="July" year="2013"/>
+                </front>
+            </reference>
+            <reference anchor="SP.800-106"
+                target="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf">
+                <front>
+                    <title>Randomized Hashing for Digital Signatures</title>
+                    <author>
+                        <organization>NIST</organization>
+                    </author>
+                    <date month="February" year="2009"/>
                 </front>
             </reference>
         </references>
@@ -971,6 +1027,9 @@
 					"SHA2-512/256"
 				]
 			}
+		],
+		"conformances": [
+			"SP800-106"
 		]
 	},
 	{
@@ -1038,6 +1097,9 @@
 					"SHA2-512/256"
 				]
 			}
+		]
+		"conformances": [
+			"SP800-106"
 		]
 	}
 ]
@@ -1422,6 +1484,19 @@
                         "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
                     }
                 ]
+            },
+            {
+                "tgId": 2,
+                "l": 2048,
+                "n": 224,
+                "sha": "SHA-1",
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "message": "C1FEBB069145F6A9693A2EEAD3A4771743725113B173576429DFA1B95CD577C29ADAD1DBF82CCA583578DBB4EAB237BE10553C701A647492D9B4325C9E2C2245EF199D0A63876C7FE26C78260631185B3B40E57F1A66DC37E4346365ABADC5AD9FE1E6030E73FEF5D456D7F79C59C73D19DE0963D9C126D51DAB7E627D41D6B963147FCD6E323A45A3BF40403CFAE36397E0A6826629C21EAF553649B8A2B4159713F180BC5E1DC061708C9CE0D52A53F5370432566ECD55953C2C8CF29BB5305B2116674DD99A9B12FDF1347E585BDCE128E46ED31036AE7B3F5957FA30BD52A40BF43BB20C7CD9A5D8428D1D4895EF9427BDB0ED5A3C4F5CC874CAB2407455"
+                    }
+                ]
             }
         ]
     }
@@ -1433,28 +1508,38 @@
                 <figure>
                     <artwork>
                         <![CDATA[
-[
-    {
-        "acvVersion": <acvp-version>
+[{
+        "acvVersion": ""
     },
     {
         "vsId": 1564,
-        "testGroups": [
-        {
-          "tgId": 1,
-          "p": "C8DC6C77CC31ADAE68F3221D59C75538F6956517FF915B96939D0355D3AE7D00789EDDFF13C6707CFAC855EE79FC5A25F7243FF8D6FAD5E89CC799FB275ADB2A6F573FDF69FBF3C3C358C51E229B7799D78416F33F2F20420F35BDABB967435C78EFE843BADF4D93A65538B54723BBF1489D20482A295224CA870EE7F65BC7A17611221D58DB4B51D9C32A359D93032DD97942E8042EC4458D1E78B97D783D14243AEFDE455ED9AEC1925FE49E4B2A9B2160D710CCBEA6BC679E2A2A5307F5CD6B7C8E1078E83DF39A636ACE7E6EED18FBDC56ED89AC21B2ED133566D4696609E0AD0C95DC776893AB71AC9E223CE318CE26FBAE29B812075975F6B73DAF3529",
-          "q": "B1B7BCF2467F8CC46FCDD2A41327C2698D9E0A3F36682E17546EAE5B",
-          "g": "6C07130A6F6D05AAC9350936EE06B1303035FE460CEBF21DDA00CC08CD5E8A788D8C3F6B4B0A567A82DBF373CE36A40ADCF77D0CB6CA9AB93D1C0051E354AEB27BBC808A4950E91E2BFFFEF7427DBEA5E05BC9A3C003F6796C0A3EF3CF7D30378657A0966AE952BDC038645199F3C2FBBFD0B4E6E489E97D6DF8A9AD4356B34A3CD289DF9BA53F95A62E110B2BA84D668D7F72EA6CA471B6624F0F2E5CB54C9E96367CD4659BC64EC731B7F60CE0F08B58CFB29090DBDE6BDD7EC16689A9CC3913F3F009E03280342150C0899814532F471594C883B3941ADA81EB95274BB0B8900C492D92AD5686141DBB302DD2C2B4EEA8C2C7AD9B616DF0A520B9CCF7074F",
-          "y": "79143F63ECCC06B3D35C61DA2FB8ED359F8FBF014D699C3B6E150E60443BA461C256498F52262AD3850FECDA5F01F4702F5411BF25F0D9A4CF21F9B84B8FEF8C5E83563A1AE35C253D07011E5492106F46C7DF2624948E3662DAC129E5A094A6180F24480D3FFBD2F223156E68EBD6378ECBA010DF0CB6B3DD12045D8015E66160821AF5A12C8FE239AB331EBCDE6B906A40197769A74780700420C40428A81FBDEB94B9FE37183E9401167AFF6AEAE9968A6FBD11AFB3EB60ED076627CC2873EA2034BAEF2427C1BABF858D4E783B0FE3C51B39661EFBD9518F93A554E5E37428AFC62CF0C61A3B9248B56BBA0282E9BB7A8A6FB14D2CA4AAA9DC3245722525",
-          "tests": [
-            {
-              "tcId": 1,
-              "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
-              "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314"
+        "testGroups": [{
+                "tgId": 1,
+                "p": "C8DC6C77CC31ADAE68F3221D59C75538F6956517FF915B96939D0355D3AE7D00789EDDFF13C6707CFAC855EE79FC5A25F7243FF8D6FAD5E89CC799FB275ADB2A6F573FDF69FBF3C3C358C51E229B7799D78416F33F2F20420F35BDABB967435C78EFE843BADF4D93A65538B54723BBF1489D20482A295224CA870EE7F65BC7A17611221D58DB4B51D9C32A359D93032DD97942E8042EC4458D1E78B97D783D14243AEFDE455ED9AEC1925FE49E4B2A9B2160D710CCBEA6BC679E2A2A5307F5CD6B7C8E1078E83DF39A636ACE7E6EED18FBDC56ED89AC21B2ED133566D4696609E0AD0C95DC776893AB71AC9E223CE318CE26FBAE29B812075975F6B73DAF3529",
+                "q": "B1B7BCF2467F8CC46FCDD2A41327C2698D9E0A3F36682E17546EAE5B",
+                "g": "6C07130A6F6D05AAC9350936EE06B1303035FE460CEBF21DDA00CC08CD5E8A788D8C3F6B4B0A567A82DBF373CE36A40ADCF77D0CB6CA9AB93D1C0051E354AEB27BBC808A4950E91E2BFFFEF7427DBEA5E05BC9A3C003F6796C0A3EF3CF7D30378657A0966AE952BDC038645199F3C2FBBFD0B4E6E489E97D6DF8A9AD4356B34A3CD289DF9BA53F95A62E110B2BA84D668D7F72EA6CA471B6624F0F2E5CB54C9E96367CD4659BC64EC731B7F60CE0F08B58CFB29090DBDE6BDD7EC16689A9CC3913F3F009E03280342150C0899814532F471594C883B3941ADA81EB95274BB0B8900C492D92AD5686141DBB302DD2C2B4EEA8C2C7AD9B616DF0A520B9CCF7074F",
+                "y": "79143F63ECCC06B3D35C61DA2FB8ED359F8FBF014D699C3B6E150E60443BA461C256498F52262AD3850FECDA5F01F4702F5411BF25F0D9A4CF21F9B84B8FEF8C5E83563A1AE35C253D07011E5492106F46C7DF2624948E3662DAC129E5A094A6180F24480D3FFBD2F223156E68EBD6378ECBA010DF0CB6B3DD12045D8015E66160821AF5A12C8FE239AB331EBCDE6B906A40197769A74780700420C40428A81FBDEB94B9FE37183E9401167AFF6AEAE9968A6FBD11AFB3EB60ED076627CC2873EA2034BAEF2427C1BABF858D4E783B0FE3C51B39661EFBD9518F93A554E5E37428AFC62CF0C61A3B9248B56BBA0282E9BB7A8A6FB14D2CA4AAA9DC3245722525",
+                "tests": [{
+                    "tcId": 1,
+                    "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
+                    "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314"
+                }]
             },
-          ]
+            {
+                "tgId": 2,
+                "p": "77CC31ADAE68F3221D59C75538F6...",
+                "q": "82E17546E564816AFB54987C879A...",
+                "g": "B1303035FE460CEBF21DDA00CC08...",
+                "y": "D699C3B6E150E60443BA461C2564...",
+                "tests": [{
+                    "tcId": 1,
+                    "r": "4E7F70A92EC0E6871E2EA27585C0263E2AF539D5F1402A24E01FDB4B",
+                    "s": "641A74C54A0B642DED9FE6EEA311299F4FC759CA98D6EC339A823314",
+                    "randomValue": "23678643ACB7283497...",
+                    "randomValueLen": 1024
+                }]
+            }
         ]
-      }
     }
 ]
           ]]>
@@ -1484,6 +1569,7 @@
             "q": "D3C53E62338D4231E42FA9683175C404FBF52759",
             "g": "7BDDD6B8E9B4667397B278F98F446C418EF1A502068B3082F9CE1D639F5FAA67048ACD4F50E1F855467465A653D2245B7E31C910A18EF79F098ACF73BFC43B1B5E7BFB065FB7A89583C5C23105018D0525AFA9C40B6C343E69CFC2B6B2A87FB4265FDE13D6F19A7BF7A1302AA14EDFA56FD1526241316D1BA182683B8E306CDA",
             "hashAlg": "SHA-1",
+            "isMessageRandomized": true,
             "tests": [
               {
                 "tcId": 1,
@@ -1491,6 +1577,26 @@
                 "y": "A3A2F1AFC3091204B7D7ED3617A80E0FD57221BE67E852A1558CA08984CB56F3A0EF37749B5EA4D2EC824ED5E7EDB0D25A72C8DEFA0F409909E31C2C23BB7A24B8103F11F9781A0F0A15FE6F6DAEFD42CD5FA7444221CB545BB0CDB95DC9D76E0DB9AF193E6832934537B0B05D177BA8F7DA48D9DD84D27B8AFE9481BE520B",
                 "r": "C390851DE10669399308D9F401B0286AA1F4189D",
                 "s": "26BE6EFDCD2ED6946BFCFE2D396AB3A2E84B2FF8"
+              },
+            ]
+          },
+          {
+            "tgId": 2,
+            "l": 1024,
+            "n": 160,
+            "p": "66F108D370A2A9E87DBD49BC09A27017621A...",
+            "q": "1F855467465A653D2245B7E31C910A18EF79...",
+            "g": "F098ACF73BFC43B1B5E7BFB065FBBDDD6B8E...",
+            "hashAlg": "SHA-1",
+            "tests": [
+              {
+                "tcId": 1,
+                "message": "A0F409909E31C2C23BB7A24B8103F11F...",
+                "randomValue": "DB0D25A72C8DEFA0F409909E31C2..."
+                "randomValueLen": 1024,
+                "y": "A3A284CB56F3A0EF37749B5EA4D2EC824ED5E7EAD481BE520B...",
+                "r": "15FE6F6DAEFD42CD5FA7444221CB545BB0CDB95DC9D76E0...",
+                "s": "B9AF193E6832934537B0B05D177BA8F7DA48D9DD84D27B8AFE9..."
               },
             ]
           }

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -387,7 +387,7 @@
                             <ttcol align="left">Valid algorithm modes</ttcol>
                             <ttcol align="left">Optional</ttcol>
                             <c>SP800-106</c>
-                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</c>
+                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of `"conformance": "SP800-106"`.</c>
                             <c>SigGen, SigVer</c>
                             <c>Yes</c>
                         </texttable>
@@ -450,9 +450,9 @@
                     <c>The public key curve point y</c>
                     <c>value</c>
                     <c>Yes</c>
-                    <c>isMessageRandomized</c>
+                    <c>conformance</c>
                     <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
-                    <c>boolean</c>
+                    <c>"SP800-106"</c>
                     <c>Yes</c>
                     <c>tests</c>
                     <c>Array of individual test vector JSON objects, which are defined in 																																							
@@ -930,7 +930,7 @@
                 "tgId": 2,
                 "curve": "P-224",
                 "hashAlg": "SHA2-224",
-                "isMessageRandomized": true
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,
@@ -1022,7 +1022,7 @@
                 "tgId": 2,
                 "curve": "P-192",
                 "hashAlg": "SHA-1",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                         "tcId": 2,

--- a/src/acvp_sub_ecdsa.xml
+++ b/src/acvp_sub_ecdsa.xml
@@ -154,6 +154,9 @@
 							The ACVP server SHALL support a variety of curves/hash function for creation and delivery to/from the IUT.
                             Key pair generation/verification testing SHALL be provided by the ACVP server. Both Signature Generation and Validation testing mechanmisms SHALL be provided by the ACVP server.
                           </t>
+                          <t>
+                            SP800-106 - (3) Randomized Hashing and (4) Digital Signatures Using Randomized Hashing.  The IUT SHALL be provided or provide a random value that should be used to "randomize" a message prior to signing and/or verifying an original message.
+                          </t>
                         </list>
                     </t>
                 </section>
@@ -169,6 +172,9 @@
                             The ACVP server SHALL NOT provide testing for the validity of domain parameters as testing is (currently) limited to approved NIST curves. 
 							Testing SHALL NOT provide assurances the IUT has validated a set of domain parameters prior to their use.
                             Domain parameter and key pair management SHALL NOT be within scope of ACVP testing.
+                          </t>
+                          <t>
+                          SP800-106 - 3.3 The Random Value. DSA, ECDSA, and RSA have random values generated as per their signing process, this random value can be used as the input to the message randomization function, doing so however is out of scope of this testing.
                           </t>
                         </list>
                     </t>
@@ -247,6 +253,15 @@
 						
                         
                         <xref target="supported_modes" />
+                    </c>
+                    <c>Yes</c>
+                    <c>conformances</c>
+                    <c>Used to denote the conformances that can apply to specific modes of DSA.</c>
+                    <c>Array of strings</c>
+                    <c>See                                                                                     
+
+                        
+                        <xref target="supported_conformances" />
                     </c>
                     <c>Yes</c>
                 </texttable>
@@ -364,6 +379,19 @@
                 </section>
             </section>
         </section>
+        <section anchor="supported_conformances" title="Supported DSA Conformances">
+            <t>Conformances MAY be used to test additional features of certain algorithms.</t>
+            <texttable anchor="conformances_table" title="DSA Conformances">
+                            <ttcol align="left">String Value</ttcol>
+                            <ttcol align="left">Description</ttcol>
+                            <ttcol align="left">Valid algorithm modes</ttcol>
+                            <ttcol align="left">Optional</ttcol>
+                            <c>SP800-106</c>
+                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</c>
+                            <c>SigGen, SigVer</c>
+                            <c>Yes</c>
+                        </texttable>
+        </section>
         <section anchor="test_vectors" title="Test Vectors">
             <t>The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual ECDSA function. This section describes the JSON schema for a test vector set used with ECDSA algorithms.</t>
             <t>The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy.</t>
@@ -422,6 +450,10 @@
                     <c>The public key curve point y</c>
                     <c>value</c>
                     <c>Yes</c>
+                    <c>isMessageRandomized</c>
+                    <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
+                    <c>boolean</c>
+                    <c>Yes</c>
                     <c>tests</c>
                     <c>Array of individual test vector JSON objects, which are defined in 																																							
 							
@@ -461,6 +493,14 @@
                     <c>Yes</c>
                     <c>message</c>
                     <c>The message used to generate signature or verify signature</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c>randomValue</c>
+                    <c>The random value to be used as an input into the message randomization function as described in <xref target="SP.800-106" />.</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c>randomValueLen</c>
+                    <c>The random value's bit length.</c>
                     <c>value</c>
                     <c>Yes</c>
                 </texttable>
@@ -506,6 +546,14 @@
                 <c>Yes</c>
                 <c>s</c>
                 <c>The signature component S</c>
+                <c>value</c>
+                <c>Yes</c>
+                <c>randomValue</c>
+                <c>The random value to be used as an input into the message randomization function as described in <xref target="SP.800-106" />.</c>
+                <c>value</c>
+                <c>Yes</c>
+                <c>randomValueLen</c>
+                <c>The random value's bit length.</c>
                 <c>value</c>
                 <c>Yes</c>
                 <c>testPassed</c>
@@ -560,6 +608,16 @@
                         <organization>NIST</organization>
                     </author>
                     <date month="July" year="2013"/>
+                </front>
+            </reference>
+            <reference anchor="SP.800-106"
+                target="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf">
+                <front>
+                    <title>Randomized Hashing for Digital Signatures</title>
+                    <author>
+                        <organization>NIST</organization>
+                    </author>
+                    <date month="February" year="2009"/>
                 </front>
             </reference>
         </references>
@@ -667,7 +725,10 @@
 				"SHA2-512/224",
 				"SHA2-512/256"
 			]
-		}]
+		}],
+		"conformances": [
+			"SP800-106"
+		]
 	},
 	{
 		"algorithm": "ECDSA",
@@ -709,7 +770,10 @@
 				"SHA2-512/224",
 				"SHA2-512/256"
 			]
-		}]
+		}],
+		"conformances": [
+			"SP800-106"
+		]
 	}
 ]
             ]]>
@@ -852,13 +916,25 @@
         "revision": "1.0",
         "testGroups": [
             {
-				"tgId": 1,
+                "tgId": 1,
                 "curve": "P-224",
                 "hashAlg": "SHA2-224",
                 "tests": [
                     {
                         "tcId": 1,
                         "message": "AB6F57713A3BD323B4AFDCFBE202EE00A9CF5C787D19FD9094323C57FEA8B7FBE31559EC1CAC6D29C3229A58811CF2BAE2B78183DFDABD055B741EA86496454F085D17D5BCD1B82B533B533A1E5804B2DAA0ED43F8BF59FBEB16BDD4D7C065165CB9B085CECD5BCFFA794339D5A81B1949F569CAACA208B9E3E6A217A1B3A596"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "curve": "P-224",
+                "hashAlg": "SHA2-224",
+                "isMessageRandomized": true
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "message": "23B4AFDCFBE202EE00A9CF5C787D19FD90..."
                     }
                 ]
             }
@@ -880,16 +956,30 @@
         "vsId": 1564,
         "testGroups": [
             {
-				"tgId": 1,
-				"qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
+                "tgId": 1,
+                "qx": "3B1D9E4D986F651C3C213B2A1304693BDB8BA632CB93A3547B89EF31",
                 "qy": "E56F7B7C9E6355E573B7B3B6C0E1ECD70E4ABDF1554EAD8A68ABA1A4",
-				"tests": [
-					{
-						"tcId": 1,
-						"r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
-						"s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
-					}
-				]
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                        "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "qx": "A1304693BDBA632CB93A3B8BA632CB93A3...",
+                "qy": "ECD70E4ABBA632CB93A3BA632CB93A3DF1...",
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "r": "3E2A9588DF3D3F11B16368A30C8C34C572655BA8516AF5C914E94FF4",
+                        "s": "C6E4A8C51E0A0E11C4C6D6F8F3C51A0FA440BC6FF28EBACDBB20922A",
+                        "randomValue": "0A0E11C4C6D6F8F3C51..."
+                        "randomValueLen": 1024
+                    }
+                ]
             }
         ]
     }
@@ -914,7 +1004,7 @@
         "revision": "1.0",
         "testGroups": [
             {
-				"tgId": 1,
+                "tgId": 1,
                 "curve": "P-192",
                 "hashAlg": "SHA-1",
                 "tests": [
@@ -925,6 +1015,24 @@
                         "qy": "55847857E5E48025BE9053952E0E1ECFB1D883CF9F085386",
                         "r": "E31121E544D476DC3FA79B4DCB0A7252B6E80468BBF22843",
                         "s": "6E3F47F2327E36AD936E0F4BE245C05F264BA9300E9E7DD9"
+                    }
+                ]
+            },
+            {
+                "tgId": 2,
+                "curve": "P-192",
+                "hashAlg": "SHA-1",
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                        "tcId": 2,
+                        "message": "D38A81D04A06A8C4760AC15DB266B17B48B...",
+                        "randomValue": "1527E0FE37FD1162F5DD0D975E83C0D...",
+                        "randomValueLen": 1024
+                        "qx": "D1E896486D9D986A464D3469941F93FC65556E2CB...",
+                        "qy": "ADCB8D50375DC76907195B6AF6C06F...",
+                        "r": "6D9D986A464D3469941F93FC65556E2CB8AB5F113...",
+                        "s": "8E713EB6106EF0E19E241DB4B4831E06437E5C..."
                     }
                 ]
             }
@@ -946,13 +1054,20 @@
         "vsId": 1564,
         "testGroups": [
             {
-				"tgId": 1,
-				"tests": [
-					{
-						"tcId": 1,
-						"testPassed": false
-					}
-				]
+                "tgId": 1,
+                "tests": [
+                    {
+                        "tcId": 1,
+                        "testPassed": false
+                    }
+                ],
+                "tgId": 2,
+                "tests" [
+                    {
+                        "tcId": 2,
+                        "testPassed": true
+                    }
+                ]
             }
         ]
     }

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -801,7 +801,7 @@
                             <ttcol align="left">Valid algorithm modes</ttcol>
                             <ttcol align="left">Optional</ttcol>
                             <c>SP800-106</c>
-                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</c>
+                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of `"conformance": "SP800-106"`.</c>
                             <c>SigGen, SigVer</c>
                             <c>Yes</c>
                         </texttable>
@@ -948,9 +948,9 @@
                     <c/>
                     <c/>
                     <c/>
-                    <c>isMessageRandomized</c>
+                    <c>conformance</c>
                     <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
-                    <c>boolean</c>
+                    <c>"SP800-106"</c>
                     <c>Yes</c>
                 </texttable>
             </section>
@@ -2396,7 +2396,7 @@
                  "sigType" : "ansx9.31",
                  "hashAlg" : "SHA2-256",
                  "modulo" : 2048,
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11165,
@@ -2409,7 +2409,7 @@
                 "sigType": "ansx9.31",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests": [
                     {
                       "tcId" : 11166,
@@ -2422,7 +2422,7 @@
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 2048,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                    {
                      "tcId" : 11167,
@@ -2435,7 +2435,7 @@
                 "sigType" : "pkcs1v1.5",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11168,
@@ -2448,7 +2448,7 @@
                 "sigType" : "pss",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 2048,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11169,
@@ -2462,7 +2462,7 @@
                 "sigType" : "pss",
                 "hashAlg" : "SHA2-256",
                 "modulo" : 3072,
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11170,
@@ -2594,7 +2594,7 @@
                  "modulo" : 2048,
                  "e" : "166f67",
                  "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11174,
@@ -2613,7 +2613,7 @@
                  "testType": "AFT",
                  "e" : "89ca09",
                  "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11175,
@@ -2632,7 +2632,7 @@
                  "testType": "AFT",
                  "e" : "49d2a1",
                  "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",  
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11176,
@@ -2651,7 +2651,7 @@
                 "testType": "AFT",
                 "e" : "ac6db1",
                 "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11177,
@@ -2670,7 +2670,7 @@
                  "testType": "AFT",
                  "e" : "10e43f",
                  "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",  
-                 "isMessageRandomized": true,
+                 "conformance": "SP800-106",
                  "tests" : [
                     {
                       "tcId" : 11178,
@@ -2689,7 +2689,7 @@
                 "testType": "AFT",
                 "e" : "fe3079",
                 "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
-                "isMessageRandomized": true,
+                "conformance": "SP800-106",
                 "tests" : [
                     {
                       "tcId" : 11179,

--- a/src/acvp_sub_rsa.xml
+++ b/src/acvp_sub_rsa.xml
@@ -190,6 +190,9 @@
                             FIPS.186-2.  The ACVP server MAY provide a means of testing legacy RSA functions such as RSA.sigVer.  
                             This testing is provided to ensure an IUT is capable of verifying a signature that is no longer approved for generation, given the same capabilities.
                           </t>
+                          <t>
+                            SP800-106 - (3) Randomized Hashing and (4) Digital Signatures Using Randomized Hashing.  The IUT SHALL be provided or provide a random value that should be used to "randomize" a message prior to signing and/or verifying an original message.
+                          </t>
                         </list>
                     </t>
                 </section>
@@ -203,6 +206,9 @@
                           <t>
                             FIPS.186-4 - 5 The RSA Digital Signature Algorithm. Though the ACVP server SHALL support a variety of parameter sizes/hash functions, the IUT's selection of these is out of scope of testing.
                             Key pair management SHALL NOT be within scope of ACVP testing.
+                          </t>
+                          <t>
+                          SP800-106 - 3.3 The Random Value. DSA, ECDSA, and RSA have random values generated as per their signing process, this random value can be used as the input to the message randomization function, doing so however is out of scope of this testing.
                           </t>
                         </list>
                     </t>
@@ -331,6 +337,15 @@
                         <xref target="supported_modes"/>
                     </c>
                     <c>No</c>
+                    <c>conformances</c>
+                    <c>Used to denote the conformances that can apply to specific modes of DSA.</c>
+                    <c>Array of strings</c>
+                    <c>See                                                                                     
+
+                        
+                        <xref target="supported_conformances" />
+                    </c>
+                    <c>Yes</c>
                 </texttable>
             </section>
             <section anchor="supported_modes" title="Supported RSA Modes Capabilities">
@@ -778,6 +793,19 @@
                 </section>
             </section>
         </section>
+        <section anchor="supported_conformances" title="Supported DSA Conformances">
+            <t>Conformances MAY be used to test additional features of certain algorithms.</t>
+            <texttable anchor="conformances_table" title="DSA Conformances">
+                            <ttcol align="left">String Value</ttcol>
+                            <ttcol align="left">Description</ttcol>
+                            <ttcol align="left">Valid algorithm modes</ttcol>
+                            <ttcol align="left">Optional</ttcol>
+                            <c>SP800-106</c>
+                            <c>This conformance signifies the SigGen and/or SigVer modes support randomized message hashing as described in <xref target="SP.800-106"/>. Utilizing this conformance SHALL generate additional test groups, denoted with a group level property of "isMessageRandomized".</c>
+                            <c>SigGen, SigVer</c>
+                            <c>Yes</c>
+                        </texttable>
+        </section>
         <section anchor="test_vectors" title="Test Vectors">
             <t>The ACVP server provides test vectors to the ACVP client, which are then processed by the client and returned to
 	    the ACVP server for validation.  A typical ACVP validation session would require multiple test vector
@@ -916,6 +944,14 @@
                     <c>The salt length for the group in bytes</c>
                     <c>value</c>
                     <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>isMessageRandomized</c>
+                    <c>Signifies all test cases within the group should utilize random message hashing as described in <xref target="SP.800-106" />.</c>
+                    <c>boolean</c>
+                    <c>Yes</c>
                 </texttable>
             </section>
             <section title="Test Case JSON Schema" anchor="tvjs">
@@ -982,6 +1018,22 @@
                     <c>message</c>
                     <c>the message to be signed</c>
                     <c>hex value</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>randomValue</c>
+                    <c>The random value to be used as an input into the message randomization function as described in <xref target="SP.800-106" />.</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>randomValueLen</c>
+                    <c>The random value's bit length.</c>
+                    <c>value</c>
                     <c>Yes</c>
                     <c/>
                     <c/>
@@ -1236,6 +1288,22 @@
                 <c>the digital signature value</c>
                 <c>hex value</c>
                 <c>Yes</c>
+                <c/>
+                <c/>
+                <c/>
+                <c/>
+                <c>randomValue</c>
+                <c>The random value to be used as an input into the message randomization function as described in <xref target="SP.800-106" />.</c>
+                <c>value</c>
+                <c>Yes</c>
+                <c/>
+                <c/>
+                <c/>
+                <c/>
+                <c>randomValueLen</c>
+                <c>The random value's bit length.</c>
+                <c>value</c>
+                <c>Yes</c>
             </texttable>
         </section>
         <!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
@@ -1318,6 +1386,16 @@
                         <organization>NIST</organization>
                     </author>
                     <date month="September" year="2014"/>
+                </front>
+            </reference>
+            <reference anchor="SP.800-106"
+                target="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf">
+                <front>
+                    <title>Randomized Hashing for Digital Signatures</title>
+                    <author>
+                        <organization>NIST</organization>
+                    </author>
+                    <date month="February" year="2009"/>
                 </front>
             </reference>
         </references>
@@ -1661,6 +1739,9 @@
                     }
                 ]
          }
+      ],
+      "conformances": [
+        "SP800-106"
       ]
    }
 ]]>
@@ -1823,6 +1904,9 @@
                     }
                  ]
           }
+      ],
+      "conformances": [
+        "SP800-106"
       ]
    }
 ]]>
@@ -2305,7 +2389,88 @@
                       "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
                     }
                  ]
-             }
+             },
+
+             {
+                 "tgId": 7,
+                 "sigType" : "ansx9.31",
+                 "hashAlg" : "SHA2-256",
+                 "modulo" : 2048,
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11165,
+                      "message" : "f648ffc4ed74845803fec53ba865d3889b3892e402d96c5eba814698ec84b32ce1d7684917cff19d942ba2787a55cf2edce540bdd067dfafc55eb442178913c7e164144813f2446dc4ba9aa0c90fad708695233304016df04420b27cd31b08e29ff9ea080965e7903bb297fdbc1cd31741512590c7307ee7ded0278d48c4fa47"
+                    }
+                 ]
+             },
+             {
+                "tgId": 8,
+                "sigType": "ansx9.31",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests": [
+                    {
+                      "tcId" : 11166,
+                      "message" : "f5feb83726c8839aeaec00a67f46ee2c3f5226b169e47ec42419ec8fc18defab41ce2a391711522e2f244bee2ea48e1dfc70ceb1805ddb4caa2cc6cab7b94615b0745a41341530d5788c46668c37cf6be058584c06c6abbcb9e3f4491fcd22314bd99078063de537cf0c3937206879bef3f30ca98586b6bb5a26bd3581334ba7"
+                    }
+                 ]
+             },
+             {
+                "tgId": 9,
+                "sigType" : "pkcs1v1.5",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 2048,
+                "isMessageRandomized": true,
+                "tests" : [
+                   {
+                     "tcId" : 11167,
+                     "message" : "5af283b1b76ab2a695d794c23b35ca7371fc779e92ebf589e304c7f923d8cf976304c19818fcd89d6f07c8d8e08bf371068bdf28ae6ee83b2e02328af8c0e2f96e528e16f852f1fc5455e4772e288a68f159ca6bdcf902b858a1f94789b3163823e2d0717ff56689eec7d0e54d93f520d96e1eb04515abc70ae90578ff38d31b"
+                   }
+                ]
+             },
+             {
+                "tgId": 10,
+                "sigType" : "pkcs1v1.5",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11168,
+                      "message" : "bcf6074333a7ede592ffc9ecf1c51181287e0a69363f467de4bf6b5aa5b03759c150c1c2b23b023cce8393882702b86fb0ef9ef9a1b0e1e01cef514410f0f6a05e2252fd3af4e566d4e9f79b38ef910a73edcdfaf89b4f0a429614dabab46b08da94405e937aa049ec5a7a8ded33a338bb9f1dd404a799e19ddb3a836aa39c77"
+                    }
+                 ]
+             },
+             {
+                "tgId": 11,
+                "sigType" : "pss",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 2048,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11169,
+                      "saltLen" : 20,
+                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f"
+                    }
+                 ]
+             },
+             {
+                "tgId": 12,
+                "sigType" : "pss",
+                "hashAlg" : "SHA2-256",
+                "modulo" : 3072,
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11170,
+                      "saltLen" : 20,
+                      "message" : "c16499110ed577202aed2d3e4d51ded6c66373faef6533a860e1934c63484f87a8d9b92f3ac45197b2909710abba1daf759fe0510e9bd8dd4d73cec961f06ee07acd9d42c6d40dac9f430ef90374a7e944bde5220096737454f96b614d0f6cdd9f08ed529a4ad0e759cf3a023dc8a30b9a872974af9b2af6dc3d111d0feb7006"
+                    }
+                 ]
+             }             
        ]
     }
   ]
@@ -2419,7 +2584,122 @@
                       "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
                     }
                  ]
-             }
+             },
+
+             {
+                 "tgId": 7,
+                 "sigType" : "ansx9.31",
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "modulo" : 2048,
+                 "e" : "166f67",
+                 "n" : "944ded6daaf602e1771eaa49c02fcbaca0bdd70c8ed571ad5a0f499090f08d103b6181f573667aa8c03700af024de08535d56579ae98c7af3569dec4b8b9e418814a680f0506e3828a32280f8830a3612b9b9dc5c41408cc5fcee98bbbc7a1e871d088b73cca1114916025767fb9ec5efea72dd98757d6b9ae78f682e8ca6e7cb6ac4f626596fb37d18a61d34cef2783a96ba7d8e091c564dbefb69ac7a1db2e8aaf857a43edbc688d153ab768e14b7fa6dbdc686882f261c0c72af090acffc91b481915151dc977be3b584dcd25d9a77a0b983721647e2ac7b93754c20213de0b2bc3174062a22e48275cedba9c0d23a2dc9aecb430b0d7eeff5d67a05d140d",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11174,
+                      "message" : "ff17e5e88ad5cd0dc463ae0b286273b3905271939c60ed70577edef018b9f596a7c7dbf3a1e0ba1b1ed0fe5790495d19ef7d143513ec744d617b9e8da9c78b994fb84fc4a9599e83a9e78f21bc28a0b4f1fdfa4f5e3bf779c0b7e2de61a0fe453f12c9c26ae7812daed1e8d272a6456ae0faab4b46f37ddbbc59324a08ed5681", 
+                      "randomValue": "ab676ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "299f16d55cc0405a9459a3b7cbbb05ce1983d165674579f3b2b5e1436a4fbdc44e0c14e578e19212cd87afe7765cafd93b112e83903104e1e98e9765c3582eecc298cc10fe42e539ba58c84f8a9318bbb2ec372429db637b7c5678c96798b95dc7b2be73b5cab0f5bac6fffaf1f63554735b793431e3ad116d52b38c0c7cb6e0ffbdb0edb1f6ed6696c98da9a9591d7d2104bb746465041259c116ec0acc61f2704107e4dbb455be24c54e1892d9c98ffeb8ed56ca502d02ab40e7806fbb0b2c583236cc43a9488ec2df558310cea60e4c0a5cc8d84a162dd01c01f6dc817f484f69ea9ce8f6c8bc2d574c4b1f2626cd6f9552630d55d7d69aeacfc42348c22f"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 8,
+                 "sigType" : "ansx9.31",
+                 "modulo" : 3072,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "89ca09",
+                 "n" : "ab3c3b9b176bc55ea65f847ca68560624c76149711fbf8c3eb471d8008466cbac645c8ae551cf280cfa03c04d28ee15495bfb6d289cba0dfe8ade4fdbcf9445c9e59e53655b76f28f0fb1015cec9ccaa93b51f946adfb8df8324e7a12090191b189f06eac46384dfc3084fc67bc182ba87b24b539c09e8a5364ef83174f8157f524df4aff35d1e9d48967665cb43193d070ad269e3423cd9d8f3c3e6167f8c2f13b50cb585a15ccfbe35a36e7f40c9cc192bee4d87792314fd664f03da8374b081126bc3fb6c3eca1649320a2054442c12096c281254daa9b8c2867f7a25a51e9d6285e1740fd9b0dfaf95c0388943a2ebd023ff7d7128549f968e777d37c17e1179a7f47431401b1a0bf5deecd258333ebeb8964a5f76e76e07705de0fe4b4a0bee27b2466e7d3e74c755b73cdfc0b1b654ea861aa8df871845aac85738b4fb564016d97740c51f7bb59623ee0cbbda3d8010c9af8952fec1ec21018ff4af6b9eba169667bf3b32408fd74edda7e3d6a05fe0ad065d093c9bbe414457147c51",
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11175,
+                      "message" : "7cdcd58f9f290bd550c46b61f15b7fe082b8741cba8acedb57685a04b213640496fb2b70520592ec0d8c184b5aa60af80da8f8944cec65e0e9d1c2deef049e337afe17d0ccce94d19e19b6a5b45f8b70b47f05ad387eab1822848fcb302780a7d0ec80f5350b794daa732bb7260e6911214685b1a7c8094bab88a7149d057327", 
+                      "randomValue": "ab61bc76ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "1c3d10d8b876e2cae5e8210fd2dd53d9b1245b961e69f6fd7759cd27e7a88dd7fc59f517972f4e6a0b480c837bd7d768292f5784ac5f1df692a9699e32d976ebd1a4282af727a5605cbc5b28d8dae834bdcad391282e6bef543bd11a3d72ef984195236043b655217c8cd8bd3247f29afe17ad0af20dc703df5d7ad49af1ff4bb247717dc6335c45e5845d92772c4e4eef5e2efb4a1c45cb2ffe296cecc4474ab81ec17401b4d3c5129a59a40da2ba8c8fa548a0ae8bbe43b1f1f1dbe029e28dc61a762ed2665ac1bbd6eb6aeecf1bca4b450e8df7bed087f7d390733fa477823eaaf59d0bf7a0c7a8150850b413a05237bd253350d5091a12219a35a58a0ef6fc15024f24b9ef2bd7b27ace7bedc30c9f9ecd1e828966cec760e555d019507560c2ba68dc562300460453f937abca74ca25a7de5fa66e4f28fdefb3030126c0f93b8304717c5a28d07ef095069ca9b6925f6e5ad11497b03a2b2c6660485e0e99b13c334084b038a4d81556c5b7c9ed766fd3fb30bf6931e22e94f647f619d4"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 9,
+                 "sigType" : "pkcs1v1.5",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "49d2a1",
+                 "n" : "c47abacc2a84d56f3614d92fd62ed36ddde459664b9301dcd1d61781cfcc026bcb2399bee7e75681a80b7bf500e2d08ceae1c42ec0b707927f2b2fe92ae852087d25f1d260cc74905ee5f9b254ed05494a9fe06732c3680992dd6f0dc634568d11542a705f83ae96d2a49763d5fbb24398edf3702bc94bc168190166492b8671de874bb9cecb058c6c8344aa8c93754d6effcd44a41ed7de0a9dcd9144437f212b18881d042d331a4618a9e630ef9bb66305e4fdf8f0391b3b2313fe549f0189ff968b92f33c266a4bc2cffc897d1937eeb9e406f5d0eaa7a14782e76af3fce98f54ed237b4a04a4159a5f6250a296a902880204e61d891c4da29f2d65f34cbb",  
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11176,
+                      "message" : "95123c8d1b236540b86976a11cea31f8bd4e6c54c235147d20ce722b03a6ad756fbd918c27df8ea9ce3104444c0bbe877305bc02e35535a02a58dcda306e632ad30b3dc3ce0ba97fdf46ec192965dd9cd7f4a71b02b8cba3d442646eeec4af590824ca98d74fbca934d0b6867aa1991f3040b707e806de6e66b5934f05509bea",
+                      "randomValue": "ab676ab761abca76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "51265d96f11ab338762891cb29bf3f1d2b3305107063f5f3245af376dfcc7027d39365de70a31db05e9e10eb6148cb7f6425f0c93c4fb0e2291adbd22c77656afc196858a11e1c670d9eeb592613e69eb4f3aa501730743ac4464486c7ae68fd509e896f63884e9424f69c1c5397959f1e52a368667a598a1fc90125273d9341295d2f8e1cc4969bf228c860e07a3546be2eeda1cde48ee94d062801fe666e4a7ae8cb9cd79262c017b081af874ff00453ca43e34efdb43fffb0bb42a4e2d32a5e5cc9e8546a221fe930250e5f5333e0efe58ffebf19369a3b8ae5a67f6a048bc9ef915bda25160729b508667ada84a0c27e7e26cf2abca413e5e4693f4a9405"
+                    }
+                 ]
+             },
+             {
+                "tgId": 10,
+                "sigType" : "pkcs1v1.5",
+                "modulo" : 3072,
+                "hashAlg" : "SHA2-256",
+                "testType": "AFT",
+                "e" : "ac6db1",
+                "n" : "9bbb099e1ec285594e73f9d11cbe81e7f1fa06fd34f3ec0b799394aed30fc2ed9de7b2a6866fde69846fb55a6ab98e552f9d20f05aa0d55c967817e4e04bdf9bf52fabcfcfa41265a7561b033ca3d56fb8e8a2e4de63e960cfb5a689129b188e5641f20dbf8908dab8e30e82f1d0e288e23869c7cac2b0318602610a776a19c1f93968c652b64f51406e7a4b2508d25b632606834a9638074e2633eb323324b8b30fdbd8e8fdad8602b11f25f3906439055afe947f9b9bcffb45dad88a1df5304c879bb4a6eddb4d3d1846bf907d2ca269845c790b2f0af8154aad9c4acb75e18a5d0e4f9f88137032b9964fe171dfa0d0f286090790f52157179a6734b5f9a64e3d2ed529722c3d3836d4501496f927a0f8e389ca35332b836d99e995f4a3e86f581bf9abdc7a10e06a6b31296ae3b43e6ddc9a0d9a7d0d9c4053af0875e851192d1de7b08d1beb7b857e227f8803a5620726a31920bcab922d3370a78033b315024a0fc1f6c276be565e58de77f294c8089ff4c43fb334d26006ab5757c65b",
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11177,
+                      "message" : "921961e184a5d9657697e3e65ceb1ed10204ec56e739df0e4f906ee194c9ed27bd9fbc0d514abe3a6e480cb3155debfcc8d9fc815719b334f7500a769488773b68e31b69cd273c824f79f58306692c0c232fc5c0c83415ef1dd59a73a063e9d7bc6ee7bf9e433c8344b3051ed616c9473a90afdde393ee88e9a5849e5f642b43",
+                      "randomValue": "ab676abab6283676a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "55362a6854a7846c4d105dc8a358fd4c02931f117631968457f422939d266682fd705e2091bfd5d1bfb52b4bfad684914489ecdad9038b75c65916a9e967630b16c76656b58404ec11ac46d8684b3e72d4392fb6e7e6c929e43ad4fb6ce6198f241b39e8bcbbc058792dde31b195b91bb14236dcb82c28a5c24d633dd847d1548dd403b3a70149371f46432db1767a00c462758c2298fe9f1f04c2ff4b96858d084ffe5a624cb85c1f9be2a60fed40133b7c571c6c467f46a0f1e48ee6e2e6d65424bf8196b0d927e0fd4141264aa5df4129d52d2fb57b8dac9386a84ecd34ecb1feac3a2b99d055eda977ddf8027f1178348a30e4cb4ecef2291d7f520794018b39f5251fd46d97282ac21f6bce6539d19aa1c21c3c220a2ddb6feed262eceebd753eaf5e0eb98cb3eb7d324a3dac0a415a18b7f36170676e8b9d3e421a6f77046bee6d9591c93f7ef0242f464f15b63132a0aee80949709429b1e76d40d60f79b2a6ab362f12e2cdd0bc66868c80278043e179a36f2815e7916378b0fbdb8e"
+                    }
+                 ]
+             },
+             {
+                 "tgId": 11,
+                 "sigType" : "pss",
+                 "modulo" : 2048,
+                 "hashAlg" : "SHA2-256",
+                 "testType": "AFT",
+                 "e" : "10e43f",
+                 "n" : "a47d04e7cacdba4ea26eca8a4c6e14563c2ce03b623b768c0d49868a57121301dbf783d82f4c055e73960e70550187d0af62ac3496f0a3d9103c2eb7919a72752fa7ce8c688d81e3aee99468887a15288afbb7acb845b7c522b5c64e678fcd3d22feb84b44272700be527d2b2025a3f83c2383bf6a39cf5b4e48b3cf2f56eef0dfff18555e31037b915248694876f3047814415164f2c660881e694b58c28038a032ad25634aad7b39171dee368e3d59bfb7299e4601d4587e68caaf8db457b75af42fc0cf1ae7caced286d77fac6cedb03ad94f1433d2c94d08e60bc1fdef0543cd2951e765b38230fdd18de5d2ca627ddc032fe05bbd2ff21e2db1c2f94d8b",  
+                 "isMessageRandomized": true,
+                 "tests" : [
+                    {
+                      "tcId" : 11178,
+                      "message" : "dfc22604b95d15328059745c6c98eb9dfb347cf9f170aff19deeec555f22285a6706c4ecbf0fb1458c60d9bf913fbae6f4c554d245d946b4bc5f34aec2ac6be8b33dc8e0e3a9d601dfd53678f5674443f67df78a3a9e0933e5f158b169ac8d1c4cd0fb872c14ca8e001e542ea0f9cfda88c42dcad8a74097a00c22055b0bd41f",
+                      "randomValue": "ab67a6786b876c6ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "992d48b21bb3d2219b44e8fcc8633cf3aeb591de90f4386496ac7ecd284cb63d7dff81a50b8c4fed9f2ef737692ea6be05248ca138947b49b4e7f3cce6640e049ac2154c40f57e22fa14f97e7a9507e1dc98b206ce6ea0e180039199d1be0a15d1f5093a459e5101aaca2a23cb1f59cad2f1fb99dc956b9d4344bad2c1121d63b915004acbfc7ac60ac9a7b0b1c6812b30bfe087f7f0c7d1625f9c4f458515e11478e3604aa39d14d08bea30b01fcd6189e6f9b701d360e4714d45556b29815c8d8fa8e46e10749ba5e8d445a4c0f487e70ab5890b7ccc1651282a54e87e7db4bb2f7d4a671e71c43c55cf6486416f171d1955037474d06a71dd078767848e5d"
+                    }
+                 ]
+             },
+             {
+                "tgId": 12,
+                "sigType" : "pss",
+                "modulo" : 3072,
+                "hashAlg" : "SHA2-512",
+                "testType": "AFT",
+                "e" : "fe3079",
+                "n" : "ce4924ff470fb99d17f66595561a74ded22092d1dc27122ae15ca8cac4bfae11daa9e37a941430dd1b81aaf472f320835ee2fe744c83f1320882a8a02316ceb375f5c4909232bb2c6520b249c88be4f47b8b86fdd93678c69e64f50089e907a5504fdd43f0cad24aaa9e317ef2ecade3b5c1fd31f3c327d70a0e2d4867e6fe3f26272e8b6a3cce17843e359b82eb7a4cad8c42460179cb6c07fa252efaec428fd5cae5208b298b255109026e21272424ec0c52e1e5f72c5ab06f5d2a05e77c193b647ec948bb844e0c2ef1307f53cb800d4f55523d86038bb9e21099a861b6b9bcc969e5dddbdf7171b37d616381b78c3b22ef66510b2765d9617556b175599879d8558100ad90b830e87ad460a22108baa5ed0f2ba9dfc05167f8ab61fc9f8ae01603f9dd5e66ce1e642b604bca9294b57fb7c0d83f054bacf4454c298a272c44bc718f54605b91e0bfafd772aebaf3828846c93018f98e315708d50be8401eb9a8778dcbd0d6db9370860411b004cd37fbb8b5df87edee7aae949fff34607b",
+                "isMessageRandomized": true,
+                "tests" : [
+                    {
+                      "tcId" : 11179,
+                      "message" : "e49f585eeccf2bf7265641fb8c0f94c717e2ff1d9045aecaa302d285353b991bf7ac5dc93b311ce9078828d268571ff909711e5c04553220f8f80f785cc405ca13e02f0d40b2ee765ba295538521663718eabe5783888c345519077a9751a1285fc236f2a25a8ae44a2df247887451c86cd646d7b3e7a44ee0ef23538eec557f",
+                      "randomValue": "ab6a9b8b6a75ba76ab76a76b...",
+                      "randomValueLen": 1024,
+                      "signature" : "4e85f68a5b06b06a17d0f3f27b3a5a119e7db02abc2d9b4afc698220da11524a885f33cd7a10ae89c98b027b69224acef4713a1463f168c8bef551ef8fedb219b6ad0b3e99d6216643e58a51bb2ae93bbef769614914eab137c1993b149171b8633f4a318f69772996ef7dc3f7748f3756d58ecdc3937632717fb40cb7ed6e5c72e172ac58ec01f4e32fffc445b60f98a628fc1b0fa4cfb6686deb125950b862f347e9eb8120fb2b5aa23d6d86eaf1edebeb133793541c4dbea0f14a9f74733da4ed11d1274d464e09a5780843d6750bace0e97029308287dd396efa0f32628171fc5ec20d3c82619b784e4cdb66cbdb28cdd263a46a3ec63e1cad7659dc3b33801432d2b5b5e10a770083b933a805a9c76cc26c912f952cec5fd8413a8c1adaee80149fa19855315075825292db24de325fa6bf3b4c06652fc8320def4236c088dd5ae43315e03672fb999c354ef61ac380b1b1c96d711fc777e345ccb94536355a321466eedcf2355dd51f688023d6b599390f3aff6201369d8103af926c83"
+                    }
+                 ]
+             }             
           ]
       }
   ]
@@ -2851,7 +3131,70 @@
                           "signature" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e"
                         }
                       ]
-                    }
+                    },
+                    {
+                      "tgId": 7,
+                      "tests": [
+                        {
+                          "tcId" : 11165,
+                          "e" : "f3e7af",
+                          "n" :"a674f0f2a01fa0a987d0ef355f36cbd7eda5a931d5eca30b18fc237a481fcea435fe514166db877ca1e645204b0e1e2a8e5f7fcf28a98306c70424f0f4025c7d8c6d89063ac7847bf52eb1f2852bdd5cc03c1cbf63875b5062f4d22b290526a5fecfe343d39c3b46626b63e91670802b4d7a066973474a757d3e5957ddc020afddbeef963643b237651f7bd58d9af4ea67da7de5620539fb904c5a0243388498013470de777c8f11924add97fa1fb11b51cab46ea38adf995ad5efd0958a98cbf022dfb0d4b128917e4b513f120629051307b4d9d1014a28c55c93aaff59f47a7c0472a8b7a1ad5dbf07252c4b2602278fe18a77ec8acb8798f9f8b720dafe03",
+                          "signature" : "4d4ea9c758775fa7e90977ac8ef2249be7a8c3f2288ef36b59f9efe8b0175f5a7405970cc1884820fc9adbadf7b17cb258293b0cfcea119bacd5f7e1de4aa99757d2cb65bd21f58adaef0754bf84e84dfc05ce1ea9fe40dcb5cf8221ce1a4a99acde9e84a2214b7a3e57d7b92d59a003b83af7b0108e9ee6c73580004244506ef3cab5bd1ddfc319a474492645b1815349f77a9f581b5f1b84e5ea03f48f2f12fffeb62e84535094277544dabe3e119b42e46f16f579b3c4d9dea86cbd616ba2e04706072293cd7eabcd667ee06bacb435004f3e8be90727e44416b6be1672ef465e01645ea38f4f899c6f6ac5f8c5c6cebdec629a00df53a923d3359821ea4d",
+                          "randomValue": "ab67a6b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11166,
+                          "e" : "ebda09",
+                          "n" : "9ef147700655a568cfffaef293b86e35f562ce3e4326bba11a049fc4e4b766270608e12d5f09dcbf4f295131a8fb0bb5875a6394bdf129e307cabb5861710a956aa9411533d46994b678aee60b5927d065b6bc3130d0bd36135a46d5153dc530e619eae17b06a6db2d75a4b31e32539a89bf1b2b350c7eccc02a573af7d0d34d98e037698301c84d3e9ae66ee5e3429bd27c908140167d3c0ec4bf7b37a4eb60456d12752bee1e0aa705d184a11917bfbe8a73c07f42ee1957fdf30c5a331f7335bf113e215c0a4c9f89099b94ce74ed76e380ecc7cea221d8bcd961cd014762f9d12049d4288f585249c9536ca8abbc2b6ea63afd9bdee0aff6ee91a2f31ca82aaa778159fa8b9bd5e72268bf89afee45494653de7764948b9b877fab124b3b66cc4ff7fb56ba4140936514436aedd2cdc34c032c5b3c385db4f8b658ed5027001d9084064de2f11bd10ef2e290e421d3f8fdd2d217dc6f5aba8d709b6b25c17c0a4825a1e3633005380f16f51614aa3a7bab5169cf840f272919a28a765ba5",
+                          "signature" : "165e7194850b81151f9389e055e82836ceedcf5f9f10426901765b694dab813eda7a5ba6702957d5b9265cad8714abf3d30fecad94823a0ddccb5d3d1ff8e7dcdf2ccf11811c3d33602533a37ce538e9540360ed2243271929a40869dbe5870f2cb6afba5042d3a9726207805fa8fd81b0cf53b0af4c3ccc285989366609911cb121b947295040a51f4a35d6d7ac4d6c4381f0e93263b3d5976354c40deeaf6b1cfe6fed3c87082eaa0393a110fbce327d68d598f9e610ba20ff2a2dc7290c8eefd1998a52e6dd63a00270f299276a176052270e5eaeb5dd1a8d0904d8d0d76d883130d7faaf99a22e2440c4e54af31b6369b4dc7a5f724389b38f22260f90157e0e7ca0a67a09529b55cafca7fefe43a93aaeae0658cc409a33fc312b3eb5afe16ae692dcfde374d74fcec50054330dba7208cda87c27692954f5969da59707f695a3804e18f4c0d1b7d8d7fd7f6250e1cb4231ef240d690f3e9154d27529736fbcdb05a691c28ee1c085654411ba2f3ee65b298b56ff08b6a4dc29240df29c",
+                          "randomValue": "ab67a6b67a86ab87687667b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                      ]
+                    },
+                    {
+                      "tgId": 8,
+                      "tests": [       
+                        {
+                          "tcId" : 11167,
+                          "e" : "260445",
+                          "n" : "cea80475324c1dc8347827818da58bac069d3419c614a6ea1ac6a3b510dcd72cc516954905e9fef908d45e13006adf27d467a7d83c111d1a5df15ef293771aefb920032a5bb989f8e4f5e1b05093d3f130f984c07a772a3683f4dc6fb28a96815b32123ccdd13954f19d5b8b24a103e771a34c328755c65ed64e1924ffd04d30b2142cc262f6e0048fef6dbc652f21479ea1c4b1d66d28f4d46ef7185e390cbfa2e02380582f3188bb94ebbf05d31487a09aff01fcbb4cd4bfd1f0a833b38c11813c84360bb53c7d4481031c40bad8713bb6b835cb08098ed15ba31ee4ba728a8c8e10f7294e1b4163b7aee57277bfd881a6f9d43e02c6925aa3a043fb7fb78d",
+                          "signature" : "6b8be97d9e518a2ede746ff4a7d91a84a1fc665b52f154a927650db6e7348c69f8c8881f7bcf9b1a6d3366eed30c3aed4e93c203c43f5528a45de791895747ade9c5fa5eee81427edee02082147aa311712a6ad5fb1732e93b3d6cd23ffd46a0b3caf62a8b69957cc68ae39f9993c1a779599cdda949bdaababb77f248fcfeaa44059be5459fb9b899278e929528ee130facd53372ecbc42f3e8de2998425860406440f248d817432de687112e504d734028e6c5620fa282ca07647006cf0a2ff83e19a916554cc61810c2e855305db4e5cf893a6a96767365794556ff033359084d7e38a8456e68e21155b76151314a29875feee09557161cbc654541e89e42"
+                          "randomValue": "ab67ab7a897ba897a6b7a6b5ab67a5...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11168,
+                          "e" : "eaf05d",
+                          "n" : "dca98304b729e819b340e26cecb730aecbd8930e334c731493b180de970e6d3bc579f86c8d5d032f8cd33c4397ee7ffd019d51b0a7dbe4f52505a1a34ae35d23cfaaf594419d509f469b1369589f9c8616a7d698513bc1d423d70070d3d72b996c23abe68b22ccc39aabd16507124042c88d4da6a7451288ec87c9244be226aac02d1817682f80cc34c6eaf37ec84d247aaedebb56c3bbcaffb5cf42f61fe1b7f3fc89748e213973bf5f679d8b8b42a47ac4afd9e51e1d1214dfe1a7e1169080bd9ad91758f6c0f9b22ae40af6b41403d8f2d96db5a088daa5ef8683f86f501f7ad3f358b6337da55c6cfc003197420c1c75abdb7be1403ea4f3e64259f5c6da3325bb87d605b6e14b5350e6e1455c9d497d81046608e38795dc85aba406c9de1f4f9990d5153b98bbabbdcbd6bb18854312b2da48b411e838f26ae3109f104dfd1619f991824ec819861e5199f26bb9b3b299bfa9ec2fd691271b58a8adecbf0ff627b54336f3df7003d70e37d11ddbd930d9aba7e88ed401acb44092fd53d5",
+                          "signature" : "d1d21b8dfa55f0681e8fa86135cf292d71b7669713c291d8f8dc246464de3bbb961b596dfc8fda6c823c384008d05bcb3dccc36accf1b2bede1a95e52258d7d1bdf1fc44e18072abd45c1392015ee71692690ef8cdaaed337dd8546783f961bb9620eb5c7b8b6716e8c600351fab7765ee38a15d32d8a2c0949825c49a7f25eedd9be7b807bbfd517913786620d249823dae6fe2fd39ac639dd74821b0c120b42f31c2c639d2c61b395f09f86851bc809b34c4981ac65cf25b2e8adcbce190ef2ef67a0189039c9110f26701c3eed731c8d9ead178220ffcac7f0f678aa22268e1d01942ec51e80eef06e2112830855e87bafe8cc9c22fd737c7abbca5eb7a221d3835a86610d24b507b5dcb4618aa421f63a5609ef5d68f5760fddf970135602efad0851bbff98fe87fa58bc365f38ee7ec8ef5aab17fd11d89d91ef4c604e0d1f001d0e08869df9225e3b4cef52ff86815e13b3efdf45776f9353769a8a51fe7d891a7ef7035eecfa259848738376886edc91cc78f6da31c2f07ee362c3d82",
+                          "randomValue": "ab67a6b7a6b5ab67aa768b6a87b65...",
+                          "randomValueLen": 1024
+                        },
+                      ]
+                    },
+                    {
+                      "tgId": 9,
+                      "tests": [
+                        {
+                          "tcId" : 11169,
+                          "e" : "86c94f",
+                          "n" : "c5062b58d8539c765e1e5dbaf14cf75dd56c2e13105fecfd1a930bbb5948ff328f126abe779359ca59bca752c308d281573bc6178b6c0fef7dc445e4f826430437b9f9d790581de5749c2cb9cb26d42b2fee15b6b26f09c99670336423b86bc5bec71113157be2d944d7ff3eebffb28413143ea36755db0ae62ff5b724eecb3d316b6bac67e89cacd8171937e2ab19bd353a89acea8c36f81c89a620d5fd2effea896601c7f9daca7f033f635a3a943331d1b1b4f5288790b53af352f1121ca1bef205f40dc012c412b40bdd27585b946466d75f7ee0a7f9d549b4bece6f43ac3ee65fe7fd37123359d9f1a850ad450aaf5c94eb11dea3fc0fc6e9856b1805ef",
+                          "signature" : "8b46f2c889d819f860af0a6c4c889e4d1436c6ca174464d22ae11b9ccc265d743c67e569accbc5a80d4dd5f1bf4039e23de52aece40291c75f8936c58c9a2f77a780bbe7ad31eb76742f7b2b8b14ca1a7196af7e673a3cfc237d50f615b75cf4a7ea78a948bedaf9242494b41e1db51f437f15fd2551bb5d24eefb1c3e60f03694d0033a1e0a9b9f5e4ab97d457dff9b9da516dc226d6d6529500308ed74a2e6d9f3c10595788a52a1bc0664aedf33efc8badd037eb7b880772bdb04a6046e9edeee4197c25507fb0f11ab1c9f63f53c8820ea8405cfd7721692475b4d72355fa9a3804f29e6b6a7b059c4441d54b28e4eed2529c6103b5432c71332ce742bcc",
+                          "randomValue": "ab67a6b7a6b5ab67aa768b6a87ba67ba6b6a754a3265...",
+                          "randomValueLen": 1024
+                        },
+                        {
+                          "tcId" : 11170,
+                          "e" : "1415a7",
+                          "n" : "a7a1882a7fb896786034d07fb1b9f6327c27bdd7ce6fe39c285ae3b6c34259adc0dc4f7b9c7dec3ca4a20d3407339eedd7a12a421da18f5954673cac2ff059156ecc73c6861ec761e6a0f2a5a033a6768c6a42d8b459e1b4932349e84efd92df59b45935f3d0e30817c66201aa99d07ae36c5d74f408d69cc08f044151ff4960e531360cb19077833adf7bce77ecfaa133c0ccc63c93b856814569e0b9884ee554061b9a20ab46c38263c094dae791aa61a17f8d16f0e85b7e5ce3b067ece89e20bc4e8f1ae814b276d234e04f4e766f501da74ea7e3817c24ea35d016676cece652b823b051625573ca92757fc720d254ecf1dcbbfd21d98307561ecaab545480c7c52ad7e9fa6b597f5fe550559c2fe923205ac1761a99737ca02d7b19822e008a8969349c87fb874c81620e38f613c8521f0381fe5ba55b74827dad3e1cf2aa29c6933629f2b286ad11be88fa6436e7e3f64a75e3595290dc0d1cd5eee7aaac54959cc53bd5a934a365e72dd81a2bd4fb9a67821bffedf2ef2bd94913de8b",
+                          "signature" : "4335707da735cfd10411c9c048ca9b60bb46e2fe361e51fbe336f9508dc945afe075503d24f836610f2178996b52c411693052d5d7aed97654a40074ed20ed6689c0501b7fbac21dc46b665ac079760086414406cd66f8537d1ebf0dce4cf0c98d4c30c71da359e9cd401ff49718fdd4d0f99efe70ad8dd8ba1304cefb88f24b0eedf70116da15932c76f0069551a245b5fc3b91ec101f1d63b9853b598c6fa1c1acdbacf9626356c760119be0955644301896d9d0d3ea5e6443cb72ca29f4d45246d16d74d00568c219182feb191179e4593dc152c608fd80536329a533b3a631566814cd654f587c2d8ce696085e6ed1b0b0278e60a049ec7a399f94fccae6462371a69695ef525e00936fa7d9781f9ee289d4105ee827a27996583033cedb2f297e7b4926d906ce0d09d84128406ab33d7da0f8a1d4d2f666568686c394d139b0e5e99337758de85910a5fa25ca2aa6d8fb1c777244e7d98de4c79bbd426a5e6f657e37477e01247432f83797fbf31b50d02b83f69ded26d4945b2bc3f86e",
+                          "randomValue": "ab67a6ab67ab4ab23b7a6b5ab67aa768b6a87b65...",
+                          "randomValueLen": 1024
+                        }
+                      ]
+                    }                    
                  ]
              }
            ]
@@ -2906,6 +3249,45 @@
                 },
                 {
                   "tcId" : 1179,
+                  "testPassed": false
+                }
+              ]
+          }
+          {
+            "tgId": 7,
+            "tests": [
+                {
+                  "tcId" : 11174,
+                  "testPassed": false
+                },
+                {
+                  "tcId" : 11175,
+                  "testPassed": false
+                }
+              ]
+          },
+          {
+            "tgId": 8,
+            "tests": [
+                {
+                  "tcId" : 11176,
+                  "testPassed": true
+                },
+                {
+                  "tcId" : 11177,
+                  "testPassed": false
+                }
+              ]
+          },
+          {
+            "tgId": 9,
+            "tests": [
+                {
+                  "tcId" : 11178,
+                  "testPassed": true
+                },
+                {
+                  "tcId" : 11179,
                   "testPassed": false
                 }
               ]


### PR DESCRIPTION
Updates specifications for `DSA`, `ECDSA`, `RSA` to support Randomized Message Hashing as described in [SP800-106](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf).

The SP800-106 testing can be utilized with `SigGen` and `SigVer` modes of `DSA`, `ECDSA`, and `RSA`.  Test groups that are to make use of randomized hashing will contain a property `"conformance": "SP800-106`.  
* SigGen - the IUT is expected to provide the `randomValue` and `randomValueLen` for the groups previously described.  
* SigVer - the IUT is expected to take in the `randomValue` and `randomValueLen` from the ACVP server to determine if the signature is valid (or not) after applying the `randomValue` transformation described in section "3.2 Message Randomization" from  [SP800-106](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-106.pdf) to the `message`.

These changes are not yet present on the server, this PR should act as an area for comments, and will be closed at the point in which the feature is available to (at a minimum) demo.