### PR TITLE
KAS spec updates

### DIFF
--- a/artifacts/acvp_sub_kas_ecc.html
+++ b/artifacts/acvp_sub_kas_ecc.html
@@ -1511,7 +1511,7 @@
 <p></p>
 
 <ul>
-<li>literal[123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[123456789ABCDEF] substitutes "123456789ABCDEF" in place of the field</li></ul>
+<li>literal[0123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[0123456789ABCDEF] substitutes "0123456789ABCDEF" in place of the field</li></ul>
 <p> </p>
 </li>
 <li>uPartyInfo <ul><li>uPartyId { || dkmNonce } <ul><li>dkmNonce is provided by party u for static schemes</li></ul>

--- a/artifacts/acvp_sub_kas_ecc.txt
+++ b/artifacts/acvp_sub_kas_ecc.txt
@@ -1034,10 +1034,10 @@ Internet-Draft                Sym Alg JSON                 November 2018
 
    Pattern candidates:
 
-   o  literal[123456789ABCDEF]
+   o  literal[0123456789ABCDEF]
 
-      *  uses the specified hex within "[]". literal[123456789ABCDEF]
-         substitutes "123456789ABCDEF" in place of the field
+      *  uses the specified hex within "[]". literal[0123456789ABCDEF]
+         substitutes "0123456789ABCDEF" in place of the field
 
    o  uPartyInfo
 

--- a/artifacts/acvp_sub_kas_ecc_Sp800-56Ar3.html
+++ b/artifacts/acvp_sub_kas_ecc_Sp800-56Ar3.html
@@ -1295,7 +1295,7 @@
 <p></p>
 
 <ul>
-<li>literal[123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[123456789ABCDEF] substitutes "123456789ABCDEF" in place of the field</li></ul>
+<li>literal[0123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[0123456789ABCDEF] substitutes "0123456789ABCDEF" in place of the field</li></ul>
 <p> </p>
 </li>
 <li>uPartyInfo <ul><li>uPartyId { || dkmNonce } { || c } </li></ul>

--- a/artifacts/acvp_sub_kas_ecc_Sp800-56Ar3.txt
+++ b/artifacts/acvp_sub_kas_ecc_Sp800-56Ar3.txt
@@ -898,10 +898,10 @@ Hammett                   Expires July 4, 2020                 [Page 16]
 Internet-Draft                Sym Alg JSON                  January 2020
 
 
-   o  literal[123456789ABCDEF]
+   o  literal[0123456789ABCDEF]
 
-      *  uses the specified hex within "[]". literal[123456789ABCDEF]
-         substitutes "123456789ABCDEF" in place of the field
+      *  uses the specified hex within "[]". literal[0123456789ABCDEF]
+         substitutes "0123456789ABCDEF" in place of the field
 
    o  uPartyInfo
 

--- a/artifacts/acvp_sub_kas_ffc.html
+++ b/artifacts/acvp_sub_kas_ffc.html
@@ -1359,7 +1359,7 @@
 <p></p>
 
 <ul>
-<li>literal[123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[123456789ABCDEF] substitutes "123456789ABCDEF" in place of the field</li></ul>
+<li>literal[0123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[0123456789ABCDEF] substitutes "0123456789ABCDEF" in place of the field</li></ul>
 <p> </p>
 </li>
 <li>uPartyInfo <ul><li>uPartyId { || dkmNonce } <ul><li>dkmNonce is provided by party u for static schemes</li></ul>

--- a/artifacts/acvp_sub_kas_ffc.txt
+++ b/artifacts/acvp_sub_kas_ffc.txt
@@ -931,10 +931,10 @@ Internet-Draft                Sym Alg JSON                September 2018
 
    Pattern candidates:
 
-   o  literal[123456789ABCDEF]
+   o  literal[0123456789ABCDEF]
 
-      *  uses the specified hex within "[]". literal[123456789ABCDEF]
-         substitutes "123456789ABCDEF" in place of the field
+      *  uses the specified hex within "[]". literal[0123456789ABCDEF]
+         substitutes "0123456789ABCDEF" in place of the field
 
    o  uPartyInfo
 

--- a/artifacts/acvp_sub_kas_ffc_Sp800-56Ar3.html
+++ b/artifacts/acvp_sub_kas_ffc_Sp800-56Ar3.html
@@ -1295,7 +1295,7 @@
 <p></p>
 
 <ul>
-<li>literal[123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[123456789ABCDEF] substitutes "123456789ABCDEF" in place of the field</li></ul>
+<li>literal[0123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[0123456789ABCDEF] substitutes "0123456789ABCDEF" in place of the field</li></ul>
 <p> </p>
 </li>
 <li>uPartyInfo <ul><li>uPartyId { || dkmNonce } { || c } </li></ul>

--- a/artifacts/acvp_sub_kas_ffc_Sp800-56Ar3.txt
+++ b/artifacts/acvp_sub_kas_ffc_Sp800-56Ar3.txt
@@ -898,10 +898,10 @@ Hammett                   Expires July 4, 2020                 [Page 16]
 Internet-Draft                Sym Alg JSON                  January 2020
 
 
-   o  literal[123456789ABCDEF]
+   o  literal[0123456789ABCDEF]
 
-      *  uses the specified hex within "[]". literal[123456789ABCDEF]
-         substitutes "123456789ABCDEF" in place of the field
+      *  uses the specified hex within "[]". literal[0123456789ABCDEF]
+         substitutes "0123456789ABCDEF" in place of the field
 
    o  uPartyInfo
 

--- a/artifacts/acvp_sub_kas_ifc.html
+++ b/artifacts/acvp_sub_kas_ifc.html
@@ -1053,7 +1053,7 @@
 </tr></thead>
 <tbody>
 <tr>
-<td class="left">Modulo</td>
+<td class="left">modulo</td>
 <td class="left">The modulo the IUT supports.</td>
 <td class="left">array of integers</td>
 <td class="left">2048, 3072, 4096, 5120, 6144, 7168, 8192</td>
@@ -1067,7 +1067,7 @@
 <td class="left"></td>
 </tr>
 <tr>
-<td class="left">FixedPublicExponent</td>
+<td class="left">fixedPubExp</td>
 <td class="left">The fixed public exponent in use for the KeyGenerationMethod.</td>
 <td class="left">hex</td>
 <td class="left">Odd number, gt 2^16, lt 2^256.</td>
@@ -1506,7 +1506,7 @@
 <p></p>
 
 <ul>
-<li>literal[123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[123456789ABCDEF] substitutes "123456789ABCDEF" in place of the field</li></ul>
+<li>literal[0123456789ABCDEF] <ul><li>uses the specified hex within "[]". literal[0123456789ABCDEF] substitutes "0123456789ABCDEF" in place of the field</li></ul>
 <p> </p>
 </li>
 <li>uPartyInfo <ul><li>uPartyId { || dkmNonce } { || c } </li></ul>
@@ -1818,7 +1818,7 @@
     "function": ["keyPairGen", "partialVal"],
     "iutId": "CAFECAFE",
     "scheme": {
-        "kas1-Party_V-confirmation": {
+        "KAS1-Party_V-confirmation": {
             "kasRole": [
                 "initiator",
                 "responder"

--- a/artifacts/acvp_sub_kas_ifc.txt
+++ b/artifacts/acvp_sub_kas_ifc.txt
@@ -674,27 +674,27 @@ Hammett                   Expires April 3, 2020                [Page 12]
 Internet-Draft                Sym Alg JSON                  October 2019
 
 
-   +-----------------+------------------+---------+--------+-----------+
-   | JSON Value      | Description      | JSON    | Valid  | Optional  |
-   |                 |                  | type    | Values |           |
-   +-----------------+------------------+---------+--------+-----------+
-   | Modulo          | The modulo the   | array   | 2048,  | No        |
-   |                 | IUT supports.    | of inte | 3072,  |           |
-   |                 |                  | gers    | 4096,  |           |
-   |                 |                  |         | 5120,  |           |
-   |                 |                  |         | 6144,  |           |
-   |                 |                  |         | 7168,  |           |
-   |                 |                  |         | 8192   |           |
-   |                 |                  |         |        |           |
-   | FixedPublicExpo | The fixed public | hex     | Odd nu | Yes,      |
-   | nent            | exponent in use  |         | mber,  | required  |
-   |                 | for the KeyGener |         | gt     | for fixed |
-   |                 | ationMethod.     |         | 2^16,  | exponent  |
-   |                 |                  |         | lt     | key gener |
-   |                 |                  |         | 2^256. | ation     |
-   |                 |                  |         |        | methods.  |
-   |                 |                  |         |        |           |
-   +-----------------+------------------+---------+--------+-----------+
+   +------------+--------------------+----------+---------+------------+
+   | JSON Value | Description        | JSON     | Valid   | Optional   |
+   |            |                    | type     | Values  |            |
+   +------------+--------------------+----------+---------+------------+
+   | modulo     | The modulo the IUT | array of | 2048,   | No         |
+   |            | supports.          | integers | 3072,   |            |
+   |            |                    |          | 4096,   |            |
+   |            |                    |          | 5120,   |            |
+   |            |                    |          | 6144,   |            |
+   |            |                    |          | 7168,   |            |
+   |            |                    |          | 8192    |            |
+   |            |                    |          |         |            |
+   | fixedPubEx | The fixed public   | hex      | Odd     | Yes,       |
+   | p          | exponent in use    |          | number, | required   |
+   |            | for the KeyGenerat |          | gt      | for fixed  |
+   |            | ionMethod.         |          | 2^16,   | exponent   |
+   |            |                    |          | lt      | key        |
+   |            |                    |          | 2^256.  | generation |
+   |            |                    |          |         | methods.   |
+   |            |                    |          |         |            |
+   +------------+--------------------+----------+---------+------------+
 
                   Table 5: Key Generation Object Options
 
@@ -1073,10 +1073,10 @@ Internet-Draft                Sym Alg JSON                  October 2019
 
    Pattern candidates:
 
-   o  literal[123456789ABCDEF]
+   o  literal[0123456789ABCDEF]
 
-      *  uses the specified hex within "[]". literal[123456789ABCDEF]
-         substitutes "123456789ABCDEF" in place of the field
+      *  uses the specified hex within "[]". literal[0123456789ABCDEF]
+         substitutes "0123456789ABCDEF" in place of the field
 
    o  uPartyInfo
 
@@ -1268,7 +1268,7 @@ Internet-Draft                Sym Alg JSON                  October 2019
     "function": ["keyPairGen", "partialVal"],
     "iutId": "CAFECAFE",
     "scheme": {
-        "kas1-Party_V-confirmation": {
+        "KAS1-Party_V-confirmation": {
             "kasRole": [
                 "initiator",
                 "responder"

--- a/src/acvp_sub_kas_ecc.xml
+++ b/src/acvp_sub_kas_ecc.xml
@@ -889,9 +889,9 @@
                     <t>Pattern candidates:</t>
                     <t>
                         <list style="symbols">
-                            <t>literal[123456789ABCDEF] <list style="symbols">
-                                    <t>uses the specified hex within "[]". literal[123456789ABCDEF]
-                                        substitutes "123456789ABCDEF" in place of the field</t>
+                            <t>literal[0123456789ABCDEF] <list style="symbols">
+                                    <t>uses the specified hex within "[]". literal[0123456789ABCDEF]
+                                        substitutes "0123456789ABCDEF" in place of the field</t>
                                 </list>
                             </t>
                             <t>uPartyInfo <list style="symbols">

--- a/src/acvp_sub_kas_ecc_Sp800-56Ar3.xml
+++ b/src/acvp_sub_kas_ecc_Sp800-56Ar3.xml
@@ -722,10 +722,10 @@
             <t>
               <list style="symbols">
                 <t>
-                  literal[123456789ABCDEF]
+                  literal[0123456789ABCDEF]
                   <list style="symbols">
-                    <t>uses the specified hex within "[]". literal[123456789ABCDEF]
-                                                substitutes "123456789ABCDEF" in place of the field</t>
+                    <t>uses the specified hex within "[]". literal[0123456789ABCDEF]
+                                                substitutes "0123456789ABCDEF" in place of the field</t>
                   </list>
                 </t>
                 <t>

--- a/src/acvp_sub_kas_ffc.xml
+++ b/src/acvp_sub_kas_ffc.xml
@@ -799,9 +799,9 @@
 					<t>Pattern candidates:</t>
 					<t>
 						<list style="symbols">
-							<t>literal[123456789ABCDEF] <list style="symbols">
-									<t>uses the specified hex within "[]". literal[123456789ABCDEF]
-										substitutes "123456789ABCDEF" in place of the field</t>
+							<t>literal[0123456789ABCDEF] <list style="symbols">
+									<t>uses the specified hex within "[]". literal[0123456789ABCDEF]
+										substitutes "0123456789ABCDEF" in place of the field</t>
 								</list>
 							</t>
 							<t>uPartyInfo <list style="symbols">

--- a/src/acvp_sub_kas_ffc_Sp800-56Ar3.xml
+++ b/src/acvp_sub_kas_ffc_Sp800-56Ar3.xml
@@ -722,10 +722,10 @@
             <t>
               <list style="symbols">
                 <t>
-                  literal[123456789ABCDEF]
+                  literal[0123456789ABCDEF]
                   <list style="symbols">
-                    <t>uses the specified hex within "[]". literal[123456789ABCDEF]
-                                                substitutes "123456789ABCDEF" in place of the field</t>
+                    <t>uses the specified hex within "[]". literal[0123456789ABCDEF]
+                                                substitutes "0123456789ABCDEF" in place of the field</t>
                   </list>
                 </t>
                 <t>

--- a/src/acvp_sub_kas_ifc.xml
+++ b/src/acvp_sub_kas_ifc.xml
@@ -522,7 +522,7 @@
                                 <ttcol align="left">JSON type</ttcol>
                                 <ttcol align="left">Valid Values</ttcol>
                                 <ttcol align="left">Optional</ttcol>
-                                <c>Modulo</c>
+                                <c>modulo</c>
                                 <c>The modulo the IUT supports.</c>
                                 <c>array of integers</c>
                                 <c>2048, 3072, 4096, 5120, 6144, 7168, 8192</c>
@@ -532,7 +532,7 @@
                                 <c />
                                 <c />
                                 <c />
-                                <c>FixedPublicExponent</c>
+                                <c>fixedPubExp</c>
                                 <c>The fixed public exponent in use for the KeyGenerationMethod.</c>
                                 <c>hex</c>
                                 <c>Odd number, gt 2^16, lt 2^256.</c>
@@ -858,10 +858,10 @@
                         <t>
                             <list style="symbols">
                                 <t>
-                                    literal[123456789ABCDEF]
+                                    literal[0123456789ABCDEF]
                                     <list style="symbols">
-                                        <t>uses the specified hex within "[]". literal[123456789ABCDEF]
-                                                substitutes "123456789ABCDEF" in place of the field</t>
+                                        <t>uses the specified hex within "[]". literal[0123456789ABCDEF]
+                                                substitutes "0123456789ABCDEF" in place of the field</t>
                                     </list>
                                 </t>
                                 <t>
@@ -1172,7 +1172,7 @@
     "function": ["keyPairGen", "partialVal"],
     "iutId": "CAFECAFE",
     "scheme": {
-        "kas1-Party_V-confirmation": {
+        "KAS1-Party_V-confirmation": {
             "kasRole": [
                 "initiator",
                 "responder"


### PR DESCRIPTION
- Updates fixedInfoPatternConstruction sample to contain even number of literals
- closes #814