### PR TITLE
Symmetric spec updates relating to MCT

### DIFF
--- a/src/symmetric/sections/97-examples.adoc
+++ b/src/symmetric/sections/97-examples.adoc
@@ -8,7 +8,7 @@ The following is a example JSON object advertising support for all block ciphers
 [source, json]
 ----
 [{
-    "acvVersion": <acvp-version>
+    "acvVersion": "{acvp-version}"
 },{
     "algorithm": "ACVP-AES-GCM",
     "revision": "1.0",
@@ -533,13 +533,13 @@ The following shows AES-GCM AFT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2055,
 	"algorithm": "ACVP-AES-GCM",
     "revision": "1.0",
 	"testGroups": [{
-            tgId": 1,
+            "tgId": 1,
             "testType": "AFT",
             "direction": "encrypt",
             "keyLen": 128,
@@ -607,7 +607,7 @@ The following shows AES-GCM AFT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2055,
 	"testGroups": [{
@@ -649,7 +649,7 @@ The following shows AES-CCM AFT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2061,
 	"algorithm": "ACVP-AES-CCM",
@@ -709,7 +709,7 @@ The following shows AES-CCM AFT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 2061,
     "testGroups": [{
@@ -747,7 +747,7 @@ The following shows AES-CBC AFT and MCT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2057,
 	"algorithm": "ACVP-AES-CBC",
@@ -819,7 +819,7 @@ The following shows AES-CBC AFT and MCT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2057,
 	"testGroups": [{
@@ -889,13 +889,13 @@ The following shows AES-CBC AFT and MCT responses.
 
 ----
 
-The following shows AES-CBC-CS1 AFT and MCT request vectors.
+The following shows AES-CBC-CS1 AFT request vectors.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2058,
 	"algorithm": "ACVP-AES-CBC-CS1",
@@ -936,44 +936,19 @@ The following shows AES-CBC-CS1 AFT and MCT request vectors.
 				"ct": "DD14A9A9A916A...",
 				"payloadLen": 471
 			}]
-		},
-		{
-			"tgId": 3,
-			"direction": "encrypt",
-			"testType": "MCT",
-			"keyLen": 256,
-			"tests": [{
-				"tcId": 63,
-				"iv": "205734F67...",
-				"key": "7C446BA54C41B6F98D5C0...",
-				"pt": "806800AE3952ED97...",
-				"payloadLen": 521
-			}]
-		}, {
-			"tgId": 4,
-			"direction": "decrypt",
-			"testType": "MCT",
-			"keyLen": 128,
-			"tests": [{
-				"tcId": 64,
-				"iv": "3E1D14BDDE1F5CB09EBA67F6...",
-				"key": "C5AB9CE14549A...",
-				"ct": "9A916A449949073...",
-				"payloadLen": 310
-			}]
 		}
 	]
 }]
 
 ----
 
-The following shows AES-CBC-CS1 AFT and MCT responses.
+The following shows AES-CBC-CS1 AFT responses.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2057,
 	"testGroups": [{
@@ -999,57 +974,19 @@ The following shows AES-CBC-CS1 AFT and MCT responses.
 					"pt": "8F52D6E73783A..."
 				}
 			]
-		},
-		{
-			"tgId": 3,
-			"tests": [{
-				"tcId": 63,
-				"resultsArray": [{
-						"key": "E5E2...",
-						"iv": "057FB...",
-						"pt": "6DA46...",
-						"ct": "3E794..."
-					},
-					{
-						"key": "DE31...",
-						"iv": "3E794...",
-						"pt": "3BD32...",
-						"ct": "9236D..."
-					}
-				]
-			}]
-		},
-		{
-			"tgId": 1,
-			"tests": [{
-				"tcId": 64,
-				"resultsArray": [{
-						"key": "F743...",
-						"iv": "FD5ED...",
-						"ct": "37ECE...",
-						"pt": "52FC3..."
-					},
-					{
-						"key": "A5BF...",
-						"iv": "52FC3...",
-						"ct": "4400F...",
-						"pt": "66204..."
-					}
-				]
-			}]
 		}
 	]
 }]
 
 ----
 
-The following shows AES-CBC-CS2 AFT and MCT request vectors.
+The following shows AES-CBC-CS2 AFT request vectors.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2058,
 	"algorithm": "ACVP-AES-CBC-CS2",
@@ -1090,44 +1027,19 @@ The following shows AES-CBC-CS2 AFT and MCT request vectors.
 				"ct": "DD14A9A9A916A...",
 				"payloadLen": 471
 			}]
