### PR TITLE
Add tgId to SHA examples

### DIFF
--- a/artifacts/draft-celi-acvp-sha-00.html
+++ b/artifacts/draft-celi-acvp-sha-00.html
@@ -880,7 +880,8 @@ MD[0] = MD[1] = MD[2] = SEED
   			"tcId": 1,
   			"len": 1,
   			"msg": "80"
-  		}]
+		}],
+		"tgId": 1
   	}]
      }]
 
@@ -906,7 +907,8 @@ MD[0] = MD[1] = MD[2] = SEED
           	"tcId": 2171,
           	"len": 2096,
           	"msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
-        }]
+        }],
+        "tgId": 1
      }]
   }]
 
@@ -927,7 +929,8 @@ MD[0] = MD[1] = MD[2] = SEED
             "tcId": 2175,
             "len": 20,
             "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
-        }]
+        }],
+        "tgId": 1
      }]
   }]
 

--- a/artifacts/draft-celi-acvp-sha-00.html
+++ b/artifacts/draft-celi-acvp-sha-00.html
@@ -850,9 +850,9 @@ MD[0] = MD[1] = MD[2] = SEED
 <pre>
 					
 {
-	"algorithm": "SHA2-256",
-	"revision": "1.0",
-	"messageLength": [{"min": 0, "max": 65535, "increment": 1}]
+  "algorithm": "SHA2-256",
+  "revision": "1.0",
+  "messageLength": [{"min": 0, "max": 65535, "increment": 1}]
 }
 
 				</pre>
@@ -862,55 +862,57 @@ MD[0] = MD[1] = MD[2] = SEED
 <p id="rfc.section.B.p.1">The following is an example JSON object for secure hash test vectors sent from the ACVP server to the crypto module. Note the single bit message is represented as "80".  This complies with SHA1 and SHA2 being big-endian by nature. All hex strings associated with SHA1 and SHA2 will be big-endian.  </p>
 <pre>
 					
-   [
-      { "acvVersion": &lt;acvp-version&gt; },
-      { "vsId": 1564,
-  	"algorithm": "SHA2-512/224",
-		"revision": "1.0",
-  	"testGroups": [
-  	{
-  		"testType": "AFT",
-  		"tests": [
-  		{
-  			"tcId": 0,
-  			"len": 0,
-  			"msg": "00"
-  		},
-  		{
-  			"tcId": 1,
-  			"len": 1,
-  			"msg": "80"
-		}],
-		"tgId": 1
-  	}]
-     }]
+[
+  { "acvVersion": &lt;acvp-version&gt; },
+  { "vsId": 1564,
+    "algorithm": "SHA2-512/224",
+    "revision": "1.0",
+    "testGroups": [
+    {
+      "testType": "AFT",
+      "tests": [
+      {
+        "tcId": 0,
+        "len": 0,
+        "msg": "00"
+      },
+      {
+        "tcId": 1,
+        "len": 1,
+        "msg": "80"
+      }],
+      "tgId": 1
+    }]
+  }
+]
 
 				</pre>
 <p id="rfc.section.B.p.2">The following is another example JSON object for secure hash test vectors sent from the ACVP server to the crypto module.</p>
 <pre>
 					
