### PR TITLE
Update for vectorSetUrls

### DIFF
--- a/artifacts/draft-fussell-acvp-spec-00.html
+++ b/artifacts/draft-fussell-acvp-spec-00.html
@@ -2522,7 +2522,7 @@ https://acvts.nist.gov/validation/acvp/v1/testSessions/1
         "createdOn": "2018-05-31T12:03:43Z",
         "expiresOn": "2018-06-30T12:03:43Z",
         "encryptAtRest": false,
-        "vectorSetsUrl": "/acvp/v1/testSessions/2/vectorSets",
+        "vectorSetUrls": ["/acvp/v1/testSessions/2/vectorSets/1"],
         "publishable": false,
         "passed": true,
         "isSample": true,

--- a/artifacts/draft-fussell-acvp-spec-00.txt
+++ b/artifacts/draft-fussell-acvp-spec-00.txt
@@ -2698,7 +2698,7 @@ Internet-Draft                ACV Protocol                     June 2019
            "createdOn": "2018-05-31T12:03:43Z",
            "expiresOn": "2018-06-30T12:03:43Z",
            "encryptAtRest": false,
-           "vectorSetsUrl": "/acvp/v1/testSessions/2/vectorSets",
+           "vectorSetUrls": ["/acvp/v1/testSessions/2/vectorSets/1"],
            "publishable": false,
            "passed": true,
            "isSample": true,

--- a/src/draft-fussell-acvp-spec-00.xml
+++ b/src/draft-fussell-acvp-spec-00.xml
@@ -2469,7 +2469,7 @@ https://acvts.nist.gov/validation/acvp/v1/testSessions/1
         "createdOn": "2018-05-31T12:03:43Z",
         "expiresOn": "2018-06-30T12:03:43Z",
         "encryptAtRest": false,
-        "vectorSetsUrl": "/acvp/v1/testSessions/2/vectorSets",
+        "vectorSetUrls": ["/acvp/v1/testSessions/2/vectorSets/1"],
         "publishable": false,
         "passed": true,
         "isSample": true,


### PR DESCRIPTION
Here's the response to POSTing to /testSessions on the demo server at
the moment:

```
[ {
  "acvVersion" : "1.0"
}, {
  "url" : "/acvp/v1/testSessions/1691",
  "vectorSetUrls" : [ "/acvp/v1/testSessions/1691/vectorSets/6953" ],
  "accessToken" : "<omitted>"
} ]
```

Note that the response contains `vectorSetUrls`, not `vectorSetsUrl` as
currently documented. This change aligns the documentation with the demo
server.