### PR TITLE
Removes SHA1 as valid hash algorithm for HKDF testing

### DIFF
--- a/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
@@ -85,7 +85,6 @@ Evaluated as:
 
 The following hash functions MAY be advertised by an ACVP compliant client under the 'hmacAlg' property
 
-* SHA1
 * SHA2-224
 * SHA2-256
 * SHA2-384


### PR DESCRIPTION
* https://github.com/usnistgov/ACVP-Server/issues/84