### PR TITLE
ACVP-AES-GMAC

### DIFF
--- a/artifacts/acvp_sub_mac.html
+++ b/artifacts/acvp_sub_mac.html
@@ -379,9 +379,11 @@
 <link href="#rfc.section.2" rel="Chapter" title="2 Test Types and Test Coverage">
 <link href="#rfc.section.2.1" rel="Chapter" title="2.1 Test Coverage">
 <link href="#rfc.section.2.1.1" rel="Chapter" title="2.1.1 CMAC Requirements Covered">
-<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 CMACRequirements Not Covered">
-<link href="#rfc.section.2.1.3" rel="Chapter" title="2.1.3 HMAC Requirements Covered">
-<link href="#rfc.section.2.1.4" rel="Chapter" title="2.1.4 HMAC Requirements Not Covered">
+<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 CMAC Requirements Not Covered">
+<link href="#rfc.section.2.1.3" rel="Chapter" title="2.1.3 GMAC Requirements Covered">
+<link href="#rfc.section.2.1.4" rel="Chapter" title="2.1.4 GMAC Requirements Not Covered">
+<link href="#rfc.section.2.1.5" rel="Chapter" title="2.1.5 HMAC Requirements Covered">
+<link href="#rfc.section.2.1.6" rel="Chapter" title="2.1.6 HMAC Requirements Not Covered">
 <link href="#rfc.section.3" rel="Chapter" title="3 Capabilities Registration">
 <link href="#rfc.section.3.1" rel="Chapter" title="3.1 Required Prerequisite Algorithms for MAC Validations">
 <link href="#rfc.section.4" rel="Chapter" title="4 CMAC-AES">
@@ -402,22 +404,31 @@
 <link href="#rfc.section.5.2.3" rel="Chapter" title="5.2.3 Example CMAC-TDES Test Vector JSON Object">
 <link href="#rfc.section.5.3" rel="Chapter" title="5.3 CMAC-TDES Test Vector Responses">
 <link href="#rfc.section.5.3.1" rel="Chapter" title="5.3.1 Example CMAC-TDES Test Vector Response JSON Object">
-<link href="#rfc.section.6" rel="Chapter" title="6 HMAC">
-<link href="#rfc.section.6.1" rel="Chapter" title="6.1 HMAC Algorithm Capabilities Registration">
-<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Supported HMAC Algorithms">
-<link href="#rfc.section.6.2.1" rel="Chapter" title="6.2.1 Example HMAC Capabilities JSON Object">
-<link href="#rfc.section.6.3" rel="Chapter" title="6.3 HMAC Test Vectors">
-<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 HMAC Test Groups JSON Schema">
-<link href="#rfc.section.6.3.2" rel="Chapter" title="6.3.2 HMAC Test Case JSON Schema">
-<link href="#rfc.section.6.3.3" rel="Chapter" title="6.3.3 Example HMAC Test Vector JSON Object">
-<link href="#rfc.section.6.4" rel="Chapter" title="6.4 HMAC Test Vector Responses">
-<link href="#rfc.section.6.4.1" rel="Chapter" title="6.4.1 Example HMAC Test Vector Response JSON Object">
-<link href="#rfc.section.7" rel="Chapter" title="7 Acknowledgements">
-<link href="#rfc.section.8" rel="Chapter" title="8 IANA Considerations">
-<link href="#rfc.section.9" rel="Chapter" title="9 Security Considerations">
-<link href="#rfc.references" rel="Chapter" title="10 References">
-<link href="#rfc.references.1" rel="Chapter" title="10.1 Normative References">
-<link href="#rfc.references.2" rel="Chapter" title="10.2 Informative References">
+<link href="#rfc.section.6" rel="Chapter" title="6 GMAC">
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 AES-GMAC Algorithm Capabilities Registration">
+<link href="#rfc.section.6.1.1" rel="Chapter" title="6.1.1 Example AES-GMAC Capabilities JSON Object">
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 AES-GMAC Test Vectors">
+<link href="#rfc.section.6.2.1" rel="Chapter" title="6.2.1 AES-GMAC Test Groups JSON Schema">
+<link href="#rfc.section.6.2.2" rel="Chapter" title="6.2.2 AES-GMAC Test Case JSON Schema">
+<link href="#rfc.section.6.2.3" rel="Chapter" title="6.2.3 Example AES-GMAC Test Vector JSON Object">
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 AES-GMAC Test Vector Responses">
+<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 Example AES-GMAC Test Vector Response JSON Object">
+<link href="#rfc.section.7" rel="Chapter" title="7 HMAC">
+<link href="#rfc.section.7.1" rel="Chapter" title="7.1 HMAC Algorithm Capabilities Registration">
+<link href="#rfc.section.7.2" rel="Chapter" title="7.2 Supported HMAC Algorithms">
+<link href="#rfc.section.7.2.1" rel="Chapter" title="7.2.1 Example HMAC Capabilities JSON Object">
+<link href="#rfc.section.7.3" rel="Chapter" title="7.3 HMAC Test Vectors">
+<link href="#rfc.section.7.3.1" rel="Chapter" title="7.3.1 HMAC Test Groups JSON Schema">
+<link href="#rfc.section.7.3.2" rel="Chapter" title="7.3.2 HMAC Test Case JSON Schema">
+<link href="#rfc.section.7.3.3" rel="Chapter" title="7.3.3 Example HMAC Test Vector JSON Object">
+<link href="#rfc.section.7.4" rel="Chapter" title="7.4 HMAC Test Vector Responses">
+<link href="#rfc.section.7.4.1" rel="Chapter" title="7.4.1 Example HMAC Test Vector Response JSON Object">
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgements">
+<link href="#rfc.section.9" rel="Chapter" title="9 IANA Considerations">
+<link href="#rfc.section.10" rel="Chapter" title="10 Security Considerations">
+<link href="#rfc.references" rel="Chapter" title="11 References">
+<link href="#rfc.references.1" rel="Chapter" title="11.1 Normative References">
+<link href="#rfc.references.2" rel="Chapter" title="11.2 Informative References">
 <link href="#rfc.authors" rel="Chapter">
 
 
@@ -491,11 +502,15 @@
 </li>
 <ul><li>2.1.1.   <a href="#rfc.section.2.1.1">CMAC Requirements Covered</a>
 </li>
-<li>2.1.2.   <a href="#rfc.section.2.1.2">CMACRequirements Not Covered</a>
+<li>2.1.2.   <a href="#rfc.section.2.1.2">CMAC Requirements Not Covered</a>
 </li>
-<li>2.1.3.   <a href="#rfc.section.2.1.3">HMAC Requirements Covered</a>
+<li>2.1.3.   <a href="#rfc.section.2.1.3">GMAC Requirements Covered</a>
 </li>
-<li>2.1.4.   <a href="#rfc.section.2.1.4">HMAC Requirements Not Covered</a>
+<li>2.1.4.   <a href="#rfc.section.2.1.4">GMAC Requirements Not Covered</a>
+</li>
+<li>2.1.5.   <a href="#rfc.section.2.1.5">HMAC Requirements Covered</a>
+</li>
+<li>2.1.6.   <a href="#rfc.section.2.1.6">HMAC Requirements Not Covered</a>
 </li>
 </ul></ul><li>3.   <a href="#rfc.section.3">Capabilities Registration</a>
 </li>
@@ -537,37 +552,55 @@
 </li>
 <ul><li>5.3.1.   <a href="#rfc.section.5.3.1">Example CMAC-TDES Test Vector Response JSON Object</a>
 </li>
-</ul></ul><li>6.   <a href="#rfc.section.6">HMAC</a>
+</ul></ul><li>6.   <a href="#rfc.section.6">GMAC</a>
 </li>
-<ul><li>6.1.   <a href="#rfc.section.6.1">HMAC Algorithm Capabilities Registration</a>
+<ul><li>6.1.   <a href="#rfc.section.6.1">AES-GMAC Algorithm Capabilities Registration</a>
 </li>
-<li>6.2.   <a href="#rfc.section.6.2">Supported HMAC Algorithms</a>
+<ul><li>6.1.1.   <a href="#rfc.section.6.1.1">Example AES-GMAC Capabilities JSON Object</a>
 </li>
-<ul><li>6.2.1.   <a href="#rfc.section.6.2.1">Example HMAC Capabilities JSON Object</a>
+</ul><li>6.2.   <a href="#rfc.section.6.2">AES-GMAC Test Vectors</a>
 </li>
-</ul><li>6.3.   <a href="#rfc.section.6.3">HMAC Test Vectors</a>
+<ul><li>6.2.1.   <a href="#rfc.section.6.2.1">AES-GMAC Test Groups JSON Schema</a>
 </li>
-<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">HMAC Test Groups JSON Schema</a>
+<li>6.2.2.   <a href="#rfc.section.6.2.2">AES-GMAC Test Case JSON Schema</a>
 </li>
-<li>6.3.2.   <a href="#rfc.section.6.3.2">HMAC Test Case JSON Schema</a>
+<li>6.2.3.   <a href="#rfc.section.6.2.3">Example AES-GMAC Test Vector JSON Object</a>
 </li>
-<li>6.3.3.   <a href="#rfc.section.6.3.3">Example HMAC Test Vector JSON Object</a>
+</ul><li>6.3.   <a href="#rfc.section.6.3">AES-GMAC Test Vector Responses</a>
 </li>
-</ul><li>6.4.   <a href="#rfc.section.6.4">HMAC Test Vector Responses</a>
+<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">Example AES-GMAC Test Vector Response JSON Object</a>
 </li>
-<ul><li>6.4.1.   <a href="#rfc.section.6.4.1">Example HMAC Test Vector Response JSON Object</a>
+</ul></ul><li>7.   <a href="#rfc.section.7">HMAC</a>
 </li>
-</ul></ul><li>7.   <a href="#rfc.section.7">Acknowledgements</a>
+<ul><li>7.1.   <a href="#rfc.section.7.1">HMAC Algorithm Capabilities Registration</a>
 </li>
-<li>8.   <a href="#rfc.section.8">IANA Considerations</a>
+<li>7.2.   <a href="#rfc.section.7.2">Supported HMAC Algorithms</a>
 </li>
-<li>9.   <a href="#rfc.section.9">Security Considerations</a>
+<ul><li>7.2.1.   <a href="#rfc.section.7.2.1">Example HMAC Capabilities JSON Object</a>
 </li>
-<li>10.   <a href="#rfc.references">References</a>
+</ul><li>7.3.   <a href="#rfc.section.7.3">HMAC Test Vectors</a>
 </li>
-<ul><li>10.1.   <a href="#rfc.references.1">Normative References</a>
+<ul><li>7.3.1.   <a href="#rfc.section.7.3.1">HMAC Test Groups JSON Schema</a>
 </li>
-<li>10.2.   <a href="#rfc.references.2">Informative References</a>
+<li>7.3.2.   <a href="#rfc.section.7.3.2">HMAC Test Case JSON Schema</a>
+</li>
+<li>7.3.3.   <a href="#rfc.section.7.3.3">Example HMAC Test Vector JSON Object</a>
+</li>
+</ul><li>7.4.   <a href="#rfc.section.7.4">HMAC Test Vector Responses</a>
+</li>
+<ul><li>7.4.1.   <a href="#rfc.section.7.4.1">Example HMAC Test Vector Response JSON Object</a>
+</li>
+</ul></ul><li>8.   <a href="#rfc.section.8">Acknowledgements</a>
+</li>
+<li>9.   <a href="#rfc.section.9">IANA Considerations</a>
+</li>
+<li>10.   <a href="#rfc.section.10">Security Considerations</a>
+</li>
+<li>11.   <a href="#rfc.references">References</a>
+</li>
+<ul><li>11.1.   <a href="#rfc.references.1">Normative References</a>
+</li>
+<li>11.2.   <a href="#rfc.references.2">Informative References</a>
 </li>
 </ul><li><a href="#rfc.authors">Authors' Addresses</a>
 </li>
@@ -605,7 +638,7 @@
 
 <p> </p>
 <h1 id="rfc.section.2.1.2">
-<a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#requirements_not_covered_cmac" id="requirements_not_covered_cmac">CMACRequirements Not Covered</a>
+<a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#requirements_not_covered_cmac" id="requirements_not_covered_cmac">CMAC Requirements Not Covered</a>
 </h1>
 <p></p>
 
@@ -617,7 +650,33 @@
 
 <p> </p>
 <h1 id="rfc.section.2.1.3">