-		},
-		{
-			"tgId": 3,
-			"direction": "encrypt",
-			"testType": "MCT",
-			"keyLen": 256,
-			"tests": [{
-				"tcId": 63,
-				"iv": "205734F67...",
-				"key": "7C446BA54C41B6F98D5C0...",
-				"pt": "806800AE3952ED97...",
-				"payloadLen": 521
-			}]
-		}, {
-			"tgId": 4,
-			"direction": "decrypt",
-			"testType": "MCT",
-			"keyLen": 128,
-			"tests": [{
-				"tcId": 64,
-				"iv": "3E1D14BDDE1F5CB09EBA67F6...",
-				"key": "C5AB9CE14549A...",
-				"ct": "9A916A449949073...",
-				"payloadLen": 310
-			}]
 		}
 	]
 }]
 
 ----
 
-The following shows AES-CBC-CS2 AFT and MCT responses.
+The following shows AES-CBC-CS2 AFT  responses.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2057,
 	"testGroups": [{
@@ -1153,57 +1065,19 @@ The following shows AES-CBC-CS2 AFT and MCT responses.
 					"pt": "8F52D6E73783A..."
 				}
 			]
-		},
-		{
-			"tgId": 3,
-			"tests": [{
-				"tcId": 63,
-				"resultsArray": [{
-						"key": "E5E2...",
-						"iv": "057FB...",
-						"pt": "6DA46...",
-						"ct": "3E794..."
-					},
-					{
-						"key": "DE31...",
-						"iv": "3E794...",
-						"pt": "3BD32...",
-						"ct": "9236D..."
-					}
-				]
-			}]
-		},
-		{
-			"tgId": 1,
-			"tests": [{
-				"tcId": 64,
-				"resultsArray": [{
-						"key": "F743...",
-						"iv": "FD5ED...",
-						"ct": "37ECE...",
-						"pt": "52FC3..."
-					},
-					{
-						"key": "A5BF...",
-						"iv": "52FC3...",
-						"ct": "4400F...",
-						"pt": "66204..."
-					}
-				]
-			}]
 		}
 	]
 }]
 
 ----
 
-The following shows AES-CBC-CS3 AFT and MCT request vectors.
+The following shows AES-CBC-CS3 AFT request vectors.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2058,
 	"algorithm": "ACVP-AES-CBC-CS3",
@@ -1244,44 +1118,19 @@ The following shows AES-CBC-CS3 AFT and MCT request vectors.
 				"ct": "DD14A9A9A916A...",
 				"payloadLen": 471
 			}]
-		},
-		{
-			"tgId": 3,
-			"direction": "encrypt",
-			"testType": "MCT",
-			"keyLen": 256,
-			"tests": [{
-				"tcId": 63,
-				"iv": "205734F67...",
-				"key": "7C446BA54C41B6F98D5C0...",
-				"pt": "806800AE3952ED97...",
-				"payloadLen": 521
-			}]
-		}, {
-			"tgId": 4,
-			"direction": "decrypt",
-			"testType": "MCT",
-			"keyLen": 128,
-			"tests": [{
-				"tcId": 64,
-				"iv": "3E1D14BDDE1F5CB09EBA67F6...",
-				"key": "C5AB9CE14549A...",
-				"ct": "9A916A449949073...",
-				"payloadLen": 310
-			}]
 		}
 	]
 }]
 
 ----
 
-The following shows AES-CBC-CS3 AFT and MCT responses.
+The following shows AES-CBC-CS3 AFT responses.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2057,
 	"testGroups": [{
@@ -1307,44 +1156,6 @@ The following shows AES-CBC-CS3 AFT and MCT responses.
 					"pt": "8F52D6E73783A..."
 				}
 			]
-		},
-		{
-			"tgId": 3,
-			"tests": [{
-				"tcId": 63,
-				"resultsArray": [{
-						"key": "E5E2...",
-						"iv": "057FB...",
-						"pt": "6DA46...",
-						"ct": "3E794..."
-					},
-					{
-						"key": "DE31...",
-						"iv": "3E794...",
-						"pt": "3BD32...",
-						"ct": "9236D..."
-					}
-				]
-			}]
-		},
-		{
-			"tgId": 1,
-			"tests": [{
-				"tcId": 64,
-				"resultsArray": [{
-						"key": "F743...",
-						"iv": "FD5ED...",
-						"ct": "37ECE...",
-						"pt": "52FC3..."
-					},
-					{
-						"key": "A5BF...",
-						"iv": "52FC3...",
-						"ct": "4400F...",
-						"pt": "66204..."
-					}
-				]
-			}]
 		}
 	]
 }]