-   [
-      { "acvVersion": &lt;acvp-version&gt; },
-      { "vsId": 1564,
-  	"algorithm": "SHA2-256",
-		"revision": "1.0",
-  	"testGroups": [
+[
+  { "acvVersion": &lt;acvp-version&gt; },
+  { "vsId": 1564,
+    "algorithm": "SHA2-256",
+    "revision": "1.0",
+    "testGroups": [
     {
-      	"testType": "AFT",
-      	"tests": [
-        {
-          	"tcId": 2170,
-          	"len": 1304,
-          	"msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
-        },
-        {
-          	"tcId": 2171,
-          	"len": 2096,
-          	"msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
+      "testType": "AFT",
+      "tests": [
+      {
+        "tcId": 2170,
+        "len": 1304,
+        "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
+      },
+      {
+        "tcId": 2171,
+        "len": 2096,
+        "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
         }],
         "tgId": 1
-     }]
-  }]
+    }]
+  }
+]
 
 				</pre>
 <p id="rfc.section.B.p.3">The following is an example JSON object for secure hash Monte Carlo test vectors sent from the ACVP server to the crypto module.</p>
@@ -920,19 +922,20 @@ MD[0] = MD[1] = MD[2] = SEED
   { "acvVersion": &lt;acvp-version&gt; },
   { "vsId": 1564,
     "algorithm": "SHA-1",
-		"revision": "1.0",
+    "revision": "1.0",
     "testGroups": [
     {
-        "testType": "MCT",
-        "tests": [
-        {
-            "tcId": 2175,
-            "len": 20,
-            "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
-        }],
-        "tgId": 1
-     }]
-  }]
+      "testType": "MCT",
+      "tests": [
+      {
+        "tcId": 2175,
+        "len": 20,
+        "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
+      }],
+      "tgId": 1
+    }]
+  }
+]
 
 				</pre>
 <h1 id="rfc.appendix.C">
@@ -946,14 +949,15 @@ MD[0] = MD[1] = MD[2] = SEED
   { "vsId": 1564,
     "testResults": [
     {
-        "tcId": 2170,
-        "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
+      "tcId": 2170,
+      "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
     },
     {
-        "tcId": 2171,
-        "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
-     }]
-  }]
+      "tcId": 2171,
+      "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
+    }]
+  }
+]
 
 				</pre>
 <p id="rfc.section.C.p.2">The following is a example JSON object for secure hash Monte Carlo test results sent from the crypto module to the ACVP server. Reduced to 2 iterations for brevity.</p>
@@ -964,19 +968,20 @@ MD[0] = MD[1] = MD[2] = SEED
   { "vsId": 1564,
     "testResults": [
     {
-		"tcId": 10246,
-		"resultsArray": [
-		{
-			"md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
-		},
-		{
-			"md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
-		},
-		{
-			"md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
-		}]
+      "tcId": 10246,
+      "resultsArray": [
+      {
+        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
+      },
+      {
+        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
+      },
+      {
+        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
+      }]
     }]
   }
+]
 
 				</pre>
 <h1 id="rfc.authors"><a href="#rfc.authors">Author's Address</a></h1>

--- a/artifacts/draft-celi-acvp-sha-00.txt
+++ b/artifacts/draft-celi-acvp-sha-00.txt
@@ -549,10 +549,10 @@ Appendix B.  Example Test Vectors JSON Object
                            "tcId": 1,
                            "len": 1,
                            "msg": "80"
-                   }]
+                   }],
+                   "tgId": 1
            }]
         }]
-
 
 
 
@@ -584,13 +584,38 @@ Internet-Draft                Sym Alg JSON                 November 2018
                 "tcId": 2171,
                 "len": 2096,
                 "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
-        }]
+        }],
+        "tgId": 1
      }]
   }]
 
 
    The following is an example JSON object for secure hash Monte Carlo
    test vectors sent from the ACVP server to the crypto module.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 11]
+
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
    [
@@ -606,16 +631,10 @@ Internet-Draft                Sym Alg JSON                 November 2018
                "tcId": 2175,
                "len": 20,
                "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
-           }]
+           }],
+           "tgId": 1
         }]
      }]
-
-
-
-
-Celi                       Expires May 5, 2019                 [Page 11]
-
-Internet-Draft                Sym Alg JSON                 November 2018
 
 
 Appendix C.  Example Test Results JSON Object
