### PR TITLE
Updates to the allowed "auxFunctions" across KAS ECC/FFC/IFC and OneS…

### DIFF
--- a/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
@@ -106,7 +106,7 @@ Note that AT LEAST one KDF Method is required for KAS schemes.  The following *M
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 

--- a/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
@@ -106,7 +106,7 @@ Note that AT LEAST one KDF Method is required for KAS schemes.  The following *M
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA@-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethod| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 

--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -144,7 +144,7 @@ Note that *AT LEAST* one KDF Method is required for KAS schemes.  The following 
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 

--- a/src/kas/sp800-56cr1/onestep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56cr1/onestep/sections/05-capabilities.adoc
@@ -41,7 +41,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 |===
 | JSON Value| Description| JSON Type| Valid Values
 
-| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, KMAC-128, KMAC-256
+| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). Required for MAC based auxFunctions.| array of string| default, random
 |===
 


### PR DESCRIPTION
…tep KDF.

- HMAC based `auxFunctions` have been added to the list of allowed functions.
- https://github.com/usnistgov/ACVP-Server/issues/7