### PR TITLE
Adds requiresEmptyIv property for Feedback KDF

### DIFF
--- a/artifacts/acvp_sub_kdf108.html
+++ b/artifacts/acvp_sub_kdf108.html
@@ -396,7 +396,7 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.21.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.22.2 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Fussell, B., Ed." />
@@ -744,7 +744,21 @@
 </tr>
 <tr>
 <td class="left">supportsEmptyIv</td>
-<td class="left">Whether the IUT supports an empty IV.</td>
+<td class="left">Whether the IUT supports an empty IV for Feedback KDF.</td>
+<td class="left">boolean</td>
+<td class="left">true/false</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">requiresEmptyIv</td>
+<td class="left">Whether the IUT requires an empty IV for Feedback KDF.</td>
 <td class="left">boolean</td>
 <td class="left">true/false</td>
 <td class="left">No</td>
@@ -918,6 +932,18 @@
 <td class="left">counterLength</td>
 <td class="left">Expected length of the counter in bits.</td>
 <td class="left">integer</td>
+<td class="left">No</td>
+</tr>
+<tr>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+<td class="left"></td>
+</tr>
+<tr>
+<td class="left">zeroLengthIv</td>
+<td class="left">Whether or not the group utilizes a null IV.</td>
+<td class="left">boolean</td>
 <td class="left">No</td>
 </tr>
 <tr>
@@ -1254,7 +1280,8 @@
                 24,
                 32
             ],
-            "supportsEmptyIv": true
+            "supportsEmptyIv": true,
+            "requiresEmptyIv": false
         },
         {
             "kdfMode": "double pipeline iteration",

--- a/artifacts/acvp_sub_kdf108.txt
+++ b/artifacts/acvp_sub_kdf108.txt
@@ -69,7 +69,7 @@ Table of Contents
      2.3.  Supported SP800-108 KDF Modes . . . . . . . . . . . . . .   5
      2.4.  Supported KDF Modes Capabilities  . . . . . . . . . . . .   6
      2.5.  Supported SP800-108 KDF MACs  . . . . . . . . . . . . . .   8
-   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   8
+   3.  Test Vectors  . . . . . . . . . . . . . . . . . . . . . . . .   9
      3.1.  Test Groups JSON Schema . . . . . . . . . . . . . . . . .   9
      3.2.  Test Case JSON Schema . . . . . . . . . . . . . . . . . .  10
    4.  Test Vector Responses . . . . . . . . . . . . . . . . . . . .  11
@@ -238,13 +238,13 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |              | revision to    |              |         |          |
    |              | use.           |              |         |          |
    |              |                |              |         |          |
-   | prereqVals   | prerequistie   | array of     | See Sec | No       |
-   |              | algorithm      | prereqAlgVal | tion 2. |          |
-   |              | validations    | objects      | 1       |          |
+   | prereqVals   | prerequistie   | array of     | See     | No       |
+   |              | algorithm      | prereqAlgVal | Section |          |
+   |              | validations    | objects      | 2.1     |          |
    |              |                |              |         |          |
-   | capabilities | array of JSON  | Array of     | See Sec |
-   |              | objects, each  | JSON objects | tion 2. |
-   |              | with fields    |              | 4       |
+   | capabilities | array of JSON  | Array of     | See     |
+   |              | objects, each  | JSON objects | Section |
+   |              | with fields    |              | 2.4     |
    |              | pertaining to  |              |         |
    |              | the KDF mode   |              |         |
    |              | identified     |              |         |
@@ -301,8 +301,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | JSON Value       | Description | JSON    | Valid       | Optional |
    |                  |             | type    | Values      |          |
    +------------------+-------------+---------+-------------+----------+
-   | kdfMode          | The KDF     | value   | See         | No       |
-   |                  | mode for    |         | Section 2.3 |          |
+   | kdfMode          | The KDF     | value   | See Section | No       |
+   |                  | mode for    |         | 2.3         |          |
    |                  | testing.    |         |             |          |
    |                  |             |         |             |          |
    | macMode          | The MAC     | array   | Any non-    | No       |
@@ -383,9 +383,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    | supportsEmptyIv  | Whether the | boolean | true/false  | No       |
    |                  | IUT         |         |             |          |
    |                  | supports an |         |             |          |
-   |                  | empty IV.   |         |             |          |
-   +------------------+-------------+---------+-------------+----------+
-
+   |                  | empty IV    |         |             |          |
+   |                  | for         |         |             |          |
+   |                  | Feedback    |         |             |          |
 
 
 
@@ -393,6 +393,17 @@ Fussell                 Expires February 2, 2019                [Page 7]
 
 Internet-Draft                Sym Alg JSON                   August 2018
 
+
+   |                  | KDF.        |         |             |          |
+   |                  |             |         |             |          |
+   | requiresEmptyIv  | Whether the | boolean | true/false  | No       |
+   |                  | IUT         |         |             |          |
+   |                  | requires an |         |             |          |
+   |                  | empty IV    |         |             |          |
+   |                  | for         |         |             |          |
+   |                  | Feedback    |         |             |          |
+   |                  | KDF.        |         |             |          |
+   +------------------+-------------+---------+-------------+----------+
 
                    Table 3: KDF Capabilities JSON Values
 
@@ -431,6 +442,14 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
    o  HMAC-SHA3-512
 
+
+
+
+Fussell                 Expires February 2, 2019                [Page 8]
+
+Internet-Draft                Sym Alg JSON                   August 2018
+
+
 3.  Test Vectors
 
    The ACVP server provides test vectors to the ACVP client, which are
@@ -440,15 +459,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    vector set represents an individual Key Derivation Function (KDF),
    such as SNMP, SSH, etc.  This section describes the JSON schema for a
    test vector set used with SP800-108 KDF algorithms.
-
-
-
-
-
-Fussell                 Expires February 2, 2019                [Page 8]
-
-Internet-Draft                Sym Alg JSON                   August 2018
-
 
    The test vector set JSON schema is a multi-level hierarchy that
    contains meta data for the entire vector set as well as individual
@@ -491,16 +501,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
 Fussell                 Expires February 2, 2019                [Page 9]
 
 Internet-Draft                Sym Alg JSON                   August 2018
@@ -515,9 +515,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                 | the entire vector set.     |         |          |
    |                 |                            |         |          |
    | kdfMode         | The kdfMode used for the   | value   | No       |
-   |                 | test group.  See           |         |          |
-   |                 | Section 2.3 for possible   |         |          |
-   |                 | values                     |         |          |
+   |                 | test group.  See Section   |         |          |
+   |                 | 2.3 for possible values    |         |          |
    |                 |                            |         |          |
    | macMode         | Psuedorandom function HMAC | value   | No       |
    |                 | or CMAC used               |         |          |
@@ -533,6 +532,9 @@ Internet-Draft                Sym Alg JSON                   August 2018
    |                 |                            |         |          |
    | counterLength   | Expected length of the     | integer | No       |
    |                 | counter in bits.           |         |          |
+   |                 |                            |         |          |
+   | zeroLengthIv    | Whether or not the group   | boolean | No       |
+   |                 | utilizes a null IV.        |         |          |
    |                 |                            |         |          |
    | tests           | Array of individual test   | array   | No       |
    |                 | vector JSON objects, which |         |          |
@@ -551,8 +553,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
    test case is a JSON object that represents a single test vector to be
    processed by the ACVP client.  The following table describes the JSON
    elements for each SP800-108 KDF test vector.
-
-
 
 
 
@@ -823,7 +823,8 @@ Internet-Draft                Sym Alg JSON                   August 2018
                    24,
                    32
                ],