-<a href="#rfc.section.2.1.3">2.1.3.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
+<a href="#rfc.section.2.1.3">2.1.3.</a> <a href="#requirements_covered_gmac" id="requirements_covered_gmac">GMAC Requirements Covered</a>
+</h1>
+<p></p>
+
+<ul class="empty">
+<li>SP 800-38d - 5.1 Block Cipher.  ACVP testing SHALL make use of the AES block cipher when testing GMAC. </li>
+<li>SP 800-38d - 5.2 Two Gcm Functions. ACVP testing MAY test both the generate and verify functions of GCM (without making use of a payload) to help ensure a proper implementation. The ACVP and IUT MAY test the encrypt (generate) and decrypt (verify) utilizing a key, iv/nonce, and aad as described in this document section.</li>
+<li>SP 800-38d - 6 Mathematical Components of GCM. GHASH and GCTR produce intermediate values and SHALL be (indirectly) evaluated for correctness via the ACVP generated GMAC test vectors. </li>
+<li>SP 800-38d - 7 GCM Specification. When the IUT registers a direction capability of "encrypt", the ACVP server MUST generate vectors for the GCM-AE function.  When the IUT registers a capability of "decrypt", the ACVP server MUST generate test vectors for the GCM-AD function.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.2.1.4">
+<a href="#rfc.section.2.1.4">2.1.4.</a> <a href="#requirements_not_covered_gmac" id="requirements_not_covered_gmac">GMAC Requirements Not Covered</a>
+</h1>
+<p></p>
+
+<ul class="empty">
+<li>SP 800-38d - 5.2.1.1 Input Data. GMAC MUST NOT make use of a plaintext.</li>
+<li>SP 800-38d - 5.2.1.2 Output Data. GMAC MUST NOT make use of a ciphertext.</li>
+<li>SP 800-38d - 7 GCM Specification. The ACVP server MUST NOT make use of a plaintext or ciphertext for the generation of test vectors for use in GMAC testing.</li>
+<li>SP 800-38d - 8 Uniqueness Requirement on IVs and Keys. Key establishment, IV construction, or number of invocations for a specific key/iv SHALL NOT be tested under the scope of the ACVP testing.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.2.1.5">
+<a href="#rfc.section.2.1.5">2.1.5.</a> <a href="#requirements_covered_hmac" id="requirements_covered_hmac">HMAC Requirements Covered</a>
 </h1>
 <p></p>
 
@@ -628,10 +687,10 @@
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.2.1.4">
-<a href="#rfc.section.2.1.4">2.1.4.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
+<h1 id="rfc.section.2.1.6">
+<a href="#rfc.section.2.1.6">2.1.6.</a> <a href="#requirements_not_covered_hmac" id="requirements_not_covered_hmac">HMAC Requirements Not Covered</a>
 </h1>
-<p id="rfc.section.2.1.4.p.1">N/A</p>
+<p id="rfc.section.2.1.6.p.1">N/A</p>
 <h1 id="rfc.section.3">
 <a href="#rfc.section.3">3.</a> <a href="#caps_reg" id="caps_reg">Capabilities Registration</a>
 </h1>
@@ -2652,13 +2711,661 @@
             
                         </pre>
 <h1 id="rfc.section.6">
-<a href="#rfc.section.6">6.</a> <a href="#hmac_root" id="hmac_root">HMAC</a>
+<a href="#rfc.section.6">6.</a> <a href="#gmac" id="gmac">GMAC</a>
 </h1>
 <h1 id="rfc.section.6.1">
-<a href="#rfc.section.6.1">6.1.</a> <a href="#hmac_caps_reg" id="hmac_caps_reg">HMAC Algorithm Capabilities Registration</a>
+<a href="#rfc.section.6.1">6.1.</a> <a href="#gmac_caps_reg" id="gmac_caps_reg">AES-GMAC Algorithm Capabilities Registration</a>
 </h1>
 <p id="rfc.section.6.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
 <div id="rfc.table.18"></div>
+<div id="gmac_caps_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Algorithm Capabilities JSON Values</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Valid Values</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The MAC algorithm to be validated.</td>
+<td class="left">value</td>
+<td class="left">ACVP-AES-GMAC</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+<td class="left">"1.0"</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">prereqVals</td>
+<td class="left">prerequistie algorithm validations, See <a href="#prereq_algs" class="xref">Section 3.1</a> for examples </td>
+<td class="left">array of prereqAlgVal objects</td>
+<td class="left">See <a href="#prereq_algs" class="xref">Section 3.1</a> </td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The GMAC direction(s) to test.</td>
+<td class="left">array</td>
+<td class="left">encrypt, decrypt</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">The keyLen supported</td>
+<td class="left">value</td>
+<td class="left">128, 192, 256</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">ivLen</td>
+<td class="left">The IV lengths supported in bits. Min/max/increment and values must be mod 8.</td>
+<td class="left">Domain</td>
+<td class="left">8-1024</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">ivGen</td>
+<td class="left">The IV generation method (from the perspective of the IUT).</td>
+<td class="left">string</td>
+<td class="left">internal, external</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">ivGenMode</td>
+<td class="left">The IV generation mode for use when the IUT is internally generating IVs.</td>
+<td class="left">string</td>
+<td class="left">8.2.1, 8.2.2</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tagLen</td>
+<td class="left">The supported mac/tag lengths.</td>
+<td class="left">Domain</td>
+<td class="left">32, 64, 96, 104, 112, 120, 128</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.6.1.1">
+<a href="#rfc.section.6.1.1">6.1.1.</a> <a href="#gmac_app-reg-ex" id="gmac_app-reg-ex">Example AES-GMAC Capabilities JSON Object</a>
+</h1>
+<p id="rfc.section.6.1.1.p.1">The following is an example JSON object advertising support for AES-GMAC.</p>
+<pre>
+                            
+{
+  "algorithm": "ACVP-AES-GMAC",
+  "revision": "1.0",
+  "direction": [
+    "encrypt",
+    "decrypt"
+  ],
+  "keyLen": [
+    128
+  ],
+  "ivLen": [
+    96,
+    120
+  ],
+  "ivGen": "external",
+  "aadLen": [
+    8,
+    120
+  ],
+  "tagLen": [
+    32,
+    128
+  ]
+}
+            
+                        </pre>
+<h1 id="rfc.section.6.2">
+<a href="#rfc.section.6.2">6.2.</a> <a href="#gmac_test_vectors" id="gmac_test_vectors">AES-GMAC Test Vectors</a>
+</h1>
+<p id="rfc.section.6.2.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as ACVP-AES-GMAC. This section describes the JSON schema for a test vector set used with the ACVP-AES-GMAC crypto algorithm.</p>
+<p id="rfc.section.6.2.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<div id="rfc.table.19"></div>
+<div id="gmac_vs_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Vector Set JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">algorithm</td>
+<td class="left">The algorithm used for the test vectors.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">revision</td>
+<td class="left">The algorithm testing revision to use.</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#gmac_tgjs" class="xref">Section 6.2.1</a> </td>
+<td class="left">array</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.6.2.1">
+<a href="#rfc.section.6.2.1">6.2.1.</a> <a href="#gmac_tgjs" id="gmac_tgjs">AES-GMAC Test Groups JSON Schema</a>
+</h1>
+<p id="rfc.section.6.2.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<div id="rfc.table.20"></div>
+<div id="gmac_vs_tg_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Test Group JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">Numeric identifier for the test group, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testType</td>
+<td class="left">Test category type (AFT)</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">direction</td>
+<td class="left">The direction of the tests - encrypt or decrypt</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">keyLen</td>
+<td class="left">Length of key in bits to use</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">ivLen</td>
+<td class="left">Length of IV in bits</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">ivGen</td>
+<td class="left">IV Generation (internal or external)</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">ivGenMode</td>
+<td class="left">The mode an internal IV has been generated using.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">aadLen</td>
+<td class="left">Length of AAD in bits</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tagLen</td>
+<td class="left">Length of tag/MAC in bits to generate/verify</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#gmac_tvjs" class="xref">Section 6.2.2</a> </td>
+<td class="left">array</td>
+<td class="left">No</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.6.2.2">
+<a href="#rfc.section.6.2.2">6.2.2.</a> <a href="#gmac_tvjs" id="gmac_tvjs">AES-GMAC Test Case JSON Schema</a>
+</h1>
+<p id="rfc.section.6.2.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<div id="rfc.table.21"></div>
+<div id="gmac_vs_tc_table2"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Test Case JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">key</td>
+<td class="left">Encryption key to use AES</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">iv</td>
+<td class="left">Value of the IV.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">aad</td>
+<td class="left">Value of the AAD.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tag</td>
+<td class="left">MAC/tag value, for validating on a decrypt operation.</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.6.2.3">
+<a href="#rfc.section.6.2.3">6.2.3.</a> <a href="#gmac_test_vector_json" id="gmac_test_vector_json">Example AES-GMAC Test Vector JSON Object</a>
+</h1>
+<p id="rfc.section.6.2.3.p.1">The following is an example JSON test vector object for AES-GMAC.</p>
+<pre>
+                            
+{
+  "vsId": 0,
+  "algorithm": "ACVP-AES-GMAC",
+  "revision": "1.0",
+  "isSample": false,
+  "testGroups": [{
+      "tgId": 1,
+      "testType": "AFT",
+      "direction": "encrypt",
+      "keyLen": 128,
+      "ivLen": 96,
+      "ivGen": "external",
+      "aadLen": 0,
+      "tagLen": 32,
+      "tests": [{
+        "tcId": 1,
+        "key": "B1E9747F9E016F0376B1F379CD345B8A",
+        "aad": "",
+        "iv": "6294CEEDFCC3037A023100E8"
+      }]
+    },
+    {
+      "tgId": 2,
+      "testType": "AFT",
+      "direction": "decrypt",
+      "keyLen": 128,
+      "ivLen": 96,
+      "ivGen": "external",
+      "aadLen": 0,
+      "tagLen": 32,
+      "tests": [{
+        "tcId": 2,
+        "key": "CD345B8AE016F03765E9747F9B1F379A",
+        "aad": "",
+        "iv": "6207CEEDFA094CC3032310E8",
+        "tag": "AB1254CE"
+      }]
+    }
+  ]
+}
+            
+                        </pre>
+<h1 id="rfc.section.6.3">
+<a href="#rfc.section.6.3">6.3.</a> <a href="#gmac_vector_responses" id="gmac_vector_responses">AES-GMAC Test Vector Responses</a>
+</h1>
+<p id="rfc.section.6.3.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.22"></div>
+<div id="gmac_vr_top_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Vector Set Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">acvVersion</td>
+<td class="left">Protocol version identifier</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">vsId</td>
+<td class="left">Unique numeric identifier for the vector set</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testGroups</td>
+<td class="left">Array of JSON objects that represent each test vector group. See <a href="#gmac_vr_group_table" class="xref">Table 23</a> </td>
+<td class="left">array</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.6.3.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<div id="rfc.table.23"></div>
+<div id="gmac_vr_group_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Vector Set Group Response JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tgId</td>
+<td class="left">The test group Id</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tests</td>
+<td class="left">The tests associated to the group specified in tgId</td>
+<td class="left">value</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<p id="rfc.section.6.3.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<div id="rfc.table.24"></div>
+<div id="gmac_vs_tr_table"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>AES-GMAC Test Case Results JSON Object</caption>
+<thead><tr>
+<th class="left">JSON Value</th>
+<th class="left">Description</th>
+<th class="left">JSON type</th>
+<th class="left">Optional</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="left">tcId</td>
+<td class="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td class="left">value</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">tag</td>
+<td class="left">value of the computed tag/MAC output</td>
+<td class="left">value</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">testPassed</td>
+<td class="left">The result of decrypt verify</td>
+<td class="left">boolean</td>
+<td class="left">Yes</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+</tbody>
+</table>
+<h1 id="rfc.section.6.3.1">
+<a href="#rfc.section.6.3.1">6.3.1.</a> <a href="#gmac_test_vector_response_json" id="gmac_test_vector_response_json">Example AES-GMAC Test Vector Response JSON Object</a>
+</h1>
+<p id="rfc.section.6.3.1.p.1">The following is an example JSON test vector response object for AES-GMAC.</p>
+<pre>
+                            
+{
+  "vsId": 1,
+  "algorithm": "ACVP-AES-GMAC",
+  "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+        "tcId": 1,
+        "tag": "6FA27FDC"
+      }]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+        "tcId": 2,
+        "testPassed": true
+      }]
+    }
+  ]
+}
+            
+                        </pre>
+<h1 id="rfc.section.7">
+<a href="#rfc.section.7">7.</a> <a href="#hmac_root" id="hmac_root">HMAC</a>
+</h1>
+<h1 id="rfc.section.7.1">
+<a href="#rfc.section.7.1">7.1.</a> <a href="#hmac_caps_reg" id="hmac_caps_reg">HMAC Algorithm Capabilities Registration</a>
+</h1>
+<p id="rfc.section.7.1.p.1">Each algorithm capability advertised is a self-contained JSON object using the following values.</p>
+<div id="rfc.table.25"></div>
 <div id="hmac_caps_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Algorithm Capabilities JSON Values</caption>
@@ -2674,7 +3381,7 @@
 <td class="left">algorithm</td>
 <td class="left">The MAC algorithm and mode to be validated.</td>
 <td class="left">value</td>
-<td class="left">See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> </td>
+<td class="left">See <a href="#hmac_supported_algs" class="xref">Section 7.2</a> </td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -2728,7 +3435,7 @@
 </tr>
 <tr>
 <td class="left">macLen</td>
