### PR TITLE
KAS "1.0" revision specification updates and/or clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ The demo server allows validation of the following algorithms (a superset of the
 * [EDDSA mode: sigVer](./draft-celi-acvp-eddsa.txt) - [HTML](./draft-celi-acvp-eddsa.html) - DEMO only
 
 ### Key Agreement
+#### Full KAS Testing
+
+  Tests against shared secret computation (SSC), key derivation functions (KDF), and optionally key confirmation (KC).  Test vectors issued under this set of tests (with the exception of 1.0 component based tests) are consider "full kas" testing.
+
 * [KAS ECC ephemeralUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
 * [KAS ECC fullMqv](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
 * [KAS ECC fullUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
@@ -195,7 +199,6 @@ The demo server allows validation of the following algorithms (a superset of the
 * [KAS ECC onePassMqv](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
 * [KAS ECC OnePassUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
 * [KAS ECC staticUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
-* [KAS ECC CDH-Component](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
 * [KAS FFC dhHybrid1](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
 * [KAS FFC mqv2](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html) 
 * [KAS FFC dhEphem](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
@@ -225,9 +228,26 @@ The demo server allows validation of the following algorithms (a superset of the
 * [KAS IFC KAS2-Party_V-confirmation](./draft-hammett-acvp-kas-ifc.txt) - [HTML](./draft-hammett-acvp-kas-ifc.html) - DEMO only
 * [KTS IFC KTS-OAEP-basic](./draft-hammett-acvp-kas-ifc.txt) - [HTML](./draft-hammett-acvp-kas-ifc.html) - DEMO only
 * [KTS IFC KTS-OAEP-Party_V-confirmation](./draft-hammett-acvp-kas-ifc.txt) - [HTML](./draft-hammett-acvp-kas-ifc.html) - DEMO only
-* [KAS KDF HKDF Sp800-56Cr1](./draft-hammett-acvp-kas-kdf-hkdf.txt) - [HTML](./draft-hammett-acvp-kas-kdf-hkdf.html)
-* [KAS KDF OneStep Sp800-56Cr1](./draft-hammett-acvp-kas-kdf-onestep.txt) - [HTML](./draft-hammett-acvp-kas-kdf-onestep.html)
-* [KAS KDF TwoStep Sp800-56Cr1](./draft-hammett-acvp-kas-kdf-twostep.txt) - [HTML](./draft-hammett-acvp-kas-kdf-twostep.html)
+
+#### KAS SSC Testing
+
+Standalone KAS SSC testing from SP800-56A/B.  Can be used in conjunction with KDF testing (as opposed to full KAS testing) to be considered a valid KAS implementation.
+
+* [KAS ECC ephemeralUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC fullMqv](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC fullUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC onePassDh](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC onePassMqv](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC OnePassUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC staticUnified](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS ECC CDH-Component](./draft-fussell-acvp-kas-ecc.txt) - [HTML](./draft-fussell-acvp-kas-ecc.html)
+* [KAS FFC dhHybrid1](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
+* [KAS FFC mqv2](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html) 
+* [KAS FFC dhEphem](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
+* [KAS FFC dhHybridOneFlow](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
+* [KAS FFC mqv1](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
+* [KAS FFC dhOneFlow](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
+* [KAS FFC dhStatic](./draft-fussell-acvp-kas-ffc.txt) - [HTML](./draft-fussell-acvp-kas-ffc.html)
 * [KAS ECC SSC ephemeralUnified Sp800-56Ar3](./draft-hammett-acvp-kas-ssc-ecc.txt) - [HTML](./draft-hammett-acvp-kas-ssc-ecc.html)
 * [KAS ECC SSC fullMqv Sp800-56Ar3](./draft-hammett-acvp-kas-ssc-ecc.txt) - [HTML](./draft-hammett-acvp-kas-ssc-ecc.html)
 * [KAS ECC SSC fullUnified Sp800-56Ar3](./draft-hammett-acvp-kas-ssc-ecc.txt) - [HTML](./draft-hammett-acvp-kas-ssc-ecc.html)
@@ -244,6 +264,14 @@ The demo server allows validation of the following algorithms (a superset of the
 * [KAS FFC SSC dhStatic Sp800-56Ar3](./draft-hammett-acvp-kas-ssc-ffc.txt) - [HTML](./draft-hammett-acvp-kas-ssc-ffc.html)
 * [KAS IFC SSC KAS1 Sp800-56Br2](./draft-hammett-acvp-kas-ssc-ifc.txt) - [HTML](./draft-hammett-acvp-kas-ssc-ifc.html) - DEMO only
 * [KAS IFC SSC KAS2 Sp800-56Br2](./draft-hammett-acvp-kas-ssc-ifc.txt) - [HTML](./draft-hammett-acvp-kas-ssc-ifc.html) - DEMO only
+
+#### KAS KDF Testing SP800-56Cr1
+
+  Standalone KAS KDF testing from SP800-56Cr1.  Can be used in conjunction with SSC testing (as opposed to full KAS testing) to be considered a valid KAS implementation.
+
+* [KAS KDF HKDF Sp800-56Cr1](./draft-hammett-acvp-kas-kdf-hkdf.txt) - [HTML](./draft-hammett-acvp-kas-kdf-hkdf.html)
+* [KAS KDF OneStep Sp800-56Cr1](./draft-hammett-acvp-kas-kdf-onestep.txt) - [HTML](./draft-hammett-acvp-kas-kdf-onestep.html)
+* [KAS KDF TwoStep Sp800-56Cr1](./draft-hammett-acvp-kas-kdf-twostep.txt) - [HTML](./draft-hammett-acvp-kas-kdf-twostep.html)
 
 ### KDFs
 * [Counter KDF](./draft-celi-acvp-kbkdf.txt) - [HTML](./draft-celi-acvp-kbkdf.html)

--- a/src/kas/sp800-56ar2/ecc/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/04-testtypes.adoc
@@ -23,7 +23,7 @@ The tests described in this document have the intention of ensuring an implement
 
 * SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
 
-* SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS SHALL make use of a hash function. The hash function *MAY* be used for confirmation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
+* SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS SHALL make use of a hash function. The hash function *MAY* be used for validation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
 
 * SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is *REQUIRED* only for kdfKc, though is utilized for both kdfNoKc and kdfKc.
 

--- a/src/kas/sp800-56ar2/ecc/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/04-testtypes.adoc
@@ -14,52 +14,50 @@ There are two test types for KAS testing:
 
 === Test Coverage
 
-The tests described in this document have the intention of ensuring an implementation is conformant to <<SP800-56a>>. 
+The tests described in this document have the intention of ensuring an implementation is conformant to <<SP800-56Ar2>>. 
 
 [[requirements_covered_kas_ecc]]
 ==== KAS-ECC Requirements Covered
                         
-* SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
+* SP 800-56Ar2 - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
 
-* SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
+* SP 800-56Ar2 - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
 
-* SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS SHALL make use of a hash function. The hash function *MAY* be used for validation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
+* SP 800-56Ar2 - 5.1 Cryptographic Hash Functions. All modes of performing KAS SHALL make use of a hash function. The hash function *MAY* be used for validation of a successfully generated shared secret Z (noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
 
-* SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is *REQUIRED* only for kdfKc, though is utilized for both kdfNoKc and kdfKc.
+* SP 800-56Ar2 - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is *REQUIRED* only for kdfKc, though is utilized for both kdfNoKc and kdfKc.
 
-* SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT SHALL be expected to generate nonces.
+* SP 800-56Ar2 - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT SHALL be expected to generate nonces.
 
-* SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation *SHALL* be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters *SHALL* generate all keypairs (party U/V, static/ephemeral) for a single test case.
+* SP 800-56Ar2 - 5.5 Domain Parameters. Domain Parameter Generation *SHALL* be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters *SHALL* generate all keypairs (party U/V, static/ephemeral) for a single test case.
 
-* SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, *MAY* inject bad keypairs that the IUT *MUST* be able detect. These random tests are only present in groups given appropriate assurance functions see: <<supported_functions>>
+* SP 800-56Ar2 - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, *MAY* inject bad keypairs that the IUT *MUST* be able detect. These random tests are only present in groups given appropriate assurance functions see: <<supported_functions>>
                             
-* SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV *SHALL* be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
+* SP 800-56Ar2 - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV *SHALL* be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
 
-* SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes. All schemes/modes save noKdfNoKc (component) *MUST* make use of a KDF. KDF construction *SHALL* utilize <<oiPatternConstruction>> for its pattern. 
+* SP 800-56Ar2 - 5.8 Key-Derivation Methods for Key-Agreement Schemes. All schemes/modes save noKdfNoKc (component) *MUST* make use of a KDF. KDF construction *SHALL* utilize <<oiPatternConstruction>> for its pattern. 
 
-* SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT *MAY* be Providers or Recipients of said confirmation. Additionally, key confirmation *MAY* be performed on one or both parties (depending on scheme).
+* SP 800-56Ar2 - 5.9 Key Confirmation. Most KAS schemes *MAY* allow for a Key Confirmation process, the ACVP server and IUT *MAY* be Providers or Recipients of said confirmation. Additionally, key confirmation *MAY* be performed on one or both parties (depending on scheme).
 
-* SP 800-56a - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
+* SP 800-56Ar2 - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
 
 [[requirements_not_covered_kas_ecc]]
 ==== KAS-ECC Requirements Not Covered
                         
-* SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server *SHALL NOT* make a distinction between IUT generated keys via a trusted third party and the IUT itself.
+* SP 800-56Ar2 - 4.1 Key Establishment Preparations. The ACVP server *SHALL NOT* make a distinction between IUT generated keys via a trusted third party and the IUT itself.
 
-* SP 800-56a - 5.3 Random Number Generation. The IUT *MUST* perform all random number generation with a validated random number generator. A DRBG is *REQUIRED* as a prerequisite to KAS, but *SHALL NOT* be in the scope testing assurances. 
+* SP 800-56Ar2 - 5.3 Random Number Generation. The IUT *MUST* perform all random number generation with a validated random number generator. A DRBG is *REQUIRED* as a prerequisite to KAS, but *SHALL NOT* be in the scope testing assurances. 
 
-* SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.5 *MUST* be used, however their generation *SHALL NOT* be in scope of KAS testing assurances.
+* SP 800-56Ar2 - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.4 *MUST* be used, however their generation *SHALL NOT* be in scope of KAS testing assurances.
 
-* SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server *SHALL* generate all domain parameters, IUT validation of such parameters is *SHALL NOT* be in scope for KAS testing.
+* SP 800-56Ar2 - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server *SHALL* generate all domain parameters, IUT validation of such parameters is *SHALL NOT* be in scope for KAS testing.
 
-* SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter Management *SHALL NOT* be in scope for KAS testing.
+* SP 800-56Ar2 - 5.5.3 Domain Parameter Management. Domain Parameter Management *SHALL NOT* be in scope for KAS testing.
 
-* SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs *MUST* be used in each KAS scheme, the generation, assurances, and management of said key-pairs *SHALL NOT* be in scope of KAS testing.
+* SP 800-56Ar2 - 5.6 Key-Pair Generation. While Key-Pairs *MUST* be used in each KAS scheme, the generation, assurances, and management of said key-pairs *SHALL NOT* be in scope of KAS testing.
 
-* SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes. Two-step Key-Derivation (Extraction-then-Expansion) *SHALL NOT* be utilized in KAS testing.
+* SP 800-56Ar2 - 5.8 Key-Derivation Methods for Key-Agreement Schemes. Two-step Key-Derivation (Extraction-then-Expansion) *SHALL NOT* be utilized in KAS testing.
 
-* SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as being a valid MAC function; it however *SHALL NOT* (currently) be supported in KAS testing.
+* SP 800-56Ar2 - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective *SHALL NOT* be in scope.
 
-* SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective *SHALL NOT* be in scope.
-
-* SP 800-56a - 8 Key Recovery. Key Recovery *SHALL NOT* be in scope of KAS testing.
+* SP 800-56Ar2 - 8 Key Recovery. Key Recovery *SHALL NOT* be in scope of KAS testing.

--- a/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
@@ -59,8 +59,8 @@ The following function types *MAY* be advertised by the ACVP compliant crypto mo
 * dpGen - IUT can perform domain parameter generation (FFC only)
 * dpVal - IUT can perform domain parameter validation (FFC only)
 * keyPairGen - IUT can perform keypair generation.
-* fullVal - IUT can perform full public key validation ( <<SP800-56a>> section 5.6.2.3.1 / 5.6.2.3.3) 
-* partialVal - IUT can perform partial public key validation ( <<SP800-56a>> section 5.6.2.3.2 / 5.6.2.3.4) 
+* fullVal - IUT can perform full public key validation ( <<SP800-56Ar2>> section 5.6.2.3.1 / 5.6.2.3.3) 
+* partialVal - IUT can perform partial public key validation ( <<SP800-56Ar2>> section 5.6.2.3.2 / 5.6.2.3.4) 
 * keyRegen - IUT can regenerate keys given a specific seed and domain parameter (pqg for FFC, curve for ECC)
 
 [[schemes]]

--- a/src/kas/sp800-56ar2/ecc/sections/98-references.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/98-references.adoc
@@ -55,11 +55,11 @@ date.value:: 2013-07
 
 
 [%bibitem]
-=== SP800-56Ar3 Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography
-id:: SP800-56a
+=== SP800-56Ar2 Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography
+id:: SP800-56Ar2
 link::
 link.type:: src
-link.content:: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf
+link.content:: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
 contributor::
 contributor.role:: author
 contributor.person.name.initial:: E.
@@ -79,20 +79,14 @@ contributor.person.affiliation.organization.name:: National Institute of Standar
 contributor.person.affiliation.organization.abbreviation:: NIST
 contributor::
 contributor.role:: author
-contributor.person.name.initial:: A.
-contributor.person.name.surname:: Vassilev
+contributor.person.name.initial:: M.
+contributor.person.name.surname:: Smid
 contributor.person.affiliation.organization.name:: National Institute of Standards and Technology
 contributor.person.affiliation.organization.abbreviation:: NIST
-contributor::
-contributor.role:: author
-contributor.person.name.initial:: R.
-contributor.person.name.surname:: Davis
-contributor.person.affiliation.organization.name:: National Security Agency
-contributor.person.affiliation.organization.abbreviation:: NSA
 contributor::
 contributor.role:: publisher
 contributor.organization.name:: National Institute of Standards and Technology
 contributor.organization.abbreviation:: NIST
 date::
 date.type:: published
-date.value:: 2018-04
+date.value:: 2013-05

--- a/src/kas/sp800-56ar2/ffc/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/04-testtypes.adoc
@@ -14,54 +14,52 @@ There are two test types for KAS testing:
 
 === Test Coverage
 
-The tests described in this document have the intention of ensuring an implementation is conformant to <<SP800-56a>>. 
+The tests described in this document have the intention of ensuring an implementation is conformant to <<SP800-56Ar2>>. 
 
 [[requirements_covered_kas_ffc]]
 ==== KAS-FFC Requirements Covered
                         
-* SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
+* SP 800-56Ar2 - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
 
-* SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
+* SP 800-56Ar2 - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
 
-* SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS *SHALL* make use of a hash function. The hash function *MAY* be used for validation of a successfully generated shared secret Z *noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
+* SP 800-56Ar2 - 5.1 Cryptographic Hash Functions. All modes of performing KAS *SHALL* make use of a hash function. The hash function *MAY* be used for validation of a successfully generated shared secret Z *noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
 
-* SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is *REQUIRED* only for kdfKc, though is utilized for both kdfNoKc and kdfKc.
+* SP 800-56Ar2 - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is *REQUIRED* only for kdfKc, though is utilized for both kdfNoKc and kdfKc.
 
-* SP 800-56a - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT *SHALL* be expected to generate nonces.
+* SP 800-56Ar2 - 5.4 Nonce. Nonces are made use of in various KAS schemes - both the ACVP server and IUT *SHALL* be expected to generate nonces.
 
-* SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation *SHALL* be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters *SHALL* generate all keypairs (party U/V, static/ephemeral) for a single test case.
+* SP 800-56Ar2 - 5.5 Domain Parameters. Domain Parameter Generation *SHALL* be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters *SHALL* generate all keypairs (party U/V, static/ephemeral) for a single test case.
 
-* SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, *MAY* inject bad keypairs that the IUT *MUST* be able detect. These random tests are only present in groups given appropriate assurance functions see: <<supported_functions>>
+* SP 800-56Ar2 - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, *MAY* inject bad keypairs that the IUT *MUST* be able detect. These random tests are only present in groups given appropriate assurance functions see: <<supported_functions>>
                             
-* SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV *SHALL* be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
+* SP 800-56Ar2 - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV *SHALL* be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
 
-* SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes. All schemes/modes save noKdfNoKc (component) *MUST* make use of a KDF. KDF construction *SHALL* utilize <<oiPatternConstruction>> for its pattern. 
+* SP 800-56Ar2 - 5.8 Key-Derivation Methods for Key-Agreement Schemes. All schemes/modes save noKdfNoKc (component) *MUST* make use of a KDF. KDF construction *SHALL* utilize <<oiPatternConstruction>> for its pattern. 
 
-* SP 800-56a - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT *MAY* be Providers or Recipients of said confirmation. Additionally, key confirmation *MAY* be performed on one or both parties (depending on scheme).
+* SP 800-56Ar2 - 5.9 Key Confirmation. Most KAS schemes allow for a Key Confirmation process, the ACVP server and IUT *MAY* be Providers or Recipients of said confirmation. Additionally, key confirmation *MAY* be performed on one or both parties (depending on scheme).
 
-* SP 800-56a - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
+* SP 800-56Ar2 - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
 
 [[requirements_not_covered_kas_ffc]]
 ==== KAS-FFC Requirements Not Covered
               
-* SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server *SHALL NOT* make a distinction between IUT generated keys via a trusted third party and the IUT itself.
+* SP 800-56Ar2 - 4.1 Key Establishment Preparations. The ACVP server *SHALL NOT* make a distinction between IUT generated keys via a trusted third party and the IUT itself.
 
-* SP 800-56a - 5.3 Random Number Generation. The IUT *MUST* perform all random number generation with a validated random number generator. A DRBG is *REQUIRED* as a prerequisite to KAS, but *SHALL NOT* be in the scope testing assurances. 
+* SP 800-56Ar2 - 5.3 Random Number Generation. The IUT *MUST* perform all random number generation with a validated random number generator. A DRBG is *REQUIRED* as a prerequisite to KAS, but *SHALL NOT* be in the scope testing assurances. 
 
-* SP 800-56a - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.5 *MUST* be used, however their generation *SHALL NOT*  be in scope of KAS testing assurances
+* SP 800-56Ar2 - 5.4 Nonce. Nonce generation is utilized for several schemes. The various methods of generating a nonce described in section 5.4 *MUST* be used, however their generation *SHALL NOT* be in scope of KAS testing assurances.
 
-* SP 800-56a - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server *SHALL* generate all domain parameters, IUT validation of such parameters is *SHALL NOT* be in scope for KAS testing.
+* SP 800-56Ar2 - 5.5.2 Assurances of Domain-Parameter Validity. The ACVP server *SHALL* generate all domain parameters, IUT validation of such parameters is *SHALL NOT* be in scope for KAS testing.
 
-* SP 800-56a - 5.5.3 Domain Parameter Management. Domain Parameter Management *SHALL NOT* be in scope for KAS testing.
+* SP 800-56Ar2 - 5.5.3 Domain Parameter Management. Domain Parameter Management *SHALL NOT* be in scope for KAS testing.
 
-* SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs *MUST* be used in each KAS scheme, the generation, assurances, and management of said key-pairs *SHALL NOT* be in scope of KAS testing.
+* SP 800-56Ar2 - 5.6 Key-Pair Generation. While Key-Pairs *MUST* be used in each KAS scheme, the generation, assurances, and management of said key-pairs *SHALL NOT* be in scope of KAS testing.
 
-* SP 800-56a - 5.8 Key-Derivation Methods for Key-Agreement Schemes. Two-step Key-Derivation (Extraction-then-Expansion) *SHALL NOT* be utilized in KAS testing.
+* SP 800-56Ar2 - 5.8 Key-Derivation Methods for Key-Agreement Schemes. Two-step Key-Derivation (Extraction-then-Expansion) *SHALL NOT* be utilized in KAS testing.
 
-* SP 800-56a - 5.9 Key Confirmation. KMAC is referenced in 800-56a as being a valid MAC function; it however *SHALL NOT* (currently) be supported in KAS testing.
+* SP 800-56Ar2 - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective *SHALL NOT* be in scope.
 
-* SP 800-56a - 5.7 Rationale for Selecting a Specific Scheme. It is expected that the IUT registers all schemes it supports in its capabilities registration. Selecting specific schemes from a KAS testing perspective *SHALL NOT* be in scope.
-
-* SP 800-56a - 8 Key Recovery. Key Recovery *SHALL NOT* be in scope of KAS testing.
+* SP 800-56Ar2 - 8 Key Recovery. Key Recovery *SHALL NOT* be in scope of KAS testing.
 
     

--- a/src/kas/sp800-56ar2/ffc/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/04-testtypes.adoc
@@ -23,7 +23,7 @@ The tests described in this document have the intention of ensuring an implement
 
 * SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the Key Agreement process. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
 
-* SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS *SHALL* make use of a hash function. The hash function *MAY* be used for confirmation of a successfully generated shared secret Z *noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
+* SP 800-56a - 5.1 Cryptographic Hash Functions. All modes of performing KAS *SHALL* make use of a hash function. The hash function *MAY* be used for validation of a successfully generated shared secret Z *noKdfNoKc), or as a primitive within the KDF being tested (kdfNoKc and kdfKc).
 
 * SP 800-56a - 5.2 Message Authentication Code (MAC) Algorithm. A MAC is utilized for confirmation of success for kdfNoKc and kdfKc modes of KAS. Note - a MAC prerequisite is *REQUIRED* only for kdfKc, though is utilized for both kdfNoKc and kdfKc.
 

--- a/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
@@ -59,7 +59,7 @@ The following function types *MAY* be advertised by the ACVP compliant crypto mo
 * dpGen - IUT can perform domain parameter generation (FFC only)
 * dpVal - IUT can perform domain parameter validation (FFC only)
 * keyPairGen - IUT can perform keypair generation.
-* fullVal - IUT can perform full public key validation ( <<SP800-56a>> section 5.6.2.3.1 / 5.6.2.3.3) 
+* fullVal - IUT can perform full public key validation ( <<SP800-56Ar2>> section 5.6.2.3.1 / 5.6.2.3.3) 
 * keyRegen - IUT can regenerate keys given a specific seed and domain parameter (pqg for FFC, curve for ECC)
 
 [[schemes]]

--- a/src/kas/sp800-56ar2/ffc/sections/98-references.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/98-references.adoc
@@ -55,11 +55,11 @@ date.value:: 2013-07
 
 
 [%bibitem]
-=== SP800-56Ar3 Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography
-id:: SP800-56a
+=== SP800-56Ar2 Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography
+id:: SP800-56Ar2
 link::
 link.type:: src
-link.content:: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf
+link.content:: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
 contributor::
 contributor.role:: author
 contributor.person.name.initial:: E.
@@ -79,20 +79,14 @@ contributor.person.affiliation.organization.name:: National Institute of Standar
 contributor.person.affiliation.organization.abbreviation:: NIST
 contributor::
 contributor.role:: author
-contributor.person.name.initial:: A.
-contributor.person.name.surname:: Vassilev
+contributor.person.name.initial:: M.
+contributor.person.name.surname:: Smid
 contributor.person.affiliation.organization.name:: National Institute of Standards and Technology
 contributor.person.affiliation.organization.abbreviation:: NIST
-contributor::
-contributor.role:: author
-contributor.person.name.initial:: R.
-contributor.person.name.surname:: Davis
-contributor.person.affiliation.organization.name:: National Security Agency
-contributor.person.affiliation.organization.abbreviation:: NSA
 contributor::
 contributor.role:: publisher
 contributor.organization.name:: National Institute of Standards and Technology
 contributor.organization.abbreviation:: NIST
 date::
 date.type:: published
-date.value:: 2018-04
+date.value:: 2013-05

--- a/src/kas/sp800-56ar3/ssc/ecc/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56ar3/ssc/ecc/sections/04-testtypes.adoc
@@ -15,12 +15,12 @@ The tests described in this document have the intention of ensuring an implement
 
 ==== Requirements Covered
 
-* SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
-* SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the shared secret computation. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
-* SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation SHALL be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters SHALL generate all keypairs (party U/V, static/ephemeral) for a single test case.
-* SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, MAY inject bad keypairs that the IUT MUST be able detect. These random tests are only present in groups given appropriate assurance functions see: Section 3.3
-* SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV SHALL be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
-* SP 800-56a - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
+* SP 800-56Ar3 - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
+* SP 800-56Ar3 - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the shared secret computation. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
+* SP 800-56Ar3 - 5.6 Domain Parameters. Domain Parameter Generation SHALL be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters SHALL generate all keypairs (party U/V, static/ephemeral) for a single test case.
+* SP 800-56Ar3 - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, MAY inject bad keypairs that the IUT MUST be able detect. These random tests are only present in groups given appropriate assurance functions see: Section 3.3
+* SP 800-56Ar3 - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV SHALL be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
+* SP 800-56Ar3 - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
 
 ==== Requirements Not Covered
 

--- a/src/kas/sp800-56ar3/ssc/ffc/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56ar3/ssc/ffc/sections/04-testtypes.adoc
@@ -15,12 +15,12 @@ The tests described in this document have the intention of ensuring an implement
 
 ==== Requirements Covered
 
-* SP 800-56a - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
-* SP 800-56a - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the shared secret computation. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
-* SP 800-56a - 5.6 Domain Parameters. Domain Parameter Generation SHALL be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters SHALL generate all keypairs (party U/V, static/ephemeral) for a single test case.
-* SP 800-56a - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, MAY inject bad keypairs that the IUT MUST be able detect. These random tests are only present in groups given appropriate assurance functions see: Section 3.3
-* SP 800-56a - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV SHALL be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
-* SP 800-56a - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
+* SP 800-56Ar3 - 4.1 Key Establishment Preparations. The ACVP server is responsible for generating domain parameters as per the IUT's capability registration.
+* SP 800-56Ar3 - 4.2 Key-Agreement Process. Both the ACVP server and IUT participate in the shared secret computation. The server and IUT can both take the roles of party U/V, and as such the "performer" of steps depicted in "Figure 2: Key Agreement process" can vary.
+* SP 800-56Ar3 - 5.6 Domain Parameters. Domain Parameter Generation SHALL be performed solely from the ACVP server, with constraints from the IUTs capabilities registration. The same set of domain parameters SHALL generate all keypairs (party U/V, static/ephemeral) for a single test case.
+* SP 800-56Ar3 - 5.6 Key-Pair Generation. While Key-Pairs are used in each KAS scheme, the generation of said key-pairs is out of scope for KAS testing. Random tests from the VAL groups, MAY inject bad keypairs that the IUT MUST be able detect. These random tests are only present in groups given appropriate assurance functions see: Section 3.3
+* SP 800-56Ar3 - 4.3 DLC-based Key-Transport Process / 5.7 DLC Primitives. Depending on the scheme used, either Diffie Hellman or MQV SHALL be used to negotiate a shared secret of z. Testing and validation of such key exchanges is covered under their respective schemes.
+* SP 800-56Ar3 - 6 Key Agreement Schemes. All schemes specified in referenced document are supported for validation with the ACVP server.
 
 ==== Requirements Not Covered
 

--- a/src/kas/sp800-56cr1/hkdf/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56cr1/hkdf/sections/04-testtypes.adoc
@@ -18,7 +18,7 @@ The tests described in this document have the intention of ensuring an implement
 
 ==== Requirements Covered
 
-* SP 800-56Cr1 - 5 Two-Step Key Derivation.  All functionality described in the specification is covered by ACVP testing.
+* SP 800-56Cr1 - 5 Two-Step Key Derivation.  HKDF is a subset of the TwoStep derivation function described and is covered by ACVP testing.
 
 ==== Requirements Not Covered
 


### PR DESCRIPTION
- Changes "confirmation" to "validation" within a requirements covered section.
  - To avoid confusion between "key confirmation" and the "confirmation" (or validation) of both parties arriving at the same shared secret `z`
- Updates "1.0" revision of KAS to point to the [SP800-56Ar2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf) document rather than [SP800-56Ar3](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf)
  - includes updating of section numbers from requirements covered/not covered.
- Some clarifications within the readme that distinguish between "Full KAS" testing, and "Piecemeal KAS" testing.
- https://github.com/usnistgov/ACVP-Server/issues/7