@@ -644,6 +663,17 @@ Appendix C.  Example Test Results JSON Object
    to 2 iterations for brevity.
 
 
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 12]
+
+Internet-Draft                Sym Alg JSON                 November 2018
+
+
 [
   { "acvVersion": <acvp-version> },
   { "vsId": 1564,
@@ -664,16 +694,6 @@ Appendix C.  Example Test Results JSON Object
   }
 
 
-
-
-
-
-
-Celi                       Expires May 5, 2019                 [Page 12]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 Author's Address
 
    Christopher Celi (editor)
@@ -683,26 +703,6 @@ Author's Address
    USA
 
    Email: christopher.celi@nist.gov
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/artifacts/draft-celi-acvp-sha-00.txt
+++ b/artifacts/draft-celi-acvp-sha-00.txt
@@ -82,8 +82,8 @@ Table of Contents
      6.2.  Informative References  . . . . . . . . . . . . . . . . .   9
    Appendix A.  Example Secure Hash Capabilities JSON Object . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  10
-   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  12
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
+   Appendix C.  Example Test Results JSON Object . . . . . . . . . .  13
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  14
 
 1.  Introduction
 
@@ -516,9 +516,9 @@ Appendix A.  Example Secure Hash Capabilities JSON Object
 
 
    {
-           "algorithm": "SHA2-256",
-           "revision": "1.0",
-           "messageLength": [{"min": 0, "max": 65535, "increment": 1}]
+     "algorithm": "SHA2-256",
+     "revision": "1.0",
+     "messageLength": [{"min": 0, "max": 65535, "increment": 1}]
    }
 
 
@@ -531,28 +531,28 @@ Appendix B.  Example Test Vectors JSON Object
    SHA2 will be big-endian.
 
 
-      [
-         { "acvVersion": <acvp-version> },
-         { "vsId": 1564,
-           "algorithm": "SHA2-512/224",
-                   "revision": "1.0",
-           "testGroups": [
-           {
-                   "testType": "AFT",
-                   "tests": [
-                   {
-                           "tcId": 0,
-                           "len": 0,
-                           "msg": "00"
-                   },
-                   {
-                           "tcId": 1,
-                           "len": 1,
-                           "msg": "80"
-                   }],
-                   "tgId": 1
-           }]
-        }]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -562,36 +562,36 @@ Celi                       Expires May 5, 2019                 [Page 10]
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+   [
+     { "acvVersion": <acvp-version> },
+     { "vsId": 1564,
+       "algorithm": "SHA2-512/224",
+       "revision": "1.0",
+       "testGroups": [
+       {
+         "testType": "AFT",
+         "tests": [
+         {
+           "tcId": 0,
+           "len": 0,
+           "msg": "00"
+         },
+         {
+           "tcId": 1,
+           "len": 1,
+           "msg": "80"
+         }],
+         "tgId": 1
+       }]
+     }
+   ]
+
+
    The following is another example JSON object for secure hash test
    vectors sent from the ACVP server to the crypto module.
 
 
-   [
-      { "acvVersion": <acvp-version> },
-      { "vsId": 1564,
-        "algorithm": "SHA2-256",
-                "revision": "1.0",
-        "testGroups": [
-    {
-        "testType": "AFT",
-        "tests": [
-        {
-                "tcId": 2170,
-                "len": 1304,
-                "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
-        },
-        {
-                "tcId": 2171,
-                "len": 2096,
-                "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
-        }],
-        "tgId": 1
-     }]
-  }]
 
-
-   The following is an example JSON object for secure hash Monte Carlo
-   test vectors sent from the ACVP server to the crypto module.
 
 
 
@@ -618,23 +618,60 @@ Celi                       Expires May 5, 2019                 [Page 11]
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
+[
+  { "acvVersion": <acvp-version> },
+  { "vsId": 1564,
+    "algorithm": "SHA2-256",
+    "revision": "1.0",
+    "testGroups": [
+    {
+      "testType": "AFT",
+      "tests": [
+      {
+        "tcId": 2170,
+        "len": 1304,
+        "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
+      },
+      {
+        "tcId": 2171,
+        "len": 2096,
+        "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
+        }],
+        "tgId": 1
+    }]
+  }
+]
+
+
+   The following is an example JSON object for secure hash Monte Carlo
+   test vectors sent from the ACVP server to the crypto module.
+
+
    [
      { "acvVersion": <acvp-version> },
      { "vsId": 1564,
        "algorithm": "SHA-1",
-                   "revision": "1.0",
+       "revision": "1.0",
        "testGroups": [
        {
-           "testType": "MCT",
-           "tests": [
-           {
-               "tcId": 2175,
-               "len": 20,
-               "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
-           }],
-           "tgId": 1
-        }]
-     }]
+         "testType": "MCT",
+         "tests": [
+         {
+           "tcId": 2175,
+           "len": 20,
+           "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
+         }],
+         "tgId": 1
+       }]
+     }
+   ]
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 12]
+
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 Appendix C.  Example Test Results JSON Object
@@ -648,14 +685,15 @@ Appendix C.  Example Test Results JSON Object
   { "vsId": 1564,
     "testResults": [
     {
-        "tcId": 2170,
-        "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
+      "tcId": 2170,
+      "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
     },
     {
-        "tcId": 2171,
-        "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
-     }]
-  }]
+      "tcId": 2171,
+      "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
+    }]
+  }
+]
 
 
    The following is a example JSON object for secure hash Monte Carlo
