### PR TITLE
Updates KDF SP800-108 to include additional HMAC types

### DIFF
--- a/artifacts/acvp_sub_kdf108.html
+++ b/artifacts/acvp_sub_kdf108.html
@@ -762,11 +762,17 @@
 <li>CMAC-AES192</li>
 <li>CMAC-AES256</li>
 <li>CMAC-TDES</li>
-<li>HMAC-SHA1</li>
-<li>HMAC-SHA224</li>
-<li>HMAC-SHA256</li>
-<li>HMAC-SHA384</li>
-<li>HMAC-SHA512</li>
+<li>HMAC-SHA-1</li>
+<li>HMAC-SHA2-224</li>
+<li>HMAC-SHA2-256</li>
+<li>HMAC-SHA2-384</li>
+<li>HMAC-SHA2-512</li>
+<li>HMAC-SHA2-512/224</li>
+<li>HMAC-SHA2-512/256</li>
+<li>HMAC-SHA3-224</li>
+<li>HMAC-SHA3-256</li>
+<li>HMAC-SHA3-384</li>
+<li>HMAC-SHA3-512</li>
 </ul>
 
 <p> </p>
@@ -1189,11 +1195,11 @@
                 "CMAC-AES192",
                 "CMAC-AES256",
                 "CMAC-TDES",
