### PR TITLE
Acvp 1152

### DIFF
--- a/src/xof/sections/06-test-vectors.adoc
+++ b/src/xof/sections/06-test-vectors.adoc
@@ -33,8 +33,8 @@ Each test group *SHALL* contain an array of one or more test cases. Each test ca
 | len | Length of each tuple for TupleHash | array of integer
 | outLen | Length of the digest | integer
 | functionName | The function name used in the XOF | string
-| customization | The ASCII customization string used | string
-| hexCustomization | The hex customization string used | hex
+| customization | The ASCII customization string used (between 0 and 161 ASCII characters in length) | string
+| customizationHex | The hex customization string used (between 0 and 322 hex characters in length) | hex
 | msg | Value of the message or seed. Messages are represented as little-endian hex for all SHA3 variations | hex
 | keyLen | Length of the key used in KMAC | integer
 | key | The key used in KMAC | hex


### PR DESCRIPTION
Updated the XOF spec Test Case JSON Schema table to include the bounds for the customization and customizationHex test case properties. Also updated the table to use the correct property name for customizationHex (vs hexCustomization). Closes #1152 