@@ -663,35 +701,33 @@ Appendix C.  Example Test Results JSON Object
    to 2 iterations for brevity.
 
 
-
-
-
-
-
-
-Celi                       Expires May 5, 2019                 [Page 12]
-
-Internet-Draft                Sym Alg JSON                 November 2018
-
-
 [
   { "acvVersion": <acvp-version> },
   { "vsId": 1564,
     "testResults": [
     {
-                "tcId": 10246,
-                "resultsArray": [
-                {
-                        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
-                },
-                {
-                        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
-                },
-                {
-                        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
-                }]
+      "tcId": 10246,
+      "resultsArray": [
+      {
+        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
+      },
+      {
+        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
+      },
+      {
+        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
+      }]
     }]
   }
+]
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 13]
+
+Internet-Draft                Sym Alg JSON                 November 2018
 
 
 Author's Address
@@ -725,4 +761,24 @@ Author's Address
 
 
 
-Celi                       Expires May 5, 2019                 [Page 13]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Celi                       Expires May 5, 2019                 [Page 14]

--- a/src/draft-celi-acvp-sha-00.xml
+++ b/src/draft-celi-acvp-sha-00.xml
@@ -507,7 +507,8 @@ MD[0] = MD[1] = MD[2] = SEED
   			"tcId": 1,
   			"len": 1,
   			"msg": "80"
-  		}]
+		}],
+		"tgId": 1
   	}]
      }]
 ]]>
@@ -536,7 +537,8 @@ MD[0] = MD[1] = MD[2] = SEED
           	"tcId": 2171,
           	"len": 2096,
           	"msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
-        }]
+        }],
+        "tgId": 1
      }]
   }]
 ]]>
@@ -560,7 +562,8 @@ MD[0] = MD[1] = MD[2] = SEED
             "tcId": 2175,
             "len": 20,
             "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
-        }]
+        }],
+        "tgId": 1
      }]
   }]
 ]]>

--- a/src/draft-celi-acvp-sha-00.xml
+++ b/src/draft-celi-acvp-sha-00.xml
@@ -472,9 +472,9 @@ MD[0] = MD[1] = MD[2] = SEED
 				<artwork>
 					<![CDATA[
 {
-	"algorithm": "SHA2-256",
-	"revision": "1.0",
-	"messageLength": [{"min": 0, "max": 65535, "increment": 1}]
+  "algorithm": "SHA2-256",
+  "revision": "1.0",
+  "messageLength": [{"min": 0, "max": 65535, "increment": 1}]
 }
 ]]>
 				</artwork>