-<td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#hmac_supported_algs" class="xref">Section 6.2</a>). </td>
+<td class="left">The supported mac sizes. (range dependent on algorithm, see <a href="#hmac_supported_algs" class="xref">Section 7.2</a>). </td>
 <td class="left">Domain</td>
 <td class="left">32-512</td>
 <td class="left">No</td>
@@ -2742,17 +3449,17 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.1.p.2">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.7.1.p.2">keyLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
-<li>2 values below the Hash's block length. See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> </li>
+<li>2 values below the Hash's block length. See <a href="#hmac_supported_algs" class="xref">Section 7.2</a> </li>
 <li>The Hash's block length.</li>
 <li>2 values above the Hash's block length.</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.1.p.4">macLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
+<p id="rfc.section.7.1.p.4">macLen for HMAC contains a Domain of values, the server may choose values defined by these rules:</p>
 <p></p>
 
 <ul>
@@ -2762,11 +3469,11 @@
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.2">
-<a href="#rfc.section.6.2">6.2.</a> <a href="#hmac_supported_algs" id="hmac_supported_algs">Supported HMAC Algorithms</a>
+<h1 id="rfc.section.7.2">
+<a href="#rfc.section.7.2">7.2.</a> <a href="#hmac_supported_algs" id="hmac_supported_algs">Supported HMAC Algorithms</a>
 </h1>
-<p id="rfc.section.6.2.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
-<div id="rfc.table.19"></div>
+<p id="rfc.section.7.2.p.1">The following algorithms may be advertised by the ACVP compliant crypto module:</p>
+<div id="rfc.table.26"></div>
 <div id="hmac_table_algInfo"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>Algorithms w/ block size and max CMAC length.</caption>
@@ -2888,10 +3595,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6.2.1">
-<a href="#rfc.section.6.2.1">6.2.1.</a> <a href="#hmac_app-reg-ex" id="hmac_app-reg-ex">Example HMAC Capabilities JSON Object</a>
+<h1 id="rfc.section.7.2.1">
+<a href="#rfc.section.7.2.1">7.2.1.</a> <a href="#hmac_app-reg-ex" id="hmac_app-reg-ex">Example HMAC Capabilities JSON Object</a>
 </h1>
-<p id="rfc.section.6.2.1.p.1">The following is an example JSON object advertising support for HMAC.</p>
+<p id="rfc.section.7.2.1.p.1">The following is an example JSON object advertising support for HMAC.</p>
 <pre>
                             
 {
@@ -2914,12 +3621,12 @@
 }
             
                         </pre>
-<h1 id="rfc.section.6.3">
-<a href="#rfc.section.6.3">6.3.</a> <a href="#hmac_test_vectors" id="hmac_test_vectors">HMAC Test Vectors</a>
+<h1 id="rfc.section.7.3">
+<a href="#rfc.section.7.3">7.3.</a> <a href="#hmac_test_vectors" id="hmac_test_vectors">HMAC Test Vectors</a>
 </h1>
-<p id="rfc.section.6.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC crypto algorithms.</p>
-<p id="rfc.section.6.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
-<div id="rfc.table.20"></div>
+<p id="rfc.section.7.3.p.1">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as HMAC-SHA-1, HMAC-SHA2-224, CMAC-AES, etc. This section describes the JSON schema for a test vector set used with HMAC crypto algorithms.</p>
+<p id="rfc.section.7.3.p.2">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy. </p>
+<div id="rfc.table.27"></div>
 <div id="hmac_vs_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Vector Set JSON Object</caption>
@@ -2951,7 +3658,7 @@
 </tr>
 <tr>
 <td class="left">algorithm</td>
-<td class="left">The algorithm and mode used for the test vectors. See <a href="#hmac_supported_algs" class="xref">Section 6.2</a> for possible values. </td>
+<td class="left">The algorithm and mode used for the test vectors. See <a href="#hmac_supported_algs" class="xref">Section 7.2</a> for possible values. </td>
 <td class="left">value</td>
 </tr>
 <tr>
@@ -2971,16 +3678,16 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of test group JSON objects, which are defined in <a href="#hmac_tgjs" class="xref">Section 6.3.1</a> </td>
+<td class="left">Array of test group JSON objects, which are defined in <a href="#hmac_tgjs" class="xref">Section 7.3.1</a> </td>
 <td class="left">array</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6.3.1">
-<a href="#rfc.section.6.3.1">6.3.1.</a> <a href="#hmac_tgjs" id="hmac_tgjs">HMAC Test Groups JSON Schema</a>
+<h1 id="rfc.section.7.3.1">
+<a href="#rfc.section.7.3.1">7.3.1.</a> <a href="#hmac_tgjs" id="hmac_tgjs">HMAC Test Groups JSON Schema</a>
 </h1>
-<p id="rfc.section.6.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
-<div id="rfc.table.21"></div>
+<p id="rfc.section.7.3.1.p.1">The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure HMAC and CMAC JSON elements of the Test Group JSON object.</p>
+<div id="rfc.table.28"></div>
 <div id="hmac_vs_tg_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Test Group JSON Object</caption>
@@ -3053,17 +3760,17 @@
 </tr>
 <tr>
 <td class="left">tests</td>
-<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#hmac_tvjs" class="xref">Section 6.3.2</a> </td>
+<td class="left">Array of individual test vector JSON objects, which are defined in <a href="#hmac_tvjs" class="xref">Section 7.3.2</a> </td>
 <td class="left">array</td>
 <td class="left">No</td>
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6.3.2">
-<a href="#rfc.section.6.3.2">6.3.2.</a> <a href="#hmac_tvjs" id="hmac_tvjs">HMAC Test Case JSON Schema</a>
+<h1 id="rfc.section.7.3.2">
+<a href="#rfc.section.7.3.2">7.3.2.</a> <a href="#hmac_tvjs" id="hmac_tvjs">HMAC Test Case JSON Schema</a>
 </h1>
-<p id="rfc.section.6.3.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
-<div id="rfc.table.22"></div>
+<p id="rfc.section.7.3.2.p.1">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each secure MAC test vector.</p>
+<div id="rfc.table.29"></div>
 <div id="hmac_vs_tc_table2"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Test Case JSON Object</caption>
@@ -3112,10 +3819,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6.3.3">
-<a href="#rfc.section.6.3.3">6.3.3.</a> <a href="#hmac_test_vector_json" id="hmac_test_vector_json">Example HMAC Test Vector JSON Object</a>
+<h1 id="rfc.section.7.3.3">
+<a href="#rfc.section.7.3.3">7.3.3.</a> <a href="#hmac_test_vector_json" id="hmac_test_vector_json">Example HMAC Test Vector JSON Object</a>
 </h1>
-<p id="rfc.section.6.3.3.p.1">The following is an example JSON test vector object for HMAC.</p>
+<p id="rfc.section.7.3.3.p.1">The following is an example JSON test vector object for HMAC.</p>
 <pre>
                             
 {
@@ -3183,11 +3890,11 @@
 }
             
                         </pre>
-<h1 id="rfc.section.6.4">
-<a href="#rfc.section.6.4">6.4.</a> <a href="#hmac_vector_responses" id="hmac_vector_responses">HMAC Test Vector Responses</a>
+<h1 id="rfc.section.7.4">
+<a href="#rfc.section.7.4">7.4.</a> <a href="#hmac_vector_responses" id="hmac_vector_responses">HMAC Test Vector Responses</a>
 </h1>
-<p id="rfc.section.6.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
-<div id="rfc.table.23"></div>
+<p id="rfc.section.7.4.p.1">After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.</p>
+<div id="rfc.table.30"></div>
 <div id="hmac_vr_top_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Vector Set Response JSON Object</caption>
@@ -3219,7 +3926,7 @@
 </tr>
 <tr>
 <td class="left">testGroups</td>
-<td class="left">Array of JSON objects that represent each test vector group. See <a href="#hmac_vr_group_table" class="xref">Table 24</a> </td>
+<td class="left">Array of JSON objects that represent each test vector group. See <a href="#hmac_vr_group_table" class="xref">Table 31</a> </td>
 <td class="left">array</td>
 </tr>
 <tr>
@@ -3229,8 +3936,8 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.4.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
-<div id="rfc.table.24"></div>
+<p id="rfc.section.7.4.p.2">The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms SHALL require the client to send back group level properties in their response. This structure helps accommodate that.</p>
+<div id="rfc.table.31"></div>
 <div id="hmac_vr_group_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Vector Set Group Response JSON Object</caption>
@@ -3262,8 +3969,8 @@
 </tr>
 </tbody>
 </table>
-<p id="rfc.section.6.4.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
-<div id="rfc.table.25"></div>
+<p id="rfc.section.7.4.p.3">Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each DRBG test vector.</p>
+<div id="rfc.table.32"></div>
 <div id="hmac_vs_tr_table"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
 <caption>HMAC Test Case Results JSON Object</caption>
@@ -3300,10 +4007,10 @@
 </tr>
 </tbody>
 </table>
-<h1 id="rfc.section.6.4.1">
-<a href="#rfc.section.6.4.1">6.4.1.</a> <a href="#hmac_test_vector_response_json" id="hmac_test_vector_response_json">Example HMAC Test Vector Response JSON Object</a>
+<h1 id="rfc.section.7.4.1">
+<a href="#rfc.section.7.4.1">7.4.1.</a> <a href="#hmac_test_vector_response_json" id="hmac_test_vector_response_json">Example HMAC Test Vector Response JSON Object</a>
 </h1>
-<p id="rfc.section.6.4.1.p.1">The following is an example JSON test vector response object for HMAC.</p>
+<p id="rfc.section.7.4.1.p.1">The following is an example JSON test vector response object for HMAC.</p>
 <pre>
                             
 {
@@ -3357,22 +4064,22 @@
 }
             
                         </pre>
-<h1 id="rfc.section.7">
-<a href="#rfc.section.7">7.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
-</h1>
-<p id="rfc.section.7.p.1">TBD...</p>
 <h1 id="rfc.section.8">
-<a href="#rfc.section.8">8.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
+<a href="#rfc.section.8">8.</a> <a href="#Acknowledgements" id="Acknowledgements">Acknowledgements</a>
 </h1>
-<p id="rfc.section.8.p.1">This memo includes no request to IANA.</p>
+<p id="rfc.section.8.p.1">TBD...</p>
 <h1 id="rfc.section.9">
-<a href="#rfc.section.9">9.</a> <a href="#Security" id="Security">Security Considerations</a>
+<a href="#rfc.section.9">9.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
-<p id="rfc.section.9.p.1">Security considerations are addressed by the ACVP specification.</p>
+<p id="rfc.section.9.p.1">This memo includes no request to IANA.</p>
+<h1 id="rfc.section.10">
+<a href="#rfc.section.10">10.</a> <a href="#Security" id="Security">Security Considerations</a>
+</h1>
+<p id="rfc.section.10.p.1">Security considerations are addressed by the ACVP specification.</p>
 <h1 id="rfc.references">
-<a href="#rfc.references">10.</a> References</h1>
+<a href="#rfc.references">11.</a> References</h1>
 <h1 id="rfc.references.1">
-<a href="#rfc.references.1">10.1.</a> Normative References</h1>
+<a href="#rfc.references.1">11.1.</a> Normative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="ACVP">[ACVP]</b></td>
@@ -3386,7 +4093,7 @@
 </tr>
 </tbody></table>
 <h1 id="rfc.references.2">
-<a href="#rfc.references.2">10.2.</a> Informative References</h1>
+<a href="#rfc.references.2">11.2.</a> Informative References</h1>
 <table><tbody>
 <tr>
 <td class="reference"><b id="CMACVS">[CMACVS]</b></td>
@@ -3417,6 +4124,11 @@
 <td class="reference"><b id="SP-800-38B">[SP-800-38B]</b></td>
 <td class="top">
 <a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf">Recommendation for Block Cipher Modes of Operation: The CMAC Mode for Authentication</a>", 2005.</td>
+</tr>
+<tr>
+<td class="reference"><b id="SP-800-38D">[SP-800-38D]</b></td>
+<td class="top">
+<a>NIST</a>, "<a href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf">Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC</a>", 2007.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>

--- a/artifacts/acvp_sub_mac.txt
+++ b/artifacts/acvp_sub_mac.txt
@@ -63,49 +63,49 @@ Table of Contents
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
    2.  Test Types and Test Coverage  . . . . . . . . . . . . . . . .   3
-     2.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Test Coverage . . . . . . . . . . . . . . . . . . . . . .   4
        2.1.1.  CMAC Requirements Covered . . . . . . . . . . . . . .   4
