### PR TITLE
Adds Conditioning Components as testable algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ All current information about ACVP may be found within this Github project. View
   * [Key Agreement](#key-agreement)
   * [KDFs](#kdfs)
   * [SafePrimes](#safe-primes)
+  * [ConditioningComponents](#conditioning-components)
 * [Accessing the demo server](#accessing-the-demo-server)
 * [Contribution guidelines](contribution-guidelines)
 * [Related projects](#related-projects)
@@ -261,6 +262,11 @@ The demo server allows validation of the following algorithms (a superset of the
 ### Safe Primes
 * [SafePrimes KeyGen](./draft-hammett-acvp-safe-primes.txt) - [HTML](./draft-hammett-acvp-safe-primes.html)
 * [SafePrimes KeyVer](./draft-hammett-acvp-safe-primes.txt) - [HTML](./draft-hammett-acvp-safe-primes.html)
+
+### Conditioning Components
+* [ConditioningComponent AES-CBC-MAC](./draft-celi-acvp-conditioning-components.txt) - [HTML](.draft-celi-acvp-conditioning-components.html)
+* [ConditioningComponent BlockCipher_DF](./draft-celi-acvp-conditioning-components.txt) - [HTML](.draft-celi-acvp-conditioning-components.html)
+* [ConditioningComponent Hash_DF](./draft-celi-acvp-conditioning-components.txt) - [HTML](.draft-celi-acvp-conditioning-components.html)
 
 The prod server supports all of the above except for the EdDSA variants, AES-FF3-1, KAS/KTS-IFC, and AES-GCM-SIV. Some of these algorithms have NIST SP800 series drafts in progress and will be available on the prod server when the draft becomes a standard. 
 

--- a/src/conditioning-components/sections/03-supported.adoc
+++ b/src/conditioning-components/sections/03-supported.adoc
@@ -1,0 +1,24 @@
+
+[#supported]
+== Supported Conditioning Components
+
+Conditioning is an optional process during entropy collection shown in Section 2.2.2 of <<SP800-90B>>. There are two types of conditioning components supported by <<SP800-90B>>: vetted and non-vetted. A vetted conditioning component comes from a specific list of options. All <<SP800-90B>> vetted conditioning components are available via ACVP. This document rounds out the list with options not covered in other algorithm testing.
+
+The following conditioning components *MAY* be advertised by the ACVP compliant cryptographic module:
+
+* ConditioningComponents / AES-CBC-MAC / SP800-90B
+* ConditioningComponents / BlockCipher_DF / SP800-90B
+* ConditioningComponents / Hash_DF / SP800-90B
+
+[[hash_supported]]
+=== Supported Hash Functions for Hash_DF
+
+For the Hash Derivation Function, Hash_DF, the following hash functions *MAY* be advertised by the ACVP compliant cryptographic module:
+
+* SHA-1
+* SHA2-224
+* SHA2-256
+* SHA2-384
+* SHA2-512
+* SHA2-512/224
+* SHA2-512/256

--- a/src/conditioning-components/sections/04-testtypes.adoc
+++ b/src/conditioning-components/sections/04-testtypes.adoc
@@ -1,0 +1,11 @@
+
+[#testtypes]
+== Test Types and Test Coverage
+
+This section describes the design of the tests used to validate implementations of Conditioning Components.
+
+=== Test Types
+
+There is one test-type for Conditioning Components: Algorithm Functional Tests. The testType field definitions are:
+
+* "AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'MAC', or 'derive' operation. AFTs cause the implementation under test to exercise nomral operations on a single block, multiple blocks, or partial blocks. In all cases,random data is used. The functional tests are designed to verify that the logical components of the cryptographic implementation (block chunking, block padding etc.) are operating correctly.

--- a/src/conditioning-components/sections/05-capabilities.adoc
+++ b/src/conditioning-components/sections/05-capabilities.adoc
@@ -1,0 +1,121 @@
+
+[[caps_reg]]
+
+[[cipher_caps_reg]]
+=== Conditioning Component Algorithm Capabilities Registration
+
+This section describes the constructs for advertising support of conditioning component algorithms to the ACVP server.
+
+[[mode_cipher_caps]]
+==== Block Cipher Based Conditioning Component Capabilities
+
+The following ConditioningComponent / AES-CBC-MAC / SP800-90B and ConditioningComponent / BlockCipher_DF / SP800-90B capabilities *MAY* be advertised by the ACVP compliant crypto module:
+
+[[caps_table]]
+.Block Cipher Conditioning Component Algorithm Capabilities JSON Values
+|===
+| JSON Value | Description | JSON type | Valid Values
+
+| algorithm | The algorithm to be validated | string | "ConditioningComponent"
+| mode | The specific conditioning component to be validated | "AES-CBC-MAC" or "BlockCipher_DF"
+| revision | The algorithm testing revision to use | string | "SP800-90B"
+| keyLen | The length of keys supported in bits | array | [128, 192, 256]
+| payloadLen | The lengths in bits supported by the IUT | domain | [{"min": 8, "max": 65536, "inc": 8}]
+|===
+
+NOTE: For ConditioningComponent / AES-CBC-MAC / SP800-90B, the payload itself is processed through the encryption engine. Therefore the minimum 'payloadLen' is 128 bits and the minimum increment is 128 bits. In other words, all values within the 'payloadLen' must correspond to complete AES blocks in bits (a multiple of 128).
+
+The following is an example of a registration for ConditioningComponents / AES-CBC-MAC / SP800-90B
+
+[source, json]
+----
+{
+  "algorithm": "ConditioningComponent",
+  "mode": "AES-CBC-MAC",
+  "revision": "SP800-90B",
+  "keyLen": [
+    128,
+    192,
+    256
+  ],
+  "payloadLen": [
+    {
+      "min": 128,
+      "max": 65536,
+      "increment": 128
+    }
+  ]
+}
+----
+
+The following is an example of a registration for ConditioningComponents / BlockCipher_DF / SP800-90B
+
+[source, json]
+----
+{
+  "algorithm": "ConditioningComponent",
+  "mode": "BlockCipher_DF",
+  "revision": "SP800-90B",
+  "keyLen": [
+    128,
+    192,
+    256
+  ],
+  "payloadLen": [
+    {
+      "min": 8,
+      "max": 65536,
+      "increment": 8
+    }
+  ]
+}
+----
+
+[[mode_hash_caps]]
+==== Hash Based Conditioning Component Capabilities
+
+The following ConditioningComponent / Hash_DF / SP800-90B capabilities *MAY* be advertised by the ACVP compliant crypto module:
+
+[[hash_caps_table]]
+.Hash Conditioning Component Algorithm Capabilities JSON Values
+|===
+| JSON Value | Description | JSON type | Valid Values
+
+| algorithm | The algorithm to be validated | string | "ConditioningComponent"
+| mode | The specific conditioning component to be validated | "Hash_DF"
+| revision | The algorithm testing revision to use | string | "SP800-90B"
+| capabilities | An array of supported capability objects | array of objects | Each element in the array is made of exactly one 'payloadLen' field and one 'hashAlg' field
+| payloadLen | The lengths in bits supported by the IUT | domain | [{"min": 1, "max": 65536, "inc": 1}]
+| hashAlg | The hash algorithm that supports the specific lengths | array | Any non-zero number of elements from <<hash_supported>>
+|===
+
+The following is an example of a registration for ConditioningComponents / Hash_DF / SP800-90B
+
+[source, json]
+----
+{
+  "algorithm": "ConditioningComponent",
+  "mode": "Hash_DF",
+  "revision": "SP800-90B",
+  "capabilities": [
+    {
+      "payloadLen": [
+        {
+          "min": 1,
+          "max": 65536,
+          "increment": 1
+        }
+      ],
+      "hashAlg": [
+        "SHA-1",
+        "SHA2-224",
+        "SHA2-256",
+        "SHA2-384",
+        "SHA2-512",
+        "SHA2-512/224",
+        "SHA2-512/256"
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/06-blockcipher-df-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-blockcipher-df-test-vectors.adoc
@@ -27,8 +27,8 @@ Each test group contains an array of one or more test cases. Each test case is a
 | JSON Value | Description | JSON Type
 
 | tcId | Test case identifier | integer
-| input | The input into the derivation function | hex
-| inputLen | The length in bits of the input | integer
+| payload | The input into the derivation function | hex
+| payloadLen | The length in bits of the input | integer
 |===
 
 Here is an abbreviated yet fully constructed example of the prompt for ConditioningComponent / BlockCipher_DF / SP800-90B
@@ -48,13 +48,13 @@ Here is an abbreviated yet fully constructed example of the prompt for Condition
       "tests": [
         {
           "tcId": 1,
-          "inputString": "2874215320DADAC...",
-          "inputLen": 54112
+          "payload": "2874215320DADAC...",
+          "payloadLen": 54112
         },
         {
           "tcId": 2,
-          "inputString": "36",
-          "inputLen": 8
+          "payload": "36",
+          "payloadLen": 8
         }
       ]
     }

--- a/src/conditioning-components/sections/06-blockcipher-df-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-blockcipher-df-test-vectors.adoc
@@ -1,0 +1,63 @@
+
+[[bc_df_tgjs]]
+=== Conditioning Component BlockCipher_DF Test Groups JSON Schema
+
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the ConditioningComponent / BlockCipher_DF / SP800-90B JSON elements of the Test Group JSON object.
+
+[[bc_df_vs_tg_table]]
+.Conditioning Component BlockCipher_DF Test Group JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| tgId | The unique group identifier | integer
+| testType | Describes the operation the client should perform on the test data | string
+| keyLen | The length of the key used in the group | integer
+| tests | Array of individual test cases, see <<bc_df_tvjs>> | array
+|===
+
+The 'tgId', 'testType' and 'tests' objects *MUST* appear in every test group element communicated from the server to the client as a part of a prompt.
+
+[[bc_df_tvjs]]
+=== Conditioning Component BlockCipher_DF Test Case JSON Schema
+
+Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ConditioningComponent / BlockCipher_DF / SP800-90B test vector.
+
+.Conditioning Component BlockCipher_DF Test Case JSON Object
+|===
+| JSON Value | Description | JSON Type
+
+| tcId | Test case identifier | integer
+| input | The input into the derivation function | hex
+| inputLen | The length in bits of the input | integer
+|===
+
+Here is an abbreviated yet fully constructed example of the prompt for ConditioningComponent / BlockCipher_DF / SP800-90B
+
+[source, json]
+----
+{
+  "vsId": 42,
+  "algorithm": "ConditioningComponent",
+  "mode": "BlockCipher_DF",
+  "revision": "SP800-90B",
+  "testGroups": [
+    {
+      "tgId": 1,
+      "keyLen": 128,
+      "testType": "AFT",
+      "tests": [
+        {
+          "tcId": 1,
+          "inputString": "2874215320DADAC...",
+          "inputLen": 54112
+        },
+        {
+          "tcId": 2,
+          "inputString": "36",
+          "inputLen": 8
+        }
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/06-cbc-mac-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-cbc-mac-test-vectors.adoc
@@ -1,0 +1,63 @@
+
+[[cbc_mac_tgjs]]
+=== Conditioning Component AES-CBC-MAC Test Groups JSON Schema
+
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the ConditioningComponent / AES-CBC-MAC / SP800-90B JSON elements of the Test Group JSON object.
+
+[[cbc_mac_vs_tg_table]]
+.Conditioning Component AES-CBC-MAC Test Group JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| tgId | The unique group identifier | integer
+| testType | Describes the operation the client should perform on the test data | string
+| keyLen | The length of the key used in the group | integer
+| tests | Array of individual test cases, see <<cbc_mac_tvjs>> | array
+|===
+
+The 'tgId', 'testType' and 'tests' objects *MUST* appear in every test group element communicated from the server to the client as a part of a prompt.
+
+[[cbc_mac_tvjs]]
+=== Conditioning Component AES-CBC-MAC Test Case JSON Schema
+
+Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ConditioningComponent / AES-CBC-MAC / SP800-90B test vector.
+
+.Conditioning Component AES-CBC-MAC Test Case JSON Object
+|===
+| JSON Value | Description | JSON Type
+
+| tcId | Test case identifier | integer
+| pt | The plaintext | hex
+| key | The key | hex
+|===
+
+Here is an abbreviated yet fully constructed example of the prompt for ConditioningComponent / AES-CBC-MAC / SP800-90B
+
+[source, json]
+----
+{
+  "vsId": 42,
+  "algorithm": "ConditioningComponent",
+  "mode": "AES-CBC-MAC",
+  "revision": "SP800-90B",
+  "testGroups": [
+    {
+      "tgId": 1,
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [
+        {
+          "tcId": 1,
+          "pt": "FE44418EF94E5DA8...",
+          "key": "E618ADF7E7CEBB46465C0B18A924768A"
+        },
+        {
+          "tcId": 2,
+          "pt": "6ABEED30F813C137D47BF1E9E837DAEE",
+          "key": "D1C1B7FFB2CCE0BBF13D4F7B4A246A8D"
+        }
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/06-hash-df-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-hash-df-test-vectors.adoc
@@ -27,8 +27,8 @@ Each test group contains an array of one or more test cases. Each test case is a
 | JSON Value | Description | JSON Type
 
 | tcId | Test case identifier | integer
-| input | The input into the derivation function | hex
-| inputLen | The length in bits of the input | integer
+| payload | The input into the derivation function | hex
+| payloadLen | The length in bits of the input | integer
 |===
 
 Here is an abbreviated yet fully constructed example of the prompt for ConditioningComponent / Hash_DF / SP800-90B
@@ -48,13 +48,13 @@ Here is an abbreviated yet fully constructed example of the prompt for Condition
       "tests": [
         {
           "tcId": 1,
-          "inputString": "2874215320DADAC...",
-          "inputLen": 54112
+          "payload": "2874215320DADAC...",
+          "payloadLen": 54112
         },
         {
           "tcId": 2,
-          "inputString": "36",
-          "inputLen": 8
+          "payload": "36",
+          "payloadLen": 8
         }
       ]
     }

--- a/src/conditioning-components/sections/06-hash-df-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-hash-df-test-vectors.adoc
@@ -1,0 +1,63 @@
+
+[[hash_df_tgjs]]
+=== Conditioning Component Hash_DF Test Groups JSON Schema
+
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the ConditioningComponent / Hash_DF / SP800-90B JSON elements of the Test Group JSON object.
+
+[[hash_df_vs_tg_table]]
+.Conditioning Component Hash_DF Test Group JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| tgId | The unique group identifier | integer
+| testType | Describes the operation the client should perform on the test data | string
+| hashAlg | The hash algorithm used in the derivation function | string
+| tests | Array of individual test cases, see <<hash_df_tvjs>> | array
+|===
+
+The 'tgId', 'testType' and 'tests' objects *MUST* appear in every test group element communicated from the server to the client as a part of a prompt.
+
+[[hash_df_tvjs]]
+=== Conditioning Component Hash_DF Test Case JSON Schema
+
+Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ConditioningComponent / Hash_DF / SP800-90B test vector.
+
+.Conditioning Component Hash_DF Test Case JSON Object
+|===
+| JSON Value | Description | JSON Type
+
+| tcId | Test case identifier | integer
+| input | The input into the derivation function | hex
+| inputLen | The length in bits of the input | integer
+|===
+
+Here is an abbreviated yet fully constructed example of the prompt for ConditioningComponent / Hash_DF / SP800-90B
+
+[source, json]
+----
+{
+  "vsId": 42,
+  "algorithm": "ConditioningComponent",
+  "mode": "Hash_DF",
+  "revision": "SP800-90B",
+  "testGroups": [
+    {
+      "tgId": 1,
+      "hashAlg": "SHA2-256",
+      "testType": "AFT",
+      "tests": [
+        {
+          "tcId": 1,
+          "inputString": "2874215320DADAC...",
+          "inputLen": 54112
+        },
+        {
+          "tcId": 2,
+          "inputString": "36",
+          "inputLen": 8
+        }
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/06-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-test-vectors.adoc
@@ -1,0 +1,20 @@
+
+[[tgjs]]
+== Test Vectors
+
+The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual crypto algorithm, such as ConditioningComponent / AES-CBC-MAC / SP800-90B, ConditioningComponent / Hash_DF / SP800-90B, etc. This section describes the JSON schema for a test vector set used with Conditioning Component crypto algorithms.
+
+The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy.
+
+[[conditioningcomponent_vs_top_table]]
+.Conditioning Component Vector Set JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| acvVersion | Protocol version identifier | string
+| vsId | Unique numeric identifier for the vector set | integer
+| algorithm | The algorithm used for the test vectors | string
+| mode | The mode used for the test vectors | string
+| revision | The algorithm testing revision to use | string
+| testGroups | Array of test group JSON objects, which are defined in <<cbc_mac_tgjs>>, <<bc_df_tgjs>>, or <<hash_df_tgjs>> depending on the algorithm | array
+|===

--- a/src/conditioning-components/sections/07-blockcipher-df-responses.adoc
+++ b/src/conditioning-components/sections/07-blockcipher-df-responses.adoc
@@ -1,0 +1,44 @@
+[[bc_df_responses]]
+=== Conditioning Component BlockCipher_DF Test Responses
+
+Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ConditioningComponent / BlockCipher_DF / SP800-90B test vector.
+
+The following table describes the JSON elements for the test case responses for ConditioningComponent / BlockCipher_DF / SP800-90B.
+
+[[bc_df_vs_tr_table]]
+.Conditioning Component BlockCipher_DF Test Case Results JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| tcId | Numeric identifier for the test case | integer
+| requestedBits | The output of the derivation function | hex
+|===
+
+NOTE: In the case of BlockCipher_DF, the output is always 128-bits regardless of the size of the input.
+
+The following is an example of the response for ConditioningComponent / BlockCipher_DF / SP800-90B .
+
+[source, json]
+----
+{
+  "vsId": 42,
+  "algorithm": "ConditioningComponent",
+  "mode": "BlockCipher_DF",
+  "revision": "SP800-90B",
+  "testGroups": [
+    {
+      "tgId": 1,
+      "tests": [
+        {
+          "tcId": 1,
+          "requestedBits": "4A8575F3EA300812C60B19678620CA9F"
+        },
+        {
+          "tcId": 2,
+          "requestedBits": "2F85CD9748F4CEE2F9BAE939874D8321"
+        }
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/07-cbc-mac-responses.adoc
+++ b/src/conditioning-components/sections/07-cbc-mac-responses.adoc
@@ -1,0 +1,44 @@
+[[cbc_mac_responses]]
+=== Conditioning Component AES-CBC-MAC Test Responses
+
+Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ConditioningComponent / AES-CBC-MAC / SP800-90B test vector.
+
+The following table describes the JSON elements for the test case responses for ConditioningComponent / AES-CBC-MAC / SP800-90B.
+
+[[cbc_mac_vs_tr_table]]
+.Conditioning Component AES-CBC-MAC Test Case Results JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| tcId | Numeric identifier for the test case | integer
+| ct | The ciphertext output | hex
+|===
+
+NOTE: In the case of AES-CBC-MAC, the output is always 128-bits regardless of the size of the input.
+
+The following is an example of the response for ConditioningComponent / AES-CBC-MAC / SP800-90B .
+
+[source, json]
+----
+{
+  "vsId": 42,
+  "algorithm": "ConditioningComponent",
+  "mode": "AES-CBC-MAC",
+  "revision": "SP800-90B",
+  "testGroups": [
+    {
+      "tgId": 1,
+      "tests": [
+        {
+          "tcId": 1,
+          "ct": "4A8575F3EA300812C60B19678620CA9F"
+        },
+        {
+          "tcId": 2,
+          "ct": "2F85CD9748F4CEE2F9BAE939874D8321"
+        }
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/07-hash-df-responses.adoc
+++ b/src/conditioning-components/sections/07-hash-df-responses.adoc
@@ -1,0 +1,42 @@
+[[hash_df_responses]]
+=== Conditioning Component Hash_DF Test Responses
+
+Each test group contains an array of one or more test cases. Each test case is a JSON object that represents a single test vector to be processed by the ACVP client. The following table describes the JSON elements for each ConditioningComponent / Hash_DF / SP800-90B test vector.
+
+The following table describes the JSON elements for the test case responses for ConditioningComponent / Hash_DF / SP800-90B.
+
+[[hash_df_vs_tr_table]]
+.Conditioning Component Hash_DF Test Case Results JSON Object
+|===
+| JSON Value | Description | JSON type
+
+| tcId | Numeric identifier for the test case | integer
+| requestedBits | The output of the derivation function | hex
+|===
+
+The following is an example of the response for ConditioningComponent / Hash_DF / SP800-90B .
+
+[source, json]
+----
+{
+  "vsId": 42,
+  "algorithm": "ConditioningComponent",
+  "mode": "Hash_DF",
+  "revision": "SP800-90B",
+  "testGroups": [
+    {
+      "tgId": 1,
+      "tests": [
+        {
+          "tcId": 1,
+          "requestedBits": "4A8575F3EA300812C60B19678620CA9F"
+        },
+        {
+          "tcId": 2,
+          "requestedBits": "2F85CD9748F4CEE2F9BAE939874D8321"
+        }
+      ]
+    }
+  ]
+}
+----

--- a/src/conditioning-components/sections/07-responses.adoc
+++ b/src/conditioning-components/sections/07-responses.adoc
@@ -1,0 +1,46 @@
+
+[[vector_responses]]
+== Test Vector Responses
+
+After the ACVP client downloads and processes a vector set, it must send the response vectors back to the ACVP server. The following table describes the JSON object that represents a vector set response.
+
+.Response JSON Object
+|===
+| JSON Property | Description | JSON Type
+
+| acvVersion | The version of the protocol | string
+| vsId | The vector set identifier | integer
+| testGroups | The test group data, see <<response_group_table>> | array
+|===
+
+An example of this is the following
+
+[source, json]
+----
+{
+    "acvVersion": "version",
+    "vsId": 1,
+    "testGroups": [ ... ]
+}
+----
+
+The testGroups section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms *SHALL* require the client to send back group level properties in their response. This structure helps accommodate that. The following is a skeleton for the test group structure. Additional properties may be included at this level depending on the algorithm, mode and revision.
+
+[[response_group_table]]
+.Response Test Group JSON Objects
+|===
+| JSON Property | Description | JSON Type
+
+| tgId | The test group identifier | integer
+| tests | The test case data, depending on the algorithm see <<cbc_mac_vs_tr_table>>, <<bc_df_vs_tr_table>>, or <<hash_df_vs_tr_table>> | array
+|===
+
+An example of this is the following
+
+[source, json]
+----
+{
+    "tgId": 1,
+    "tests": [ ... ]
+}
+----

--- a/src/conditioning-components/sections/98-references.adoc
+++ b/src/conditioning-components/sections/98-references.adoc
@@ -1,0 +1,40 @@
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC7991,RFC 7991]]]
+* [[[RFC8174,RFC 8174]]]
+
+[%bibitem]
+=== Automatic Cryptographic Validation Protocol
+id:: ACVP
+docid::
+  id::: ACVP
+contributor::
+contributor.person.name.initial:: B.
+contributor.person.name.surname:: Fussell
+contributor.person.affiliation.organization.name:: Cisco
+contributor::
+contributor.person.name.initial:: A.
+contributor.person.name.surname:: Vassilev
+contributor.person.affiliation.organization.name:: National Institute of Standards and Technology
+contributor.person.affiliation.organization.abbreviation:: NIST
+contributor::
+contributor.person.name.initial:: H.
+contributor.person.name.surname:: Booth
+contributor.person.affiliation.organization.name:: National Institute of Standards and Technology
+contributor.person.affiliation.organization.abbreviation:: NIST
+contributor::
+contributor.role:: publisher
+contributor.organization.name:: National Institute of Standards and Technology
+contributor.organization.abbreviation:: NIST
+date::
+date.type:: published
+date.value:: 2019-07-01
+
+[%bibitem]
+=== SP800-90B Spec
+id:: SP800-90B
+docid::
+  id::: SP800-90B

--- a/src/draft-celi-acvp-conditioning-components.adoc
+++ b/src/draft-celi-acvp-conditioning-components.adoc
@@ -1,0 +1,58 @@
+= ACVP ConditioningComponents JSON Specification
+:doctype: internet-draft
+:docname: acvp-conditioning-components
+:docnumber: draft-ietf-acvp-sub-conditioning-components
+:abbrev: ACVP ConditioningComponents
+:ipr: trust200902
+:submission-type: independent
+:area: Internet
+:intended-series: informational
+:revdate: 2020-09-01
+:forename_initials: C.C.
+:lastname: Celi
+:fullname: Christopher Celi
+:organization: National Institute of Standards and Technology
+:street: 100 Bureau Drive
+:city: Gaithersburg
+:code: 20899
+:country: United States of America
+:email: christopher.celi@nist.gov
+:role: editor
+:docfile: draft-celi-acvp-conditioning-components.adoc
+:mn-document-class: ietf
+:mn-output-extensions: xml,rfc,txt,html
+:xrefstyle: full
+:area: General
+:keyword: acvp, crypto
+
+// Singular name of the algorithm
+:spec-algorithm: Conditioning Component
+:algo-short-name: Conditioning Component
+
+include::common/common-sections/00-abstract.adoc[]
+include::common/common-sections/01-intro.adoc[]
+include::common/common-sections/02-conventions.adoc[]
+include::conditioning-components/sections/03-supported.adoc[]
+include::conditioning-components/sections/04-testtypes.adoc[]
+
+include::common/common-sections/05-capabilities-description.adoc[]
+include::common/common-sections/051-prerequisites.adoc[]
+include::conditioning-components/sections/05-capabilities.adoc[]
+
+include::common/common-sections/06-test-vector-intro.adoc[]
+include::conditioning-components/sections/06-test-vectors.adoc[]
+include::conditioning-components/sections/06-cbc-mac-test-vectors.adoc[]
+include::conditioning-components/sections/06-blockcipher-df-test-vectors.adoc[]
+include::conditioning-components/sections/06-hash-df-test-vectors.adoc[]
+
+include::conditioning-components/sections/07-responses.adoc[]
+include::conditioning-components/sections/07-cbc-mac-responses.adoc[]
+include::conditioning-components/sections/07-blockcipher-df-responses.adoc[]
+include::conditioning-components/sections/07-hash-df-responses.adoc[]
+
+include::common/common-sections/10-security.adoc[]
+include::common/common-sections/11-iana.adoc[]
+include::common/common-sections/99-acknowledgements.adoc[]
+
+// References must be given before appendixes
+include::conditioning-components/sections/98-references.adoc[]


### PR DESCRIPTION
SP800-90B lists several vetted conditioning components that can be used as a part of an entropy source. Most vetted conditioning components already have corresponding algorithms within ACVP. This update rounds out the list to allow specific validations for CBC-MAC, Hash-DF and BlockCipher-DF. 