### PR TITLE
Fix column count in symmetric cipher table 6

### DIFF
--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -117,7 +117,7 @@ The following grid outlines which properties are *REQUIRED*, as well as the poss
 
 The following grid outlines which properties are *REQUIRED*, as well as the possible values a server *MAY* support for each miscellaneous block cipher algorithm:
 
-[cols="<,<,<,<,<,<,<,<,<"]
+[cols="<,<,<,<,<,<,<,<,<,<"]
 [[property_grid_misc]]
 .Miscellaneous Block Cipher Algorithm Capabilities Applicability Grid
 


### PR DESCRIPTION
Nine columns were declared in the Miscellaneous Block Cipher Algorithm Capabilities Applicability Grid (Table 6 in the block cipher document), but ten headers are used. The table doesn't display correctly with this mismatch, so I added the last column to the declaration.