-       2.1.2.  CMACRequirements Not Covered  . . . . . . . . . . . .   4
-       2.1.3.  HMAC Requirements Covered . . . . . . . . . . . . . .   4
-       2.1.4.  HMAC Requirements Not Covered . . . . . . . . . . . .   4
-   3.  Capabilities Registration . . . . . . . . . . . . . . . . . .   5
-     3.1.  Required Prerequisite Algorithms for MAC Validations  . .   5
-   4.  CMAC-AES  . . . . . . . . . . . . . . . . . . . . . . . . . .   6
-     4.1.  CMAC-AES Algorithm Capabilities Registration  . . . . . .   6
-       4.1.1.  Example CMAC-AES Capabilities JSON Object . . . . . .   7
-     4.2.  CMAC-AES Test Vectors . . . . . . . . . . . . . . . . . .  10
-       4.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .  11
-       4.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  12
-       4.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  13
-     4.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  17
-       4.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  18
-   5.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  21
-     5.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  21
-       5.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  24
-     5.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  25
-       5.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  26
-       5.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  27
-       5.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  28
-     5.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  34
-       5.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  35
-   6.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  38
-     6.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  38
-     6.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  40
-       6.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  40
-     6.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  41
-       6.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  42
-       6.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  43
-       6.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  44
-     6.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  45
-       6.4.1.  Example HMAC Test Vector Response JSON Object . . . .  46
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  47
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  48
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  48
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  48
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  48
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  48
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  49
-
+       2.1.2.  CMAC Requirements Not Covered . . . . . . . . . . . .   4
+       2.1.3.  GMAC Requirements Covered . . . . . . . . . . . . . .   4
+       2.1.4.  GMAC Requirements Not Covered . . . . . . . . . . . .   5
+       2.1.5.  HMAC Requirements Covered . . . . . . . . . . . . . .   5
+       2.1.6.  HMAC Requirements Not Covered . . . . . . . . . . . .   5
+   3.  Capabilities Registration . . . . . . . . . . . . . . . . . .   6
+     3.1.  Required Prerequisite Algorithms for MAC Validations  . .   6
+   4.  CMAC-AES  . . . . . . . . . . . . . . . . . . . . . . . . . .   7
+     4.1.  CMAC-AES Algorithm Capabilities Registration  . . . . . .   7
+       4.1.1.  Example CMAC-AES Capabilities JSON Object . . . . . .   8
+     4.2.  CMAC-AES Test Vectors . . . . . . . . . . . . . . . . . .  11
+       4.2.1.  CMAC-AES Test Groups JSON Schema  . . . . . . . . . .  12
+       4.2.2.  CMAC-AES Test Case JSON Schema  . . . . . . . . . . .  13
+       4.2.3.  Example CMAC-AES Test Vector JSON Object  . . . . . .  14
+     4.3.  CMAC-AES Test Vector Responses  . . . . . . . . . . . . .  18
+       4.3.1.  Example CMAC-AES Test Vector Response JSON Object . .  19
+   5.  CMAC-TDES . . . . . . . . . . . . . . . . . . . . . . . . . .  22
+     5.1.  CMAC-TDES Algorithm Capabilities Registration . . . . . .  22
+       5.1.1.  Example CMAC-TDES Capabilities JSON Object  . . . . .  25
+     5.2.  CMAC-TDES Test Vectors  . . . . . . . . . . . . . . . . .  26
+       5.2.1.  CMAC-TDES Test Groups JSON Schema . . . . . . . . . .  27
+       5.2.2.  CMAC-TDES Test Case JSON Schema . . . . . . . . . . .  28
+       5.2.3.  Example CMAC-TDES Test Vector JSON Object . . . . . .  29
+     5.3.  CMAC-TDES Test Vector Responses . . . . . . . . . . . . .  35
+       5.3.1.  Example CMAC-TDES Test Vector Response JSON Object  .  36
+   6.  GMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  39
+     6.1.  AES-GMAC Algorithm Capabilities Registration  . . . . . .  39
+       6.1.1.  Example AES-GMAC Capabilities JSON Object . . . . . .  40
+     6.2.  AES-GMAC Test Vectors . . . . . . . . . . . . . . . . . .  41
+       6.2.1.  AES-GMAC Test Groups JSON Schema  . . . . . . . . . .  42
+       6.2.2.  AES-GMAC Test Case JSON Schema  . . . . . . . . . . .  43
+       6.2.3.  Example AES-GMAC Test Vector JSON Object  . . . . . .  44
+     6.3.  AES-GMAC Test Vector Responses  . . . . . . . . . . . . .  45
+       6.3.1.  Example AES-GMAC Test Vector Response JSON Object . .  47
+   7.  HMAC  . . . . . . . . . . . . . . . . . . . . . . . . . . . .  48
+     7.1.  HMAC Algorithm Capabilities Registration  . . . . . . . .  48
+     7.2.  Supported HMAC Algorithms . . . . . . . . . . . . . . . .  49
+       7.2.1.  Example HMAC Capabilities JSON Object . . . . . . . .  50
+     7.3.  HMAC Test Vectors . . . . . . . . . . . . . . . . . . . .  50
+       7.3.1.  HMAC Test Groups JSON Schema  . . . . . . . . . . . .  51
+       7.3.2.  HMAC Test Case JSON Schema  . . . . . . . . . . . . .  52
 
 
 
@@ -113,6 +113,17 @@ Fussell & Hammett       Expires February 2, 2019                [Page 2]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+       7.3.3.  Example HMAC Test Vector JSON Object  . . . . . . . .  53
+     7.4.  HMAC Test Vector Responses  . . . . . . . . . . . . . . .  54
+       7.4.1.  Example HMAC Test Vector Response JSON Object . . . .  55
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  56
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  57
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  57
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  57
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  57
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  57
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  58
 
 1.  Introduction
 
@@ -151,6 +162,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
       and the "gen" direction of CMAC by running the randomly chosen key
       and message data (with constraints as per the IUT's capabilities
       registration) through the MAC algorithm.  CMAC has an additional
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 3]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
       "ver" direction present in its testing to ensure the IUT can
       successfully determine when a MAC does not match its originating
       message/key combination.
@@ -159,16 +178,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    The tests described in this document have the intention of ensuring
    an implementation is conformant to [SP-800-38B] and [FIPS-198-1].
-
-
-
-
-
-
-Fussell & Hammett       Expires February 2, 2019                [Page 3]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
 2.1.1.  CMAC Requirements Covered
 
@@ -182,7 +191,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
       and message.  Using the provided test case, the IUT is expected to
       validate the mac against the provided key and message.
 
-2.1.2.  CMACRequirements Not Covered
+2.1.2.  CMAC Requirements Not Covered
 
       SP 800-38b - 5.4 Sub-keys.  While sub-keys are computed, as they
       are intermediate values, are not validated via current testing.
@@ -197,7 +206,54 @@ Internet-Draft                Sym Alg JSON                   August 2018
       random sampling of valid MAC lengths as per the IUT registration -
       this generally includes the minimum and maximum mac length.
 
-2.1.3.  HMAC Requirements Covered
+2.1.3.  GMAC Requirements Covered
+
+      SP 800-38d - 5.1 Block Cipher.  ACVP testing SHALL make use of the
+      AES block cipher when testing GMAC.
+
+      SP 800-38d - 5.2 Two Gcm Functions.  ACVP testing MAY test both
+      the generate and verify functions of GCM (without making use of a
+      payload) to help ensure a proper implementation.  The ACVP and IUT
+      MAY test the encrypt (generate) and decrypt (verify) utilizing a
+      key, iv/nonce, and aad as described in this document section.
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019                [Page 4]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+      SP 800-38d - 6 Mathematical Components of GCM.  GHASH and GCTR
+      produce intermediate values and SHALL be (indirectly) evaluated
+      for correctness via the ACVP generated GMAC test vectors.
+
+      SP 800-38d - 7 GCM Specification.  When the IUT registers a
+      direction capability of "encrypt", the ACVP server MUST generate
+      vectors for the GCM-AE function.  When the IUT registers a
+      capability of "decrypt", the ACVP server MUST generate test
+      vectors for the GCM-AD function.
+
+2.1.4.  GMAC Requirements Not Covered
+
+      SP 800-38d - 5.2.1.1 Input Data.  GMAC MUST NOT make use of a
+      plaintext.
+
+      SP 800-38d - 5.2.1.2 Output Data.  GMAC MUST NOT make use of a
+      ciphertext.
+
+      SP 800-38d - 7 GCM Specification.  The ACVP server MUST NOT make
+      use of a plaintext or ciphertext for the generation of test
+      vectors for use in GMAC testing.
+
+      SP 800-38d - 8 Uniqueness Requirement on IVs and Keys.  Key
+      establishment, IV construction, or number of invocations for a
+      specific key/iv SHALL NOT be tested under the scope of the ACVP
+      testing.
+
+2.1.5.  HMAC Requirements Covered
 
       FIPS 198-1 - 3 Cryptographic Keys.  The ACVP server will test,
       depending on the nature of the IUT capabilities registration, keys
@@ -212,7 +268,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
       Groups will be created containing a random sampling of valid MAC
       lengths from the IUT registration.
 
-2.1.4.  HMAC Requirements Not Covered
+2.1.6.  HMAC Requirements Not Covered
 
    N/A
 
@@ -221,7 +277,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019                [Page 4]
+Fussell & Hammett       Expires February 2, 2019                [Page 5]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -277,7 +333,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019                [Page 5]
+Fussell & Hammett       Expires February 2, 2019                [Page 6]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -333,7 +389,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019                [Page 6]
+Fussell & Hammett       Expires February 2, 2019                [Page 7]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -389,7 +445,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019                [Page 7]
+Fussell & Hammett       Expires February 2, 2019                [Page 8]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -445,7 +501,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019                [Page 8]
+Fussell & Hammett       Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -501,7 +557,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019                [Page 9]
+Fussell & Hammett       Expires February 2, 2019               [Page 10]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -557,7 +613,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 10]
+Fussell & Hammett       Expires February 2, 2019               [Page 11]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -613,7 +669,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 11]
+Fussell & Hammett       Expires February 2, 2019               [Page 12]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -669,7 +725,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 12]
+Fussell & Hammett       Expires February 2, 2019               [Page 13]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -725,7 +781,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 13]
+Fussell & Hammett       Expires February 2, 2019               [Page 14]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -781,7 +837,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 14]
+Fussell & Hammett       Expires February 2, 2019               [Page 15]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -837,7 +893,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 15]
+Fussell & Hammett       Expires February 2, 2019               [Page 16]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -893,7 +949,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 16]
+Fussell & Hammett       Expires February 2, 2019               [Page 17]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -949,7 +1005,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 17]
+Fussell & Hammett       Expires February 2, 2019               [Page 18]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1005,7 +1061,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 18]
+Fussell & Hammett       Expires February 2, 2019               [Page 19]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1061,7 +1117,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 19]
+Fussell & Hammett       Expires February 2, 2019               [Page 20]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1117,7 +1173,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 20]
+Fussell & Hammett       Expires February 2, 2019               [Page 21]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1173,7 +1229,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 21]
+Fussell & Hammett       Expires February 2, 2019               [Page 22]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1229,7 +1285,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 22]
+Fussell & Hammett       Expires February 2, 2019               [Page 23]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1285,7 +1341,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 23]
+Fussell & Hammett       Expires February 2, 2019               [Page 24]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1341,7 +1397,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 24]
+Fussell & Hammett       Expires February 2, 2019               [Page 25]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1397,7 +1453,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 25]
+Fussell & Hammett       Expires February 2, 2019               [Page 26]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1453,7 +1509,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 26]
+Fussell & Hammett       Expires February 2, 2019               [Page 27]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1509,7 +1565,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 27]
+Fussell & Hammett       Expires February 2, 2019               [Page 28]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1565,7 +1621,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 28]
+Fussell & Hammett       Expires February 2, 2019               [Page 29]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1621,7 +1677,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 29]
+Fussell & Hammett       Expires February 2, 2019               [Page 30]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1677,7 +1733,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 30]
+Fussell & Hammett       Expires February 2, 2019               [Page 31]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1733,7 +1789,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 31]
+Fussell & Hammett       Expires February 2, 2019               [Page 32]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1789,7 +1845,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 32]
+Fussell & Hammett       Expires February 2, 2019               [Page 33]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1845,7 +1901,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 33]
+Fussell & Hammett       Expires February 2, 2019               [Page 34]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1901,7 +1957,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 34]
+Fussell & Hammett       Expires February 2, 2019               [Page 35]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -1957,7 +2013,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 35]
+Fussell & Hammett       Expires February 2, 2019               [Page 36]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2013,7 +2069,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 36]
+Fussell & Hammett       Expires February 2, 2019               [Page 37]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2069,7 +2125,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 37]
+Fussell & Hammett       Expires February 2, 2019               [Page 38]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2086,56 +2142,511 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-6.  HMAC
+6.  GMAC
 
-6.1.  HMAC Algorithm Capabilities Registration
+6.1.  AES-GMAC Algorithm Capabilities Registration
 
    Each algorithm capability advertised is a self-contained JSON object
    using the following values.
 
