### PR TITLE
draft-celi-acvp-sha-00: add test groups to examples.

### DIFF
--- a/artifacts/draft-celi-acvp-sha-00.html
+++ b/artifacts/draft-celi-acvp-sha-00.html
@@ -404,7 +404,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Celi, C., Ed." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-1.0" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-acvp-subsha-01" />
   <meta name="dct.issued" scheme="ISO8601" content="2018-11-01" />
   <meta name="dct.abstract" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
   <meta name="description" content="This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification." />
@@ -438,7 +438,7 @@
   </table>
 
   <p class="title">ACVP Secure Hash Algorithm (SHA) JSON Specification<br />
-  <span class="filename">draft-ietf-acvp-subsha-1.0</span></p>
+  <span class="filename">draft-ietf-acvp-subsha-01</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This document defines the JSON schema for using SHA1 and SHA2 with the ACVP specification.</p>
@@ -510,7 +510,7 @@
 
   <h1 id="rfc.section.1">
 <a href="#rfc.section.1">1.</a> Introduction</h1>
-<p id="rfc.section.1.p.1">The Automated Cryptographic Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware cryptographic module. The intention of the protocol is to minimize human involvement in the testing of cryptography.  The ACVP specification defines how a cryptographic module communicates with an ACVP server, including cryptographic capabilities negotiation, session management, authentication, vector processing and more. Note that the ACVP specification does not define algorithm-specific JSON constructs for performing the cryptographic validation. However, a series of ACVP sub-specifications defines the constructs for testing individual cryptographic algorithms. Each sub-specification addresses a specific class or subset of cryptographic algorithms. This sub-specification defines the JSON constructs for testing hash cryptographic algorithms using ACVP.  The ACVP server performs a set of tests on the hash functions in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as SHA-1, SHA2-256 and SHA2-512.  </p>
+<p id="rfc.section.1.p.1">The Automated Cryptographic Validation Protocol <a href="#ACVP" class="xref">[ACVP]</a> defines a mechanism to automatically verify the cryptographic implementation of a software or hardware cryptographic module. The intention of the protocol is to minimize human involvement in the testing of cryptography.  The ACVP specification defines how a cryptographic module communicates with an ACVP server, including cryptographic capabilities negotiation, session management, authentication, vector processing and more. Note that the ACVP specification does not define algorithm-specific JSON constructs for performing the cryptographic validation. However, a series of ACVP sub-specifications defines the constructs for testing individual cryptographic algorithms. Each sub-specification addresses a specific class or subset of cryptographic algorithms. This sub-specification defines the JSON constructs for testing hash cryptographic algorithms using ACVP.  The ACVP server performs a set of tests on the hash functions in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as SHA-1, SHA2-256 and SHA2-512.  </p>
 <h1 id="rfc.section.1.1">
 <a href="#rfc.section.1.1">1.1.</a> Requirements Language</h1>
 <p id="rfc.section.1.1.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted in <a href="#RFC2119" class="xref">RFC 2119</a>.  </p>
@@ -537,7 +537,7 @@
 <p id="rfc.section.3.p.1">This section describes the design of the tests used to validate implementations of SHA-1 and SHA-2.  There are two types of tests for SHA-1 and SHA-2: functional tests and Monte Carlo tests. Each has a specific value to be used in the testType field. The testType field definitions are: </p>
 
 <ul>
-<li>"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'hash' operation.  AFTs cause the implementation under test to exercise nomral operations on a single block, multiple blocks, or partial blocks. In all cases, random data is used. The functional tests are designed to verify that the logical components of the hash function (block chunking, block padding etc.) are operating correctly.  </li>
+<li>"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'hash' operation.  AFTs cause the implementation under test to exercise normal operations on a single block, multiple blocks, or partial blocks. In all cases, random data is used. The functional tests are designed to verify that the logical components of the hash function (block chunking, block padding etc.) are operating correctly.  </li>
 <li>"MCT" - Monte Carlo Test. These tests exercise the implementation under test under strenuous circumstances. The implementation under test must process the test vectors according to the correct algorithm and mode in this document. MCTs can help detect potential memory leaks over time, and problems in allocation of resources, addressing variables, error handling, and generally improper behavior in response to random inputs. Each MCT processes 100 pseudorandom tests. Each algorithm and mode SHOULD have at least one MCT group. See <a href="#MC_test" class="xref">Section 3.1</a> for implementation details.  </li>
 </ul>
 
@@ -545,19 +545,20 @@
 <h1 id="rfc.section.3.1">
 <a href="#rfc.section.3.1">3.1.</a> <a href="#MC_test" id="MC_test">Monte Carlo tests for SHA-1 and SHA-2</a>
 </h1>
