### PR TITLE
KTS property `ktsMethods` -> `ktsMethod`

### DIFF
--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -125,7 +125,7 @@ KTS Schemes
 
 | kasRole| Roles supported for key agreement| array| initiator and/or responder| No
 | kdfMethods| The KDF methods to use when testing KAS schemes. | object| <<kdfmethods>>| Only applicable (as well as *REQUIRED*) for KAS schemes.
-| ktsMethods| The KTS methods to use when testing KTS schemes. | object| <<ktsmethods>>| Only applicable (as well as *REQUIRED*) for KTS schemes.
+| ktsMethod| The KTS method to use when testing KTS schemes. | object| <<ktsmethod>>| Only applicable (as well as *REQUIRED*) for KTS schemes.
 | macMethods| The MAC methods to use when testing KAS or KTS schemes with key confirmation. | object| <<macmethods>>| *REQUIRED* for KAS/KTS schemes making use of Key Confirmation.
 | l | The length of the key to derive (using a KDF) or transport (using a KTS scheme - note that the IUT may be providing their own wrapped key of length `l` for KTS AFT testing as an initiator).  This value should be large enough to accommodate the key length used for the mac algorithms in use for key confirmation, ideally the maximum value the IUT can support with their KAS/KTS implementation.  Maximum value (for testing purposes) is 1024.| integer| 128 minimum without KC, 136 minimum with KC, maximum 1024.| No
 |===
@@ -185,7 +185,7 @@ Note this capabilities object is very similar to the capability object from SP80
 | macSaltMethod| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 | fixedInfoPattern| The pattern used for fixedInfo construction. | string| See <<fixedinfopatcon>> | No
 | encoding| The encoding type to use with fixedInfo construction.  Note concatenation is currently supported.  ASN.1 should be coming. | array of string| concatenation| No
-| kdfMode| The strategy for running the KDF. | string| counter, fedback, double pipeline iteration| No
+| kdfMode| The strategy for running the KDF. | string| counter, feedback, double pipeline iteration| No
 | macMode| The macMode supported by the KDF. | array of string| CMAC-AES128, CMAC-AES192, CMAC-AES256, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512| No
 | fixedDataOrder| The counter locations supported by the KDF. | array of string| none, before fixed data, after fixed data, before iterator| No
 | counterLength| The counter lengths supported for the KDF. | array of integer| 8, 16, 24, 32| Not optional for counter mode.
@@ -195,7 +195,7 @@ Note this capabilities object is very similar to the capability object from SP80
 |===
 
 
-[[ktsmethods]]
+[[ktsmethod]]
 ===== Supported KTS Method
 
 Note that this method is *REQUIRED* when testing KTS schemes.

--- a/src/kas/sp800-56br2/sections/06-test-vectors.adoc
+++ b/src/kas/sp800-56br2/sections/06-test-vectors.adoc
@@ -57,7 +57,7 @@ Describes the KTS configuration for use under the test group.
 
 | associatedDataPattern| The pattern used for constructing the associated data. | value - see <<fixedinfopatcon>>. | Yes
 | encoding| The encoding type used when constructing the data. | value - see <<fixedinfopatcon>>. | Yes
-| hashAlg| The hash algorithm used for the OAEP function. | value - see <<ktsmethods>>. | No
+| hashAlg| The hash algorithm used for the OAEP function. | value - see <<ktsmethod>>. | No
 |===
 
 


### PR DESCRIPTION
* corrects type in "feedback"
* https://github.com/usnistgov/ACVP/issues/1184