+   +----------+----------------+-------------+--------------+----------+
+   | JSON     | Description    | JSON type   | Valid Values | Optional |
+   | Value    |                |             |              |          |
+   +----------+----------------+-------------+--------------+----------+
+   | algorith | The MAC        | value       | ACVP-AES-    | No       |
+   | m        | algorithm to   |             | GMAC         |          |
+   |          | be validated.  |             |              |          |
+   |          |                |             |              |          |
+   | revision | The algorithm  | value       | "1.0"        | No       |
+   |          | testing        |             |              |          |
+   |          | revision to    |             |              |          |
+   |          | use.           |             |              |          |
+   |          |                |             |              |          |
+   | prereqVa | prerequistie   | array of pr | See          | No       |
+   | ls       | algorithm      | ereqAlgVal  | Section 3.1  |          |
+   |          | validations,   | objects     |              |          |
+   |          | See            |             |              |          |
+   |          | Section 3.1    |             |              |          |
+   |          | for examples   |             |              |          |
+   |          |                |             |              |          |
+   | directio | The GMAC       | array       | encrypt,     | No       |
+   | n        | direction(s)   |             | decrypt      |          |
+   |          | to test.       |             |              |          |
+   |          |                |             |              |          |
+   | keyLen   | The keyLen     | value       | 128, 192,    | No       |
+   |          | supported      |             | 256          |          |
+   |          |                |             |              |          |
+   | ivLen    | The IV lengths | Domain      | 8-1024       | No       |
+   |          | supported in   |             |              |          |
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Fussell & Hammett       Expires February 2, 2019               [Page 38]
+Fussell & Hammett       Expires February 2, 2019               [Page 39]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   |          | bits. Min/max/ |             |              |          |
+   |          | increment and  |             |              |          |
+   |          | values must be |             |              |          |
+   |          | mod 8.         |             |              |          |
+   |          |                |             |              |          |
+   | ivGen    | The IV         | string      | internal,    | No       |
+   |          | generation     |             | external     |          |
+   |          | method (from   |             |              |          |
+   |          | the            |             |              |          |
+   |          | perspective of |             |              |          |
+   |          | the IUT).      |             |              |          |
+   |          |                |             |              |          |
+   | ivGenMod | The IV         | string      | 8.2.1, 8.2.2 | Yes      |
+   | e        | generation     |             |              |          |
+   |          | mode for use   |             |              |          |
+   |          | when the IUT   |             |              |          |
+   |          | is internally  |             |              |          |
+   |          | generating     |             |              |          |
+   |          | IVs.           |             |              |          |
+   |          |                |             |              |          |
+   | tagLen   | The supported  | Domain      | 32, 64, 96,  | No       |
+   |          | mac/tag        |             | 104, 112,    |          |
+   |          | lengths.       |             | 120, 128     |          |
+   |          |                |             |              |          |
+   +----------+----------------+-------------+--------------+----------+
+
+           Table 18: AES-GMAC Algorithm Capabilities JSON Values
+
+6.1.1.  Example AES-GMAC Capabilities JSON Object
+
+   The following is an example JSON object advertising support for AES-
+   GMAC.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 40]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   {
+     "algorithm": "ACVP-AES-GMAC",
+     "revision": "1.0",
+     "direction": [
+       "encrypt",
+       "decrypt"
+     ],
+     "keyLen": [
+       128
+     ],
+     "ivLen": [
+       96,
+       120
+     ],
+     "ivGen": "external",
+     "aadLen": [
+       8,
+       120
+     ],
+     "tagLen": [
+       32,
+       128
+     ]
+   }
+
+
+6.2.  AES-GMAC Test Vectors
+
+   The ACVP server provides test vectors to the ACVP client, which are
+   then processed and returned to the ACVP server for validation.  A
+   typical ACVP validation session would require multiple test vector
+   sets to be downloaded and processed by the ACVP client.  Each test
+   vector set represents an individual crypto algorithm, such as ACVP-
+   AES-GMAC.  This section describes the JSON schema for a test vector
+   set used with the ACVP-AES-GMAC crypto algorithm.
+
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
+   test vectors to be processed by the ACVP client.  The following table
+   describes the JSON elements at the top level of the hierarchy.
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 41]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | algorithm  | The algorithm used for the test vectors.    | value  |
+   |            |                                             |        |
+   | revision   | The algorithm testing revision to use.      | value  |
+   |            |                                             |        |
+   | testGroups | Array of test group JSON objects, which are | array  |
+   |            | defined in Section 6.2.1                    |        |
+   +------------+---------------------------------------------+--------+
+
+                 Table 19: AES-GMAC Vector Set JSON Object
+
+6.2.1.  AES-GMAC Test Groups JSON Schema
+
+   The testGroups element at the top level in the test vector JSON
+   object is an array of test groups.  Test vectors are grouped into
+   similar test cases to reduce the amount of data transmitted in the
+   vector set.  For instance, all test vectors that use the same key
+   size would be grouped together.  The Test Group JSON object contains
+   meta data that applies to all test vectors within the group.  The
+   following table describes the secure HMAC and CMAC JSON elements of
+   the Test Group JSON object.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 42]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +-----------+------------------------------------+-------+----------+
+   | JSON      | Description                        | JSON  | Optional |
+   | Value     |                                    | type  |          |
+   +-----------+------------------------------------+-------+----------+
+   | tgId      | Numeric identifier for the test    | value | No       |
+   |           | group, unique across the entire    |       |          |
+   |           | vector set.                        |       |          |
+   |           |                                    |       |          |
+   | testType  | Test category type (AFT)           | value | No       |
+   |           |                                    |       |          |
+   | direction | The direction of the tests -       | value | No       |
+   |           | encrypt or decrypt                 |       |          |
+   |           |                                    |       |          |
+   | keyLen    | Length of key in bits to use       | value | No       |
+   |           |                                    |       |          |
+   | ivLen     | Length of IV in bits               | value | No       |
+   |           |                                    |       |          |
+   | ivGen     | IV Generation (internal or         | value | No       |
+   |           | external)                          |       |          |
+   |           |                                    |       |          |
+   | ivGenMode | The mode an internal IV has been   | value | Yes      |
+   |           | generated using.                   |       |          |
+   |           |                                    |       |          |
+   | aadLen    | Length of AAD in bits              | value | No       |
+   |           |                                    |       |          |
+   | tagLen    | Length of tag/MAC in bits to       | value | No       |
+   |           | generate/verify                    |       |          |
+   |           |                                    |       |          |
+   | tests     | Array of individual test vector    | array | No       |
+   |           | JSON objects, which are defined in |       |          |
+   |           | Section 6.2.2                      |       |          |
+   +-----------+------------------------------------+-------+----------+
+
+                 Table 20: AES-GMAC Test Group JSON Object
+
+6.2.2.  AES-GMAC Test Case JSON Schema
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each secure MAC test vector.
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 43]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +--------+---------------------------------------+-------+----------+
+   | JSON   | Description                           | JSON  | Optional |
+   | Value  |                                       | type  |          |
+   +--------+---------------------------------------+-------+----------+
+   | tcId   | Numeric identifier for the test case, | value | No       |
+   |        | unique across the entire vector set.  |       |          |
+   |        |                                       |       |          |
+   | key    | Encryption key to use AES             | value | No       |
+   |        |                                       |       |          |
+   | iv     | Value of the IV.                      | value | No       |
+   |        |                                       |       |          |
+   | aad    | Value of the AAD.                     | value | No       |
+   |        |                                       |       |          |
+   | tag    | MAC/tag value, for validating on a    | value | Yes      |
+   |        | decrypt operation.                    |       |          |
+   +--------+---------------------------------------+-------+----------+
+
+                 Table 21: AES-GMAC Test Case JSON Object
+
+6.2.3.  Example AES-GMAC Test Vector JSON Object
+
+   The following is an example JSON test vector object for AES-GMAC.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 44]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   {
+     "vsId": 0,
+     "algorithm": "ACVP-AES-GMAC",
+     "revision": "1.0",
+     "isSample": false,
+     "testGroups": [{
+         "tgId": 1,
+         "testType": "AFT",
+         "direction": "encrypt",
+         "keyLen": 128,
+         "ivLen": 96,
+         "ivGen": "external",
+         "aadLen": 0,
+         "tagLen": 32,
+         "tests": [{
+           "tcId": 1,
+           "key": "B1E9747F9E016F0376B1F379CD345B8A",
+           "aad": "",
+           "iv": "6294CEEDFCC3037A023100E8"
+         }]
+       },
+       {
+         "tgId": 2,
+         "testType": "AFT",
+         "direction": "decrypt",
+         "keyLen": 128,
+         "ivLen": 96,
+         "ivGen": "external",
+         "aadLen": 0,
+         "tagLen": 32,
+         "tests": [{
+           "tcId": 2,
+           "key": "CD345B8AE016F03765E9747F9B1F379A",
+           "aad": "",
+           "iv": "6207CEEDFA094CC3032310E8",
+           "tag": "AB1254CE"
+         }]
+       }
+     ]
+   }
+
+
+6.3.  AES-GMAC Test Vector Responses
+
+   After the ACVP client downloads and processes a vector set, it must
+   send the response vectors back to the ACVP server.  The following
+   table describes the JSON object that represents a vector set
+   response.
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 45]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+---------------------------------------------+--------+
+   | JSON Value | Description                                 | JSON   |
+   |            |                                             | type   |
+   +------------+---------------------------------------------+--------+
+   | acvVersion | Protocol version identifier                 | value  |
+   |            |                                             |        |
+   | vsId       | Unique numeric identifier for the vector    | value  |
+   |            | set                                         |        |
+   |            |                                             |        |
+   | testGroups | Array of JSON objects that represent each   | array  |
+   |            | test vector group. See Table 23             |        |
+   |            |                                             |        |
+   +------------+---------------------------------------------+--------+
+
+            Table 22: AES-GMAC Vector Set Response JSON Object
+
+   The testGroups section is used to organize the ACVP client response
+   in a similar manner to how it receives vectors.  Several algorithms
+   SHALL require the client to send back group level properties in their
+   response.  This structure helps accommodate that.
+
+   +-----------+--------------------------------------------+----------+
+   | JSON      | Description                                | JSON     |
+   | Value     |                                            | type     |
+   +-----------+--------------------------------------------+----------+
+   | tgId      | The test group Id                          | value    |
+   |           |                                            |          |
+   | tests     | The tests associated to the group          | value    |
+   |           | specified in tgId                          |          |
+   |           |                                            |          |
+   +-----------+--------------------------------------------+----------+
+
+         Table 23: AES-GMAC Vector Set Group Response JSON Object
+
+   Each test group contains an array of one or more test cases.  Each
+   test case is a JSON object that represents a single test vector to be
+   processed by the ACVP client.  The following table describes the JSON
+   elements for each DRBG test vector.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 46]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+   +------------+---------------------------------+---------+----------+
+   | JSON Value | Description                     | JSON    | Optional |
+   |            |                                 | type    |          |
+   +------------+---------------------------------+---------+----------+
+   | tcId       | Numeric identifier for the test | value   | No       |
+   |            | case, unique across the entire  |         |          |
+   |            | vector set.                     |         |          |
+   |            |                                 |         |          |
+   | tag        | value of the computed tag/MAC   | value   | Yes      |
+   |            | output                          |         |          |
+   |            |                                 |         |          |
+   | testPassed | The result of decrypt verify    | boolean | Yes      |
+   |            |                                 |         |          |
+   +------------+---------------------------------+---------+----------+
+
+             Table 24: AES-GMAC Test Case Results JSON Object
+
+6.3.1.  Example AES-GMAC Test Vector Response JSON Object
+
+   The following is an example JSON test vector response object for AES-
+   GMAC.
+
+
+   {
+     "vsId": 1,
+     "algorithm": "ACVP-AES-GMAC",
+     "revision": "1.0",
+     "testGroups": [{
+         "tgId": 1,
+         "tests": [{
+           "tcId": 1,
+           "tag": "6FA27FDC"
+         }]
+       },
+       {
+         "tgId": 2,
+         "tests": [{
+           "tcId": 2,
+           "testPassed": true
+         }]
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 47]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
+7.  HMAC
+
+7.1.  HMAC Algorithm Capabilities Registration
+
+   Each algorithm capability advertised is a self-contained JSON object
+   using the following values.
 
    +------------+-----------------+--------------+----------+----------+
    | JSON Value | Description     | JSON type    | Valid    | Optional |
    |            |                 |              | Values   |          |
    +------------+-----------------+--------------+----------+----------+
    | algorithm  | The MAC         | value        | See Sect | No       |
-   |            | algorithm and   |              | ion 6.2  |          |
+   |            | algorithm and   |              | ion 7.2  |          |
    |            | mode to be      |              |          |          |
    |            | validated.      |              |          |          |
    |            |                 |              |          |          |
@@ -2161,16 +2672,23 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | (range          |              |          |          |
    |            | dependent on    |              |          |          |
    |            | algorithm, see  |              |          |          |
-   |            | Section 6.2).   |              |          |          |
+   |            | Section 7.2).   |              |          |          |
    |            |                 |              |          |          |
    +------------+-----------------+--------------+----------+----------+
 
-             Table 18: HMAC Algorithm Capabilities JSON Values
+             Table 25: HMAC Algorithm Capabilities JSON Values
 
    keyLen for HMAC contains a Domain of values, the server may choose
    values defined by these rules:
 
-   o  2 values below the Hash's block length.  See Section 6.2
+   o  2 values below the Hash's block length.  See Section 7.2
+
+
+
+Fussell & Hammett       Expires February 2, 2019               [Page 48]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
 
    o  The Hash's block length.
 
@@ -2179,20 +2697,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    macLen for HMAC contains a Domain of values, the server may choose
    values defined by these rules:
 
-
-
-Fussell & Hammett       Expires February 2, 2019               [Page 39]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
-
    o  The smallest HMAC length supported
 
    o  A second HMAC length supported
 
    o  The largest HMAC length supported
 
-6.2.  Supported HMAC Algorithms
+7.2.  Supported HMAC Algorithms
 
    The following algorithms may be advertised by the ACVP compliant
    crypto module:
@@ -2224,22 +2735,20 @@ Internet-Draft                Sym Alg JSON                   August 2018
            |                   |              |                |
            +-------------------+--------------+----------------+
 
-          Table 19: Algorithms w/ block size and max CMAC length.
-
-6.2.1.  Example HMAC Capabilities JSON Object
-
-   The following is an example JSON object advertising support for HMAC.
+          Table 26: Algorithms w/ block size and max CMAC length.
 
 
 
 
 
-
-
-
-Fussell & Hammett       Expires February 2, 2019               [Page 40]
+Fussell & Hammett       Expires February 2, 2019               [Page 49]
 
 Internet-Draft                Sym Alg JSON                   August 2018
+
+
+7.2.1.  Example HMAC Capabilities JSON Object
+
+   The following is an example JSON object advertising support for HMAC.
 
 
    {
@@ -2262,7 +2771,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-6.3.  HMAC Test Vectors
+7.3.  HMAC Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
    then processed and returned to the ACVP server for validation.  A
@@ -2288,12 +2797,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-
-
-
-Fussell & Hammett       Expires February 2, 2019               [Page 41]
+Fussell & Hammett       Expires February 2, 2019               [Page 50]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2307,18 +2811,18 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | vsId       | Unique numeric identifier for the vector set | value |
    |            |                                              |       |
    | algorithm  | The algorithm and mode used for the test     | value |
-   |            | vectors. See Section 6.2 for possible        |       |
+   |            | vectors. See Section 7.2 for possible        |       |
    |            | values.                                      |       |
    |            |                                              |       |
    | revision   | The algorithm testing revision to use.       | value |
    |            |                                              |       |
    | testGroups | Array of test group JSON objects, which are  | array |
-   |            | defined in Section 6.3.1                     |       |
+   |            | defined in Section 7.3.1                     |       |
    +------------+----------------------------------------------+-------+
 
-                   Table 20: HMAC Vector Set JSON Object
+                   Table 27: HMAC Vector Set JSON Object
 
-6.3.1.  HMAC Test Groups JSON Schema
+7.3.1.  HMAC Test Groups JSON Schema
 
    The testGroups element at the top level in the test vector JSON
    object is an array of test groups.  Test vectors are grouped into
@@ -2349,7 +2853,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 42]
+Fussell & Hammett       Expires February 2, 2019               [Page 51]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2373,12 +2877,12 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |          |                                     |       |          |
    | tests    | Array of individual test vector     | array | No       |
    |          | JSON objects, which are defined in  |       |          |
-   |          | Section 6.3.2                       |       |          |
+   |          | Section 7.3.2                       |       |          |
    +----------+-------------------------------------+-------+----------+
 
-                   Table 21: HMAC Test Group JSON Object
+                   Table 28: HMAC Test Group JSON Object
 
-6.3.2.  HMAC Test Case JSON Schema
+7.3.2.  HMAC Test Case JSON Schema
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -2398,19 +2902,19 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |        |                                       |       |          |
    +--------+---------------------------------------+-------+----------+
 
-                   Table 22: HMAC Test Case JSON Object
+                   Table 29: HMAC Test Case JSON Object
 
 
 
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 43]
+Fussell & Hammett       Expires February 2, 2019               [Page 52]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-6.3.3.  Example HMAC Test Vector JSON Object
+7.3.3.  Example HMAC Test Vector JSON Object
 
    The following is an example JSON test vector object for HMAC.
 