-<p id="rfc.section.3.1.p.1">The MCTs start with an initial condition (SEED which is a single message) and perform a series of chained computations.  </p>
+<p id="rfc.section.3.1.p.1">The MCTs start with an initial condition (SEED, which is a single message) and perform a series of chained computations.  </p>
 <p id="rfc.section.3.1.p.2">The algorithm is shown in <a href="#xml_figureMCT" class="xref">Figure 1</a>.  </p>
 <div id="rfc.figure.1"></div>
 <div id="xml_figureMCT"></div>
 <p>SHA-1 and SHA-2 Monte Carlo Test</p>
 <pre>
 						
-For j = 0 to 99
-MD[0] = MD[1] = MD[2] = SEED
-	For i = 3 to 1003
-		MSG[i] = MD[i-3] || MD[i-2] || MD[i-1]
-		MD[i] = SHA(MSG[i])
-	Output MD[1002]
+For i = 0 to 99
+  MD[0] = MD[1] = MD[2] = SEED
+  For j = 3 to 1002
+    MSG[j] = MD[j-3] || MD[j-2] || MD[j-1]
+    MD[j] = SHA(MSG[j])
+  SEED = MD[1002]
+  Output SEED
 						
 					</pre>
 <p class="figure">Figure 1</p>
@@ -577,7 +578,7 @@ MD[0] = MD[1] = MD[2] = SEED
 <a href="#rfc.section.4">4.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
 </h1>
 <p id="rfc.section.4.p.1">This section describes the constructs for advertising support of hash algorithms to the ACVP server. ACVP REQUIRES cryptographic modules to register their capabilities in a registration.  This allows the cryptographic module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  </p>
-<p id="rfc.section.4.p.2">The hash algorithm capabilities MUST be advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value MUST be an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value MUST be part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP Protocol Specification Section XXX for details on the registration message.  Each hash algorithm capability advertised SHALL be a self-contained JSON object.  </p>
+<p id="rfc.section.4.p.2">The hash algorithm capabilities MUST be advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value MUST be an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value MUST be part of the 'capability_exchange' element of the ACVP JSON registration message.  See the ACVP Protocol Specification Section 11.15.2 for details on the registration message.  Each hash algorithm capability advertised SHALL be a self-contained JSON object.  </p>
 <h1 id="rfc.section.4.1">
 <a href="#rfc.section.4.1">4.1.</a> <a href="#hash_caps_reg" id="hash_caps_reg">HASH Algorithm Capabilities Registration</a>
 </h1>
@@ -655,7 +656,7 @@ MD[0] = MD[1] = MD[2] = SEED
 <h1 id="rfc.section.5.1">
 <a href="#rfc.section.5.1">5.1.</a> <a href="#tgjs" id="tgjs">Test Groups</a>
 </h1>
-<p id="rfc.section.5.1.p.1">Test vector sets MUST contain one or many test groups, each sharing similar properties.  For instance, all test vectors that use the same testType would be grouped together.  The testGroups element at the top level of the test vector JSON object SHALL be the array of test groups.  The Test Group JSON object MUST contain meta-data that applies to all test cases within the group.  The following table describes the JSON elements that MAY appear from the server in the Test Group JSON object: </p>
+<p id="rfc.section.5.1.p.1">Test vector sets MUST contain one or more test groups, each sharing similar properties.  For instance, all test vectors that use the same testType would be grouped together.  The testGroups element at the top level of the test vector JSON object SHALL be the array of test groups.  The Test Group JSON object MUST contain meta-data that applies to all test cases within the group.  The following table describes the JSON elements that MAY appear from the server in the Test Group JSON object: </p>
 <div id="rfc.table.3"></div>
 <div id="vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -706,13 +707,13 @@ MD[0] = MD[1] = MD[2] = SEED
 </tr>
 <tr>
 <td class="left">len</td>
-<td class="left">Length of the message or MCT seed</td>
+<td class="left">Length, in bits, of the message or MCT seed</td>
 <td class="left">integer</td>
 </tr>
 <tr>
 <td class="left">msg</td>
 <td class="left">Value of the message or MCT seed in big-endian hex</td>
-<td class="left">integer</td>
+<td class="left">string</td>
 </tr>
 </tbody>
 </table>
@@ -742,9 +743,8 @@ MD[0] = MD[1] = MD[2] = SEED
 <td class="left">integer</td>
 </tr>
 <tr>
