### PR TITLE
Adds SHA-1 / HMAC-SHA-1 as valid algorithm for use in KTS and KAS

### DIFF
--- a/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
@@ -169,10 +169,10 @@ Each parameter set advertised is a self-contained JSON object using the followin
 [[parameter_set_details]]
 ==== KAS ECC Parameter Set Details
 
-* eb: Len n - 224-255, min Len h - 112, min hash len - 224, min keySize - 112, min macSize - 64
-* ec: Len n - 256-283, min Len h - 128, min hash len - 256, min keySize - 128, min macSize - 64
-* ed: Len n - 384-511, min Len h - 192, min hash len - 384, min keySize - 192, min macSize - 64
-* ee: Len n - 512+, min Len h - 256, min hash len - 512, min keySize - 256, min macSize - 64
+* eb: Len n - 224-255, min Len h - 112, min hash len - 112, min keySize - 112, min macSize - 64
+* ec: Len n - 256-283, min Len h - 128, min hash len - 128, min keySize - 128, min macSize - 64
+* ed: Len n - 384-511, min Len h - 192, min hash len - 192, min keySize - 192, min macSize - 64
+* ee: Len n - 512+, min Len h - 256, min hash len - 256, min keySize - 256, min macSize - 64
 
 "noKdfNoKc" *REQUIRES* "hashAlg"
 
@@ -214,6 +214,7 @@ The following ECC Curves *MAY* be advertised by the ACVP compliant crypto module
 
 The following SHA methods *MAY* be advertised by the ACVP compliant crypto module:
 
+* SHA-1
 * SHA2-224
 * SHA2-256
 * SHA2-384
@@ -226,6 +227,7 @@ The following MAC options *MAY* be advertised for registration under a "kdfNoKc"
 
 * AES-CCM
 * CMAC
+* HMAC-SHA-1
 * HMAC-SHA2-224
 * HMAC-SHA2-256
 * HMAC-SHA2-384

--- a/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
@@ -167,9 +167,9 @@ Each parameter set advertised is a self-contained JSON object using the followin
 
 fb/fc changes minimum allowed values on options.
 
-* fb: Len p - 2048, Len q - 224, min hash len - 224, min keySize - 112, min macSize - 64
+* fb: Len p - 2048, Len q - 224, min hash len - 112, min keySize - 112, min macSize - 64
 
-* fc: Len p - 2048, Len q - 256, min hash len - 256, min keySize - 128, min macSize - 64
+* fc: Len p - 2048, Len q - 256, min hash len - 112, min keySize - 128, min macSize - 64
 
 "noKdfNoKc" *REQUIRES* "hashAlg"
 
@@ -192,6 +192,7 @@ fb/fc changes minimum allowed values on options.
 
 The following SHA methods *MAY* be advertised by the ACVP compliant crypto module:
 
+* SHA-1
 * SHA2-224
 * SHA2-256
 * SHA2-384
@@ -204,6 +205,7 @@ The following MAC options *MAY* be advertised for registration under a "kdfNoKc"
 
 * AES-CCM
 * CMAC
+* HMAC-SHA-1
 * HMAC-SHA2-224
 * HMAC-SHA2-256
 * HMAC-SHA2-384

--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -160,7 +160,7 @@ Note that *AT LEAST* one KDF Method is required for KAS schemes.  The following 
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 
@@ -204,7 +204,7 @@ Note that this method is *REQUIRED* when testing KTS schemes.
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| hashAlgs | The hash algorithms available to the IUT. | array of string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512| No
+| hashAlgs | The hash algorithms available to the IUT. | array of string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512| No
 | supportsNullAssociatedData | Does the IUT support a null associated data (fixedInfo)?| boolean| true, false| No
 | associatedDataPattern | The patten used to construct the associated data.| string| <<fixedinfopatcon>>| Yes
 | encoding| The encoding type to use for associated data construction. | string| concatenation| Not optional when using an associated data pattern.
@@ -262,6 +262,7 @@ Note that *AT LEAST* one mac method must be supplied when making use of Key Conf
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
 | CMAC| Utilizes CMAC as the MAC algorithm. | object| See <<supmacopt>>.  Note that the keyLen must be 128, 192, or 256 for this MAC.| Yes
+| HMAC-SHA-1| Utilizes HMAC-SHA-1 as the MAC algorithm. | object| See <<supmacopt>>| Yes
 | HMAC-SHA2-224| Utilizes HMAC-SHA2-224 as the MAC algorithm. | object| See <<supmacopt>>| Yes
 | HMAC-SHA2-256| Utilizes HMAC-SHA2-256 as the MAC algorithm. | object| See <<supmacopt>>| Yes
 | HMAC-SHA2-384| Utilizes HMAC-SHA2-384 as the MAC algorithm. | object| See <<supmacopt>>| Yes

--- a/src/kas/sp800-56br2/ssc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/ssc/sections/05-capabilities.adoc
@@ -83,6 +83,7 @@ An optional hash function that should be applied to `z` from both the ACVP serve
 
 The following hash functions *MAY* be advertised by an ACVP compliant server:
 
+* SHA-1
 * SHA2-224
 * SHA2-256
 * SHA2-384

--- a/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
@@ -85,6 +85,7 @@ Evaluated as:
 
 The following hash functions MAY be advertised by an ACVP compliant client under the 'hmacAlg' property
 
+* SHA-1
 * SHA2-224
 * SHA2-256
 * SHA2-384

--- a/src/kas/sp800-56c/onestep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/onestep/sections/05-capabilities.adoc
@@ -41,7 +41,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 |===
 | JSON Value| Description| JSON Type| Valid Values
 
-| auxFunctionName| The auxiliary function to use.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). Required for MAC based auxFunctions.| array of string| default, random
 |===
 


### PR DESCRIPTION
* https://github.com/usnistgov/ACVP/issues/1170