-                "HMAC-SHA1",
-                "HMAC-SHA224",
-                "HMAC-SHA256",
-                "HMAC-SHA384",
-                "HMAC-SHA512"
+                "HMAC-SHA-1",
+                "HMAC-SHA2-224",
+                "HMAC-SHA2-256",
+                "HMAC-SHA2-384",
+                "HMAC-SHA2-512"
             ],
             "supportedLengths": [
                 {
@@ -1222,11 +1228,11 @@
                 "CMAC-AES192",
                 "CMAC-AES256",
                 "CMAC-TDES",
-                "HMAC-SHA1",
-                "HMAC-SHA224",
-                "HMAC-SHA256",
-                "HMAC-SHA384",
-                "HMAC-SHA512"
+                "HMAC-SHA-1",
+                "HMAC-SHA2-224",
+                "HMAC-SHA2-256",
+                "HMAC-SHA2-384",
+                "HMAC-SHA2-512"
             ],
             "supportedLengths": [
                 {
@@ -1257,11 +1263,11 @@
                 "CMAC-AES192",
                 "CMAC-AES256",
                 "CMAC-TDES",
-                "HMAC-SHA1",
-                "HMAC-SHA224",
-                "HMAC-SHA256",
-                "HMAC-SHA384",
-                "HMAC-SHA512"
+                "HMAC-SHA-1",
+                "HMAC-SHA2-224",
+                "HMAC-SHA2-256",
+                "HMAC-SHA2-384",
+                "HMAC-SHA2-512"
             ],
             "supportedLengths": [
                 {

--- a/artifacts/acvp_sub_kdf108.txt
+++ b/artifacts/acvp_sub_kdf108.txt
@@ -409,15 +409,27 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  CMAC-TDES
 
-   o  HMAC-SHA1
+   o  HMAC-SHA-1
 
-   o  HMAC-SHA224
+   o  HMAC-SHA2-224
 
-   o  HMAC-SHA256
+   o  HMAC-SHA2-256
 
-   o  HMAC-SHA384
+   o  HMAC-SHA2-384
 
-   o  HMAC-SHA512
+   o  HMAC-SHA2-512
+
+   o  HMAC-SHA2-512/224
+
+   o  HMAC-SHA2-512/256
+
+   o  HMAC-SHA3-224
+
+   o  HMAC-SHA3-256
+
+   o  HMAC-SHA3-384
+
+   o  HMAC-SHA3-512
 
 3.  Test Vectors
 
@@ -429,18 +441,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    such as SNMP, SSH, etc.  This section describes the JSON schema for a
    test vector set used with SP800-108 KDF algorithms.
 
-   The test vector set JSON schema is a multi-level hierarchy that
-   contains meta data for the entire vector set as well as individual
-   test vectors to be processed by the ACVP client.The following table
-   describes the JSON elements at the top level of the hierarchy.
-
-
-
-
-
-
-
-
 
 
 
@@ -449,6 +449,11 @@ Fussell                 Expires February 2, 2019                [Page 8]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   The test vector set JSON schema is a multi-level hierarchy that
+   contains meta data for the entire vector set as well as individual
+   test vectors to be processed by the ACVP client.The following table
+   describes the JSON elements at the top level of the hierarchy.
 
    +------------+---------------------------------------------+--------+
    | JSON Value | Description                                 | JSON   |
@@ -481,11 +486,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    Group JSON object.
 
    The KDF test group for KDF108 is as follows:
-
-
-
-
-
 
 
 
@@ -756,11 +756,11 @@ Appendix A.  Example SP800-108 KDF Capabilities JSON Object
                    "CMAC-AES192",
                    "CMAC-AES256",
                    "CMAC-TDES",
-                   "HMAC-SHA1",
-                   "HMAC-SHA224",
-                   "HMAC-SHA256",
-                   "HMAC-SHA384",
-                   "HMAC-SHA512"
+                   "HMAC-SHA-1",
+                   "HMAC-SHA2-224",
+                   "HMAC-SHA2-256",
+                   "HMAC-SHA2-384",
+                   "HMAC-SHA2-512"
                ],
                "supportedLengths": [
                    {
@@ -797,11 +797,11 @@ Internet-Draft                Sym Alg JSON                   August 2018
                    "CMAC-AES192",
                    "CMAC-AES256",
                    "CMAC-TDES",
-                   "HMAC-SHA1",
-                   "HMAC-SHA224",
-                   "HMAC-SHA256",
-                   "HMAC-SHA384",
-                   "HMAC-SHA512"
+                   "HMAC-SHA-1",
+                   "HMAC-SHA2-224",
+                   "HMAC-SHA2-256",
+                   "HMAC-SHA2-384",
+                   "HMAC-SHA2-512"
                ],
                "supportedLengths": [
                    {
@@ -832,8 +832,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
                    "CMAC-AES192",
                    "CMAC-AES256",
                    "CMAC-TDES",
-                   "HMAC-SHA1",
-                   "HMAC-SHA224",
+                   "HMAC-SHA-1",
+                   "HMAC-SHA2-224",
 
 
 
@@ -842,9 +842,9 @@ Fussell                 Expires February 2, 2019               [Page 15]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
-                   "HMAC-SHA256",
-                   "HMAC-SHA384",
-                   "HMAC-SHA512"
+                   "HMAC-SHA2-256",
+                   "HMAC-SHA2-384",
+                   "HMAC-SHA2-512"
                ],
                "supportedLengths": [
                    {

--- a/src/acvp_sub_kdf108.xml
+++ b/src/acvp_sub_kdf108.xml
@@ -277,11 +277,17 @@
             <t>CMAC-AES192</t>
             <t>CMAC-AES256</t>
             <t>CMAC-TDES</t>
-            <t>HMAC-SHA1</t>
-            <t>HMAC-SHA224</t>
-            <t>HMAC-SHA256</t>
-            <t>HMAC-SHA384</t>
-            <t>HMAC-SHA512</t>
+            <t>HMAC-SHA-1</t>
+            <t>HMAC-SHA2-224</t>
+            <t>HMAC-SHA2-256</t>
+            <t>HMAC-SHA2-384</t>
+            <t>HMAC-SHA2-512</t>
+            <t>HMAC-SHA2-512/224</t>
+            <t>HMAC-SHA2-512/256</t>
+            <t>HMAC-SHA3-224</t>
+            <t>HMAC-SHA3-256</t>
+            <t>HMAC-SHA3-384</t>
+            <t>HMAC-SHA3-512</t>
           </list>
         </t>
       </section>
@@ -577,11 +583,11 @@
                 "CMAC-AES192",
                 "CMAC-AES256",
                 "CMAC-TDES",
-                "HMAC-SHA1",
-                "HMAC-SHA224",
-                "HMAC-SHA256",
-                "HMAC-SHA384",
-                "HMAC-SHA512"
+                "HMAC-SHA-1",
+                "HMAC-SHA2-224",
+                "HMAC-SHA2-256",
+                "HMAC-SHA2-384",
+                "HMAC-SHA2-512"
             ],
             "supportedLengths": [
                 {
@@ -610,11 +616,11 @@
                 "CMAC-AES192",
                 "CMAC-AES256",
                 "CMAC-TDES",
-                "HMAC-SHA1",
-                "HMAC-SHA224",
-                "HMAC-SHA256",
-                "HMAC-SHA384",
-                "HMAC-SHA512"
+                "HMAC-SHA-1",
+                "HMAC-SHA2-224",
+                "HMAC-SHA2-256",
+                "HMAC-SHA2-384",
+                "HMAC-SHA2-512"
             ],
             "supportedLengths": [
                 {
@@ -645,11 +651,11 @@
                 "CMAC-AES192",
                 "CMAC-AES256",
                 "CMAC-TDES",
-                "HMAC-SHA1",
-                "HMAC-SHA224",
-                "HMAC-SHA256",
-                "HMAC-SHA384",
-                "HMAC-SHA512"
+                "HMAC-SHA-1",
+                "HMAC-SHA2-224",
+                "HMAC-SHA2-256",
+                "HMAC-SHA2-384",
+                "HMAC-SHA2-512"
             ],
             "supportedLengths": [
                 {


### PR DESCRIPTION
- corrects typos related to HMAC-SHA2*

This change is not yet on demo/prod, will use the merge of this PR to indicate the changes are on (at a minimum) the demo server.