-<td class="left">testResults</td>
-<td class="left">Array of JSON objects that represent each test vector result, which uses the same JSON schema as defined in <a href="#tcjs" class="xref">Section 5.2</a>
-</td>
+<td class="left">testGroups</td>
+<td class="left">Array of JSON objects that represent the results of each test group.</td>
 <td class="left">array of testGroup objects</td>
 </tr>
 </tbody>
@@ -790,13 +790,13 @@ MD[0] = MD[1] = MD[2] = SEED
 </tr>
 <tr>
 <td class="left">md</td>
-<td class="left">The IUT's message digest response to an AFT test</td>
+<td class="left">The IUT's message digest response to an AFT test, hex encoded. (Omitted for non-AFT test cases.)</td>
 <td class="left">string (hex)</td>
 </tr>
 <tr>
 <td class="left">resultsArray</td>
-<td class="left">Array of JSON objects that represent each iteration of an MCT. Each iteration will contain the msg and md</td>
-<td class="left">array of objects containing the md</td>
+<td class="left">Array of JSON objects that represent each iteration of an MCT. Each element contains a single key, &#8220;md&#8221;, whose value is the hex encoded output of that iteration. (Omitted for non-MCT test cases.)</td>
+<td class="left">array of 100 objects</td>
 </tr>
 </tbody>
 </table>
@@ -831,18 +831,11 @@ MD[0] = MD[1] = MD[2] = SEED
 </tbody></table>
 <h1 id="rfc.references.2">
 <a href="#rfc.references.2">6.2.</a> Informative References</h1>
-<table><tbody>
-<tr>
+<table><tbody><tr>
 <td class="reference"><b id="FIPS-180-4">[FIPS-180-4]</b></td>
 <td class="top">
 <a>NIST</a>, "<a>Secure Hash Standard (SHS)</a>", August 2015.</td>
-</tr>
-<tr>
-<td class="reference"><b id="SHAVS">[SHAVS]</b></td>
-<td class="top">
-<a title="NIST">Lawrence E. Bassham III, LEB.</a>, "<a>The Secure Hash Algorithm Validation System (SHAVS)</a>", 2014.</td>
-</tr>
-</tbody></table>
+</tr></tbody></table>
 <h1 id="rfc.appendix.A">
 <a href="#rfc.appendix.A">Appendix A.</a> <a href="#app-reg-ex" id="app-reg-ex">Example Secure Hash Capabilities JSON Object</a>
 </h1>
@@ -902,12 +895,12 @@ MD[0] = MD[1] = MD[2] = SEED
       {
         "tcId": 2170,
         "len": 1304,
-        "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
+        "msg": "7f65733c...706d707"
       },
       {
         "tcId": 2171,
         "len": 2096,
-        "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
+        "msg": "e2c3b1a2...946e8e13"
         }],
         "tgId": 1
     }]
@@ -947,38 +940,46 @@ MD[0] = MD[1] = MD[2] = SEED
 [
   { "acvVersion": &lt;acvp-version&gt; },
   { "vsId": 1564,
-    "testResults": [
+    "testGroups": [
     {
-      "tcId": 2170,
-      "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
-    },
-    {
-      "tcId": 2171,
-      "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
-    }]
+      "tgId": 1,
+      "tests": [
+      {
+        "tcId": 2170,
+        "md": "7115011d...3c4283f3"
+      },
+      {
+        "tcId": 2171,
+        "md": "79820a52...3a79acd5"
+      }]
+    }
   }
 ]
 
 				</pre>
