### PR TITLE
Corrects prerequisites for KAS KDF specifications

### DIFF
--- a/src/kas/sp800-56cr1/hkdf/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56cr1/hkdf/sections/05-capabilities.adoc
@@ -30,7 +30,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 |===
 | JSON Value | Description | JSON Type | Valid Values
 
-| algorithm | a prerequisite algorithm | value | CMAC, DRBG, HMAC, KMAC, SHA
+| algorithm | a prerequisite algorithm | value | DRBG, HMAC, SHA
 | valValue | algorithm validation number | value | actual number or "same"
 | prereqAlgVal | prerequisite algorithm validation | object with algorithm and valValue properties| see above
 |===

--- a/src/kas/sp800-56cr1/onestep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56cr1/onestep/sections/05-capabilities.adoc
@@ -29,7 +29,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 |===
 | JSON Value | Description | JSON Type | Valid Values
 
-| algorithm | a prerequisite algorithm | value | CMAC, DRBG, HMAC, KMAC, SHA
+| algorithm | a prerequisite algorithm | value | DRBG, HMAC, KMAC, SHA
 | valValue | algorithm validation number | value | actual number or "same"
 | prereqAlgVal | prerequisite algorithm validation | object with algorithm and valValue properties| see above
 |===

--- a/src/kas/sp800-56cr1/twostep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56cr1/twostep/sections/05-capabilities.adoc
@@ -27,7 +27,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 |===
 | JSON Value | Description | JSON Type | Valid Values
 
-| algorithm | a prerequisite algorithm | value | CMAC, DRBG, HMAC, KMAC, SHA
+| algorithm | a prerequisite algorithm | value | CMAC, DRBG, HMAC, SHA
 | valValue | algorithm validation number | value | actual number or "same"
 | prereqAlgVal | prerequisite algorithm validation | object with algorithm and valValue properties| see above
 |===


### PR DESCRIPTION
from https://github.com/usnistgov/ACVP/issues/954#issuecomment-676044636 addresses:

> prerequisites: only HMAC SHA2 or SHA3 are supported - why are there so many other prereqs defined (CMAC, KMAC, ...)?

#954 