-               "supportsEmptyIv": true
+               "supportsEmptyIv": true,
+               "requiresEmptyIv": false
            },
            {
                "kdfMode": "double pipeline iteration",
@@ -833,7 +834,6 @@ Internet-Draft                Sym Alg JSON                   August 2018
                    "CMAC-AES256",
                    "CMAC-TDES",
                    "HMAC-SHA-1",
-                   "HMAC-SHA2-224",
 
 
 
@@ -842,6 +842,7 @@ Fussell                 Expires February 2, 2019               [Page 15]
 Internet-Draft                Sym Alg JSON                   August 2018
 
 
+                   "HMAC-SHA2-224",
                    "HMAC-SHA2-256",
                    "HMAC-SHA2-384",
                    "HMAC-SHA2-512"
@@ -876,7 +877,6 @@ Appendix B.  Example Test Vectors JSON Object
 
    The following is a example JSON object for SP800-108 KDF test vectors
    sent from the ACVP server to the crypto module.
-
 
 
 

--- a/src/acvp_sub_kdf108.xml
+++ b/src/acvp_sub_kdf108.xml
@@ -263,7 +263,17 @@
           <c/>
           <c/>
           <c>supportsEmptyIv</c>
-          <c>Whether the IUT supports an empty IV.</c>
+          <c>Whether the IUT supports an empty IV for Feedback KDF.</c>
+          <c>boolean</c>
+          <c>true/false</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>requiresEmptyIv</c>
+          <c>Whether the IUT requires an empty IV for Feedback KDF.</c>
           <c>boolean</c>
           <c>true/false</c>
           <c>No</c>
@@ -385,6 +395,14 @@
           <c>counterLength</c>
           <c>Expected length of the counter in bits.</c>
           <c>integer</c>
+          <c>No</c>
+          <c/>
+          <c/>
+          <c/>
+          <c/>
+          <c>zeroLengthIv</c>
+          <c>Whether or not the group utilizes a null IV.</c>
+          <c>boolean</c>
           <c>No</c>
           <c/>
           <c/>
@@ -642,7 +660,8 @@
                 24,
                 32
             ],
-            "supportsEmptyIv": true
+            "supportsEmptyIv": true,
+            "requiresEmptyIv": false
         },
         {
             "kdfMode": "double pipeline iteration",


### PR DESCRIPTION
`requiresEmptyIv` sits next to `supportsEmptyIv`. The difference being, if `requiresEmptyIv` is set to true, no groups that utilize an IV for Feedback KDF will be included in the vector set. If `supportsEmptyIv` is set to true while `requiresEmptyIv` is set to false, then both groups that utilize IV and do not utilize IV for Feedback KDF will be included.

Fixes #729 