### PR TITLE
Fix typo in messaging.adoc

### DIFF
--- a/src/protocol/sections/11-messaging.adoc
+++ b/src/protocol/sections/11-messaging.adoc
@@ -360,7 +360,7 @@ A request resource is not externally updateable, but *SHOULD* update based on se
 Returns a paged listing of requests for the current user. Each element in the `data` array is a `request object` as described in <<request_get>>. See also <<paging_response>> for a description of a paged response.
 
 [[request_get]]
-==== Vendor Information
+==== Request Information
 
 *GET /requests/{requestId}*
 


### PR DESCRIPTION
In 11-messaging.adoc, the request documentation section was titled with
"Vendor Infromation" which I'm assuming was a copy/pasta error.