### PR TITLE
KDF adds `customKeyInLength` to give more fine grained control of the…

### DIFF
--- a/src/kdf/sections/05-capabilities.adoc
+++ b/src/kdf/sections/05-capabilities.adoc
@@ -60,6 +60,7 @@ The complete list of KDF key generation capabilities may be advertised by the AC
 | counterLength | The length of the counter in bits | array | Any non-empty subset of {0, 8, 16, 24, 32}
 | supportsEmptyIv | Whether or not the IUT supports an empty IV | boolean | true/false
 | requiresEmptyIv | Whether or not the IUT requires an empty IV | boolean | true/false
+| customKeyInLength | Optional value used to control the length of the keyIn produced by the ACVP server for the capability.  This field cannot be used to alter the keyIn length for AES/TDES based macModes, as the keyIns expected by those algorithms is fixed. | integer | 112-4096
 |===
 
 NOTE: The 'fixedDataOrder' options "none" and "before iterator" are not valid for "counter" KDF. The 'fixedDataOrder' option "middle fixed data" is not valid for "feedback" nor "double pipeline iterator" KDF.


### PR DESCRIPTION
… keyIn lengths produced from the perspective of the IUT.

* The location of this new property isn't completely ideal, but was done this way to be non breaking.  If you have an IUT that needs this fine grained control of keyIn lengths for each individual macMode, then you will need to do capability objects per macMode (as an example).  This will not impact you, and will not be needed if your implementation can support the output length of the PRF as your keyIn length, so 224 for SHA2-224, 160 for SHA1, 512 for SHA2-512, etc
* https://github.com/usnistgov/ACVP/issues/1013#issuecomment-848835125