### PR TITLE
SP 800-108 updates for ACVP-1178

### DIFF
--- a/src/kdf/sections/04-testtypes.adoc
+++ b/src/kdf/sections/04-testtypes.adoc
@@ -14,3 +14,9 @@ There is only one test type: functional tests. Each has a specific value to be u
 === Test Coverage
 
 The tests described in this document have the intention of ensuring an implementation is conformant to <<SP800-108>>. 
+
+==== Requirements Covered ====
+* The ACVP server tests the IUT's ability to derive keying material using the "modes of iteration" defined in sections 5.1, 5.2 and 5.3 of <<SP800-108>>. The server supports testing the IUT against the various MACs or PRFs listed in <<valid-mac>>. It also supports testing varying 1) the location of the counter within the input data, 2) the length of the derived keying material, and 3) the counter length. 
+
+==== Requirements Not Covered ====
+* The tests described in this document do not validate the construction of the fixed input data string described in <<SP800-108>> Sections 5, 7.5 and 7.6.

--- a/src/kdf/sections/05-capabilities.adoc
+++ b/src/kdf/sections/05-capabilities.adoc
@@ -34,7 +34,7 @@ A registration *SHALL* use these properties:
 [[kdfmodes]]
 ==== Supported SP 800-108 KDF Modes
 
-The following SP800-108 KDF modes may be advertised by the ACVP compliant crypto module:
+The following SP800-108 KDF modes or "modes of iteration" may be advertised by the ACVP compliant crypto module:
 
 * counter
 * feedback
@@ -53,9 +53,9 @@ The complete list of KDF key generation capabilities may be advertised by the AC
 |===
 | JSON Value | Description | JSON Type | Valid Values
 
-| kdfMode | The type of SP800-108 KDF | string | See <<kdfmodes>>
-| macMode | The MAC algorithm used | string | See <<valid-mac>>
-| supportedLengths | The key lengths supported in bits | domain | Min: 1, Max: 4096
+| kdfMode | The type of SP800-108 KDF or "mode of iteration" | string | See <<kdfmodes>>
+| macMode | The MAC or PRF algorithm used | string | See <<valid-mac>>
+| supportedLengths | The supported derived keying material lengths in bits | domain | Min: 1, Max: 4096
 | fixedDataOrder | Describes where the counter appears in the fixed data | array | Any non-empty subset of {"none", "after fixed data", "before fixed  data", "middle fixed data", "before iterator"}
 | counterLength | The length of the counter in bits | array | Any non-empty subset of {0, 8, 16, 24, 32}
 | supportsEmptyIv | Whether or not the IUT supports an empty IV | boolean | true/false
@@ -72,7 +72,7 @@ NOTE: When 'counterLength' contains a value of "0", 'fixedDataOrder' must contai
 [#valid-mac]
 ==== Supported SP 800-108 KDF MACs
 
-The following MAC functions *MAY* be advertised by an ACVP compliant client
+The following MAC or PRF functions *MAY* be advertised by an ACVP compliant client
 
 * CMAC-AES128
 * CMAC-AES192

--- a/src/kdf/sections/06-test-vectors.adoc
+++ b/src/kdf/sections/06-test-vectors.adoc
@@ -10,12 +10,12 @@ The testGroups element at the top level in the test vector JSON object is an arr
 
 | tgId | Test group identifier | integer
 | kdfMode | The kdfMode used for the test group | string
-| macMode | Psuedorandom function HMAC or CMAC used | string
+| macMode | Psuedorandom function (PRF) HMAC or CMAC used | string
 | counterLocation | "none", "after fixed data", "before fixed data", "middle fixed data", or "before iterator"| string
-| keyOutLength | Expected length of the derived key in bits | integer
+| keyOutLength | Expected length of the derived keying material or key in bits | integer
 | counterLength | Expected length of the counter in bits | integer
 | zeroLengthIv | Whether or not the group utilizes a null IV | boolean
-| testType | Describes the operation being performed | string | No
+| testType | Describes the operation being performed | string 
 | tests | Array of individual test cases | array
 |===
 
@@ -79,3 +79,4 @@ The following is a example JSON object for SP 800-108 KDF test vectors sent from
             
                     
 ....
+

--- a/src/kdf/sections/07-responses.adoc
+++ b/src/kdf/sections/07-responses.adoc
@@ -54,9 +54,11 @@ The following table describes the JSON properties that represent a test case res
 
 | tcId | The test case identifier | integer
 | breakLocation | The bit location in the fixed data where the counter is placed | integer
-| fixedData | The fixed data used | hex
-| keyOut | The outputted key | hex
+| fixedData | The fixed input data used by the IUT | hex
+| keyOut | The outputted keying material or key | hex
 |===
+
+NOTE: the fixedData or fixed input data string that is used by the IUT is needed by the ACVP server to verify that the IUT correctly derived the keying material. The server does not validate the correct construction of the fixed input data string.  For guidance on constructing a valid fixed input data string, please consult <<SP800-108>> Sections 5, 7.5 and 7.6.
 
 === Example Test Vector Response JSON
 
@@ -83,3 +85,5 @@ The following is an abbreviated example of a JSON object for SP800-108 KDF test 
             
                     
 ....
+
+NOTE: Please note that the values used in the example JSON object are not real values. In particular, the value for the fixedData property is not an example of a validly formed fixed input data string. 


### PR DESCRIPTION
-updated some of the wording in the spec to more closely align with the language used in SP 800-108
-added sections 6.1.1 and 6.1.2 to describe what is tested by the ACVP server
-clarified that the sample response provided is not a real response, e.g., look to the SP 800-108 spec for rules for defining the input fixed info
-closes #1178 