@@ -1357,7 +1168,7 @@ The following shows AES-ECB AFT and MCT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2056,
 	"algorithm": "ACVP-AES-ECB",
@@ -1435,7 +1246,7 @@ The following shows AES-ECB AFT and MCT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2056,
 	"testGroups": [{
@@ -1507,7 +1318,7 @@ The following shows AES-OFB AFT and MCT request vectors.
 [source, json]
 ----
 [{
-    "acvVersion": <acvp-version>,
+    "acvVersion": "{acvp-version}",
 },{
 	"vsId": 2060,
 	"algorithm": "ACVP-AES-OFB",
@@ -1577,7 +1388,7 @@ The following shows AES-OFB AFT and MCT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2060,
 	"testGroups": [{
@@ -1653,7 +1464,7 @@ The following shows AES-CFB1 AFT and MCT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2062,
 	"algorithm": "ACVP-AES-CFB1",
@@ -1729,7 +1540,7 @@ The following shows AES-CFB1 AFT and MCT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2062,
 	"testGroups": [{
@@ -1804,7 +1615,7 @@ The following shows AES-CFB8 AFT and MCT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2058,
 	"algorithm": "ACVP-AES-CFB8",
@@ -1874,7 +1685,7 @@ The following shows AES-CFB8 AFT and MCT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2058,
 	"testGroups": [{
@@ -1950,7 +1761,7 @@ The following shows AES-CFB128 AFT and MCT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2059,
 	"algorithm": "ACVP-AES-CFB128",
@@ -2020,7 +1831,7 @@ The following shows AES-CFB128 AFT and MCT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2059,
 	"testGroups": [{
@@ -2096,7 +1907,7 @@ The following shows AES-CTR AFT and counter request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2066,
 	"algorithm": "ACVP-AES-CTR",
@@ -2159,7 +1970,7 @@ The following shows AES-CTR AFT and counter responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2066,
 	"testGroups": [{
@@ -2204,7 +2015,7 @@ The following shows AES-XPN AFT request vectors.
 [source, json]
 ----
 [{
-  "acvVersion": <acvp-version>
+  "acvVersion": "{acvp-version}"
 },{
   "algorithm": "ACVP-AES-XPN",
   "revision": "1.0",
@@ -2253,7 +2064,7 @@ The following shows AES-XPN AFT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
   "vsId": 1,
   "testGroups": [
@@ -2282,7 +2093,7 @@ The following shows AES-XTS AFT request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2065,
 	"algorithm": "ACVP-AES-XTS",
@@ -2334,7 +2145,7 @@ The following shows AES-XTS AFT responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2065,
 	"testGroups": [{
@@ -2372,7 +2183,7 @@ The following shows AES-KW request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2063,
 	"algorithm": "ACVP-AES-KW",
@@ -2420,7 +2231,7 @@ The following shows AES-KW responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2063,
 	"testGroups": [{
@@ -2458,7 +2269,7 @@ The following shows AES-KWP request vectors.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2064,
 	"algorithm": "ACVP-AES-KWP",
@@ -2506,7 +2317,7 @@ The following shows AES-KWP responses.
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
 	"vsId": 2064,
 	"testGroups": [{
@@ -2548,7 +2359,7 @@ The following is a example JSON object for test vectors sent from the ACVP serve
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-ECB",
@@ -2581,7 +2392,7 @@ The following is a example JSON object for test results sent from the crypto mod
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 1564,
     "testGroups": [{
@@ -2606,7 +2417,7 @@ The following is a example JSON object for test vectors sent from the ACVP serve
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-CFB1",
@@ -2652,7 +2463,7 @@ The following is a example JSON object for test results sent from the crypto mod
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 1564,
     "testGroups": [{
@@ -2700,7 +2511,7 @@ The following is a example JSON object for test vectors sent from the ACVP serve
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 1564,
     "algorithm": "ACVP-TDES-ECB",
@@ -2727,7 +2538,7 @@ The following is a example JSON object for test results sent from the crypto mod
 [source, json]
 ----
 [{
-	"acvVersion": <acvp-version>
+	"acvVersion": "{acvp-version}"
 },{
     "vsId": 1564,
     "testGroups": [{


### PR DESCRIPTION
- MCT is no longer valid for AES-CBC-CS*, removing json reference examples