### PR TITLE
Removes partialVal as a valid option from KAS-FFC / 1.0 document

### DIFF
--- a/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
@@ -60,7 +60,6 @@ The following function types *MAY* be advertised by the ACVP compliant crypto mo
 * dpVal - IUT can perform domain parameter validation (FFC only)
 * keyPairGen - IUT can perform keypair generation.
 * fullVal - IUT can perform full public key validation ( <<SP800-56a>> section 5.6.2.3.1 / 5.6.2.3.3) 
-* partialVal - IUT can perform partial public key validation ( <<SP800-56a>> section 5.6.2.3.2 / 5.6.2.3.4) 
 * keyRegen - IUT can regenerate keys given a specific seed and domain parameter (pqg for FFC, curve for ECC)
 
 [[schemes]]


### PR DESCRIPTION
- closes #1005