@@ -2461,7 +2965,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 44]
+Fussell & Hammett       Expires February 2, 2019               [Page 53]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2488,7 +2992,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 }
 
 
-6.4.  HMAC Test Vector Responses
+7.4.  HMAC Test Vector Responses
 
    After the ACVP client downloads and processes a vector set, it must
    send the response vectors back to the ACVP server.  The following
@@ -2505,11 +3009,11 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |            | set                                         |        |
    |            |                                             |        |
    | testGroups | Array of JSON objects that represent each   | array  |
-   |            | test vector group. See Table 24             |        |
+   |            | test vector group. See Table 31             |        |
    |            |                                             |        |
    +------------+---------------------------------------------+--------+
 
-              Table 23: HMAC Vector Set Response JSON Object
+              Table 30: HMAC Vector Set Response JSON Object
 
    The testGroups section is used to organize the ACVP client response
    in a similar manner to how it receives vectors.  Several algorithms
@@ -2517,7 +3021,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 45]
+Fussell & Hammett       Expires February 2, 2019               [Page 54]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2536,7 +3040,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |           |                                            |          |
    +-----------+--------------------------------------------+----------+
 
-           Table 24: HMAC Vector Set Group Response JSON Object
+           Table 31: HMAC Vector Set Group Response JSON Object
 
    Each test group contains an array of one or more test cases.  Each
    test case is a JSON object that represents a single test vector to be
@@ -2554,9 +3058,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |        |                                       |       |          |
    +--------+---------------------------------------+-------+----------+
 
-               Table 25: HMAC Test Case Results JSON Object
+               Table 32: HMAC Test Case Results JSON Object
 
-6.4.1.  Example HMAC Test Vector Response JSON Object
+7.4.1.  Example HMAC Test Vector Response JSON Object
 
    The following is an example JSON test vector response object for
    HMAC.
@@ -2573,7 +3077,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 46]
+Fussell & Hammett       Expires February 2, 2019               [Page 55]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
@@ -2621,7 +3125,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
    }
 
 
-7.  Acknowledgements
+8.  Acknowledgements
 
    TBD...
 
@@ -2629,22 +3133,22 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 47]
+Fussell & Hammett       Expires February 2, 2019               [Page 56]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-8.  IANA Considerations
+9.  IANA Considerations
 
    This memo includes no request to IANA.
 
-9.  Security Considerations
+10.  Security Considerations
 
    Security considerations are addressed by the ACVP specification.
 
-10.  References
+11.  References
 
-10.1.  Normative References
+11.1.  Normative References
 
    [ACVP]     authSurName, authInitials., "ACVP Specification", 2016.
 
@@ -2653,7 +3157,7 @@ Internet-Draft                Sym Alg JSON                   August 2018
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
 
-10.2.  Informative References
+11.2.  Informative References
 
    [CMACVS]   Sharon S. Keller, SSK., "The CMAC Validation System
               (CMACVS)", 2011.
@@ -2685,10 +3189,16 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-Fussell & Hammett       Expires February 2, 2019               [Page 48]
+Fussell & Hammett       Expires February 2, 2019               [Page 57]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   [SP-800-38D]
+              NIST, "Recommendation for Block Cipher Modes of Operation:
+              Galois/Counter Mode (GCM) and GMAC", 2007,
+              <https://nvlpubs.nist.gov/nistpubs/Legacy/SP/
+              nistspecialpublication800-38d.pdf>.
 
 Authors' Addresses
 
@@ -2735,10 +3245,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-Fussell & Hammett       Expires February 2, 2019               [Page 49]
+Fussell & Hammett       Expires February 2, 2019               [Page 58]

--- a/artifacts/draft-celi-acvp-block-ciph-00.html
+++ b/artifacts/draft-celi-acvp-block-ciph-00.html
@@ -1572,7 +1572,7 @@ For i = 0 to 399
 <td class="left">"1.0"</td>
 <td class="left">["encrypt", "decrypt"]</td>
 <td class="left">[128, 192, 256]</td>
-<td class="left">{"Min": 0, "Max": 65536, "Inc": any}</td>
+<td class="left">{"Min": 8, "Max": 65536, "Inc": 8}</td>
 <td class="left">{"Min": 8, "Max": 1024, "Inc": any}</td>
 <td class="left">["internal", "external"]</td>
 <td class="left">["8.2.1", "8.2.2"]</td>
@@ -1585,7 +1585,7 @@ For i = 0 to 399
 <td class="left">"1.0"</td>
 <td class="left">["encrypt", "decrypt"]</td>
 <td class="left">[128, 256]</td>
-<td class="left">{"Min": 0, "Max": 65536, "Inc": 8}</td>
+<td class="left">{"Min": 8, "Max": 65536, "Inc": 8}</td>
 <td class="left"></td>
 <td class="left"></td>
 <td class="left"></td>
@@ -1598,7 +1598,7 @@ For i = 0 to 399
 <td class="left">"1.0"</td>
 <td class="left">["encrypt", "decrypt"]</td>
 <td class="left">[128, 192, 256]</td>
-<td class="left">{"Min": 0, "Max": 65536, "Inc": any}</td>
+<td class="left">{"Min": 8, "Max": 65536, "Inc": 8}</td>
 <td class="left"></td>
 <td class="left">["internal", "external"]</td>
 <td class="left">["8.2.1", "8.2.2"]</td>
