### PR TITLE
Fixed typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 							<li><a href="#hashes">Secure Hash</a></li>
 							<li><a href="#xofs">XOFs</a></li>
 							<li><a href="#macs">Message Authentication</a></li>
-							<li><a href="#drbs">DRBGs</a></li>
+							<li><a href="#drbgs">DRBGs</a></li>
 							<li><a href="#dss">Digital Signature</a></li>
 							<li><a href="#kas">Key Agreement</a></li>
 							<li><a href="#kdfs">KDFs</a></li>


### PR DESCRIPTION
The DRBG link in the "Jump to" section had a typo, it linked to "drbs" instead of "drbgs"