@@ -489,28 +489,29 @@ MD[0] = MD[1] = MD[2] = SEED
 			<figure>
 				<artwork>
 					<![CDATA[
-   [
-      { "acvVersion": <acvp-version> },
-      { "vsId": 1564,
-  	"algorithm": "SHA2-512/224",
-		"revision": "1.0",
-  	"testGroups": [
-  	{
-  		"testType": "AFT",
-  		"tests": [
-  		{
-  			"tcId": 0,
-  			"len": 0,
-  			"msg": "00"
-  		},
-  		{
-  			"tcId": 1,
-  			"len": 1,
-  			"msg": "80"
-		}],
-		"tgId": 1
-  	}]
-     }]
+[
+  { "acvVersion": <acvp-version> },
+  { "vsId": 1564,
+    "algorithm": "SHA2-512/224",
+    "revision": "1.0",
+    "testGroups": [
+    {
+      "testType": "AFT",
+      "tests": [
+      {
+        "tcId": 0,
+        "len": 0,
+        "msg": "00"
+      },
+      {
+        "tcId": 1,
+        "len": 1,
+        "msg": "80"
+      }],
+      "tgId": 1
+    }]
+  }
+]
 ]]>
 				</artwork>
 			</figure>
@@ -519,28 +520,29 @@ MD[0] = MD[1] = MD[2] = SEED
 			<figure>
 				<artwork>
 					<![CDATA[
-   [
-      { "acvVersion": <acvp-version> },
-      { "vsId": 1564,
-  	"algorithm": "SHA2-256",
-		"revision": "1.0",
-  	"testGroups": [
+[
+  { "acvVersion": <acvp-version> },
+  { "vsId": 1564,
+    "algorithm": "SHA2-256",
+    "revision": "1.0",
+    "testGroups": [
     {
-      	"testType": "AFT",
-      	"tests": [
-        {
-          	"tcId": 2170,
-          	"len": 1304,
-          	"msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
-        },
-        {
-          	"tcId": 2171,
-          	"len": 2096,
-          	"msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
+      "testType": "AFT",
+      "tests": [
+      {
+        "tcId": 2170,
+        "len": 1304,
+        "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
+      },
+      {
+        "tcId": 2171,
+        "len": 2096,
+        "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
         }],
         "tgId": 1
-     }]
-  }]
+    }]
+  }
+]
 ]]>
 				</artwork>
 			</figure>
@@ -553,19 +555,20 @@ MD[0] = MD[1] = MD[2] = SEED
   { "acvVersion": <acvp-version> },
   { "vsId": 1564,
     "algorithm": "SHA-1",
-		"revision": "1.0",
+    "revision": "1.0",
     "testGroups": [
     {
-        "testType": "MCT",
-        "tests": [
-        {
-            "tcId": 2175,
-            "len": 20,
-            "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
-        }],
-        "tgId": 1
-     }]
-  }]
+      "testType": "MCT",
+      "tests": [
+      {
+        "tcId": 2175,
+        "len": 20,
+        "msg": "331b04d56f6e3ed5af349bf1fd9f9591b6ec886e",
+      }],
+      "tgId": 1
+    }]
+  }
+]
 ]]>
 				</artwork>
 			</figure>
@@ -582,14 +585,15 @@ MD[0] = MD[1] = MD[2] = SEED
   { "vsId": 1564,
     "testResults": [
     {
-        "tcId": 2170,
-        "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
+      "tcId": 2170,
+      "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
     },
     {
-        "tcId": 2171,
-        "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
-     }]
-  }]
+      "tcId": 2171,
+      "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
+    }]
+  }
+]
 ]]>
 				</artwork>
 			</figure>
@@ -603,19 +607,20 @@ MD[0] = MD[1] = MD[2] = SEED
   { "vsId": 1564,
     "testResults": [
     {
-		"tcId": 10246,
-		"resultsArray": [
-		{
-			"md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
-		},
-		{
-			"md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
-		},
-		{
-			"md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
-		}]
+      "tcId": 10246,
+      "resultsArray": [
+      {
+        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
+      },
+      {
+        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
+      },
+      {
+        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
+      }]
     }]
   }
+]
 ]]>
 				</artwork>
 			</figure>


### PR DESCRIPTION
I haven't checked whether other files may have the same omission, this is just the first one that I'm implementing.

Also, the re-indentation may be more churn then you wish, happy to drop it if so. Also happy to reindent in a different way if there's a defined style that you like.