-<p id="rfc.section.C.p.2">The following is a example JSON object for secure hash Monte Carlo test results sent from the crypto module to the ACVP server. Reduced to 2 iterations for brevity.</p>
+<p id="rfc.section.C.p.2">The following is a example JSON object for secure hash Monte Carlo test results sent from the crypto module to the ACVP server. (Reduced to three iterations for brevity.)</p>
 <pre>
 					
 [
   { "acvVersion": &lt;acvp-version&gt; },
   { "vsId": 1564,
-    "testResults": [
+    "testGroups": [
     {
-      "tcId": 10246,
-      "resultsArray": [
+      "tgId": 1,
+      "tests": [
       {
-        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
-      },
-      {
-        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
-      },
-      {
-        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
-      }]
+        "tcId": 10246,
+        "resultsArray": [
+        {
+          "md": "220b2bd1...e3c023f7"
+        },
+        {
+          "md": "5eec0361...0ff2caf9"
+        },
+        {
+          "md": "efbed761...d4d23ce6"
+        }]
+      }
     }]
   }
 ]

--- a/artifacts/draft-celi-acvp-sha-00.txt
+++ b/artifacts/draft-celi-acvp-sha-00.txt
@@ -9,7 +9,7 @@ Expires: May 5, 2019
 
 
           ACVP Secure Hash Algorithm (SHA) JSON Specification
-                       draft-ietf-acvp-subsha-1.0
+                       draft-ietf-acvp-subsha-01
 
 Abstract
 
@@ -79,7 +79,7 @@ Table of Contents
      5.6.  Security Considerations . . . . . . . . . . . . . . . . .   9
    6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   9
      6.1.  Normative References  . . . . . . . . . . . . . . . . . .   9
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .   9
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .  10
    Appendix A.  Example Secure Hash Capabilities JSON Object . . . .  10
    Appendix B.  Example Test Vectors JSON Object . . . . . . . . . .  10
    Appendix C.  Example Test Results JSON Object . . . . . . . . . .  13
@@ -87,7 +87,7 @@ Table of Contents
 
 1.  Introduction
 
-   The Automated Cryptographic Validation Protocol (ACVP) defines a
+   The Automated Cryptographic Validation Protocol [ACVP] defines a
    mechanism to automatically verify the cryptographic implementation of
    a software or hardware cryptographic module.  The intention of the
    protocol is to minimize human involvement in the testing of
@@ -149,7 +149,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
    o  "AFT" - Algorithm Functional Test.  These tests can be processed
       by the client using a normal 'hash' operation.  AFTs cause the
-      implementation under test to exercise nomral operations on a
+      implementation under test to exercise normal operations on a
       single block, multiple blocks, or partial blocks.  In all cases,
       random data is used.  The functional tests are designed to verify
       that the logical components of the hash function (block chunking,
@@ -176,7 +176,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 3.1.  Monte Carlo tests for SHA-1 and SHA-2
 
-   The MCTs start with an initial condition (SEED which is a single
+   The MCTs start with an initial condition (SEED, which is a single
    message) and perform a series of chained computations.
 
    The algorithm is shown in Figure 1.
@@ -184,12 +184,13 @@ Internet-Draft                Sym Alg JSON                 November 2018
                      SHA-1 and SHA-2 Monte Carlo Test
 
 
-   For j = 0 to 99
-   MD[0] = MD[1] = MD[2] = SEED
-           For i = 3 to 1003
-                   MSG[i] = MD[i-3] || MD[i-2] || MD[i-1]
-                   MD[i] = SHA(MSG[i])
-           Output MD[1002]
+   For i = 0 to 99
+     MD[0] = MD[1] = MD[2] = SEED
+     For j = 3 to 1002
+       MSG[j] = MD[j-3] || MD[j-2] || MD[j-1]
+       MD[j] = SHA(MSG[j])
+     SEED = MD[1002]
+     Output SEED
 
 
                                  Figure 1
@@ -220,7 +221,6 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
-
 Celi                       Expires May 5, 2019                  [Page 4]
 
 Internet-Draft                Sym Alg JSON                 November 2018
@@ -241,7 +241,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
    individual JSON object defined in this section.  The 'algorithms'
    value MUST be part of the 'capability_exchange' element of the ACVP
    JSON registration message.  See the ACVP Protocol Specification
-   Section XXX for details on the registration message.  Each hash
+   Section 11.15.2 for details on the registration message.  Each hash
    algorithm capability advertised SHALL be a self-contained JSON
    object.
 
@@ -312,7 +312,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 5.1.  Test Groups
 
-   Test vector sets MUST contain one or many test groups, each sharing
+   Test vector sets MUST contain one or more test groups, each sharing
    similar properties.  For instance, all test vectors that use the same
    testType would be grouped together.  The testGroups element at the
    top level of the test vector JSON object SHALL be the array of test
@@ -370,8 +370,8 @@ Internet-Draft                Sym Alg JSON                 November 2018
    +---------+-----------------------------------------------+---------+
    | tcId    | Numeric identifier for the test case, unique  | integer |
    |         | across the entire vector set.                 |         |
-   | len     | Length of the message or MCT seed             | integer |
-   | msg     | Value of the message or MCT seed in big-      | integer |
+   | len     | Length, bits, of the message or MCT seed      | integer |
+   | msg     | Value of the message or MCT seed in big-      | string  |
    |         | endian hex                                    |         |
    +---------+-----------------------------------------------+---------+
 
@@ -394,17 +394,16 @@ Celi                       Expires May 5, 2019                  [Page 7]
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-   +-------------+-----------------------------------------+-----------+
-   | JSON Value  | Description                             | JSON type |
-   +-------------+-----------------------------------------+-----------+
-   | acvVersion  | Protocol version identifier             | string    |
-   | vsId        | Unique numeric identifier for the       | integer   |
-   |             | vector set                              |           |
-   | testResults | Array of JSON objects that represent    | array of  |
-   |             | each test vector result, which uses the | testGroup |
-   |             | same JSON schema as defined in Section  | objects   |
-   |             | 5.2                                     |           |
-   +-------------+-----------------------------------------+-----------+
+   +------------+-------------------------------------+----------------+
+   | JSON Value | Description                         | JSON type      |
+   +------------+-------------------------------------+----------------+
+   | acvVersion | Protocol version identifier         | string         |
+   | vsId       | Unique numeric identifier for the   | integer        |
+   |            | vector set                          |                |
+   | testGroups | Array of JSON objects that          | array of       |
+   |            | represent the results of each test  | testGroup      |
+   |            | group.                              | objects        |
+   +------------+-------------------------------------+----------------+
 
                  Table 5: Vector Set Response JSON Object
 
@@ -445,24 +444,28 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
 
 
+
 Celi                       Expires May 5, 2019                  [Page 8]
 
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-   +--------------+-------------------------------------+--------------+
-   | JSON Value   | Description                         | JSON type    |
-   +--------------+-------------------------------------+--------------+
-   | tcId         | Numeric identifier for the test     | integer      |
-   |              | case, unique across the entire      |              |
-   |              | vector set.                         |              |
-   | md           | The IUT's message digest response   | string (hex) |
-   |              | to an AFT test                      |              |
-   | resultsArray | Array of JSON objects that          | array of     |
-   |              | represent each iteration of an MCT. | objects      |
-   |              | Each iteration will contain the msg | containing   |
-   |              | and md                              | the md       |
-   +--------------+-------------------------------------+--------------+
+   +--------------+------------------------------------------+---------+
+   | JSON Value   | Description                              | JSON    |
+   |              |                                          | type    |
+   +--------------+------------------------------------------+---------+
+   | tcId         | Numeric identifier for the test case,    | integer |
+   |              | unique across the entire vector set.     |         |
+   | md           | The IUT's message digest response to an  | string  |
+   |              | AFT test, hex encoded. (Omitted for non- | (hex)   |
+   |              | AFT test cases.)                         |         |
+   | resultsArray | Array of JSON objects that represent     | array   |
+   |              | each iteration of an MCT. Each element   | of 100  |
+   |              | contains a single key, "md", whose value | objects |
+   |              | is the hex encoded output of that        |         |
+   |              | iteration. (Omitted for non-MCT test     |         |
+   |              | cases.)                                  |         |
+   +--------------+------------------------------------------+---------+
 
                   Table 7: Test Case Results JSON Object
 
@@ -493,10 +496,7 @@ Internet-Draft                Sym Alg JSON                 November 2018
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
 
-6.2.  Informative References
 
-   [FIPS-180-4]
-              NIST, "Secure Hash Standard (SHS)", August 2015.
 
 
 
@@ -506,8 +506,10 @@ Celi                       Expires May 5, 2019                  [Page 9]
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-   [SHAVS]    Lawrence E. Bassham III, LEB., "The Secure Hash Algorithm
-              Validation System (SHAVS)", 2014.
+6.2.  Informative References
+
+   [FIPS-180-4]
+              NIST, "Secure Hash Standard (SHS)", August 2015.
 
 Appendix A.  Example Secure Hash Capabilities JSON Object
 
@@ -529,8 +531,6 @@ Appendix B.  Example Test Vectors JSON Object
    message is represented as "80".  This complies with SHA1 and SHA2
    being big-endian by nature.  All hex strings associated with SHA1 and
    SHA2 will be big-endian.
-
-
 
 
 
@@ -618,29 +618,29 @@ Celi                       Expires May 5, 2019                 [Page 11]
 Internet-Draft                Sym Alg JSON                 November 2018
 
 
-[
-  { "acvVersion": <acvp-version> },
-  { "vsId": 1564,
-    "algorithm": "SHA2-256",
-    "revision": "1.0",
-    "testGroups": [
-    {
-      "testType": "AFT",
-      "tests": [
-      {
-        "tcId": 2170,
-        "len": 1304,
-        "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
-      },
-      {
-        "tcId": 2171,
-        "len": 2096,
-        "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
-        }],
-        "tgId": 1
-    }]
-  }
-]
+   [
+     { "acvVersion": <acvp-version> },
+     { "vsId": 1564,
+       "algorithm": "SHA2-256",
+       "revision": "1.0",
+       "testGroups": [
+       {
+         "testType": "AFT",
+         "tests": [
+         {
+           "tcId": 2170,
+           "len": 1304,
+           "msg": "7f65733c...706d707"
+         },
+         {
+           "tcId": 2171,
+           "len": 2096,
+           "msg": "e2c3b1a2...946e8e13"
+           }],
+           "tgId": 1
+       }]
+     }
+   ]
 
 
    The following is an example JSON object for secure hash Monte Carlo
@@ -680,46 +680,46 @@ Appendix C.  Example Test Results JSON Object
    sent from the crypto module to the ACVP server.
 
 
-[
-  { "acvVersion": <acvp-version> },
-  { "vsId": 1564,
-    "testResults": [
-    {
-      "tcId": 2170,
-      "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
-    },
-    {
-      "tcId": 2171,
-      "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
-    }]
-  }
-]
+   [
+     { "acvVersion": <acvp-version> },
+     { "vsId": 1564,
+       "testGroups": [
+       {
+         "tgId": 1,
+         "tests": [
+         {
+           "tcId": 2170,
+           "md": "7115011d...3c4283f3"
+         },
+         {
+           "tcId": 2171,
+           "md": "79820a52...3a79acd5"
+         }]
+       }
+     }
+   ]
 
 
    The following is a example JSON object for secure hash Monte Carlo
-   test results sent from the crypto module to the ACVP server.  Reduced
-   to 2 iterations for brevity.
+   test results sent from the crypto module to the ACVP server.
+   (Reduced to three iterations for brevity.)
 
 
-[
-  { "acvVersion": <acvp-version> },
-  { "vsId": 1564,
-    "testResults": [
-    {
-      "tcId": 10246,
-      "resultsArray": [
-      {
-        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
-      },
-      {
-        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
-      },
-      {
-        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
-      }]
-    }]
-  }
-]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -728,6 +728,31 @@ Appendix C.  Example Test Results JSON Object
 Celi                       Expires May 5, 2019                 [Page 13]
 
 Internet-Draft                Sym Alg JSON                 November 2018
+
+
+   [
+     { "acvVersion": <acvp-version> },
+     { "vsId": 1564,
+       "testGroups": [
+       {
+         "tgId": 1,
+         "tests": [
+         {
+           "tcId": 10246,
+           "resultsArray": [
+           {
+             "md": "220b2bd1...e3c023f7"
+           },
+           {
+             "md": "5eec0361...0ff2caf9"
+           },
+           {
+             "md": "efbed761...d4d23ce6"
+           }]
+         }
+       }]
+     }
+   ]
 
 
 Author's Address
@@ -739,31 +764,6 @@ Author's Address
    USA
 
    Email: christopher.celi@nist.gov
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/draft-celi-acvp-sha-00.xml
+++ b/src/draft-celi-acvp-sha-00.xml
@@ -27,7 +27,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="info" docName="draft-ietf-acvp-subsha-1.0" ipr="trust200902">
+<rfc category="info" docName="draft-ietf-acvp-subsha-01" ipr="trust200902">
 	<!-- category values: std, bcp, info, exp, and historic
     	 ipr values: full3667, noModification3667, noDerivatives3667
     	 you can add the attributes updates="NNNN" and obsoletes="NNNN"
@@ -100,7 +100,7 @@
 	<middle>
 		<section title="Introduction">
 			<t>
-                The Automated Cryptographic Validation Protocol (ACVP) defines a mechanism to automatically
+                The Automated Cryptographic Validation Protocol <xref target="ACVP"/> defines a mechanism to automatically
                 verify the cryptographic implementation of a software or hardware cryptographic module. The intention of the protocol
                 is to minimize human involvement in the testing of cryptography.
                 The ACVP specification defines how a cryptographic module communicates with an ACVP
@@ -147,7 +147,7 @@
 				<list style="symbols">
 					<t>
 						"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'hash' operation.
-						AFTs cause the implementation under test to exercise nomral operations on a single block, multiple blocks, or partial blocks. In all cases,
+						AFTs cause the implementation under test to exercise normal operations on a single block, multiple blocks, or partial blocks. In all cases,
 						random data is used. The functional tests are designed to verify that the logical components of the hash function (block chunking, block padding etc.)
 						are operating correctly.
 					</t>
@@ -163,7 +163,7 @@
 
 			<section anchor="MC_test" title="Monte Carlo tests for SHA-1 and SHA-2">
 				<t>
-					The MCTs start with an initial condition (SEED which is a single message) and perform a series of chained computations.
+					The MCTs start with an initial condition (SEED, which is a single message) and perform a series of chained computations.
 				</t>
 
 				<t>
@@ -173,12 +173,13 @@
 					<preamble>SHA-1 and SHA-2 Monte Carlo Test</preamble>
 					<artwork align="left">
 						<![CDATA[
-For j = 0 to 99
-MD[0] = MD[1] = MD[2] = SEED
-	For i = 3 to 1003
-		MSG[i] = MD[i-3] || MD[i-2] || MD[i-1]
-		MD[i] = SHA(MSG[i])
-	Output MD[1002]
+For i = 0 to 99
+  MD[0] = MD[1] = MD[2] = SEED
+  For j = 3 to 1002
+    MSG[j] = MD[j-3] || MD[j-2] || MD[j-1]
+    MD[j] = SHA(MSG[j])
+  SEED = MD[1002]
+  Output SEED
 						]]>
 					</artwork>
 				</figure>
@@ -218,7 +219,7 @@ MD[0] = MD[1] = MD[2] = SEED
                 value of the ACVP registration message. The 'algorithms' value MUST be an array, where each
                 array element is an individual JSON object defined in this section. The 'algorithms'
                 value MUST be part of the 'capability_exchange' element of the ACVP JSON registration message.
-                See the ACVP Protocol Specification Section XXX for details on the registration message.
+                See the ACVP Protocol Specification Section 11.15.2 for details on the registration message.
 
                 Each hash algorithm capability advertised SHALL be a self-contained JSON object.
             </t>
@@ -288,7 +289,7 @@ MD[0] = MD[1] = MD[2] = SEED
 
 			<section title="Test Groups" anchor="tgjs">
                 <t>
-                    Test vector sets MUST contain one or many test groups, each sharing similar properties.
+                    Test vector sets MUST contain one or more test groups, each sharing similar properties.
                     For instance, all test vectors that use the same testType would be grouped
                     together.  The testGroups element at the top level of the test vector JSON object SHALL be the array of test
                     groups.  The Test Group JSON object MUST contain meta-data that applies to all test cases within
@@ -330,12 +331,12 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>integer</c>
 
 					<c>len</c>
-					<c>Length of the message or MCT seed</c>
+					<c>Length, in bits, of the message or MCT seed</c>
 					<c>integer</c>
 
 					<c>msg</c>
 					<c>Value of the message or MCT seed in big-endian hex</c>
-					<c>integer</c>
+					<c>string</c>
 				</texttable>
 				<t>
 					All properties described in the previous table MUST appear in the prompt file from the server for every testCase object.
@@ -360,9 +361,8 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>Unique numeric identifier for the vector set</c>
 					<c>integer</c>
 
-					<c>testResults</c>
-					<c>Array of JSON objects that represent each test vector result, which uses the
-						same JSON schema as defined in <xref target="tcjs"/></c>
+					<c>testGroups</c>
+					<c>Array of JSON objects that represent the results of each test group.</c>
 					<c>array of testGroup objects</c>
 				</texttable>
 
@@ -400,12 +400,12 @@ MD[0] = MD[1] = MD[2] = SEED
 					<c>integer</c>
 
 					<c>md</c>
-					<c>The IUT's message digest response to an AFT test</c>
+					<c>The IUT's message digest response to an AFT test, hex encoded. (Omitted for non-AFT test cases.)</c>
 					<c>string (hex)</c>
 
 					<c>resultsArray</c>
-					<c>Array of JSON objects that represent each iteration of an MCT. Each iteration will contain the msg and md</c>
-					<c>array of objects containing the md</c>
+					<c>Array of JSON objects that represent each iteration of an MCT. Each element contains a single key, &ldquo;md&rdquo;, whose value is the hex encoded output of that iteration. (Omitted for non-MCT test cases.)</c>
+					<c>array of 100 objects</c>
 				</texttable>
 				<t>
 					Note: The tcId MUST be included in every test case object sent between the client and the server.
@@ -433,7 +433,8 @@ MD[0] = MD[1] = MD[2] = SEED
 	<back>
 		<references title="Normative References">
 			<!--?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml"?-->
-			&RFC2119;			<reference anchor="ACVP">
+			&RFC2119;
+			<reference anchor="ACVP">
 				<front>
 					<title>ACVP Specification</title>
 					<author initials="B" surname="Fussell">
@@ -445,16 +446,6 @@ MD[0] = MD[1] = MD[2] = SEED
 		</references>
 
 		<references title="Informative References">
-			<reference anchor="SHAVS">
-				<front>
-					<title>The Secure Hash Algorithm Validation System (SHAVS)</title>
-					<author initials="LEB" surname="Lawrence E. Bassham III">
-						<organization>NIST</organization>
-					</author>
-					<date year="2014"/>
-				</front>
-			</reference>
-
 			<reference anchor="FIPS-180-4">
 				<front>
 					<title>Secure Hash Standard (SHS)</title>
@@ -532,12 +523,12 @@ MD[0] = MD[1] = MD[2] = SEED
       {
         "tcId": 2170,
         "len": 1304,
-        "msg": "7f65733c73c6d9b06838ca3fd3f0fed4c642c58bba59ed0c8b2ae618c4aa24611d3fc59f427574e0d6f38d1fb8ad8119855b7d5c5e2946a1ebb0685b9f258f903ed035e89dc07d04aabe5f10ab7f069ccb1e76a7d2c972fd34ba9dc44d68df51ebff0a400d0ebec3ea808a3a35ce5304a073fa959f9f39c96e2fce7855dddc4b2bb48ece19c8fdc6a02354c4dd0232fa0c424f4e4c1563ada1f943a23feb4d2706d707"
+        "msg": "7f65733c...706d707"
       },
       {
         "tcId": 2171,
         "len": 2096,
-        "msg": "e2c3b1a24fbc47a05acbc950e3a32baa968ea1e2610fb2322bc68ed9c395a1641601682ca6db8420371f0dc4cb1c287ad1d5dc019aa8213b0c2d3a339a61455e74041121fa3f2f94778a4c860ccdbec1eac55c8ec4aa937c850fb65e3e0996936293538a3531718482d42e9c8cfe13054826ca94c95e2f7efc33a96295d5bb8a4978d66e3ef97279c0c55d1035f752d153c0cd18900c1ec8da62bc48890cddcb927943d5fddf59fb99247eeaeeffa1aa735b0e2401fc87e28864971701f823dfa35f42c75a2b4f9075bb3c309e5f281a10be34bf047593556c01e1d7e4dfb64de6f17a4d3d247bc2bc503cec2f6011a892b2e8f281c16aa8f00143901c0abd9dc1f9946e8e13"
+        "msg": "e2c3b1a2...946e8e13"
         }],
         "tgId": 1
     }]
@@ -583,41 +574,49 @@ MD[0] = MD[1] = MD[2] = SEED
 [
   { "acvVersion": <acvp-version> },
   { "vsId": 1564,
-    "testResults": [
+    "testGroups": [
     {
-      "tcId": 2170,
-      "md": "7115011d389f379798455039d5da962a077d1620d52d7e983af9b49e3c4283f3"
-    },
-    {
-      "tcId": 2171,
-      "md": "79820a5256eb1371cf8bc94fa17eaedc25aa5d28ae8706cbf77b9a6e3a79acd5"
-    }]
+      "tgId": 1,
+      "tests": [
+      {
+        "tcId": 2170,
+        "md": "7115011d...3c4283f3"
+      },
+      {
+        "tcId": 2171,
+        "md": "79820a52...3a79acd5"
+      }]
+    }
   }
 ]
 ]]>
 				</artwork>
 			</figure>
 			<t>The following is a example JSON object for secure hash Monte Carlo test results sent