@@ -2545,7 +2545,7 @@ POST [
             96
         ],
         "payloadLen": [
-            0,
+            8,
             256
         ],
         "aadLen": [
@@ -2704,7 +2704,7 @@ POST [
             128
         ],
         "payloadLen": [
-            0,
+            8,
             128
         ],
         "aadLen": [
@@ -3116,20 +3116,20 @@ POST [
             "ivLen": 96,
             "ivGen": "external",
             "ivGenMode": "8.2.2",
-            "payloadLen": 0,
+            "payloadLen": 8,
             "aadLen": 0,
             "tagLen": 32,
             "tests": [
                 {
                     "tcId": 1,
-                    "plainText": "",
+                    "plainText": "AB",
                     "key": "10B8D4C9658590A...",
                     "aad": "",
                     "iv": "3D026F3D590BF1A7..."
                 },
                 {
                     "tcId": 2,
-                    "plainText": "",
+                    "plainText": "CD",
                     "key": "934865822A3ECCB...",
                     "aad": "",
                     "iv": "273F3B30341C779E..."
@@ -3144,7 +3144,7 @@ POST [
             "ivLen": 96,
             "ivGen": "external",
             "ivGenMode": "8.2.2",
-            "payloadLen": 0,
+            "payloadLen": 8,
             "aadLen": 120,
             "tagLen": 32,
             "tests": [
@@ -3153,7 +3153,7 @@ POST [
                     "key": "88AB5441AE2...",
                     "aad": "4E956EF528D...",
                     "iv": "810628011BB0...",
-                    "cipherText": "",
+                    "cipherText": "AB",
                     "tag": "1180FD89"
                 },
                 {
@@ -3161,7 +3161,7 @@ POST [
                     "key": "9149BE47FAEB...",
                     "aad": "938A8FA71324...",
                     "iv": "FF6B72FF25B55...",
-                    "cipherText": "",
+                    "cipherText": "CD",
                     "tag": "6C7528F0"
                 }
 			]
@@ -3181,13 +3181,13 @@ POST [
 			"tests": [{
 					"tcId": 1,
 					"iv": "01020304F966B8...",
-					"ct": "",
+					"ct": "CD",
 					"tag": "427F668E58F56..."
 				},
 				{
 					"tcId": 2,
 					"iv": "01020304C2855...",
-					"ct": "",
+					"ct": "AB",
 					"tag": "D95BD66F7789..."
 				}
 			]
@@ -3196,7 +3196,7 @@ POST [
 			"tgId": 2,
 			"tests": [{
 					"tcId": 902,
-					"pt": "763BF..."
+					"pt": "76"
 				},
 				{
 					"tcId": 903,

--- a/artifacts/draft-celi-acvp-block-ciph-00.txt
+++ b/artifacts/draft-celi-acvp-block-ciph-00.txt
@@ -1444,7 +1444,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
    +-----+----+-----+----+------+-----+------+------+------+-----+-----+
    | AES | "1 | ["e | [1 | {"Mi | {"M | ["in | ["8. |      | {"M | {[3 |
    | -   | .0 | ncr | 28 | n":  | in" | tern | 2.1" |      | in" | 2,  |
-   | GCM | "  | ypt | ,  | 0, " | :   | al", | , "8 |      | :   | 64, |
+   | GCM | "  | ypt | ,  | 8, " | :   | al", | , "8 |      | :   | 64, |
    |     |    | ",  | 19 | Max" | 8,  | "ext | .2.2 |      | 0,  | 96, |
    |     |    | "de | 2, | : 65 | "Ma | erna | "]   |      | "Ma | 104 |
    |     |    | cry | 25 | 536, | x": | l"]  |      |      | x": | , 1 |
@@ -1458,13 +1458,13 @@ Celi                     Expires August 5, 2019                [Page 26]
 Internet-Draft                Sym Alg JSON                 February 2019
 
 
-   |     |    |     |    | any} | "In |      |      |      | "In | , 1 |
+   |     |    |     |    | 8}   | "In |      |      |      | "In | , 1 |
    |     |    |     |    |      | c": |      |      |      | c": | 28] |
    |     |    |     |    |      | any |      |      |      | any | }   |
    |     |    |     |    |      | }   |      |      |      | }   |     |
    | AES | "1 | ["e | [1 | {"Mi |     |      |      |      | {"M |     |
    | -GC | .0 | ncr | 28 | n":  |     |      |      |      | in" |     |
-   | M-  | "  | ypt | ,  | 0, " |     |      |      |      | :   |     |
+   | M-  | "  | ypt | ,  | 8, " |     |      |      |      | :   |     |
    | SIV |    | ",  | 25 | Max" |     |      |      |      | 0,  |     |
    |     |    | "de | 6] | : 65 |     |      |      |      | "Ma |     |
    |     |    | cry |    | 536, |     |      |      |      | x": |     |
@@ -1475,13 +1475,13 @@ Internet-Draft                Sym Alg JSON                 February 2019
    |     |    |     |    |      |     |      |      |      | 8}  |     |
    | AES | "1 | ["e | [1 | {"Mi |     | ["in | ["8. | ["in | {"M | {[3 |
    | -   | .0 | ncr | 28 | n":  |     | tern | 2.1" | tern | in" | 2,  |
-   | XPN | "  | ypt | ,  | 0, " |     | al", | , "8 | al", | :   | 64, |
+   | XPN | "  | ypt | ,  | 8, " |     | al", | , "8 | al", | :   | 64, |
    |     |    | ",  | 19 | Max" |     | "ext | .2.2 | "ext | 1,  | 96, |
    |     |    | "de | 2, | : 65 |     | erna | "]   | erna | "Ma | 104 |
    |     |    | cry | 25 | 536, |     | l"]  |      | l"]  | x": | , 1 |
    |     |    | pt" | 6] | "Inc |     |      |      |      | 655 | 12, |
    |     |    | ]   |    | ":   |     |      |      |      | 36, | 120 |
-   |     |    |     |    | any} |     |      |      |      | "In | , 1 |
+   |     |    |     |    | 8}   |     |      |      |      | "In | , 1 |
    |     |    |     |    |      |     |      |      |      | c": | 28] |
    |     |    |     |    |      |     |      |      |      | any | }   |
    |     |    |     |    |      |     |      |      |      | }   |     |
@@ -2425,7 +2425,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
             96
         ],
         "payloadLen": [
-            0,
+            8,
             256
         ],
         "aadLen": [
@@ -2608,7 +2608,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
             128
         ],
         "payloadLen": [
-            0,
+            8,
             128
         ],
         "aadLen": [
@@ -3095,20 +3095,20 @@ Internet-Draft                Sym Alg JSON                 February 2019
                "ivLen": 96,
                "ivGen": "external",
                "ivGenMode": "8.2.2",
-               "payloadLen": 0,
+               "payloadLen": 8,
                "aadLen": 0,
                "tagLen": 32,
                "tests": [
                    {
                        "tcId": 1,
-                       "plainText": "",
+                       "plainText": "AB",
                        "key": "10B8D4C9658590A...",
                        "aad": "",
                        "iv": "3D026F3D590BF1A7..."
                    },
                    {
                        "tcId": 2,
-                       "plainText": "",
+                       "plainText": "CD",
                        "key": "934865822A3ECCB...",
                        "aad": "",
                        "iv": "273F3B30341C779E..."
@@ -3123,7 +3123,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
                "ivLen": 96,
                "ivGen": "external",
                "ivGenMode": "8.2.2",
-               "payloadLen": 0,
+               "payloadLen": 8,
                "aadLen": 120,
                "tagLen": 32,
                "tests": [
@@ -3140,7 +3140,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
 
                        "aad": "4E956EF528D...",
                        "iv": "810628011BB0...",
-                       "cipherText": "",
+                       "cipherText": "AB",
                        "tag": "1180FD89"
                    },
                    {
@@ -3148,7 +3148,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
                        "key": "9149BE47FAEB...",
                        "aad": "938A8FA71324...",
                        "iv": "FF6B72FF25B55...",
-                       "cipherText": "",
+                       "cipherText": "CD",
                        "tag": "6C7528F0"
                    }
                            ]
@@ -3203,13 +3203,13 @@ Internet-Draft                Sym Alg JSON                 February 2019
                            "tests": [{
                                            "tcId": 1,
                                            "iv": "01020304F966B8...",
-                                           "ct": "",
+                                           "ct": "CD",
                                            "tag": "427F668E58F56..."
                                    },
                                    {
                                            "tcId": 2,
                                            "iv": "01020304C2855...",
-                                           "ct": "",
+                                           "ct": "AB",
                                            "tag": "D95BD66F7789..."
                                    }
                            ]
@@ -3218,7 +3218,7 @@ Internet-Draft                Sym Alg JSON                 February 2019
                            "tgId": 2,
                            "tests": [{
                                            "tcId": 902,
-                                           "pt": "763BF..."
+                                           "pt": "76"
                                    },
                                    {
                                            "tcId": 903,

--- a/src/acvp_sub_mac.xml
+++ b/src/acvp_sub_mac.xml
@@ -160,7 +160,7 @@
                     </t>
                 </section>
 
-                <section anchor="requirements_not_covered_cmac" title="CMACRequirements Not Covered">
+                <section anchor="requirements_not_covered_cmac" title="CMAC Requirements Not Covered">
                     <t>
                     <list>
                         <t>SP 800-38b - 5.4 Sub-keys. While sub-keys are computed, as they are
@@ -173,6 +173,36 @@
                             The ACVP server will test a random sampling of valid MAC lengths as per
                             the IUT registration - this generally includes the minimum and maximum
                             mac length. </t>
+                    </list>
+                    </t>
+                </section>
+
+                <section anchor="requirements_covered_gmac" title="GMAC Requirements Covered">
+                    <t>
+                    <list>
+                        <t> SP 800-38d - 5.1 Block Cipher.  ACVP testing SHALL make use of the AES block cipher when testing GMAC. </t>
+                        <t> SP 800-38d - 5.2 Two Gcm Functions. ACVP testing MAY test both the generate and verify functions of GCM 
+                            (without making use of a payload) to help ensure a proper implementation. The ACVP and IUT MAY test the encrypt (generate) 
+                            and decrypt (verify) utilizing a key, iv/nonce, and aad as described in this document section.</t>
+                        <t> SP 800-38d - 6 Mathematical Components of GCM. GHASH and GCTR produce intermediate values and SHALL 
+                            be (indirectly) evaluated for correctness via the ACVP generated GMAC test vectors. </t>
+                        <t> SP 800-38d - 7 GCM Specification. When the IUT registers a direction capability of "encrypt", 
+                            the ACVP server MUST generate vectors for the GCM-AE function.  When the IUT registers a capability of "decrypt",
+                            the ACVP server MUST generate test vectors for the GCM-AD function.</t>
+
+                    </list>
+                    </t>
+                </section>
+
+                <section anchor="requirements_not_covered_gmac" title="GMAC Requirements Not Covered">
+                    <t>
+                    <list>
+                        <t> SP 800-38d - 5.2.1.1 Input Data. GMAC MUST NOT make use of a plaintext.</t>
+                        <t> SP 800-38d - 5.2.1.2 Output Data. GMAC MUST NOT make use of a ciphertext.</t>
+                        <t> SP 800-38d - 7 GCM Specification. The ACVP server MUST NOT make use of a plaintext or ciphertext 
+                        for the generation of test vectors for use in GMAC testing.</t>
+                        <t> SP 800-38d - 8 Uniqueness Requirement on IVs and Keys. Key establishment, IV construction, 
+                        or number of invocations for a specific key/iv SHALL NOT be tested under the scope of the ACVP testing.</t>
                     </list>
                     </t>
                 </section>
@@ -1955,6 +1985,508 @@
                 </section>
             </section>
         </section>
+        <section anchor="gmac" title="GMAC">
+        <section anchor="gmac_caps_reg" title="AES-GMAC Algorithm Capabilities Registration">
+                <t>Each algorithm capability advertised is a self-contained JSON object using the
+                    following values.</t>
+                <texttable anchor="gmac_caps_table"
+                    title="AES-GMAC Algorithm Capabilities JSON Values">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Valid Values</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>algorithm</c>
+                    <c>The MAC algorithm to be validated.</c>
+                    <c>value</c>
+                    <c>ACVP-AES-GMAC</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c>"1.0"</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>prereqVals</c>
+                    <c>prerequistie algorithm validations, See <xref target="prereq_algs"/> for
+                        examples </c>
+                    <c>array of prereqAlgVal objects</c>
+                    <c>See <xref target="prereq_algs"/>
+                    </c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>direction</c>
+                    <c>The GMAC direction(s) to test.</c>
+                    <c>array</c>
+                    <c>encrypt, decrypt</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>keyLen</c>
+                    <c>The keyLen supported</c>
+                    <c>value</c>
+                    <c>128, 192, 256</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>ivLen</c>
+                    <c>The IV lengths supported in bits. Min/max/increment and values must
+                        be mod 8.</c>
+                    <c>Domain</c>
+                    <c>8-1024</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>ivGen</c>
+                    <c>The IV generation method (from the perspective of the IUT).</c>
+                    <c>string</c>
+                    <c>internal, external</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>ivGenMode</c>
+                    <c>The IV generation mode for use when the IUT is internally generating IVs.</c>
+                    <c>string</c>
+                    <c>8.2.1, 8.2.2</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>tagLen</c>
+                    <c>The supported mac/tag lengths.</c>
+                    <c>Domain</c>
+                    <c>32, 64, 96, 104, 112, 120, 128</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <section anchor="gmac_app-reg-ex"
+                    title="Example AES-GMAC Capabilities JSON Object">
+                    <t>The following is an example JSON object advertising support for
+                        AES-GMAC.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+  "algorithm": "ACVP-AES-GMAC",
+  "revision": "1.0",
+  "direction": [
+    "encrypt",
+    "decrypt"
+  ],
+  "keyLen": [
+    128
+  ],
+  "ivLen": [
+    96,
+    120
+  ],
+  "ivGen": "external",
+  "aadLen": [
+    8,
+    120
+  ],
+  "tagLen": [
+    32,
+    128
+  ]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+        </section>   
+<section anchor="gmac_test_vectors" title="AES-GMAC Test Vectors">
+                <t>The ACVP server provides test vectors to the ACVP client, which are then
+                    processed and returned to the ACVP server for validation. A typical ACVP
+                    validation session would require multiple test vector sets to be downloaded and
+                    processed by the ACVP client. Each test vector set represents an individual
+                    crypto algorithm, such as ACVP-AES-GMAC. This section
+                    describes the JSON schema for a test vector set used with the ACVP-AES-GMAC crypto
+                    algorithm.</t>
+                <t>The test vector set JSON schema is a multi-level hierarchy that contains meta
+                    data for the entire vector set as well as individual test vectors to be
+                    processed by the ACVP client. The following table describes the JSON elements at
+                    the top level of the hierarchy. </t>
+                <texttable anchor="gmac_vs_top_table" title="AES-GMAC Vector Set JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>algorithm</c>
+                    <c>The algorithm used for the test vectors.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>revision</c>
+                    <c>The algorithm testing revision to use.</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of test group JSON objects, which are defined in <xref
+                            target="gmac_tgjs"/>
+                    </c>
+                    <c>array</c>
+                </texttable>
+                <section title="AES-GMAC Test Groups JSON Schema" anchor="gmac_tgjs">
+                    <t>The testGroups element at the top level in the test vector JSON object is an
+                        array of test groups. Test vectors are grouped into similar test cases to
+                        reduce the amount of data transmitted in the vector set. For instance, all
+                        test vectors that use the same key size would be grouped together. The Test
+                        Group JSON object contains meta data that applies to all test vectors within
+                        the group. The following table describes the secure HMAC and CMAC JSON
+                        elements of the Test Group JSON object.</t>
+                    <texttable anchor="gmac_vs_tg_table" title="AES-GMAC Test Group JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tgId</c>
+                        <c>Numeric identifier for the test group, unique across the entire vector
+                            set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>testType</c>
+                        <c>Test category type (AFT)</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>direction</c>
+                        <c>The direction of the tests - encrypt or decrypt</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>keyLen</c>
+                        <c>Length of key in bits to use</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>ivLen</c>
+                        <c>Length of IV in bits</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>ivGen</c>
+                        <c>IV Generation (internal or external)</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>ivGenMode</c>
+                        <c>The mode an internal IV has been generated using.</c>
+                        <c>value</c>
+                        <c>Yes</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>aadLen</c>
+                        <c>Length of AAD in bits</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tagLen</c>
+                        <c>Length of tag/MAC in bits to generate/verify</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tests</c>
+                        <c>Array of individual test vector JSON objects, which are defined in <xref
+                                target="gmac_tvjs"/>
+                        </c>
+                        <c>array</c>
+                        <c>No</c>
+                    </texttable>
+                </section>
+                <section title="AES-GMAC Test Case JSON Schema" anchor="gmac_tvjs">
+                    <t>Each test group contains an array of one or more test cases. Each test case
+                        is a JSON object that represents a single test vector to be processed by the
+                        ACVP client. The following table describes the JSON elements for each secure
+                        MAC test vector.</t>
+                    <texttable anchor="gmac_vs_tc_table2" title="AES-GMAC Test Case JSON Object">
+                        <ttcol align="left">JSON Value</ttcol>
+                        <ttcol align="left">Description</ttcol>
+                        <ttcol align="left">JSON type</ttcol>
+                        <ttcol align="left">Optional</ttcol>
+                        <c>tcId</c>
+                        <c>Numeric identifier for the test case, unique across the entire vector
+                            set.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>key</c>
+                        <c>Encryption key to use AES</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>iv</c>
+                        <c>Value of the IV.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>aad</c>
+                        <c>Value of the AAD.</c>
+                        <c>value</c>
+                        <c>No</c>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c/>
+                        <c>tag</c>
+                        <c>MAC/tag value, for validating on a decrypt operation.</c>
+                        <c>value</c>
+                        <c>Yes</c>
+                    </texttable>
+                </section>
+                <section anchor="gmac_test_vector_json"
+                    title="Example AES-GMAC Test Vector JSON Object">
+                    <t>The following is an example JSON test vector object for AES-GMAC.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+  "vsId": 0,
+  "algorithm": "ACVP-AES-GMAC",
+  "revision": "1.0",
+  "isSample": false,
+  "testGroups": [{
+      "tgId": 1,
+      "testType": "AFT",
+      "direction": "encrypt",
+      "keyLen": 128,
+      "ivLen": 96,
+      "ivGen": "external",
+      "aadLen": 0,
+      "tagLen": 32,
+      "tests": [{
+        "tcId": 1,
+        "key": "B1E9747F9E016F0376B1F379CD345B8A",
+        "aad": "",
+        "iv": "6294CEEDFCC3037A023100E8"
+      }]
+    },
+    {
+      "tgId": 2,
+      "testType": "AFT",
+      "direction": "decrypt",
+      "keyLen": 128,
+      "ivLen": 96,
+      "ivGen": "external",
+      "aadLen": 0,
+      "tagLen": 32,
+      "tests": [{
+        "tcId": 2,
+        "key": "CD345B8AE016F03765E9747F9B1F379A",
+        "aad": "",
+        "iv": "6207CEEDFA094CC3032310E8",
+        "tag": "AB1254CE"
+      }]
+    }
+  ]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+            </section>
+            <section anchor="gmac_vector_responses" title="AES-GMAC Test Vector Responses">
+                <t>After the ACVP client downloads and processes a vector set, it must send the
+                    response vectors back to the ACVP server. The following table describes the JSON
+                    object that represents a vector set response.</t>
+                <texttable anchor="gmac_vr_top_table"
+                    title="AES-GMAC Vector Set Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>acvVersion</c>
+                    <c>Protocol version identifier</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>vsId</c>
+                    <c>Unique numeric identifier for the vector set</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testGroups</c>
+                    <c>Array of JSON objects that represent each test vector group. See <xref
+                            target="gmac_vr_group_table"/>
+                    </c>
+                    <c>array</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>The testGroups section is used to organize the ACVP client response in a similar
+                    manner to how it receives vectors. Several algorithms SHALL require the client
+                    to send back group level properties in their response. This structure helps
+                    accommodate that.</t>
+                <texttable anchor="gmac_vr_group_table"
+                    title="AES-GMAC Vector Set Group Response JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <c>tgId</c>
+                    <c>The test group Id</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>tests</c>
+                    <c>The tests associated to the group specified in tgId</c>
+                    <c>value</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <t>Each test group contains an array of one or more test cases. Each test case is a
+                    JSON object that represents a single test vector to be processed by the ACVP
+                    client. The following table describes the JSON elements for each DRBG test
+                    vector.</t>
+                <texttable anchor="gmac_vs_tr_table"
+                    title="AES-GMAC Test Case Results JSON Object">
+                    <ttcol align="left">JSON Value</ttcol>
+                    <ttcol align="left">Description</ttcol>
+                    <ttcol align="left">JSON type</ttcol>
+                    <ttcol align="left">Optional</ttcol>
+                    <c>tcId</c>
+                    <c>Numeric identifier for the test case, unique across the entire vector
+                        set.</c>
+                    <c>value</c>
+                    <c>No</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>tag</c>
+                    <c>value of the computed tag/MAC output</c>
+                    <c>value</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c>testPassed</c>
+                    <c>The result of decrypt verify</c>
+                    <c>boolean</c>
+                    <c>Yes</c>
+                    <c/>
+                    <c/>
+                    <c/>
+                    <c/>
+                </texttable>
+                <section anchor="gmac_test_vector_response_json"
+                    title="Example AES-GMAC Test Vector Response JSON Object">
+                    <t>The following is an example JSON test vector response object for
+                        AES-GMAC.</t>
+                    <figure>
+                        <artwork>
+                            <![CDATA[
+{
+  "vsId": 1,
+  "algorithm": "ACVP-AES-GMAC",
+  "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+        "tcId": 1,
+        "tag": "6FA27FDC"
+      }]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+        "tcId": 2,
+        "testPassed": true
+      }]
+    }
+  ]
+}
+            ]]>
+                        </artwork>
+                    </figure>
+                </section>
+            </section>        
+        </section>
         <section anchor="hmac_root" title="HMAC">
             <section anchor="hmac_caps_reg" title="HMAC Algorithm Capabilities Registration">
                 <t>Each algorithm capability advertised is a self-contained JSON object using the
@@ -2540,6 +3072,17 @@
                         <organization>NIST</organization>
                     </author>
                     <date year="2005"/>
+                </front>
+            </reference>
+            <reference anchor="SP-800-38D"
+                target="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf">
+                <front>
+                    <title>Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) 
+                        and GMAC</title>
+                    <author>
+                        <organization>NIST</organization>
+                    </author>
+                    <date year="2007"/>
                 </front>
             </reference>
             <reference anchor="FIPS-198-1"

--- a/src/draft-celi-acvp-block-ciph-00.xml
+++ b/src/draft-celi-acvp-block-ciph-00.xml
@@ -1072,9 +1072,9 @@ For i = 0 to 399
                 <t>The following grid outlines which properties are REQUIRED, as well as the possible values a server MAY support for each key-wrap block cipher algorithm:</t>
                 <texttable anchor="property_grid_kw" title="Authenticated Block Cipher Algorithm Capabilities Applicability Grid">
                     <ttcol align="left">algorithm</ttcol><ttcol align="left">revision</ttcol><ttcol align="left">direction</ttcol><ttcol align="left">keyLen</ttcol><ttcol align="left">payloadLen</ttcol><ttcol align="left">ivLen</ttcol><ttcol align="left">ivGen</ttcol><ttcol align="left">ivGenMode</ttcol><ttcol align="left">saltGen</ttcol><ttcol align="left">aadLen</ttcol><ttcol align="left">tagLen</ttcol>
-                    <c>AES-GCM</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>{"Min": 0, "Max": 65536, "Inc": any}</c><c>{"Min": 8, "Max": 1024, "Inc": any}</c><c>["internal", "external"]</c><c>["8.2.1", "8.2.2"]</c><c></c><c>{"Min": 0, "Max": 65536, "Inc": any}</c><c>{[32, 64, 96, 104, 112, 120, 128]}</c>
-                    <c>AES-GCM-SIV</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 256]</c><c>{"Min": 0, "Max": 65536, "Inc": 8}</c><c></c><c></c><c></c><c></c><c>{"Min": 0, "Max": 65536, "Inc": 8}</c><c></c>
-                    <c>AES-XPN</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>{"Min": 0, "Max": 65536, "Inc": any}</c><c></c><c>["internal", "external"]</c><c>["8.2.1", "8.2.2"]</c><c>["internal", "external"]</c><c>{"Min": 1, "Max": 65536, "Inc": any}</c><c>{[32, 64, 96, 104, 112, 120, 128]}</c>
+                    <c>AES-GCM</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>{"Min": 8, "Max": 65536, "Inc": 8}</c><c>{"Min": 8, "Max": 1024, "Inc": any}</c><c>["internal", "external"]</c><c>["8.2.1", "8.2.2"]</c><c></c><c>{"Min": 0, "Max": 65536, "Inc": any}</c><c>{[32, 64, 96, 104, 112, 120, 128]}</c>
+                    <c>AES-GCM-SIV</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 256]</c><c>{"Min": 8, "Max": 65536, "Inc": 8}</c><c></c><c></c><c></c><c></c><c>{"Min": 0, "Max": 65536, "Inc": 8}</c><c></c>
+                    <c>AES-XPN</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>{"Min": 8, "Max": 65536, "Inc": 8}</c><c></c><c>["internal", "external"]</c><c>["8.2.1", "8.2.2"]</c><c>["internal", "external"]</c><c>{"Min": 1, "Max": 65536, "Inc": any}</c><c>{[32, 64, 96, 104, 112, 120, 128]}</c>
                     <c>AES-CCM</c><c>"1.0"</c><c>["encrypt", "decrypt"]</c><c>[128, 192, 256]</c><c>{"Min": 0, "Max": 256, "Inc": 8}</c><c>{"Min": 56, "Max": 104, "Inc": 8}</c><c></c><c></c><c></c><c>{"Min": 0, "Max": 524288, "Inc": any}</c><c>{"Min": 32, "Max": 128, "Inc": 16}</c>
                 </texttable>
                 <t>The following grid outlines which properties are REQUIRED, as well as the possible values a server MAY support for each miscellaneous block cipher algorithm:</t>
