### PR TITLE
Fixed example symmetric vector display bug

### DIFF
--- a/src/symmetric/sections/97-examples.adoc
+++ b/src/symmetric/sections/97-examples.adoc
@@ -605,8 +605,7 @@ The following shows AES-GCM AFT responses.
 
 [align=left,alt=,type=]
 [source, json]
----
--
+----
 [{
 	"acvVersion": <acvp-version>
 },{


### PR DESCRIPTION
Corrected an errant linebreak in  `src/symmetric/sections/97-examples.adoc` that swapped the vector and non-vector formatting in all text after the AES-GCM responses. 