-				from the crypto module to the ACVP server. Reduced to 2 iterations for brevity.</t>
+				from the crypto module to the ACVP server. (Reduced to three iterations for brevity.)</t>
 			<figure>
 				<artwork>
 					<![CDATA[
 [
   { "acvVersion": <acvp-version> },
   { "vsId": 1564,
-    "testResults": [
+    "testGroups": [
     {
-      "tcId": 10246,
-      "resultsArray": [
+      "tgId": 1,
+      "tests": [
       {
-        "md": "220b2bd187bd61affab14cdcfe76dce236c56a9072d55b4f6ac0b739e3c023f7"
-      },
-      {
-        "md": "5eec0361d25bfbc2468d70e2262783145523ffe627052585069413d30ff2caf9"
-      },
-      {
-        "md": "efbed7619701beda3eeb79946565cf33643b45783f38a4f8a855607bd4d23ce6"
-      }]
+        "tcId": 10246,
+        "resultsArray": [
+        {
+          "md": "220b2bd1...e3c023f7"
+        },
+        {
+          "md": "5eec0361...0ff2caf9"
+        },
+        {
+          "md": "efbed761...d4d23ce6"
+        }]
+      }
     }]
   }
 ]


### PR DESCRIPTION
In practice, libacvp includes testGroups in responses to hash vector
sets and that's what works with the demo server. Therefore, update the
documentation to include test groups in the examples and description
of results.

Also, fix MCT algorithm, which previously didn't update SEED and thus
produced 100 equal outputs.

Lastly, address most xml2rfc warnings; including many warnings about
over-long lines in the txt version which are fixed by eliding some of
the longer hex values in the examples.