@@ -1743,7 +1743,7 @@ POST [
             96
         ],
         "payloadLen": [
-            0,
+            8,
             256
         ],
         "aadLen": [
@@ -1902,7 +1902,7 @@ POST [
             128
         ],
         "payloadLen": [
-            0,
+            8,
             128
         ],
         "aadLen": [
@@ -2246,20 +2246,20 @@ POST [
             "ivLen": 96,
             "ivGen": "external",
             "ivGenMode": "8.2.2",
-            "payloadLen": 0,
+            "payloadLen": 8,
             "aadLen": 0,
             "tagLen": 32,
             "tests": [
                 {
                     "tcId": 1,
-                    "plainText": "",
+                    "plainText": "AB",
                     "key": "10B8D4C9658590A...",
                     "aad": "",
                     "iv": "3D026F3D590BF1A7..."
                 },
                 {
                     "tcId": 2,
-                    "plainText": "",
+                    "plainText": "CD",
                     "key": "934865822A3ECCB...",
                     "aad": "",
                     "iv": "273F3B30341C779E..."
@@ -2274,7 +2274,7 @@ POST [
             "ivLen": 96,
             "ivGen": "external",
             "ivGenMode": "8.2.2",
-            "payloadLen": 0,
+            "payloadLen": 8,
             "aadLen": 120,
             "tagLen": 32,
             "tests": [
@@ -2283,7 +2283,7 @@ POST [
                     "key": "88AB5441AE2...",
                     "aad": "4E956EF528D...",
                     "iv": "810628011BB0...",
-                    "cipherText": "",
+                    "cipherText": "AB",
                     "tag": "1180FD89"
                 },
                 {
@@ -2291,7 +2291,7 @@ POST [
                     "key": "9149BE47FAEB...",
                     "aad": "938A8FA71324...",
                     "iv": "FF6B72FF25B55...",
-                    "cipherText": "",
+                    "cipherText": "CD",
                     "tag": "6C7528F0"
                 }
 			]
@@ -2314,13 +2314,13 @@ POST [
 			"tests": [{
 					"tcId": 1,
 					"iv": "01020304F966B8...",
-					"ct": "",
+					"ct": "CD",
 					"tag": "427F668E58F56..."
 				},
 				{
 					"tcId": 2,
 					"iv": "01020304C2855...",
-					"ct": "",
+					"ct": "AB",
 					"tag": "D95BD66F7789..."
 				}
 			]
@@ -2329,7 +2329,7 @@ POST [
 			"tgId": 2,
 			"tests": [{
 					"tcId": 902,
-					"pt": "763BF..."
+					"pt": "76"
 				},
 				{
 					"tcId": 903,


### PR DESCRIPTION
GMAC will be separated from an "implied" registration from within GCM and placed into its own algorithm.
This change will (once deployed) no longer allow zero length payloads for GCM, as that is in effect a test for GMAC.

I still need to update the symmetric spec to have this payload length change, however I will not generate the artifacts on that document (for the moment) due to there being a separate PR #669 which will conflict.