### PR TITLE
States ivLen will always be 96 bits in XPN groups

### DIFF
--- a/src/symmetric/sections/06-test-vectors.adoc
+++ b/src/symmetric/sections/06-test-vectors.adoc
@@ -73,7 +73,7 @@ The following grid defines when each property is *REQUIRED* from a server for ea
 
 | AES-GCM| 128, 192, 256| "internal", "external"| "8.2.1", "8.2.2"| | within domain| within domain| within domain| within domain|
 | AES-GCM-SIV| 128, 256| | | | 96| within domain| within domain| 128|
-| AES-XPN| 128, 192, 256| "internal", "external"| "8.2.1", "8.2.2"| "internal", "external"| within domain| within domain| within domain| within domain| within domain
+| AES-XPN| 128, 192, 256| "internal", "external"| "8.2.1", "8.2.2"| "internal", "external"| 96| within domain| within domain| within domain| within domain
 | AES-CCM| 128, 192, 256| | | | within domain| within domain| within domain| within domain|
 |===
 


### PR DESCRIPTION
Fixes #1009 