### PR TITLE
Adds `% 4` back to tuple length calculation for TupleHash MCT

### DIFF
--- a/src/xof/sections/04-testtypes.adoc
+++ b/src/xof/sections/04-testtypes.adoc
@@ -105,7 +105,7 @@ MCT(Tuple, MaxOutLen, MinOutLen)
     for (i = 1; i < 1001; i++) 
     {
       workingBits = Left(T[i-1][0] || ZeroBits(288), 288);
-      tupleSize = Left(workingBits, 3) + 1; // never more than 8 tuples to a round
+      tupleSize = Left(workingBits, 3) % 4 + 1; // never more than 4 tuples to a round
       for (k = 0; k < tupleSize; k++) 
       {
         T[i][k] = Substring of workingBits from (k * 288 / tupleSize) to ((k+1) * 288 / tupleSize - 1);


### PR DESCRIPTION
- https://github.com/usnistgov/ACVP/issues/904#issuecomment-696685429