### PR TITLE
Minor spec update.  Adding note about the big endian expection for l …

### DIFF
--- a/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
@@ -39,7 +39,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 [[fixedinfopatcon]]
 ==== FixedInfoPatternConstruction
 
-IUTs *MUST* be capable of specifying how the FixedInfo is constructed for the KDF construction. Note that for the purposes of testing against the ACVP system, both uPartyInfo and vPartyInfo are *REQUIRED* to be registered within the fixed info pattern.
+IUTs *MUST* be capable of specifying how the FixedInfo is constructed for the KDF construction. Note that for the purposes of testing against the ACVP system, both uPartyInfo and vPartyInfo are *REQUIRED* to be registered within the fixed info pattern.  Also, when l is used for fixedInfo it is expected to be and is processed as a big endian byte string.
 
 Pattern candidates:
 


### PR DESCRIPTION
…when l is used for fixedInfo.