### PR TITLE
symmetric MCT fixes for ACVP-1192

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ metanorma compile -t ietf -x html file.adoc
 
 You can switch between `-x html` and `-x txt` for different RFC output formats. 
 
+If you make changes to a file that's referenced by a top level spec, run metanorma 
+on the referenced file prior to running it on the top level file. E.g.,
+
+```
+metanorma compile -t ietf -x html symmetric/sections/04-testtypes.adoc
+metanorma compile -t ietf -x html draft-celi-acvp-symmetric.adoc 
+```
+
 Or you can use the `Makefile` which is available. 
 
 To build all documents, html and txt

--- a/src/04-testtypes.xml.abort
+++ b/src/04-testtypes.xml.abort
@@ -1,0 +1,550 @@
+<ietf-standard xmlns="https://www.metanorma.org/ns/ietf" type="semantic" version="2.3.6">
+<bibdata type="standard">
+<title language="en" format="text/plain" type="main">Test Types and Test Coverage</title>
+
+
+<contributor>
+<role type="publisher"/>
+<organization>
+<name>Internet Engineering Task Force</name>
+<abbreviation>IETF</abbreviation>
+</organization>
+</contributor>
+
+<language>en</language>
+<script>Latn</script>
+<status>
+<stage>published</stage>
+</status>
+<copyright>
+<from>2021</from>
+<owner>
+<organization>
+<name>Internet Engineering Task Force</name>
+<abbreviation>IETF</abbreviation>
+</organization>
+</owner>
+</copyright>
+<series type="stream">
+<title>IETF</title>
+</series>
+<ext>
+<doctype>internet-draft</doctype>
+<ipr>trust200902</ipr>
+<pi>
+<toc>yes</toc>
+</pi>
+</ext>
+</bibdata>
+<sections>
+<clause id="testtypes" inline-header="false" obligation="normative"><title>Test Types and Test Coverage</title><p id="_9d4ebd1c-c693-4154-9a7b-877f3538b741">This section describes the design of the tests used to validate implementations of block cipher algorithms.</p>
+<clause id="_test_types" inline-header="false" obligation="normative"><title>Test Types</title><p id="_20bee6f9-6317-46b8-b72c-7113134307f3">There are three types of tests for block ciphers: functional tests, Monte Carlo tests and counter tests. Each has a specific value to be used in the testType field. The testType field definitions are:</p>
+<ul id="_9375cf91-0728-4f4b-9866-e2324464a6d5">
+<li>
+<p id="_5e26f453-8e18-4b8e-b677-399be8d467b6">"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'encrypt' or 'decrypt' operation. AFTs cause the implementation under test to exercise normal operations on a single block, multiple blocks, or (where applicable) partial blocks. In some cases random data is used, in others, static, predetermined tests are provided. The functional tests of the block cipher are designed to verify that the logical components of the cipher (GFSbox, KeySbox, block chaining etc.) are operating correctly.</p>
+</li>
+<li>
+<p id="_89193b84-6937-491c-9100-95068b669e7d">"MCT" - Monte Carlo Test. These tests exercise the implementation under test under strenuous circumstances. The implementation under test must process the test vectors according to the correct algorithm and mode in this document. MCTs can help detect potential memory leaks over time, and problems in allocation of resources, addressing variables, error handling and generally improper behavior in response to random inputs. Not every algorithm and mode combination has an MCT.
+See <xref target="MC_test"/> for implementation details.</p>
+</li>
+<li>
+<p id="_8c1d7a1d-4a54-4d9e-9f6e-2797c86195ff">"CTR" - Counter Mode Test. Counter tests are specifically for counter modes (AES-CTR and TDES-CTR) and require an implementation under test to exercise their counter mechanism. The server will send a long message to the client for encryption or decryption and back-compute the IVs used by the implementation under test. These IVs are then verified for uniqueness and an increasing (or decreasing) nature. The client processes these tests as normal AFTs. The different mode is highlighted here to signify the difference on the server side for processing.</p>
+</li>
+</ul>
+<clause id="MC_test" inline-header="false" obligation="normative"><title>Monte Carlo tests for block ciphers</title><p id="_ebb24cdc-0383-4c3b-a13f-0907c9b32396">The MCTs start with an initial condition (plaintext/ciphertext, key, and optional, or maybe multiple IVs) and perform a series of chained computations. For modes that use an IV, the IV is used in the beginning of each pseudorandom process. The IV is implicitly advanced according to the block cipher mode in use. There are separate rounds of MCT for encryption and decryption. Because some block cipher modes rely on an IV and perform calculations differently from other modes, there are specific definitions of MCT for many of the block cipher modes.</p>
+<clause id="AES-ECB-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - ECB mode</title><clause id="AES-ECB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_b8434fc9-e180-4e40-ac64-4b3e55c8819c">The initial condition for the test is the tuple (KEY, PT) set to some values.</p>
+<p id="_58b4262d-8aca-46d1-8869-f6d370c964c6">The algorithm is shown in <xref target="xml_figureMCTECB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTECB"><name>AES-ECB Monte Carlo Test</name>Key[0] = KEY
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output PT[0]
+    For j = 0 to 999
+        CT[j] = AES_ECB_ENCRYPT(Key[i], PT[j])
+        PT[j+1] = CT[j]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    PT[0] = CT[j]</sourcecode>
+</clause>
+<clause id="AES-ECB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_a5136a62-fcec-43ab-a8bb-970ecce6aa6c">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CBC-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CBC mode</title><clause id="AES-CBC-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_cea0a52b-8de4-469d-b63c-be410066fc29">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_ff5dc7e1-f76a-4c2e-a1b4-dc4f79713e2b">The algorithm is shown in <xref target="xml_figureMCTCBC"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCBC"><name>AES-CBC Monte Carlo Test</name>Key[0] = KEY
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CBC_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = IV[i]
+        Else
+            CT[j] = AES_CBC_ENCRYPT(Key[i], PT[j])
+            PT[j+1] = CT[j-1]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    IV[i+1] = CT[j]
+    PT[0] = CT[j-1]</sourcecode>
+</clause>
+<clause id="AES-CBC-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_36659fc8-1476-45d7-95f3-f685232e55de">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-OFB-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - OFB mode</title><clause id="AES-OFB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_6a751a61-e3d1-46c1-8b8e-a058cff0e05d">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_5797a8bc-0636-4e12-96dd-52446dcc0655">The algorithm is shown in <xref target="xml_figureMCTOFB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTOFB"><name>AES-OFB Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_OFB_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = IV[i]
+        Else
+            CT[j] = AES_OFB_ENCRYPT(Key[i], PT[j])
+            PT[j+1] = CT[j-1]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    IV[i+1] = CT[j]
+    PT[0] = CT[j-1]</sourcecode>
+</clause>
+<clause id="AES-OFB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_04a505af-519a-44dc-8216-ae18d6a89c90">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CFB1-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CFB1 mode</title><clause id="AES-CFB1-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_6cbf4b02-9e0b-4b20-8df4-cb17a2033da0">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_7496990d-4b1e-48bd-8939-2547410d4283">The algorithm is shown in <xref target="xml_figureMCTCFB1"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCFB1"><name>AES-CFB1 Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CFB1_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = BitJ(IV[i])
+        Else
+            CT[j] = AES_CFB1_ENCRYPT(Key[i], PT[j])
+            If ( j&lt;128 )
+                PT[j+1] = BitJ(IV[i])
+            Else
+                PT[j+1] = CT[j-128]
+    Output CT[j]
+    If ( keylen = 128 )
+        Key[i+1] = Key[i] xor (CT[j-127] || CT[j-126] || ... || CT[j])
+    If ( keylen = 192 )
+        Key[i+1] = Key[i] xor (CT[j-191] || CT[j-190] || ... || CT[j])
+    If ( keylen = 256 )
+        Key[i+1] = Key[i] xor (CT[j-255] || CT[j-254] || ... || CT[j])
+    IV[i+1] = (CT[j-127] || CT[j-126] || ... || CT[j])
+    PT[0] = CT[j-128]</sourcecode>
+</clause>
+<clause id="AES-CFB1-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_dd50ecf0-9b7c-4684-b54a-6c836fd1bc09">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CFB8-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CFB8 mode</title><clause id="AES-CFB8-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_fed67866-65a8-4585-83c1-917bfd6f6a3e">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_80da54a2-1a2f-4d8c-9b35-6ceb4bf28fdf">The algorithm is shown in <xref target="xml_figureMCTCFB8"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCFB8"><name>AES-CFB8 Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CFB8_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = ByteJ(IV[i])
+        Else
+            CT[j] = AES_CFB8_ENCRYPT(Key[i], PT[j])
+            If ( j&lt;16 )
+                PT[j+1] = ByteJ(IV[i])
+            Else
+                PT[j+1] = CT[j-16]
+    Output CT[j]
+    If ( keylen = 128 )
+        Key[i+1] = Key[i] xor (CT[j-15] || CT[j-14] || ... || CT[j])
+    If ( keylen = 192 )
+        Key[i+1] = Key[i] xor (CT[j-23] || CT[j-22] || ... || CT[j])
+    If ( keylen = 256 )
+        Key[i+1] = Key[i] xor (CT[j-31] || CT[j-30] || ... || CT[j])
+    IV[i+1] = (CT[j-15] || CT[j-14] || ... || CT[j])
+    PT[0] = CT[j-16]</sourcecode>
+</clause>
+<clause id="AES-CFB8-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_2796d7ac-7018-4a08-8de8-146d9854275e">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CFB128-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CFB128 mode</title><clause id="AES-CFB128-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_233b5b91-aed6-4720-9a54-1d8096bc3aa1">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_582d1c52-ab2d-4268-b685-802d38a62aed">The algorithm is shown in <xref target="xml_figureMCTCFB128"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCFB128"><name>AES-CFB128 Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CFB128_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = IV[i]
+        Else
+            CT[j] = AES_CFB128_ENCRYPT(Key[i], PT[j])
+            PT[j+1] = CT[j-1]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    IV[i+1] = CT[j]
+    PT[0] = CT[j-1]</sourcecode>
+</clause>
+<clause id="AES-CFB128-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_fc864413-f121-4df5-9dec-41c2ab688ede">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES_KEY_SHUFFLE" inline-header="false" obligation="normative"><title>AES Monte Carlo Key Shuffle</title><p id="_d018c5c1-9241-4ae0-bfe4-fb390be124bc">Most AES MCTs use a shared key shuffle routine. The algorithm is shown in <xref target="xml_figureAESKEY"/>.</p>
+<p id="_1c63ed58-03c5-440a-ae1e-f6771d5067f1">The initial condition for the routine is a tuple (KEY, CT) set to some values. This pseudocode is specifically for encryption. For decryption, swap all instances of CT with PT. The || symbol is used to denote concatenation. The MSB (most significant bits) and LSB (least significant bits) functions accept a bit string and an integer amount of bits to capture. For example MSB(A, 8) would capture the 8 most significant bits of the bit string A.</p>
+<sourcecode lang="code" id="xml_figureAESKEY"><name>AES Encrypt Key Shuffle Routine</name>If ( keylen = 128 )
+    Key[i+1] = Key[i] xor MSB(CT[j], 128)
+If ( keylen = 192 )
+    Key[i+1] = Key[i] xor (LSB(CT[j-1], 64) || MSB(CT[j], 128))
+If ( keylen = 256 )
+    Key[i+1] = Key[i] xor (MSB(CT[j-1], 128) || MSB(CT[j], 128))</sourcecode>
+</clause>
+<clause id="TDES-ECB-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - ECB mode</title><clause id="TDES-ECB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_f2b6384b-94bf-462d-856c-acc54ddca0ce">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, PT) set to some values.</p>
+<p id="_f671e5e1-422d-4c18-930d-b7c5efbd4650">The algorithm is shown in <xref target="xml_figureMCT_TDES_ECB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_ECB"><name>TDES-ECB Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_ECB_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j])
+        PT[j+1] = CT[i]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = CT[j]</sourcecode>
+</clause>
+<clause id="TDES-ECB-MCT-DECR" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_dc946a18-d4fa-487e-8d37-0bfc85e7ca76">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="TDES-CBC-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CBC mode</title><clause id="TDES-CBC-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_a116d0d2-114f-420d-a230-28b4760f7e39">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values.</p>
+<p id="_ef2cf8ec-d4ed-490a-83f3-4cbfc138782c">The algorithm is shown in <xref target="xml_figureMCT_TDES_CBC"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC"><name>TDES-CBC Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CBC_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        If ( j = 0 )
+            PT[j+1] = IV[0]
+        Else
+            PT[j+1] = CT[j-1]
+        IV[j+1] = CT[j]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = CT[j-1]
+    IV[0] = CT[j]</sourcecode>
+</clause>
+<clause id="TDES-CBC-MCT-DECR" inline-header="false" obligation="normative"><title>Decrypt</title><p id="_facc888c-6955-4156-b36d-ad9866668915">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the inner loop in the pseudocode with the following:</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC_DECR"><name>TDES-CBC Monte Carlo Test Decrypt</name>    For j = 0 to 9999
+        PT[j] = TDES_CBC_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV[j])
+        CT[j+1] = PT[j]
+        IV[j+1] = CT[j]</sourcecode>
+</clause></clause>
+<clause id="TDES-CBC-I-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CBC-I mode</title><clause id="TDES-CBC-I-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_b4117b67-a419-43ae-b731-3481ebdb290e">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT1, PT2, PT3) set to some values.</p>
+<p id="_dacf75b9-649d-49f8-835e-72f4e33d94fa">The algorithm is shown in <xref target="xml_figureMCT_TDES_CBC-I"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC-I"><name>TDES-CBC-I Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+PT1[0] = PT1
+PT2[0] = PT2
+PT3[0] = PT3
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output PT1[0], PT2[0], PT3[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CBC_I_ENCRYPT(Key1[i], Key2[i], Key3[i], PT1[j], PT2[j], PT3[j], IV1[j], IV2[j], IV3[j])
+        If ( j = 0 )
+            PT1[j+1] = IV1[0]
+            PT2[j+1] = IV2[0]
+            PT3[j+1] = IV3[0]
+        Else
+            PT1[j+1] = CT1[j-1]
+            PT2[j+1] = CT2[j-1]
+            PT3[j+1] = CT3[j-1]
+        IV1[j+1] = CT1[j]
+        IV2[j+1] = CT2[j]
+        IV3[j+1] = CT3[j]
+    Output CT1[j], CT2[j], CT3[j]
+    Key1[i+1] = Key1[i] xor CT1[j]
+    Key2[i+1] = Key2[i] xor CT2[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT3[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT1[0] = CT1[j-1]
+    PT2[0] = CT2[j-1]
+    PT3[0] = CT3[j-1]
+    IV1[0] = CT1[j]
+    IV2[0] = CT2[j]
+    IV3[0] = CT3[j]</sourcecode>
+</clause>
+<clause id="TDES-CBC-I-MCT-DECR" inline-header="false" obligation="normative"><title>Decrypt</title><p id="_f90e8f38-3532-4344-867e-df92c8288e37">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, CT1, CT2, CT3) set to some values.</p>
+<p id="_a5360a78-da91-48e9-ac15-630b9f97be17">The algorithm is shown in <xref target="xml_figureMCT_TDES_CBC_I_DECR"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC_I_DECR"><name>TDES-CBC-I Monte Carlo Test Decrypt</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+CT1[0] = CT1
+CT2[0] = CT2
+CT3[0] = CT3
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output CT1[0], CT2[0], CT3[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CBC_I_DECRYPT(Key1[i], Key2[i], Key3[i], CT1[j], CT2[j], CT3[j], IV1[j], IV2[j], IV3[j])
+        CT1[j+1] = PT1[j]
+        CT2[j+1] = PT2[j]
+        CT3[j+1] = PT3[j]
+        IV1[j+1] = CT1[j]
+        IV2[j+1] = CT2[j]
+        IV3[j+1] = CT3[j]
+    Output PT1[j], PT2[j], PT3[j]
+    Key1[i+1] = Key1[i] xor PT1[j]
+    Key2[i+1] = Key2[i] xor PT2[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor PT3[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT1[0] = PT1[j]
+    CT2[0] = PT2[j]
+    CT3[0] = PT3[j]
+    IV1[0] = CT1[j]
+    IV2[0] = CT2[j]
+    IV3[0] = CT3[j]</sourcecode>
+</clause></clause>
+<clause id="TDES-CFB-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CFB1, CFB8, CFB64 modes</title><clause id="TDES-CFB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_16ab2aba-1cd0-4a3e-989e-ee393ccdb0f6">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB1 has a feedback size of 1-bit.</p>
+<p id="_191687d8-827c-4d27-a1e2-d74ac2627c50">The algorithm is shown in <xref target="xml_figureMCT_TDES_CFB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CFB"><name>TDES-CFB Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CFB_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        PT[j+1] = LeftMost_K_Bits(IV[j])
+        IV[j+1] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    Output CT[j]
+    C = LeftMost_192_Bits(CT[j] || CT[j-1] || ... || CT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = LeftMost_K_Bits(IV[j])
+    IV[0] = RightMost_64-K_Bits(IV[j]) || CT[j]</sourcecode>
+</clause>
+<clause id="TDES-CFB-MCT-DEC" inline-header="false" obligation="normative"><title>Decrypt</title><p id="_79efe9be-387a-4bbe-8475-2b98b258944e">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, CT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB1 has a feedback size of 1-bit. O[j] is the O<sub>j</sub> variable internal to the Triple DES operation described in Table 43 of SP 800-20.</p>
+<p id="_20c722a5-5044-4479-9978-994772762acb">The algorithm is shown in <xref target="xml_figureMCT_TDES_CFB_DEC"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CFB_DEC"><name>TDES-CFB Monte Carlo Test Decrypt</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+CT[0] = CT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output CT[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CFB_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV[j])
+        CT[j+1] = LeftMost_K_Bits(O[j])
+        IV[j+1] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    Output PT[j]
+    C = LeftMost_192_Bits(PT[j] || PT[j-1] || ... || PT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT[0] = LeftMost_K_Bits(O[j])
+    IV[0] = RightMost_64-K_Bits(IV[j]) || CT[j]</sourcecode>
+</clause></clause>
+<clause id="TDES-CFB-P-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CFB1-P, CFB8-P, CFB64-P modes</title><p id="_423ee310-0d52-4ddd-b6d5-66988ecb0d70">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB8-P has a feedback size of 8-bits.</p>
+<p id="_a4fd605d-40f1-404f-aca2-602a16e46fa2">The algorithm is shown in <xref target="xml_figureMCT_TDES_CFB-P"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CFB-P"><name>TDES-CFB-P Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CFB_P_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV1[j], IV2[j], IV3[j])
+        PT[j+1] = LeftMost_K_Bits(IV1[j])
+    Output CT[j]
+    C = LeftMost_192_Bits(CT[j] || CT[j-1] || ... || CT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = LeftMost_K_Bits(IV1[j])
+    IV1[0] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    IV2[0] = IV1[0] + "5555555555555555" mod 2^64
+    IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64</sourcecode>
+</clause>
+<clause id="TDES-OFB-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - OFB mode</title><clause id="TDES-OFB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_56a05866-fbd7-41a4-a037-22c21557ba33">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values.</p>
+<p id="_440b3fa1-afe9-46e3-9069-7d8481bcad32">The algorithm is shown in <xref target="xml_figureMCT_TDES_OFB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_OFB"><name>TDES-OFB Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_OFB_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        PT[j+1] = IV[j]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = PT[0] xor IV[j]
+    IV[0] = CT[j]</sourcecode>
+</clause>
+<clause id="TDES-OFB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_14e980da-828b-4fc9-bc09-5b0773e742f9">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="TDES-OFB-I-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - OFB-I mode</title><clause id="TDES-OFB-I-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_f75304d4-343b-4d0e-aeba-a40dfca2738b">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT) set to some values.</p>
+<p id="_b7900257-ae48-4cdc-942e-48fd8ea13e20">The algorithm is shown in <xref target="xml_figureMCT_TDES_OFB-I"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_OFB-I"><name>TDES-OFB-I Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_OFB-I_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        PT[j+1] = IV[j]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = PT[0] xor IV1[j]
+    IV1[0] = CT[j]
+    IV2[0] = IV1[0] + "5555555555555555" mod 2^64
+    IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64</sourcecode>
+</clause>
+<clause id="TDES-OFB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_03e5cf85-9952-4d18-bf2a-3f0f6526f304">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause></clause></clause>
+<clause id="_test_coverage" inline-header="false" obligation="normative"><title>Test Coverage</title><p id="_dced8805-b0e3-4dd9-a2e8-eb8a1dab8a9e">The tests described in this document have the intention of ensuring an implementation is conformant to <xref target="FIPS-197"/> and <xref target="SP800-38A"/>.</p>
+<clause id="aes-coverage" inline-header="false" obligation="normative">
+<title>AES Requirements Covered</title>
+<p id="_659e3fd8-35f5-46f6-9481-c785ab57eaaf">In <xref target="SP800-38A"/>, both Section 5 and Section 6 which describe general modes of operation for block ciphers are tested. In <xref target="FIPS-197"/>, Section 4 outlines the AES engine and necessary functions to perform simple encrypt an decrypt operations. All AES tests perform such operations and thus rely heavily on this section. Section 5 specifically outlines the algorithm for AES and thus all AES tests rely heavily on this section as well. All of <xref target="SP800-38A-Add"/> requirements are covered. In <xref target="AES-XTS"/>, the IEEE outlines the encrypt and decrypt operations for AES-XTS.</p>
+</clause>
+<clause id="aes-not-coverage" inline-header="false" obligation="normative"><title>AES Requirements Not Covered</title><p id="_bf8b29ec-f7da-4884-92f8-5c981c3e86bf">Some requirements in the outlined specifications are not easily tested. Often they are not ideal for black-box testing such as the ACVP. In <xref target="SP800-38A"/>, Appendix A outlines padding for when the data being encrypted does not evenly fill the blocks. In these tests, all data, unless otherwise specified, is assumed to be a multiple of the block length. All exceptions to those cases are when stream ciphers specifically are being tested. In Section 5.3, IV generation which is required for all modes of AES and TDES outside of ECB, is not tested.  Appendix D outlines how errors are to be handled. As some symmetric ciphers aren't authenticated, ACVP does not include tests that change random bits in payload, IV, key or results, as these results can be successfully encrypted/decrypted, but errors aren't necessarily detectable.</p>
+<p id="_25805722-6dca-4b26-a318-fdedf757a1e7">In <xref target="FIPS-197"/>, Section 5.3 defines the inverse cipher for AES. This is not tested in the CBC, CFB (all), OFB or CTR modes.</p>
+<p id="_5c223964-f3d5-4df3-a9f6-3bfdf5081e00">In <xref target="SP800-38E"/>, the AES-XTS algorithm is restricted to 2\^20 AES blocks (128-bits each) per key. Due to the size of the data, ACVP does not test the proper usage of a key over such large amounts of data.</p>
+<p id="_5c9b62c0-1dfe-45c4-a56f-fa519a6aebdb">In the <xref target="RFC3686"/> testing conformance of AES-CTR, tests will be generated ensuring the LSB[32] of the IV represents the integer value of "1".  These tests will allow for either internal or external IV generation from the perspective of the IUT.</p></clause>
+<clause id="aes-fp-coverage" inline-header="false" obligation="normative">
+<title>AES Format Preserving Encryption Requirements Covered</title>
+<p id="_792776a4-a6fa-4fb3-b4c2-f9f86bb09cdf">All of <xref target="SP800-38Gr1"/> requirements are covered.</p>
+</clause>
+<clause id="aes-fp-not-coverage" inline-header="false" obligation="normative">
+<title>AES Format Preserving Encryption Requirements Not Covered</title>
+<p id="_da275bdd-5302-4de2-b06e-72c0f59e50a1">N/A</p>
+</clause>
+<clause id="tdes-coverage" inline-header="false" obligation="normative">
+<title>TDES Requirements Covered</title>
+<p id="_e501b715-fb8c-4c4f-8e38-eebc3c99812b">In <xref target="SP800-67r2"/>, Section 3 outlines the use for TDES with keying option 1 (three distinct keys) and decryption only for keying option 2 (K1 == K3 != K2). Depending on the cipher mode, both the forward and inverse cipher are tested. The known answer tests address these requirements.</p>
+</clause>
+<clause id="tdes-not-coverage" inline-header="false" obligation="normative">
+<title>TDES Requirements Not Covered</title>
+<p id="_f988e6b1-7cdd-4b3f-8053-d4c1ebc03300">In <xref target="SP800-67r2"/>, Section 3.3 outlines requirements for keys for proper usage of TDES. These requirements are not tested by ACVP. All keys used in the tests are randomly or staticly generated by the server. There are no checks for key equality or potentially weak keys. Section 3.3.2 outlines specific keys which are to be avoided. ACVP does not expect a client to be able to detect these keys.</p>
+</clause>
+<clause id="aead-coverage" inline-header="false" obligation="normative"><title>AEAD Requirements Covered</title><p id="_d763fd23-13ce-427f-8e9b-fc3e9841169e">In <xref target="SP800-38D"/>, Section 7 outlines the encrypt and decrypt operations for AES-GCM. This and all prerequisites to these operations  (such as GHASH) are tested as AES-GCM encrypt and decrypt operations.</p>
+<p id="_078439a4-be74-4646-aa1a-a2e3bd692d24">In <xref target="SP800-38C"/>, Section 6 outlines the encrypt and decrypt operations for AES-CCM. This and all prerequisites to these operations (such as CBC-MAC) are tested as AES-CCM encrypt and decrypt operations. In <xref target="AES-GCM-SIV"/>, the draft outlines the encrypt and decrypt operations for AES-GCM-SIV.</p></clause>
+<clause id="aead-not-coverage" inline-header="false" obligation="normative">
+<title>AEAD Requirements Not Covered</title>
+<p id="_d0057e3b-b641-42fd-8003-83a28252feaa">In <xref target="SP800-38D"/>, Section 8 outlines uniqueness requirements on IVs and keys for AES-GCM. This is considered out of bounds for the algorithm testing done by the ACVP and will not be tested.</p>
+</clause>
+<clause id="kw-coverage" inline-header="false" obligation="normative"><title>KeyWrap Requirements Covered</title><p id="_c3e3fbe1-01b2-4468-b859-145945eae3c3">In <xref target="SP800-38F"/> Section 5.2 defines the authenticated encryption and authenticated decryption operations for all three key-wrap algorithms.  As well, the padding for key-wrap with padding is defined. Algorithm Functional Tests provide assurance of these requirements for encrypt operations. For decrypt operations, there is a possibility to reject the ciphertext due to improper wrapping. This is also assured by the Algorithm Functional Tests.</p>
+<p id="_f31904e7-0e7a-4e88-91d8-2fbc7edc4700">Sections 6 and 7 outline the specific ciphers in both encrypt and decrypt directions. All facsets of these processes are tested with random data via the Algorithm Functional Tests.</p></clause>
+<clause id="kw-not-coverage" inline-header="false" obligation="normative">
+<title>KeyWrap Requirements Not Covered</title>
+<p id="_4f25c1d3-f0f6-46db-bded-2462a5724554">In <xref target="SP800-38F"/> Section 5.3 defines the length requirements allowed by an optimal implementation. The upper bounds are unreasonably large to test in a web-based model and thus an artificial maximum is selected for the payloadLen property (corresponding to both plaintext and ciphertext). The Algorithm Functional Tests SHOULD utilize both the minimum and maximum values provided in the client's registration optimally with other values.</p>
+</clause></clause></clause>
+</sections>
+</ietf-standard>

--- a/src/draft-celi-acvp-symmetric.xml.abort
+++ b/src/draft-celi-acvp-symmetric.xml.abort
@@ -1,0 +1,5072 @@
+<ietf-standard xmlns="https://www.metanorma.org/ns/ietf" type="semantic" version="2.3.6">
+<bibdata type="standard">
+<title language="en" format="text/plain" type="main">ACVP Symmetric Block Cipher Algorithm JSON Specification</title>
+<title language="en" format="text/plain" type="abbrev">ACVP Symmetric Block Ciphers</title>
+
+
+<contributor>
+<role type="editor"/>
+<person>
+<name>
+<completename>Christopher Celi</completename>
+</name>
+<email>christopher.celi@nist.gov</email>
+</person>
+</contributor>
+<contributor>
+<role type="editor"/>
+<person>
+<name>
+<completename>Russell Hammett</completename>
+</name>
+<email>russell.hammett@nist.gov</email>
+</person>
+</contributor>
+<contributor>
+<role type="publisher"/>
+<organization>
+<name>Internet Engineering Task Force</name>
+<abbreviation>IETF</abbreviation>
+</organization>
+</contributor>
+<version>
+<revision-date>2020-12-10</revision-date>
+</version>
+<language>en</language>
+<script>Latn</script>
+<status>
+<stage>informational</stage>
+</status>
+<copyright>
+<from>2021</from>
+<owner>
+<organization>
+<name>Internet Engineering Task Force</name>
+<abbreviation>IETF</abbreviation>
+</organization>
+</owner>
+</copyright>
+<series type="stream">
+<title>IETF</title>
+</series>
+<series type="intended">
+<title>informational</title>
+</series>
+<ext>
+<doctype>internet-draft</doctype>
+<area>Internet</area>
+<ipr>trust200902</ipr>
+<pi>
+<toc>yes</toc>
+</pi>
+</ext>
+</bibdata>
+<preface><acknowledgements id="acknowledgements" obligation="informative">
+<title>Acknowledgements</title>
+<p id="_8e58c3e7-abf5-4048-a78d-85f0033a4b1c">The authors thank John Foley for putting together an early draft of this specification.</p>
+</acknowledgements></preface><sections><clause id="abstract" inline-header="false" obligation="normative">
+<title>Abstract</title>
+<p id="_1856abac-9e69-42ac-a773-d1190a8ae160">This document defines the JSON schema for testing Symmetric Block Cipher implementations with the ACVP specification.</p>
+</clause>
+<clause id="introduction" inline-header="false" obligation="normative"><title>Introduction</title><p id="_84c67099-ebcb-44c8-80e5-cfdcfd5066b9">The Automated Crypto Validation Protocol (ACVP) defines a mechanism to automatically verify the cryptographic implementation of a software or hardware crypto module. The ACVP specification defines how a crypto module communicates with an ACVP server, including crypto capabilities negotiation, session management, authentication, vector processing and more. The ACVP specification does not define algorithm specific JSON constructs for performing the crypto validation. A series of ACVP sub-specifications define the constructs for testing individual crypto algorithms. Each sub-specification addresses a specific class of crypto algorithms. This sub-specification defines the JSON constructs for testing Symmetric Block Cipher implementations using ACVP.</p>
+<p id="_ba8282bb-2374-4514-bc88-eaf1306d4a59">The ACVP server performs a set of tests on the block ciphers in order to assess the correctness and robustness of the implementation. A typical ACVP validation session would require multiple tests to be performed for every supported cryptographic algorithm, such as AES-ECB, AES-CBC, AES-CTR, AES-GCM, TDES-CBC, TDES-CTR, etc.</p></clause>
+<clause id="conventions" inline-header="false" obligation="normative"><title>Conventions</title><clause id="_notation_conventions" inline-header="false" obligation="normative">
+<title>Notation conventions</title>
+<p id="_7e6574fa-39a9-42e8-8786-2879869582a2">The key words "<bcp14>MUST</bcp14>", "<bcp14>MUST NOT</bcp14>", "<bcp14>REQUIRED</bcp14>", "<bcp14>SHALL</bcp14>", "<bcp14>SHALL NOT</bcp14>", "<bcp14>SHOULD</bcp14>", "<bcp14>SHOULD NOT</bcp14>", "<bcp14>RECOMMENDED</bcp14>", "<strong>NOT RECOMMENDED</strong>", "<bcp14>MAY</bcp14>", and "<bcp14>OPTIONAL</bcp14>" in this document are to be interpreted as described in BCP 14 of <eref type="inline" bibitemid="RFC2119" citeas="RFC 2119"/> and <eref type="inline" bibitemid="RFC8174" citeas="RFC 8174"/> when, and only when, they appear in all capitals, as shown here.</p>
+</clause>
+<clause id="_terms_and_definitions" inline-header="false" obligation="normative"><title>Terms and Definitions</title><clause id="_prompt" inline-header="false" obligation="normative">
+<title>Prompt</title>
+<p id="_cee4f9e9-3a3a-405d-b74e-6185e31f1779">JSON sent from the server to the client describing the tests the client performs</p>
+</clause>
+<clause id="_registration" inline-header="false" obligation="normative">
+<title>Registration</title>
+<p id="_405d1e88-26bf-4e7c-bc87-58e514e98fca">The initial request from the client to the server describing the capabilities of one or several algorithm, mode and revision combinations</p>
+</clause>
+<clause id="_response" inline-header="false" obligation="normative">
+<title>Response</title>
+<p id="_cf238e19-3337-4d05-acc8-298cdde88000">JSON sent from the client to the server in response to the prompt</p>
+</clause>
+<clause id="_test_case" inline-header="false" obligation="normative">
+<title>Test Case</title>
+<p id="_53d8e4b2-245b-400b-b43e-420a97255c6e">An individual unit of work within a prompt or response</p>
+</clause>
+<clause id="_test_group" inline-header="false" obligation="normative">
+<title>Test Group</title>
+<p id="_e3949f64-ebdf-4965-a515-74fe96790b10">A collection of test cases that share similar properties within a prompt or response</p>
+</clause>
+<clause id="_test_vector_set" inline-header="false" obligation="normative">
+<title>Test Vector Set</title>
+<p id="_286a2933-5988-461e-89bf-c5a8b5fcdfdb">A collection of test groups under a specific algorithm, mode, and revision</p>
+</clause>
+<clause id="_validation" inline-header="false" obligation="normative">
+<title>Validation</title>
+<p id="_66492a35-be06-4fb7-83ff-e9454d02757d">JSON sent from the server to the client that specifies the correctness of the response</p>
+</clause></clause></clause>
+<clause id="supported_algs" inline-header="false" obligation="normative"><title>Supported Block Cipher Algorithms</title><p id="_230a3178-0030-4e17-8494-b6ecf8ef252a">The following block cipher algorithm and test revision pairs <bcp14>MAY</bcp14> be advertised by the ACVP compliant cryptographic module (algorithm / revision):</p>
+<ul id="_0dbb019d-b2b9-49fc-8a24-152a71baeb5e">
+<li>
+<p id="_2d07dd1e-0eb2-4af3-8524-674572e40fbe">ACVP-AES-ECB / "1.0"</p>
+</li>
+<li>
+<p id="_a5002263-132e-48f9-bc26-7d571c5a742f">ACVP-AES-CBC / "1.0"</p>
+</li>
+<li>
+<p id="_e597e381-721e-4fa7-a519-b0fd9bae2ee3">ACVP-AES-CBC-CS1 / "1.0"</p>
+</li>
+<li>
+<p id="_e557d6de-3890-4bf7-9b43-efc83251244d">ACVP-AES-CBC-CS2 / "1.0"</p>
+</li>
+<li>
+<p id="_ac190f8d-61c1-47e2-a7de-5fc9ba65b0d2">ACVP-AES-CBC-CS3 / "1.0"</p>
+</li>
+<li>
+<p id="_e79c8383-ec19-47cb-b2da-e2b62ff9fe73">ACVP-AES-OFB / "1.0"</p>
+</li>
+<li>
+<p id="_28082cc2-51fe-4277-afc9-4c376bd59111">ACVP-AES-CFB1 / "1.0"</p>
+</li>
+<li>
+<p id="_8fb56c67-6bd0-4dae-b04a-bdce916cf77e">ACVP-AES-CFB8 / "1.0"</p>
+</li>
+<li>
+<p id="_62b6d9a9-4aee-43cc-9817-c2919c2bcff0">ACVP-AES-CFB128 / "1.0"</p>
+</li>
+<li>
+<p id="_3c1bbac1-4b82-4c0c-a9f5-0e284876ecd4">ACVP-AES-CTR / "1.0"</p>
+</li>
+<li>
+<p id="_3076caf1-2f2b-44f1-aebb-bcd3101ca4a8">ACVP-AES-FF1 / "1.0"</p>
+</li>
+<li>
+<p id="_2e1df690-c290-4793-b23a-9b594d9bd6a3">ACVP-AES-FF3-1 / "1.0"</p>
+</li>
+<li>
+<p id="_6bf1b5f2-f37c-4e0e-87b3-65450585dfae">ACVP-AES-GCM / "1.0"</p>
+</li>
+<li>
+<p id="_47e420c2-e62e-4250-8f52-b5ea5f485132">ACVP-AES-GCM-SIV / "1.0"</p>
+</li>
+<li>
+<p id="_10187517-4e03-4f5c-aa3a-26849d86dd67">ACVP-AES-XPN / "1.0"</p>
+</li>
+<li>
+<p id="_428f9577-0160-4ced-bbbc-1437740a4a3e">ACVP-AES-CCM / "1.0"</p>
+</li>
+<li>
+<p id="_43ae1093-84f6-4118-a2e8-8a8f96c61bf8">ACVP-AES-XTS / "1.0"</p>
+</li>
+<li>
+<p id="_7c69b1cd-1b9d-48c9-aec3-4d8c29c88977">ACVP-AES-XTS / "2.0"</p>
+</li>
+<li>
+<p id="_ab3224d0-e9aa-4a08-bfd7-07ce7583177f">ACVP-AES-KW / "1.0"</p>
+</li>
+<li>
+<p id="_17cc052c-d050-4404-bc1e-936aad7af748">ACVP-AES-KWP / "1.0"</p>
+</li>
+<li>
+<p id="_cfb49cdd-506f-4444-b4de-01826b892e9a">ACVP-TDES-ECB / "1.0"</p>
+</li>
+<li>
+<p id="_152023ed-22af-49c6-9ef1-72b2ab49971d">ACVP-TDES-CBC / "1.0"</p>
+</li>
+<li>
+<p id="_19269f65-e5de-4524-9794-5947e6b7e343">ACVP-TDES-CBCI / "1.0"</p>
+</li>
+<li>
+<p id="_a4252cf3-9267-4dc1-ae55-d679ebcbb3a0">ACVP-TDES-CFB1 / "1.0"</p>
+</li>
+<li>
+<p id="_359c3f0a-ae56-41dc-8070-2886301a4d50">ACVP-TDES-CFB8 / "1.0"</p>
+</li>
+<li>
+<p id="_c0fda09e-4d0f-484c-93e8-6bc1549a978b">ACVP-TDES-CFB64 / "1.0"</p>
+</li>
+<li>
+<p id="_f78cddfc-6303-4675-ae2d-d21dd324d74c">ACVP-TDES-CFBP1 / "1.0"</p>
+</li>
+<li>
+<p id="_23bfb52e-fae2-4855-871d-3ea241828cdf">ACVP-TDES-CFBP8 / "1.0"</p>
+</li>
+<li>
+<p id="_53fd73f4-e5db-491b-a573-86d3eb75a3d4">ACVP-TDES-CFBP64 / "1.0"</p>
+</li>
+<li>
+<p id="_80b30d46-04f2-4646-bce6-3f1bd043c352">ACVP-TDES-OFB / "1.0"</p>
+</li>
+<li>
+<p id="_41860636-179d-436c-9819-f0805fcff7a6">ACVP-TDES-OFBI / "1.0"</p>
+</li>
+<li>
+<p id="_9c7df5eb-ce17-4be9-aa4c-9cc8acf961ef">ACVP-TDES-CTR / "1.0"</p>
+</li>
+<li>
+<p id="_3a3f0dd2-98a4-4b3f-ba9e-0b57b2072edd">ACVP-TDES-KW / "1.0"</p>
+</li>
+</ul>
+<p id="_af91aeee-4799-4a90-9160-ffb72a75e952">Multiple testing revisions of the same algorithm allow a validation server to improve testing over time without breaking functionality of existing clients. In the case of symmetric block cipher algorithms, multiple revisions of ACVP-AES-XTS exist and <bcp14>MAY</bcp14> individually be provided by a server. The revision numbers of "1.0" and "2.0" indicate a progression among the tests. In this case, the "2.0" tests are fully capable of running the "1.0" implementation of ACVP-AES-XTS. More discussion can be found within <xref target="cap_ex"/>.</p>
+<clause id="conformances" inline-header="false" obligation="normative"><title>Supported Conformances</title><p id="_c894e854-4a5f-4a8d-8ad1-171dc64def50">The following conformances <bcp14>MAY</bcp14> be advertised by the ACVP compliant cryptographic module:</p>
+<ul id="_b3953319-92c0-4634-a99b-80aca1e66c13">
+<li>
+<p id="_00f268ee-dae0-49db-8474-caf49957b8af">ACVP-AES-CCM conformance "ECMA" which expands upon AES-CCM and adheres to <eref type="inline" bibitemid="ECMA" citeas="ECMA"/>. This conformance changes the supported sizes to accomodate the specific sizes required by the use-case of the algorithm.</p>
+</li>
+<li>
+<p id="_230ef496-ee60-4111-946a-5884894e4199">ACVP-AES-CTR conformance "RFC3686".  This conformance ensures the IV is generated with the LSB[32] of the IV representing the integer "1".  This conformance also requires the additional registration property of "ivGenMode" which states if the IUT does external or internal IV generation.</p>
+</li>
+</ul></clause></clause>
+<clause id="testtypes" inline-header="false" obligation="normative"><title>Test Types and Test Coverage</title><p id="_d115acff-121b-4ce0-85a3-7bf8d0352239">This section describes the design of the tests used to validate implementations of block cipher algorithms.</p>
+<clause id="_test_types" inline-header="false" obligation="normative"><title>Test Types</title><p id="_ee5ed550-93fa-47d1-92dc-9bee87e548eb">There are three types of tests for block ciphers: functional tests, Monte Carlo tests and counter tests. Each has a specific value to be used in the testType field. The testType field definitions are:</p>
+<ul id="_2cbda0f4-a617-403a-8164-0bf6eee74453">
+<li>
+<p id="_97a5436e-cbe0-47a6-bf9e-444bf57a7312">"AFT" - Algorithm Functional Test. These tests can be processed by the client using a normal 'encrypt' or 'decrypt' operation. AFTs cause the implementation under test to exercise normal operations on a single block, multiple blocks, or (where applicable) partial blocks. In some cases random data is used, in others, static, predetermined tests are provided. The functional tests of the block cipher are designed to verify that the logical components of the cipher (GFSbox, KeySbox, block chaining etc.) are operating correctly.</p>
+</li>
+<li>
+<p id="_2655f69a-318e-4cad-8a5c-b061fed6eb8b">"MCT" - Monte Carlo Test. These tests exercise the implementation under test under strenuous circumstances. The implementation under test must process the test vectors according to the correct algorithm and mode in this document. MCTs can help detect potential memory leaks over time, and problems in allocation of resources, addressing variables, error handling and generally improper behavior in response to random inputs. Not every algorithm and mode combination has an MCT.
+See <xref target="MC_test"/> for implementation details.</p>
+</li>
+<li>
+<p id="_dcf745b0-9630-495c-9c26-564747fbb2da">"CTR" - Counter Mode Test. Counter tests are specifically for counter modes (AES-CTR and TDES-CTR) and require an implementation under test to exercise their counter mechanism. The server will send a long message to the client for encryption or decryption and back-compute the IVs used by the implementation under test. These IVs are then verified for uniqueness and an increasing (or decreasing) nature. The client processes these tests as normal AFTs. The different mode is highlighted here to signify the difference on the server side for processing.</p>
+</li>
+</ul>
+<clause id="MC_test" inline-header="false" obligation="normative"><title>Monte Carlo tests for block ciphers</title><p id="_2647869e-383f-48cc-be2b-6e182e87cc9d">The MCTs start with an initial condition (plaintext/ciphertext, key, and optional, or maybe multiple IVs) and perform a series of chained computations. For modes that use an IV, the IV is used in the beginning of each pseudorandom process. The IV is implicitly advanced according to the block cipher mode in use. There are separate rounds of MCT for encryption and decryption. Because some block cipher modes rely on an IV and perform calculations differently from other modes, there are specific definitions of MCT for many of the block cipher modes.</p>
+<clause id="AES-ECB-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - ECB mode</title><clause id="AES-ECB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_ba42e3fd-907d-4a87-91cd-eb729eddb2f1">The initial condition for the test is the tuple (KEY, PT) set to some values.</p>
+<p id="_d8c1fda4-6c70-484a-94d4-843506e73afa">The algorithm is shown in <xref target="xml_figureMCTECB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTECB"><name>AES-ECB Monte Carlo Test</name>Key[0] = KEY
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output PT[0]
+    For j = 0 to 999
+        CT[j] = AES_ECB_ENCRYPT(Key[i], PT[j])
+        PT[j+1] = CT[j]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    PT[0] = CT[j]</sourcecode>
+</clause>
+<clause id="AES-ECB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_64f1f60f-9f80-4e67-96ed-77855a8043eb">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CBC-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CBC mode</title><clause id="AES-CBC-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_20d2729e-b9d4-4a87-a190-dcb7f257c2e3">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_ef85cfdd-6eeb-4241-8baa-e37275c9ecc0">The algorithm is shown in <xref target="xml_figureMCTCBC"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCBC"><name>AES-CBC Monte Carlo Test</name>Key[0] = KEY
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CBC_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = IV[i]
+        Else
+            CT[j] = AES_CBC_ENCRYPT(Key[i], PT[j])
+            PT[j+1] = CT[j-1]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    IV[i+1] = CT[j]
+    PT[0] = CT[j-1]</sourcecode>
+</clause>
+<clause id="AES-CBC-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_9540dfb7-aadc-46ac-9c9b-946952593e39">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-OFB-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - OFB mode</title><clause id="AES-OFB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_85d3f12d-d6e3-41df-8436-1654912f002c">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_828e5d39-c0fb-4f20-9d4a-dbec22f312e3">The algorithm is shown in <xref target="xml_figureMCTOFB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTOFB"><name>AES-OFB Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_OFB_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = IV[i]
+        Else
+            CT[j] = AES_OFB_ENCRYPT(Key[i], PT[j])
+            PT[j+1] = CT[j-1]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    IV[i+1] = CT[j]
+    PT[0] = CT[j-1]</sourcecode>
+</clause>
+<clause id="AES-OFB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_41697ddb-7570-455a-9411-7ae10e0f07cf">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CFB1-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CFB1 mode</title><clause id="AES-CFB1-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_f779ce9d-fe9f-45b9-976c-8dda0f17af4c">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_ab034647-2c12-47b5-8256-ab9144f5125a">The algorithm is shown in <xref target="xml_figureMCTCFB1"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCFB1"><name>AES-CFB1 Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CFB1_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = BitJ(IV[i])
+        Else
+            CT[j] = AES_CFB1_ENCRYPT(Key[i], PT[j])
+            If ( j&lt;128 )
+                PT[j+1] = BitJ(IV[i])
+            Else
+                PT[j+1] = CT[j-128]
+    Output CT[j]
+    If ( keylen = 128 )
+        Key[i+1] = Key[i] xor (CT[j-127] || CT[j-126] || ... || CT[j])
+    If ( keylen = 192 )
+        Key[i+1] = Key[i] xor (CT[j-191] || CT[j-190] || ... || CT[j])
+    If ( keylen = 256 )
+        Key[i+1] = Key[i] xor (CT[j-255] || CT[j-254] || ... || CT[j])
+    IV[i+1] = (CT[j-127] || CT[j-126] || ... || CT[j])
+    PT[0] = CT[j-128]</sourcecode>
+</clause>
+<clause id="AES-CFB1-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_b730a7b1-bc8b-4515-94ae-163104c63566">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CFB8-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CFB8 mode</title><clause id="AES-CFB8-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_f9813c30-1b8b-4c5a-b063-b046c424fc98">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_5a0b6080-b8e9-4f57-96d9-f6bbf3b0c362">The algorithm is shown in <xref target="xml_figureMCTCFB8"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCFB8"><name>AES-CFB8 Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CFB8_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = ByteJ(IV[i])
+        Else
+            CT[j] = AES_CFB8_ENCRYPT(Key[i], PT[j])
+            If ( j&lt;16 )
+                PT[j+1] = ByteJ(IV[i])
+            Else
+                PT[j+1] = CT[j-16]
+    Output CT[j]
+    If ( keylen = 128 )
+        Key[i+1] = Key[i] xor (CT[j-15] || CT[j-14] || ... || CT[j])
+    If ( keylen = 192 )
+        Key[i+1] = Key[i] xor (CT[j-23] || CT[j-22] || ... || CT[j])
+    If ( keylen = 256 )
+        Key[i+1] = Key[i] xor (CT[j-31] || CT[j-30] || ... || CT[j])
+    IV[i+1] = (CT[j-15] || CT[j-14] || ... || CT[j])
+    PT[0] = CT[j-16]</sourcecode>
+</clause>
+<clause id="AES-CFB8-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_19bb2f61-35ff-439e-a147-43221814f9f0">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES-CFB128-MCT" inline-header="false" obligation="normative"><title>AES Monte Carlo Test - CFB128 mode</title><clause id="AES-CFB128-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_50455abd-5dd8-425b-a510-eeabadf7af10">The initial condition for the test is the tuple (KEY, IV, PT) set to some values.</p>
+<p id="_0a23154d-6be4-4b93-96f8-cf1e826ccd47">The algorithm is shown in <xref target="xml_figureMCTCFB128"/>.</p>
+<sourcecode lang="code" id="xml_figureMCTCFB128"><name>AES-CFB128 Monte Carlo Test</name>Key[0] = Key
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 99
+    Output Key[i]
+    Output IV[i]
+    Output PT[0]
+    For j = 0 to 999
+        If ( j=0 )
+            CT[j] = AES_CFB128_ENCRYPT(Key[i], IV[i], PT[j])
+            PT[j+1] = IV[i]
+        Else
+            CT[j] = AES_CFB128_ENCRYPT(Key[i], PT[j])
+            PT[j+1] = CT[j-1]
+    Output CT[j]
+    AES_KEY_SHUFFLE(Key, CT)
+    IV[i+1] = CT[j]
+    PT[0] = CT[j-1]</sourcecode>
+</clause>
+<clause id="AES-CFB128-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_c2ee3397-5df6-41b3-adad-f0bf9e6cd315">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="AES_KEY_SHUFFLE" inline-header="false" obligation="normative"><title>AES Monte Carlo Key Shuffle</title><p id="_6788b699-35c6-45e6-99d8-88ccfc1f6701">Most AES MCTs use a shared key shuffle routine. The algorithm is shown in <xref target="xml_figureAESKEY"/>.</p>
+<p id="_e05d73e1-deb5-4ae5-9615-b248669fb3d7">The initial condition for the routine is a tuple (KEY, CT) set to some values. This pseudocode is specifically for encryption. For decryption, swap all instances of CT with PT. The || symbol is used to denote concatenation. The MSB (most significant bits) and LSB (least significant bits) functions accept a bit string and an integer amount of bits to capture. For example MSB(A, 8) would capture the 8 most significant bits of the bit string A.</p>
+<sourcecode lang="code" id="xml_figureAESKEY"><name>AES Encrypt Key Shuffle Routine</name>If ( keylen = 128 )
+    Key[i+1] = Key[i] xor MSB(CT[j], 128)
+If ( keylen = 192 )
+    Key[i+1] = Key[i] xor (LSB(CT[j-1], 64) || MSB(CT[j], 128))
+If ( keylen = 256 )
+    Key[i+1] = Key[i] xor (MSB(CT[j-1], 128) || MSB(CT[j], 128))</sourcecode>
+</clause>
+<clause id="TDES-ECB-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - ECB mode</title><clause id="TDES-ECB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_6b2fc9c4-4a63-4f32-b971-ab6103c0b19d">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, PT) set to some values.</p>
+<p id="_2a39b92f-e1fb-4e6a-8399-dbae5090f8c1">The algorithm is shown in <xref target="xml_figureMCT_TDES_ECB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_ECB"><name>TDES-ECB Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_ECB_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j])
+        PT[j+1] = CT[i]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = CT[j]</sourcecode>
+</clause>
+<clause id="TDES-ECB-MCT-DECR" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_ce3001cf-9061-4a60-b789-aff7de4206eb">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="TDES-CBC-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CBC mode</title><clause id="TDES-CBC-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_325604b1-956f-4460-b11a-2d929f806fb5">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values.</p>
+<p id="_0d25b4c5-b0bf-4486-ba63-07d4ce9026ba">The algorithm is shown in <xref target="xml_figureMCT_TDES_CBC"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC"><name>TDES-CBC Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CBC_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        If ( j = 0 )
+            PT[j+1] = IV[0]
+        Else
+            PT[j+1] = CT[j-1]
+        IV[j+1] = CT[j]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = CT[j-1]
+    IV[0] = CT[j]</sourcecode>
+</clause>
+<clause id="TDES-CBC-MCT-DECR" inline-header="false" obligation="normative"><title>Decrypt</title><p id="_1513e57d-d78b-4ea7-a8f7-d8493e5baf62">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the inner loop in the pseudocode with the following:</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC_DECR"><name>TDES-CBC Monte Carlo Test Decrypt</name>    For j = 0 to 9999
+        PT[j] = TDES_CBC_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV[j])
+        CT[j+1] = PT[j]
+        IV[j+1] = CT[j]</sourcecode>
+</clause></clause>
+<clause id="TDES-CBC-I-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CBC-I mode</title><clause id="TDES-CBC-I-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_159779da-4abe-4622-ae07-183f7b7cb378">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT1, PT2, PT3) set to some values.</p>
+<p id="_14c97de1-bddc-4548-8a41-94ec692f81ec">The algorithm is shown in <xref target="xml_figureMCT_TDES_CBC-I"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC-I"><name>TDES-CBC-I Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+PT1[0] = PT1
+PT2[0] = PT2
+PT3[0] = PT3
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output PT1[0], PT2[0], PT3[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CBC_I_ENCRYPT(Key1[i], Key2[i], Key3[i], PT1[j], PT2[j], PT3[j], IV1[j], IV2[j], IV3[j])
+        If ( j = 0 )
+            PT1[j+1] = IV1[0]
+            PT2[j+1] = IV2[0]
+            PT3[j+1] = IV3[0]
+        Else
+            PT1[j+1] = CT1[j-1]
+            PT2[j+1] = CT2[j-1]
+            PT3[j+1] = CT3[j-1]
+        IV1[j+1] = CT1[j]
+        IV2[j+1] = CT2[j]
+        IV3[j+1] = CT3[j]
+    Output CT1[j], CT2[j], CT3[j]
+    Key1[i+1] = Key1[i] xor CT1[j]
+    Key2[i+1] = Key2[i] xor CT2[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT3[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT1[0] = CT1[j-1]
+    PT2[0] = CT2[j-1]
+    PT3[0] = CT3[j-1]
+    IV1[0] = CT1[j]
+    IV2[0] = CT2[j]
+    IV3[0] = CT3[j]</sourcecode>
+</clause>
+<clause id="TDES-CBC-I-MCT-DECR" inline-header="false" obligation="normative"><title>Decrypt</title><p id="_71ad2d3b-bf4a-4a47-ab05-b922b10ff3b8">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, CT1, CT2, CT3) set to some values.</p>
+<p id="_48568b69-463a-4d38-b174-aa068be714f3">The algorithm is shown in <xref target="xml_figureMCT_TDES_CBC_I_DECR"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CBC_I_DECR"><name>TDES-CBC-I Monte Carlo Test Decrypt</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+CT1[0] = CT1
+CT2[0] = CT2
+CT3[0] = CT3
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output CT1[0], CT2[0], CT3[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CBC_I_DECRYPT(Key1[i], Key2[i], Key3[i], CT1[j], CT2[j], CT3[j], IV1[j], IV2[j], IV3[j])
+        CT1[j+1] = PT1[j]
+        CT2[j+1] = PT2[j]
+        CT3[j+1] = PT3[j]
+        IV1[j+1] = CT1[j]
+        IV2[j+1] = CT2[j]
+        IV3[j+1] = CT3[j]
+    Output PT1[j], PT2[j], PT3[j]
+    Key1[i+1] = Key1[i] xor PT1[j]
+    Key2[i+1] = Key2[i] xor PT2[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor PT3[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT1[0] = PT1[j]
+    CT2[0] = PT2[j]
+    CT3[0] = PT3[j]
+    IV1[0] = CT1[j]
+    IV2[0] = CT2[j]
+    IV3[0] = CT3[j]</sourcecode>
+</clause></clause>
+<clause id="TDES-CFB-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CFB1, CFB8, CFB64 modes</title><clause id="TDES-CFB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_be6d50de-4717-45f1-953b-5d4454a06050">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB1 has a feedback size of 1-bit.</p>
+<p id="_5ae52dc2-ad4b-4d1a-a1bf-a2db792a445a">The algorithm is shown in <xref target="xml_figureMCT_TDES_CFB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CFB"><name>TDES-CFB Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CFB_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        PT[j+1] = LeftMost_K_Bits(IV[j])
+        IV[j+1] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    Output CT[j]
+    C = LeftMost_192_Bits(CT[j] || CT[j-1] || ... || CT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = LeftMost_K_Bits(IV[j])
+    IV[0] = RightMost_64-K_Bits(IV[j]) || CT[j]</sourcecode>
+</clause>
+<clause id="TDES-CFB-MCT-DEC" inline-header="false" obligation="normative"><title>Decrypt</title><p id="_9ed36423-3125-43d4-9314-ee6067a84d69">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, CT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB1 has a feedback size of 1-bit. O[j] is the O<sub>j</sub> variable internal to the Triple DES operation described in Table 43 of SP 800-20.</p>
+<p id="_0c3b707f-23bc-40e0-a3da-0016f80fea55">The algorithm is shown in <xref target="xml_figureMCT_TDES_CFB_DEC"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CFB_DEC"><name>TDES-CFB Monte Carlo Test Decrypt</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+CT[0] = CT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output CT[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CFB_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV[j])
+        CT[j+1] = LeftMost_K_Bits(O[j])
+        IV[j+1] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    Output PT[j]
+    C = LeftMost_192_Bits(PT[j] || PT[j-1] || ... || PT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT[0] = LeftMost_K_Bits(O[j])
+    IV[0] = RightMost_64-K_Bits(IV[j]) || CT[j]</sourcecode>
+</clause></clause>
+<clause id="TDES-CFB-P-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - CFB1-P, CFB8-P, CFB64-P modes</title><p id="_9b4a5cb7-b4db-452c-a38f-eb4b9c8b7dcf">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB8-P has a feedback size of 8-bits.</p>
+<p id="_5692f224-fa19-4f5a-aa96-155256c386d5">The algorithm is shown in <xref target="xml_figureMCT_TDES_CFB-P"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_CFB-P"><name>TDES-CFB-P Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_CFB_P_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV1[j], IV2[j], IV3[j])
+        PT[j+1] = LeftMost_K_Bits(IV1[j])
+    Output CT[j]
+    C = LeftMost_192_Bits(CT[j] || CT[j-1] || ... || CT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = LeftMost_K_Bits(IV1[j])
+    IV1[0] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    IV2[0] = IV1[0] + "5555555555555555" mod 2^64
+    IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64</sourcecode>
+</clause>
+<clause id="TDES-OFB-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - OFB mode</title><clause id="TDES-OFB-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_9246799d-06f9-48ef-ac60-632f5f61cabb">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values.</p>
+<p id="_1f6757ee-8027-4f51-9bf0-0fb4a01e77c6">The algorithm is shown in <xref target="xml_figureMCT_TDES_OFB"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_OFB"><name>TDES-OFB Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_OFB_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        PT[j+1] = IV[j]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = PT[0] xor IV[j]
+    IV[0] = CT[j]</sourcecode>
+</clause>
+<clause id="TDES-OFB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_aff6cc92-766a-445a-aeb8-e31b122bd976">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause>
+<clause id="TDES-OFB-I-MCT" inline-header="false" obligation="normative"><title>TDES Monte Carlo Test - OFB-I mode</title><clause id="TDES-OFB-I-MCT-ENC" inline-header="false" obligation="normative"><title>Encrypt</title><p id="_d4dfdc3b-973a-476c-b9b8-136c538a5915">The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT) set to some values.</p>
+<p id="_c31cc8fb-5161-41d3-b33d-e339b19bc323">The algorithm is shown in <xref target="xml_figureMCT_TDES_OFB-I"/>.</p>
+<sourcecode lang="code" id="xml_figureMCT_TDES_OFB-I"><name>TDES-OFB-I Monte Carlo Test</name>Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+PT[0] = PT
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output PT[0]
+    For j = 0 to 9999
+        CT[j] = TDES_OFB-I_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV[j])
+        PT[j+1] = IV[j]
+    Output CT[j]
+    Key1[i+1] = Key1[i] xor CT[j]
+    Key2[i+1] = Key2[i] xor CT[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor CT[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    PT[0] = PT[0] xor IV1[j]
+    IV1[0] = CT[j]
+    IV2[0] = IV1[0] + "5555555555555555" mod 2^64
+    IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64</sourcecode>
+</clause>
+<clause id="TDES-OFB-MCT-DEC" inline-header="false" obligation="normative">
+<title>Decrypt</title>
+<p id="_ff3974d2-cecc-4029-ba21-1887ad5195ab">The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.</p>
+</clause></clause></clause></clause>
+<clause id="_test_coverage" inline-header="false" obligation="normative"><title>Test Coverage</title><p id="_584984a2-ed6a-4afc-b778-5a1fc7569ca7">The tests described in this document have the intention of ensuring an implementation is conformant to <eref type="inline" bibitemid="FIPS-197" citeas="NIST FIPS 197"/> and <eref type="inline" bibitemid="SP800-38A" citeas="NIST SP 800-38A"/>.</p>
+<clause id="aes-coverage" inline-header="false" obligation="normative">
+<title>AES Requirements Covered</title>
+<p id="_2b41d43e-56e1-424d-bfc6-6481500a6d37">In <eref type="inline" bibitemid="SP800-38A" citeas="NIST SP 800-38A"/>, both Section 5 and Section 6 which describe general modes of operation for block ciphers are tested. In <eref type="inline" bibitemid="FIPS-197" citeas="NIST FIPS 197"/>, Section 4 outlines the AES engine and necessary functions to perform simple encrypt an decrypt operations. All AES tests perform such operations and thus rely heavily on this section. Section 5 specifically outlines the algorithm for AES and thus all AES tests rely heavily on this section as well. All of <eref type="inline" bibitemid="SP800-38A-Add" citeas="SP800-38A-Add"/> requirements are covered. In <eref type="inline" bibitemid="AES-XTS" citeas="IEEE 1619-2007"/>, the IEEE outlines the encrypt and decrypt operations for AES-XTS.</p>
+</clause>
+<clause id="aes-not-coverage" inline-header="false" obligation="normative"><title>AES Requirements Not Covered</title><p id="_7055570b-cb76-47ec-90ee-9caa18773c92">Some requirements in the outlined specifications are not easily tested. Often they are not ideal for black-box testing such as the ACVP. In <eref type="inline" bibitemid="SP800-38A" citeas="NIST SP 800-38A"/>, Appendix A outlines padding for when the data being encrypted does not evenly fill the blocks. In these tests, all data, unless otherwise specified, is assumed to be a multiple of the block length. All exceptions to those cases are when stream ciphers specifically are being tested. In Section 5.3, IV generation which is required for all modes of AES and TDES outside of ECB, is not tested.  Appendix D outlines how errors are to be handled. As some symmetric ciphers aren't authenticated, ACVP does not include tests that change random bits in payload, IV, key or results, as these results can be successfully encrypted/decrypted, but errors aren't necessarily detectable.</p>
+<p id="_9571a8ba-f8b0-4ab2-abe0-5abfe7b6aa58">In <eref type="inline" bibitemid="FIPS-197" citeas="NIST FIPS 197"/>, Section 5.3 defines the inverse cipher for AES. This is not tested in the CBC, CFB (all), OFB or CTR modes.</p>
+<p id="_fa2c2137-9f35-4027-90a9-fa9effb8edc4">In <eref type="inline" bibitemid="SP800-38E" citeas="NIST SP 800-38E"/>, the AES-XTS algorithm is restricted to 2\^20 AES blocks (128-bits each) per key. Due to the size of the data, ACVP does not test the proper usage of a key over such large amounts of data.</p>
+<p id="_df8c4030-4b29-4847-9aec-986008806a0b">In the <eref type="inline" bibitemid="RFC3686" citeas="RFC 3686"/> testing conformance of AES-CTR, tests will be generated ensuring the LSB[32] of the IV represents the integer value of "1".  These tests will allow for either internal or external IV generation from the perspective of the IUT.</p></clause>
+<clause id="aes-fp-coverage" inline-header="false" obligation="normative">
+<title>AES Format Preserving Encryption Requirements Covered</title>
+<p id="_c0536892-70b1-43f9-bd12-73a2f87f7a53">All of <eref type="inline" bibitemid="SP800-38Gr1" citeas="NIST SP 800-38G Rev. 1"/> requirements are covered.</p>
+</clause>
+<clause id="aes-fp-not-coverage" inline-header="false" obligation="normative">
+<title>AES Format Preserving Encryption Requirements Not Covered</title>
+<p id="_b064ec2a-2303-4ff3-b11c-c2317f858568">N/A</p>
+</clause>
+<clause id="tdes-coverage" inline-header="false" obligation="normative">
+<title>TDES Requirements Covered</title>
+<p id="_f54ce412-868c-4a37-931b-9319f3328611">In <eref type="inline" bibitemid="SP800-67r2" citeas="NIST SP 800-67 Rev. 2"/>, Section 3 outlines the use for TDES with keying option 1 (three distinct keys) and decryption only for keying option 2 (K1 == K3 != K2). Depending on the cipher mode, both the forward and inverse cipher are tested. The known answer tests address these requirements.</p>
+</clause>
+<clause id="tdes-not-coverage" inline-header="false" obligation="normative">
+<title>TDES Requirements Not Covered</title>
+<p id="_b4141bf7-6c65-45db-8807-ffd2c4c68c45">In <eref type="inline" bibitemid="SP800-67r2" citeas="NIST SP 800-67 Rev. 2"/>, Section 3.3 outlines requirements for keys for proper usage of TDES. These requirements are not tested by ACVP. All keys used in the tests are randomly or staticly generated by the server. There are no checks for key equality or potentially weak keys. Section 3.3.2 outlines specific keys which are to be avoided. ACVP does not expect a client to be able to detect these keys.</p>
+</clause>
+<clause id="aead-coverage" inline-header="false" obligation="normative"><title>AEAD Requirements Covered</title><p id="_829e42c9-23c4-477b-bc9d-b77d99225887">In <eref type="inline" bibitemid="SP800-38D" citeas="NIST SP 800-38D"/>, Section 7 outlines the encrypt and decrypt operations for AES-GCM. This and all prerequisites to these operations  (such as GHASH) are tested as AES-GCM encrypt and decrypt operations.</p>
+<p id="_9aa155fa-f7d8-4c49-aea4-059fa4a96414">In <eref type="inline" bibitemid="SP800-38C" citeas="NIST SP 800-38C"/>, Section 6 outlines the encrypt and decrypt operations for AES-CCM. This and all prerequisites to these operations (such as CBC-MAC) are tested as AES-CCM encrypt and decrypt operations. In <eref type="inline" bibitemid="AES-GCM-SIV" citeas="AES-GCM-SIV"/>, the draft outlines the encrypt and decrypt operations for AES-GCM-SIV.</p></clause>
+<clause id="aead-not-coverage" inline-header="false" obligation="normative">
+<title>AEAD Requirements Not Covered</title>
+<p id="_06422dcc-c750-4789-a381-061079d57961">In <eref type="inline" bibitemid="SP800-38D" citeas="NIST SP 800-38D"/>, Section 8 outlines uniqueness requirements on IVs and keys for AES-GCM. This is considered out of bounds for the algorithm testing done by the ACVP and will not be tested.</p>
+</clause>
+<clause id="kw-coverage" inline-header="false" obligation="normative"><title>KeyWrap Requirements Covered</title><p id="_2224f3b8-c58e-46aa-9a22-cd497ad4b5f0">In <eref type="inline" bibitemid="SP800-38F" citeas="NIST SP 800-38F"/> Section 5.2 defines the authenticated encryption and authenticated decryption operations for all three key-wrap algorithms.  As well, the padding for key-wrap with padding is defined. Algorithm Functional Tests provide assurance of these requirements for encrypt operations. For decrypt operations, there is a possibility to reject the ciphertext due to improper wrapping. This is also assured by the Algorithm Functional Tests.</p>
+<p id="_6a3f0824-4eb0-413e-83ac-b8a6a10aef1b">Sections 6 and 7 outline the specific ciphers in both encrypt and decrypt directions. All facsets of these processes are tested with random data via the Algorithm Functional Tests.</p></clause>
+<clause id="kw-not-coverage" inline-header="false" obligation="normative">
+<title>KeyWrap Requirements Not Covered</title>
+<p id="_d2e9769b-8410-4c1c-b916-749fd98e8034">In <eref type="inline" bibitemid="SP800-38F" citeas="NIST SP 800-38F"/> Section 5.3 defines the length requirements allowed by an optimal implementation. The upper bounds are unreasonably large to test in a web-based model and thus an artificial maximum is selected for the payloadLen property (corresponding to both plaintext and ciphertext). The Algorithm Functional Tests SHOULD utilize both the minimum and maximum values provided in the client's registration optimally with other values.</p>
+</clause></clause></clause>
+<clause id="capabilities" inline-header="false" obligation="normative"><title>Capabilities Registration</title><p id="_502076bb-d534-4db6-9ddb-1d4709760244">ACVP requires crypto modules to register their capabilities. This allows the crypto module to advertise support for specific algorithms, notifying the ACVP server which algorithms need test vectors generated for the validation process.  This section describes the constructs for advertising support of Block Cipher algorithms to the ACVP server.</p>
+<p id="_91e49ba2-5919-44d8-84f0-863746f55560">The algorithm capabilities <bcp14>MUST</bcp14> be advertised as JSON objects within the 'algorithms' value of the ACVP registration message. The 'algorithms' value is an array, where each array element is an individual JSON object defined in this section. The 'algorithms' value is part of the 'capability_exchange' element of the ACVP JSON registration message. See the ACVP specification <eref type="inline" bibitemid="ACVP" citeas="ACVP"/> for more details on the registration message.</p>
+<clause id="prerequisites" inline-header="false" obligation="normative"><title>Prerequisites</title><p id="_81b330e5-94c6-46aa-b1d0-ef0365cf72df">Each algorithm implementation <bcp14>MAY</bcp14> rely on other cryptographic primitives.	For example, RSA Signature algorithms depend on an underlying hash function. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<p id="_18047464-6bce-4054-9de8-c02ed30fdcb7">Prerequisites, if applicable, <bcp14>MUST</bcp14> be submitted in the registration as the <tt>prereqVals</tt> JSON property array inside each element of the <tt>algorithms</tt> array. Each element in the <tt>prereqVals</tt> array <bcp14>MUST</bcp14> contain the following properties</p>
+<table id="_a54972a8-97e1-42dc-9fd5-ad5d8ae0aa45">
+<name>Prerequisite Properties</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Property</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON Type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">algorithm</td>
+<td valign="top" align="left">a prerequisite algorithm</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">valValue</td>
+<td valign="top" align="left">algorithm validation number</td>
+<td valign="top" align="left">string</td>
+</tr>
+</tbody>
+</table>
+<p id="_5c8ea3e4-783e-4dba-8a18-28767db1d74c">A "valValue" of "same" <bcp14>SHALL</bcp14> be used to indicate that the prerequisite is being met by a different algorithm in the capability exchange in the same registration.</p>
+<p id="_499e4950-4675-4d4c-b071-c3eb059c3083">An example description of prerequisites within a single algorithm capability exchange looks like this</p>
+<sourcecode lang="json" id="_514c854f-fa9b-4de4-bf36-4f0f0b349460">"prereqVals":
+[
+  {
+    "algorithm": "Alg1",
+    "valValue": "Val-1234"
+  },
+  {
+    "algorithm": "Alg2",
+    "valValue": "same"
+  }
+]</sourcecode>
+</clause>
+<clause id="prereq_algs" inline-header="false" obligation="normative"><title>Required Prerequisite Algorithms for Block Cipher Validations</title><p id="_a52fbf44-714e-468f-97d0-1478dea631aa">Some block cipher algorithm implementations rely on other cryptographic primitives. For example, AES-CCM uses an underlying AES-ECB algorithm. Each of these underlying algorithm primitives <bcp14>MUST</bcp14> be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:</p>
+<table id="prereqs_table">
+<name>Required Prerequisite Algorithms JSON Values</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+<th valign="top" align="left">Example Values</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">algorithm</td>
+<td valign="top" align="left">a prerequisite algorithm</td>
+<td valign="top" align="left">string</td>
+<td valign="top" align="left">AES, DRBG, TDES</td>
+</tr>
+<tr>
+<td valign="top" align="left">valValue</td>
+<td valign="top" align="left">algorithm validation number</td>
+<td valign="top" align="left">string</td>
+<td valign="top" align="left">actual number or "same" to refer to the same submission</td>
+</tr>
+<tr>
+<td valign="top" align="left">prereqAlgVal</td>
+<td valign="top" align="left">prerequisite algorithm validation</td>
+<td valign="top" align="left">object</td>
+<td valign="top" align="left">exactly one algorithm property and one valValue property</td>
+</tr>
+</tbody>
+</table></clause>
+<clause id="cap_ex" inline-header="false" obligation="normative"><title>Block Cipher Algorithm Capabilities JSON Values</title><p id="_a5524819-514c-4fce-ac32-5ffbd150a987">Each algorithm capability advertised is a self-contained JSON object and <bcp14>SHALL</bcp14> use the following values when appropriate:</p>
+<table id="caps_table">
+<name>Block Cipher Algorithm Capabilities JSON Values</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">algorithm</td>
+<td valign="top" align="left">The block cipher algorithm and mode to be validated.</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">revision</td>
+<td valign="top" align="left">The version of the testing methodology the IUT is requesting to validate against.</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">conformances</td>
+<td valign="top" align="left">The additional conformance for the algorithm for a specific use-case</td>
+<td valign="top" align="left">array of string</td>
+</tr>
+<tr>
+<td valign="top" align="left">prereqVals</td>
+<td valign="top" align="left">Prerequisite algorithm validations</td>
+<td valign="top" align="left">array of prereqAlgVal objects described in <xref target="prereqs_table"/></td>
+</tr>
+<tr>
+<td valign="top" align="left">direction</td>
+<td valign="top" align="left">The IUT processing direction</td>
+<td valign="top" align="left">array of strings</td>
+</tr>
+<tr>
+<td valign="top" align="left">keyLen</td>
+<td valign="top" align="left">The supported key lengths in bits</td>
+<td valign="top" align="left">array of integers</td>
+</tr>
+<tr>
+<td valign="top" align="left">payloadLen</td>
+<td valign="top" align="left">The supported plain and cipher text lengths in bits. This varies depending on the algorithm type, for additional details see
+<xref target="property_grid_auth"/> and <xref target="property_grid_misc"/></td>
+<td valign="top" align="left">domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">ivLen</td>
+<td valign="top" align="left">The supported IV/Nonce lengths in bits, see <xref target="property_grid_auth"/></td>
+<td valign="top" align="left">domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">ivGen</td>
+<td valign="top" align="left">IV generation method for AES-GCM/AES-XPN algorithms</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">ivGenMode</td>
+<td valign="top" align="left">IV generation mode for AES-GCM/AES-XPN algorithms</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">saltGen</td>
+<td valign="top" align="left">Salt generation method for AES-XPN mode only</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">aadLen</td>
+<td valign="top" align="left">The supported AAD lengths in bits for AEAD algorithms</td>
+<td valign="top" align="left">domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">tagLen</td>
+<td valign="top" align="left">The supported Tag lengths in bits for AEAD algorithms, see <xref target="property_grid_auth"/></td>
+<td valign="top" align="left">array of integers</td>
+</tr>
+<tr>
+<td valign="top" align="left">kwCipher</td>
+<td valign="top" align="left">The cipher as defined in SP800-38F for key wrap mode</td>
+<td valign="top" align="left">array of strings</td>
+</tr>
+<tr>
+<td valign="top" align="left">tweakMode</td>
+<td valign="top" align="left">The format of tweak value input for AES-XTS. Hex refers to the tweakValue being a literal hex string. Number refers to the tweakValue being an integer number represented as a hex string.</td>
+<td valign="top" align="left">array of strings</td>
+</tr>
+<tr>
+<td valign="top" align="left">keyingOption</td>
+<td valign="top" align="left">The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct keys only suitable for decrypt (K1, K2, K1).</td>
+<td valign="top" align="left">array of integers</td>
+</tr>
+<tr>
+<td valign="top" align="left">overflowCounter</td>
+<td valign="top" align="left">Indicates if the implementation can handle a counter exceeding the maximum value</td>
+<td valign="top" align="left">boolean</td>
+</tr>
+<tr>
+<td valign="top" align="left">incrementalCounter</td>
+<td valign="top" align="left">Indicates if the implementation increments the counter (versus decrementing the counter)</td>
+<td valign="top" align="left">boolean</td>
+</tr>
+<tr>
+<td valign="top" align="left">performCounterTests</td>
+<td valign="top" align="left">Indicates if the implementation can perform the Counter tests which check for an always increasing (or decreasing) counter value</td>
+<td valign="top" align="left">boolean</td>
+</tr>
+<tr>
+<td valign="top" align="left">tweakLen</td>
+<td valign="top" align="left">The domain of values allowed for ACVP-AES-FF1's tweak value. Allowed range is 0-128 bits mod 8. See <xref target="property_grid_misc"/></td>
+<td valign="top" align="left">domain
+An array of objects that describes an IUT's capabilities as they pertain to ACVP-AES-FF1 and ACVP-AES-FF3-1. See <xref target="property_grid_misc"/> and <xref target="property_grid_ff_capabilities"/></td>
+</tr>
+<tr>
+<td valign="top" align="left">Array of Objects</td>
+<td valign="top" align="left">dataUnitLen</td>
+<td valign="top" align="left">The length of the ACVP-AES-XTS data unit</td>
+</tr>
+<tr>
+<td valign="top" align="left">domain</td>
+<td valign="top" align="left">dataUnitLenMatchesPayload</td>
+<td valign="top" align="left">Whether or not the length of the data unit always matches the length of the payload in ACVP-AES-XTS</td>
+</tr>
+</tbody>
+<note id="_2bab9ff8-34c8-4f32-8f44-a89852427afc">
+<p id="_34dd28ca-cac9-44a4-9352-f1c9aa84f72c">The 'conformances' property is only valid for algorithms listed in <xref target="conformances"/>. The valid values in the array are also listed in that section. The array is always optional.</p>
+</note><note id="_be2bd1f9-b430-45a0-8aaa-a9282ec860e0">
+<p id="_865b73aa-45c4-4296-9de9-4e69b2bd77e1">Some optional values are required depending on the algorithm. For example, AES-GCM requires ivLen, ivGen, ivGenMode, aadLen and tagLen. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.</p>
+</note><note id="_a1fcbcb4-4a3d-4bd3-b0c1-d67fc3134720">
+<p id="_44b2395c-10b3-42b5-943a-52689342a11a">The 'performCounterTests' option is provided for counter implementations such as linear-feedback shift registers which may not present an always increasing or decreasing counter while still ensuring the IV is unique. This value defaults to true if not present. If it is set to false, the 'overflowCounter' and 'incrementalCounter' values will not be used.</p>
+</note></table>
+
+
+
+<p id="_62c43eb6-2690-4621-8932-7949d5af5ee0">The following grid outlines which properties are <bcp14>REQUIRED</bcp14>, as well as all the possible values a server <bcp14>MAY</bcp14> support for each standard block cipher algorithm:</p>
+<table id="property_grid">
+<name>Standard Block Cipher Algorithm Capabilities Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">direction</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">keyingOption</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">AES-ECB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CBC</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-OFB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CFB1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CFB8</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CFB128</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-ECB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CBC</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CBCI</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CFB1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CFB8</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CFB64</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CFBP1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CFBP8</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CFBP64</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-OFB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-OFBI</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+</tr>
+</tbody>
+<note id="_f1238823-fccf-44c0-8383-26b0d3e32e63">
+<p id="_9a4e9aee-7e2c-42c2-a8ad-3bfbf1e8ca98">keyingOption 2 <bcp14>SHALL</bcp14> only be available for decrypt operations.</p>
+</note></table>
+
+<p id="_b548b987-befe-431d-8240-35ea02aa0bba">The following grid outlines which properties are <bcp14>REQUIRED</bcp14>, as well as the possible values a server <bcp14>MAY</bcp14> support for each key-wrap block cipher algorithm:</p>
+<table id="property_grid_kw">
+<name>Key-Wrap Block Cipher Algorithm Capabilities Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">direction</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">kwCipher</th>
+<th valign="top" align="left">keyingOption</th>
+<th valign="top" align="left">payloadLen</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">AES-KW</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">["cipher", "inverse"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">{"Min": 128, "Max": 4096, "Increment": 64}</td>
+</tr>
+<tr>
+<td valign="top" align="left">AES-KWP</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">["cipher", "inverse"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">{"Min": 8, "Max": 4096, "Increment": 8}</td>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-KW</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">["cipher", "inverse"]</td>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+<td valign="top" align="left">{"Min": 64, "Max": 4096, "Increment": 32}</td>
+</tr>
+</tbody>
+</table>
+<p id="_832046ab-e81e-4fc9-91ce-bc8c09e536c7">The underlying operations associated with different KW and KWP parameter selections are summarized in the following grid.</p>
+<table id="wrap_unwrap_ops">
+<name>Wrapping and Unwrapping Operations</name>
+<thead>
+<tr>
+<th valign="top" align="left">Operation</th>
+<th valign="top" align="left">Cipher</th>
+<th valign="top" align="left">Underlying AES Operation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">Wrap (direction encrypt)</td>
+<td valign="top" align="left">Cipher</td>
+<td valign="top" align="left">AES Encrypt</td>
+</tr>
+<tr>
+<td valign="top" align="left">Wrap (direction encrypt)</td>
+<td valign="top" align="left">Inverse</td>
+<td valign="top" align="left">AES Decrypt</td>
+</tr>
+<tr>
+<td valign="top" align="left">Unwrap (direction decrypt)</td>
+<td valign="top" align="left">Cipher</td>
+<td valign="top" align="left">AES Decrypt</td>
+</tr>
+<tr>
+<td valign="top" align="left">Unwrap (direction decrypt)</td>
+<td valign="top" align="left">Inverse</td>
+<td valign="top" align="left">AES Encrypt</td>
+</tr>
+</tbody>
+</table>
+<p id="_aac1c13c-a9db-4d1d-adfd-abc9a3f298b8">The following grid outlines which properties are <bcp14>REQUIRED</bcp14>, as well as the possible values a server <bcp14>MAY</bcp14> support for each authenticated block cipher algorithm:</p>
+<table id="property_grid_auth">
+<name>Authenticated Block Cipher Algorithm Capabilities Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">direction</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">payloadLen</th>
+<th valign="top" align="left">ivLen</th>
+<th valign="top" align="left">ivGen</th>
+<th valign="top" align="left">ivGenMode</th>
+<th valign="top" align="left">saltGen</th>
+<th valign="top" align="left">aadLen</th>
+<th valign="top" align="left">tagLen</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">AES-GCM</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 0, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left">{"Min": 8, "Max": 1024, "Inc": any}</td>
+<td valign="top" align="left">["internal", "external"]</td>
+<td valign="top" align="left">["8.2.1", "8.2.2"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">{"Min": 0, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left">[32, 64, 96, 104, 112, 120, 128]</td>
+</tr>
+<tr>
+<td valign="top" align="left">AES-GCM-SIV</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 256]</td>
+<td valign="top" align="left">{"Min": 0, "Max": 65536, "Inc": 8}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">{"Min": 0, "Max": 65536, "Inc": 8}</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-XPN</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 0, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">["internal", "external"]</td>
+<td valign="top" align="left">["8.2.1", "8.2.2"]</td>
+<td valign="top" align="left">["internal", "external"]</td>
+<td valign="top" align="left">{"Min": 1, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left">[32, 64, 96, 104, 112, 120, 128]</td>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CCM</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 0, "Max": 256, "Inc": 8}</td>
+<td valign="top" align="left">{"Min": 56, "Max": 104, "Inc": 8}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">{"Min": 0, "Max": 524288, "Inc": any}</td>
+<td valign="top" align="left">[32, 48, 64, 80, 96, 112, 128]</td>
+</tr>
+</tbody>
+</table>
+<p id="_6ca88490-b6e3-475b-ad10-387b55adbf2c">The following grid outlines which properties are <bcp14>REQUIRED</bcp14>, as well as the possible values a server <bcp14>MAY</bcp14> support for the XTS block cipher algorithm:</p>
+<table id="_35cf1580-7122-4301-b5e1-cce9cd39ce47">
+<name>XTS Block Cipher Algorithm Capabilities Applicability Grid</name>
+<tbody>
+<tr>
+<td valign="top" align="left">algorithm</td>
+<td valign="top" align="left">revision</td>
+<td valign="top" align="left">direction</td>
+<td valign="top" align="left">keyLen</td>
+<td valign="top" align="left">payloadLen</td>
+<td valign="top" align="left">tweakMode</td>
+<td valign="top" align="left">dataUnitLen</td>
+<td valign="top" align="left">dataUnitLenMatchesPayload</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-XTS</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": 128}</td>
+<td valign="top" align="left">["hex", "number"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-XTS</td>
+<td valign="top" align="left">"2.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": 8}</td>
+<td valign="top" align="left">["hex", "number"]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": 8}</td>
+<td valign="top" align="left">true, false (if this value is true, the dataUnitLen parameter <bcp14>SHALL</bcp14> not be present; if this value is false, the dataUnitLen parameter <bcp14>SHALL</bcp14> be present)</td>
+</tr>
+</tbody>
+<note id="_91792bf4-9486-40c3-a0c9-785c9873c4a7">
+<p id="_8e634019-664a-4bae-9301-f652f3c84c16">The difference in testing between ACVP-AES-XTS / "1.0" and ACVP-AES-XTS / "2.0" is the inclusion of the data unit in the "2.0" revision. The <eref type="inline" bibitemid="AES-XTS" citeas="IEEE 1619-2007"/> standard provides the concept of a data unit as a means of logically breaking apart a data stream provided to the encryption algorithm. A data unit may be larger, smaller or equal to the payload being processed. In the case of the "1.0" revision, the data unit length always matches the payload length. Thus, the "1.0" revision can be accessed via the "2.0" revision by setting the 'dataUnitLenMatchesPayload' field to true. Within the prompt, in "1.0", the test group contains the payload length for the entire group. In "2.0" this is moved to the test case level and handled on a per case basis along with the data unit length. Both values may be provided even when 'dataUnitLenMatchesPayload' is true.</p>
+</note></table>
+
+<p id="_65676059-9a80-48ff-8982-5abe17279fa7">The following grid outlines which properties are <bcp14>REQUIRED</bcp14>, as well as the possible values a server <bcp14>MAY</bcp14> support for each miscellaneous block cipher algorithm:</p>
+<table id="property_grid_misc">
+<name>Miscellaneous Block Cipher Algorithm Capabilities Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">direction</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">payloadLen</th>
+<th valign="top" align="left">keyingOption</th>
+<th valign="top" align="left">overflowCounter</th>
+<th valign="top" align="left">incrementalCounter</th>
+<th valign="top" align="left">performCounterTests</th>
+<th valign="top" align="left">tweakLen</th>
+<th valign="top" align="left">capabilities</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">AES-CBC-CS1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CBC-CS2</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CBC-CS3</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-CTR</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 1, "Max": 128, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">TDES-CTR</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">{"Min": 1, "Max": 64, "Inc": any}</td>
+<td valign="top" align="left">[1, 2] Note: 2 is only available for decrypt operations</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">AES-FF1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">Domain 0-128 bits, mod 8.</td>
+<td valign="top" align="left">At least one set
+of capabilities is required. See <xref target="property_grid_ff_capabilities"/></td>
+</tr>
+<tr>
+<td valign="top" align="left">AES-FF3-1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">["encrypt", "decrypt"]</td>
+<td valign="top" align="left">[128, 192, 256]</td>
+<td valign="top" align="left">{"Min": 128, "Max": 65536, "Inc": any}</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">At least one set of capabilities is required. See <xref target="property_grid_ff_capabilities"/></td>
+</tr>
+</tbody>
+<note id="_8f4c7310-d1f3-4370-8b70-7fc6844d1cd8">
+<p id="_00675b8e-f864-411c-bc87-890f250e076b">keyingOption 2 <bcp14>SHALL</bcp14> only be available for decrypt operations.</p>
+</note></table>
+
+<p id="property_grid_ff_capabilities">The following grid outlines which properties are <bcp14>REQUIRED</bcp14> within the capabilities object array in use for ACVP-AES-FF1 and ACVP-AES-FF3-1.</p>
+<table id="_eb022755-5135-48af-806b-0313ebd473e5">
+<thead>
+<tr>
+<th valign="top" align="left">Property Name</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">Type</th>
+<th valign="top" align="left">Valid Values</th>
+<th valign="top" align="left"/>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">alphabet</td>
+<td valign="top" align="left">An alphabet the IUT supports for Format Preserving Encryption.  Example "0123456789abcdefghijklmnopqrstuvwxyz". Alphabets should be a minimum of two characters, and a maximum of 64 (all numbers and upper and lower case letters, additionally "+" and "/").</td>
+<td valign="top" align="left">string</td>
+<td valign="top" align="left">Alphanumeric non repeating characters.</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">radix</td>
+<td valign="top" align="left">The number base for this capability, should match the number of characters from the alphabet.</td>
+<td valign="top" align="left">integer</td>
+<td valign="top" align="left">2-64</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">minLen</td>
+<td valign="top" align="left">The minimum payload length the IUT can support for this alphabet.</td>
+<td valign="top" align="left">integer</td>
+<td valign="top" align="left">2 - maxLen</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">maxLen</td>
+<td valign="top" align="left">The maximum payload length the IUT can support for this alphabet.</td>
+<td valign="top" align="left">integer</td>
+<td valign="top" align="left">minLen - variable calculation based on radix and algorithm, see <eref type="inline" bibitemid="SP800-38Gr1" citeas="NIST SP 800-38G Rev. 1"/>.</td>
+<td valign="top" align="left"/>
+</tr>
+</tbody>
+</table></clause></clause>
+<clause id="test-vectors" inline-header="false" obligation="normative"><title>Test Vectors</title><p id="_ec2f25f8-b644-4a1f-bfb5-bbaa9bc5111a">The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation test session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual algorithm defined during the capability exchange. This section describes the JSON schema for a test vector set used with Symmetric Block Cipher algorithms.</p>
+<p id="_d2fb784e-6202-4c8f-b356-fb442a5ce9a6">The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client. The following table describes the JSON elements at the top level of the hierarchy.</p>
+<table id="_b23ed52d-bb74-4c96-927d-881e6afd2dc0">
+<name>Top Level Test Vector JSON Elements</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Values</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON Type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">acvVersion</td>
+<td valign="top" align="left">Protocol version identifier</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">vsId</td>
+<td valign="top" align="left">Unique numeric vector set identifier</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">algorithm</td>
+<td valign="top" align="left">Algorithm defined in the capability exchange</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">mode</td>
+<td valign="top" align="left">Mode defined in the capability exchange</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">revision</td>
+<td valign="top" align="left">Protocol test revision selected</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">testGroups</td>
+<td valign="top" align="left">Array of test groups containing test data, see <xref target="tgjs"/></td>
+<td valign="top" align="left">array</td>
+</tr>
+</tbody>
+</table>
+<p id="_e00a8f31-b2e3-407b-801c-86b2f486adc5">An example of this would look like this</p>
+<sourcecode lang="json" id="_0ca49d34-d28e-415d-8adb-4b9b1538f4f5">{
+  "acvVersion": "version",
+  "vsId": 1,
+  "algorithm": "Alg1",
+  "mode": "Mode1",
+  "revision": "Revision1.0",
+  "testGroups": [ ... ]
+}</sourcecode>
+
+<clause id="tgjs" inline-header="false" obligation="normative"><title>Test Groups</title><p id="_120f287c-b0b1-430f-aa19-b97b2e6c942b">Test vector sets <bcp14>MUST</bcp14> contain one or many test groups, each sharing similar properties.  For instance, all test vectors that use the same key size would be grouped together. The testGroups element at the top level of the test vector JSON object <bcp14>SHALL</bcp14> be the array of test groups. The Test Group JSON object <bcp14>MUST</bcp14> contain meta-data that applies to all test cases within the group.  The following table describes the JSON elements that <bcp14>MAY</bcp14> appear from the server in the Test Group JSON object:</p>
+<table id="vs_tg_table">
+<name>Test Group JSON Object</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">tgId</td>
+<td valign="top" align="left">Numeric identifier for the test group, unique across the entire vector set.</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">direction</td>
+<td valign="top" align="left">The IUT processing direction: encrypt or decrypt</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">ivGen</td>
+<td valign="top" align="left">IV generation method</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">ivGenMode</td>
+<td valign="top" align="left">IV generation method</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">saltGen</td>
+<td valign="top" align="left">Salt generation method</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">keyLen</td>
+<td valign="top" align="left">Length of key in bits to use</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">keyingOption</td>
+<td valign="top" align="left">The TDES keying option to use</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">ivLen</td>
+<td valign="top" align="left">Length of IV in bits to use</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">payloadLen</td>
+<td valign="top" align="left">Length of plaintext or ciphertext in bits to use</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">aadLen</td>
+<td valign="top" align="left">Length of AAD in bits to use</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">tagLen</td>
+<td valign="top" align="left">Length of AEAD tag in bits to use</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">alphabet</td>
+<td valign="top" align="left">Characters representing the alphabet in use for the group. ACVP-AES-FF1 and ACVP-AES-FF3-1 only.</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">radix</td>
+<td valign="top" align="left">The number base in use for the group (should match the number of characters from the alphabet. ACVP-AES-FF1 and ACVP-AES-FF3-1 only.</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">testType</td>
+<td valign="top" align="left">The test category type (AFT, MCT or counter). See <xref target="testtypes"/> for more information about what these tests do, and how to implement them.</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">tests</td>
+<td valign="top" align="left">Array of individual test case JSON objects, which are defined in <xref target="tcjs"/></td>
+<td valign="top" align="left">array of testCase objects</td>
+</tr>
+</tbody>
+</table>
+<p id="_83a60ff7-fec6-4f19-a141-619c801d440c">Some properties <bcp14>MUST</bcp14> appear in the prompt file from the server for every testGroup object. They are as follows:</p>
+<ul id="_00fe3c41-2413-4532-bdf4-3e72e4e3fc62">
+<li>
+<p id="_3bca4ba3-27a8-4b49-8cb5-a25c016a9189">tgId</p>
+</li>
+<li>
+<p id="_2a929d76-7a2c-46d2-a2e3-8ae8e2862d55">direction</p>
+</li>
+<li>
+<p id="_29efea79-8577-4ab7-a753-7cd27602c7e6">payloadLen</p>
+</li>
+<li>
+<p id="_cef7b2f2-0b94-427e-a471-126a4856f517">testType</p>
+</li>
+<li>
+<p id="_8fb2aca4-4c4b-4152-8fed-d328b28d7899">tests</p>
+</li>
+</ul>
+<p id="_987c272f-874b-4e98-8df1-23ab0936379f">The other properties <bcp14>MAY</bcp14> appear depending on the algorithm selected for the test vector set. The following grid defines the <bcp14>REQUIRED</bcp14> properties for each standard block cipher, as well as the valid values a server <bcp14>MAY</bcp14> use:</p>
+<table id="property_grid_prompt">
+<name>Prompt Test Group Block Cipher Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">keyingOption</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">ACVP-AES-ECB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-CBC</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-OFB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-CFB1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-CFB8</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-CFB128</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-FF1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-FF3-1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-ECB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CBC</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CBCI</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CFB1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CFB8</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CFB64</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CFBP1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CFBP8</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CFBP64</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-OFB</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-OFBI</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+</tr>
+</tbody>
+</table>
+<p id="_5b3d6a23-dcdd-462d-ba9d-3b933bea19f2">The following grid defines when each property is <bcp14>REQUIRED</bcp14> from a server for each authenticated block cipher:</p>
+<table id="property_grid_prompt_auth">
+<name>Prompt Test Group Authenticated Block Cipher Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">ivGen</th>
+<th valign="top" align="left">ivGenMode</th>
+<th valign="top" align="left">saltGen</th>
+<th valign="top" align="left">ivLen</th>
+<th valign="top" align="left">payloadLen</th>
+<th valign="top" align="left">aadLen</th>
+<th valign="top" align="left">tagLen</th>
+<th valign="top" align="left">saltLen</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">ACVP-AES-GCM</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left">"internal", "external"</td>
+<td valign="top" align="left">"8.2.1", "8.2.2"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-GCM-SIV</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 256</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">96</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">128</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-XPN</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left">"internal", "external"</td>
+<td valign="top" align="left">"8.2.1", "8.2.2"</td>
+<td valign="top" align="left">"internal", "external"</td>
+<td valign="top" align="left">96</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">96</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-CCM</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left">within domain</td>
+<td valign="top" align="left"/>
+</tr>
+</tbody>
+<note id="_e29412bb-b6d3-4361-907a-12b31adacc80">
+<p id="_4a86711d-ec8f-4136-8e72-e2944f05501a">The particular values of a domain are <bcp14>REQUIRED</bcp14> to be an integer element of the domain present in the registration used. The ACVP server <bcp14>MAY</bcp14> select predetermined or random values with particular features (ex. on a block boundary, or not on a block boundary) within the domain the client provided in the registration.</p>
+</note></table>
+
+<p id="_a2afddd1-b3ca-44a4-ab6a-055b59e7dc6c">The following grid defines when each property is <bcp14>REQUIRED</bcp14> from a server for a key-wrap block cipher:</p>
+<table id="property_grid_prompt_kw">
+<name>Prompt Test Group Key-Wrap Block Cipher Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">kwCipher</th>
+<th valign="top" align="left">payloadLen</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">ACVP-AES-KW</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left">"cipher", "inverse"</td>
+<td valign="top" align="left">within domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-KWP</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left">"cipher", "inverse"</td>
+<td valign="top" align="left">within domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-KW</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">"cipher", "inverse"</td>
+<td valign="top" align="left">within domain</td>
+</tr>
+</tbody>
+<note id="_33f9d9a6-c055-4a16-9c8e-453d4c9f60f1">
+<p id="_a23213e5-bfd7-4891-8d77-7f77569e925f">The particular values of a domain are <bcp14>REQUIRED</bcp14> to be an integer element of the domain present in the registration used. The ACVP server <bcp14>MAY</bcp14> select predetermined or random values with particular features (ex. on a block boundary, or not on a block boundary) within the domain the client provided in the registration.</p>
+</note></table>
+
+<p id="_2e3e893d-fa98-4855-b2db-e77b47e89af1">The following grid defines when each property is <bcp14>REQUIRED</bcp14> from a server for the miscellaneous block ciphers:</p>
+<table id="property_grid_prompt_misc">
+<name>Prompt Test Group Miscellaneous Block Cipher Applicability Grid</name>
+<thead>
+<tr>
+<th valign="top" align="left">algorithm</th>
+<th valign="top" align="left">revision</th>
+<th valign="top" align="left">keyLen</th>
+<th valign="top" align="left">keyingOption</th>
+<th valign="top" align="left">incremental</th>
+<th valign="top" align="left">overflow</th>
+<th valign="top" align="left">tweakMode</th>
+<th valign="top" align="left">payloadLen</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">ACVP-AES-CBC-CS1</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">within domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-CTR</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 192, 256</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-XTS</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left">128, 256</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">"hex", "number"</td>
+<td valign="top" align="left">within domain</td>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-AES-XTS</td>
+<td valign="top" align="left">"2.0"</td>
+<td valign="top" align="left">128, 256</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+<td valign="top" align="left">"hex", "number"</td>
+<td valign="top" align="left"/>
+</tr>
+<tr>
+<td valign="top" align="left">ACVP-TDES-CTR</td>
+<td valign="top" align="left">"1.0"</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left">1, 2</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left">true, false</td>
+<td valign="top" align="left"/>
+<td valign="top" align="left"/>
+</tr>
+</tbody>
+<note id="_2293dd82-83dd-4639-af61-25e3941a8aea">
+<p id="_231bb319-9728-46d1-a0df-f233c4ac4390">The particular values of a domain are <bcp14>REQUIRED</bcp14> to be an integer element of the domain present in the registration used. The ACVP server <bcp14>MAY</bcp14> select predetermined or random values with particular features (ex. on a block boundary, or not on a block boundary) within the domain the client provided in the registration.</p>
+</note></table>
+</clause>
+<clause id="tcjs" inline-header="false" obligation="normative"><title>Test Cases</title><p id="_a914f0d2-3720-4f81-9dad-5f991c228a58">Each test group <bcp14>SHALL</bcp14> contain an array of one or more test cases. Each test case is a JSON object that represents a single case to be processed by the ACVP client. The following table describes the JSON elements for each test case.</p>
+<table id="vs_tc_table">
+<name>Test Case JSON Object</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">tcId</td>
+<td valign="top" align="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">key</td>
+<td valign="top" align="left">Encryption key to use for AES</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">key1, key2, key3</td>
+<td valign="top" align="left">Encryption keys to use for TDES</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">iv</td>
+<td valign="top" align="left">IV to use</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">tweak</td>
+<td valign="top" align="left">tweak used to form an IV for AES-FF1 and AES-FF3-1</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">tweakLen</td>
+<td valign="top" align="left">length of the tweak for AES-FF1 and AES-FF3-1</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">tweakValue</td>
+<td valign="top" align="left">tweakValue used to form an IV for AES-XTS when the tweakMode for the group is 'hex'</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">sequenceNumber</td>
+<td valign="top" align="left">integer used to form an IV for AES-XTS when the tweakMode for the group is 'number'</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">salt</td>
+<td valign="top" align="left">The salt to use in AES-XPN (required for AES-XPN only)</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">pt</td>
+<td valign="top" align="left">Plaintext to use</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">ct</td>
+<td valign="top" align="left">Ciphertext to use</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">payloadLen</td>
+<td valign="top" align="left">Plaintext or Ciphertext length to use in bits. Only the most significant 'payloadLen' bits will be used.</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">dataUnitLen</td>
+<td valign="top" align="left">Length of the data unit in bits for ACVP-AES-XTS</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">aad</td>
+<td valign="top" align="left">AAD to use for AEAD algorithms</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">tag</td>
+<td valign="top" align="left">Tag to use for AEAD algorithms</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+</tbody>
+<note id="_e6791b99-f18c-44d2-80e9-fa8d55c7409b">
+<p id="_af398d0c-ff7b-45dc-b61c-724a1218c8e2">The applicability of each test case property is dependent on the test group and test vector (algorithm) properties. Each test type within the test group requires specific operations to be performed and thus specific data returned to the server. Consult <xref target="testtypes"/> for more information. The tcId property <bcp14>MUST</bcp14> appear within every test case sent to and from the server.</p>
+</note></table>
+</clause></clause>
+<clause id="vector_responses" inline-header="false" obligation="normative"><title>Test Vector Responses</title><p id="_986f0553-9838-45f0-9bd2-590e3904db86">After the ACVP client downloads and processes a vector set, it <bcp14>SHALL</bcp14> send the response vectors back to the ACVP server within the alloted timeframe. The following table describes the JSON object that represents a vector set response.</p>
+<table id="vr_top_table">
+<name>Vector Set Response JSON Object</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">acvVersion</td>
+<td valign="top" align="left">Protocol version identifier</td>
+<td valign="top" align="left">string</td>
+</tr>
+<tr>
+<td valign="top" align="left">vsId</td>
+<td valign="top" align="left">Unique numeric identifier for the vector set</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">testGroups</td>
+<td valign="top" align="left">Array of JSON objects that represent each test vector group. See <xref target="vr_group_table"/></td>
+<td valign="top" align="left">array of testGroup objects</td>
+</tr>
+</tbody>
+</table>
+<p id="_5eea25ab-327a-4c6f-bcc5-7742d40f4dd1">The testGroup Response section is used to organize the ACVP client response in a similar manner to how it receives vectors. Several algorithms <bcp14>SHALL</bcp14> require the client to send back group level properties in its response. This structure helps accommodate that.</p>
+<table id="vr_group_table">
+<name>Vector Set Group Response JSON Object</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">tgId</td>
+<td valign="top" align="left">The test group identifier</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">tests</td>
+<td valign="top" align="left">The tests associated to the group specified in tgId</td>
+<td valign="top" align="left">array of testCase objects</td>
+</tr>
+</tbody>
+</table>
+<p id="_b3aec3df-54e2-4d3c-8cc2-c2ee0c07d403">Each test case is a JSON object that represents a single test object to be processed by the ACVP client. The following table describes the JSON elements for each test case object.</p>
+<table id="vs_tr_table">
+<name>Test Case Results JSON Object</name>
+<thead>
+<tr>
+<th valign="top" align="left">JSON Value</th>
+<th valign="top" align="left">Description</th>
+<th valign="top" align="left">JSON type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top" align="left">tcId</td>
+<td valign="top" align="left">Numeric identifier for the test case, unique across the entire vector set.</td>
+<td valign="top" align="left">integer</td>
+</tr>
+<tr>
+<td valign="top" align="left">pt</td>
+<td valign="top" align="left">The IUT's pt response to a decrypt test</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">ct</td>
+<td valign="top" align="left">The IUT's ct response to an encrypt test</td>
+<td valign="top" align="left">string (hex)</td>
+</tr>
+<tr>
+<td valign="top" align="left">testPassed</td>
+<td valign="top" align="left">Some test cases included with decrypt operations in AES-GCM, AES-CCM, AES-XPN, AES-KW, AES-KWP, and TDES-KW will have expected failures.</td>
+<td valign="top" align="left">boolean</td>
+</tr>
+<tr>
+<td valign="top" align="left">resultsArray</td>
+<td valign="top" align="left">Array of JSON objects that represent each iteration of a Monte Carlo Test. Each iteration will contain the key(s), pt, ct and iv</td>
+<td valign="top" align="left">array of objects containing pt, ct and iv (except for ECB mode)</td>
+</tr>
+</tbody>
+<note id="_66ba7f8f-ce19-4ea3-b88a-c561db6e70ff">
+<p id="_2814150c-4780-4994-9c45-86b792d8012a">The tcId <bcp14>MUST</bcp14> be included in every test case object sent between the client and the server.</p>
+</note></table>
+</clause>
+<clause id="security" inline-header="false" obligation="normative">
+<title>Security Considerations</title>
+<p id="_03e9e6f7-866b-4a60-bfeb-4eb758033c8d">There are no additional security considerations outside of those outlined in the ACVP document.</p>
+</clause>
+<clause id="iana" inline-header="false" obligation="normative">
+<title>IANA Considerations</title>
+<p id="_25292389-5c50-49a8-86cd-424f61bb7dc3">This document does not require any action by IANA.</p>
+</clause>
+
+
+
+
+
+</sections><annex id="app-reg-ex" inline-header="false" obligation="normative"><title>Example Capabilities JSON Object</title><p id="_0985452a-47dd-46ff-8046-ed670e4ce3e0">The following is a example JSON object advertising support for all block ciphers.</p>
+<sourcecode lang="json" id="_96743100-64bc-4289-aad9-4c88405497df">[{
+    "acvVersion": "{acvp-version}"
+  }, {
+    "algorithm": "ACVP-AES-GCM",
+    "revision": "1.0",
+    "prereqVals": [{
+        "algorithm": "ACVP-AES-ECB",
+        "valValue": "123456"
+      },
+      {
+        "algorithm": "DRBG",
+        "valValue": "123456"
+      }
+    ],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "ivGen": "internal",
+    "ivGenMode": "8.2.2",
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "tagLen": [
+      96,
+      128
+    ],
+    "ivLen": [
+      96
+    ],
+    "payloadLen": [
+      0,
+      256
+    ],
+    "aadLen": [
+      128,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-ECB",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CBC",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CBC-CS1",
+    "revision": "1.0",
+    "payloadLen": [{
+      "min": 128,
+      "max": 65536,
+      "increment": 1
+    }],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CBC-CS2",
+    "revision": "1.0",
+    "payloadLen": [{
+      "min": 128,
+      "max": 65536,
+      "increment": 1
+    }],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CBC-CS3",
+    "revision": "1.0",
+    "payloadLen": [{
+      "min": 128,
+      "max": 65536,
+      "increment": 1
+    }],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CFB8",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CFB128",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-OFB",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-XPN",
+    "revision": "1.0",
+    "prereqVals": [{
+        "algorithm": "ACVP-AES-ECB",
+        "valValue": "123456"
+      },
+      {
+        "algorithm": "DRBG",
+        "valValue": "123456"
+      }
+    ],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "ivGen": "internal",
+    "ivGenMode": "8.2.2",
+    "saltGen": "internal",
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "tagLen": [
+      96,
+      128
+    ],
+    "payloadLen": [
+      0,
+      128
+    ],
+    "aadLen": [
+      120,
+      128
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CTR",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "payloadLen": [
+      128
+    ],
+    "incrementalCounter": true,
+    "overflowCounter": false
+  },
+  {
+    "algorithm": "ACVP-AES-CTR",
+    "revision": "1.0",
+    "conformances": ["RFC3686"],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "payloadLen": [
+      128
+    ],
+    "incrementalCounter": true,
+    "overflowCounter": false,
+    "ivGenMode": "external"
+  },
+  {
+    "algorithm": "ACVP-AES-CCM",
+    "revision": "1.0",
+    "prereqVals": [{
+      "algorithm": "ACVP-AES-ECB",
+      "valValue": "same"
+    }],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "tagLen": [
+      128
+    ],
+    "ivLen": [
+      56
+    ],
+    "payloadLen": [
+      0,
+      256
+    ],
+    "aadLen": [
+      0,
+      65536
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-CFB1",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-KW",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "kwCipher": [
+      "cipher"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "payloadLen": [
+      512,
+      192,
+      128
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-KWP",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "kwCipher": [
+      "cipher"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "payloadLen": [
+      8,
+      32,
+      96,
+      808
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-FF1",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "tweakLen": [{
+      "min": 0,
+      "max": 128,
+      "increment": 8
+    }],
+    "capabilities": [{
+        "alphabet": "0123456789",
+        "radix": 10,
+        "minLen": 10,
+        "maxLen": 56
+      },
+      {
+        "alphabet": "abcdefghijklmnopqrstuvwxyz",
+        "radix": 26,
+        "minLen": 10,
+        "maxLen": 40
+      },
+      {
+        "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/",
+        "radix": 64,
+        "minLen": 10,
+        "maxLen": 28
+      }
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-FF3-1",
+    "revision": "1.0",
+    "conformances": [],
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      192,
+      256
+    ],
+    "tweakLen": [{
+      "min": 0,
+      "max": 128,
+      "increment": 8
+    }],
+    "capabilities": [{
+        "alphabet": "0123456789",
+        "radix": 10,
+        "minLen": 10,
+        "maxLen": 56
+      },
+      {
+        "alphabet": "abcdefghijklmnopqrstuvwxyz",
+        "radix": 26,
+        "minLen": 10,
+        "maxLen": 40
+      },
+      {
+        "alphabet": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/",
+        "radix": 64,
+        "minLen": 10,
+        "maxLen": 28
+      }
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-XTS",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      256
+    ],
+    "payloadLen": [
+      65536
+    ],
+    "tweakMode": [
+      "hex",
+      "number"
+    ]
+  },
+  {
+    "algorithm": "ACVP-AES-XTS",
+    "revision": "2.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyLen": [
+      128,
+      256
+    ],
+    "payloadLen": [
+      65536
+    ],
+    "tweakMode": [
+      "hex",
+      "number"
+    ],
+    "dataUnitLen": [
+      1024, 4096
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-ECB",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CBC",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CBCI",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-OFB",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-OFBI",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CFB64",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CFB8",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CFB1",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CFBP64",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CFBP8",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CFBP1",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ]
+  },
+  {
+    "algorithm": "ACVP-TDES-CTR",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "keyingOption": [
+      1
+    ],
+    "payloadLen": [
+      64
+    ],
+    "performCounterTests": false
+  },
+  {
+    "algorithm": "ACVP-TDES-KW",
+    "revision": "1.0",
+    "direction": [
+      "encrypt",
+      "decrypt"
+    ],
+    "kwCipher": [
+      "cipher"
+    ],
+    "payloadLen": [
+      512,
+      192,
+      128
+    ]
+
+  }
+]</sourcecode>
+</annex><annex id="app-vs-ex" inline-header="false" obligation="normative"><title>Example Vector Set Request/Responses JSON Object</title><p id="_9ed73188-1c9b-45ba-a1eb-3f94660418cd">The following sections provide examples of the JSON objects for each of the AES algorithms. Examples will reflect what testTypes are supported by each algorithm, ie AFT, MCT or counter.  MCT examples have only 2 iterations shown for brevity.</p>
+<p id="_c07a1652-fd4a-4723-8036-0f4b4eb72145">The following shows AES-GCM AFT request vectors.</p>
+<sourcecode lang="json" id="_5e0206e9-0f4f-4195-8d6f-2c66a9f61e92">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2055,
+  "algorithm": "ACVP-AES-GCM",
+  "revision": "1.0",
+  "testGroups": [{
+            "tgId": 1,
+            "testType": "AFT",
+            "direction": "encrypt",
+            "keyLen": 128,
+            "ivLen": 96,
+            "ivGen": "external",
+            "ivGenMode": "8.2.2",
+            "payloadLen": 0,
+            "aadLen": 0,
+            "tagLen": 32,
+            "tests": [
+                {
+                    "tcId": 1,
+                    "plainText": "",
+                    "key": "10B8D4C9658590A...",
+                    "aad": "",
+                    "iv": "3D026F3D590BF1A7..."
+                },
+                {
+                    "tcId": 2,
+                    "plainText": "",
+                    "key": "934865822A3ECCB...",
+                    "aad": "",
+                    "iv": "273F3B30341C779E..."
+                }
+      ]
+    },
+    {
+            "tgId": 19,
+            "testType": "AFT",
+            "direction": "decrypt",
+            "keyLen": 128,
+            "ivLen": 96,
+            "ivGen": "external",
+            "ivGenMode": "8.2.2",
+            "payloadLen": 0,
+            "aadLen": 120,
+            "tagLen": 32,
+            "tests": [
+                {
+                    "tcId": 271,
+                    "key": "88AB5441AE2...",
+                    "aad": "4E956EF528D...",
+                    "iv": "810628011BB0...",
+                    "cipherText": "",
+                    "tag": "1180FD89"
+                },
+                {
+                    "tcId": 272,
+                    "key": "9149BE47FAEB...",
+                    "aad": "938A8FA71324...",
+                    "iv": "FF6B72FF25B55...",
+                    "cipherText": "",
+                    "tag": "6C7528F0"
+                }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_0e2c42bc-530c-4db6-ab76-e0dee50d4dd6">The following shows AES-GCM AFT responses.</p>
+<sourcecode lang="json" id="_d5cfc0fe-85a5-4287-aacd-c154aaa1a60e">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2055,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "iv": "01020304F966B8...",
+          "ct": "",
+          "tag": "427F668E58F56..."
+        },
+        {
+          "tcId": 2,
+          "iv": "01020304C2855...",
+          "ct": "",
+          "tag": "D95BD66F7789..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 902,
+          "pt": "763BF..."
+        },
+        {
+          "tcId": 903,
+          "testPassed": false
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_6e35b0d1-a8ac-40b6-9efa-675df65908c1">The following shows AES-CCM AFT request vectors.</p>
+<sourcecode lang="json" id="_848eaae3-7fdf-41fa-9220-1d579f43902a">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2061,
+  "algorithm": "ACVP-AES-CCM",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "direction": "encrypt",
+    "testType": "AFT",
+    "ivLen": 56,
+    "payloadLen": 256,
+    "aadLen": 0,
+    "tagLen": 128,
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 1,
+      "pt": "361445511E0BD3E94E3...",
+      "key": "7DB9E755181E4160C6...",
+      "iv": "1C53ECD62BBED5",
+      "aad": ""
+    }, {
+      "tcId": 2,
+      "pt": "735CE37215A91074DBF...",
+      "key": "7DB9E755181E4160C6...",
+      "iv": "1C53ECD62BBED5",
+      "aad": ""
+    }]
+  }, {
+    "tgId": 2,
+    "direction": "decrypt",
+    "testType": "AFT",
+    "ivLen": 56,
+    "payloadLen": 0,
+    "aadLen": 0,
+    "tagLen": 128,
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 181,
+      "ct": "533427D475EBAC3FE5...",
+      "key": "A8B7C7A69E5AB940B...",
+      "iv": "1BD5816AF5BB9F",
+      "aad": ""
+    }, {
+      "tcId": 182,
+      "ct": "6B774BB2D20A8A23A1...",
+      "key": "A8B7C7A69E5AB940B...",
+      "iv": "8140308B19BCE8",
+      "aad": ""
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_9049489b-e849-401c-9d15-2fac2b585c4c">The following shows AES-CCM AFT responses.</p>
+<sourcecode lang="json" id="_77df8c5d-c057-4cd6-baa0-1304f6525517">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 2061,
+    "testGroups": [{
+            "tgId": 1,
+            "tests": [{
+                    "tcId": 1,
+                    "ct": "C8AB4A739E1..."
+                },
+                {
+                    "tcId": 2,
+                    "ct": "8DE3EC5095B..."
+                }
+            ]
+        },
+        {
+            "tgId": 2,
+            "tests": [{
+                    "tcId": 181,
+                    "testPassed": false
+                },
+                {
+                    "tcId": 182,
+                    "pt": ""
+                }
+            ]
+        }
+    ]
+}]</sourcecode>
+
+<p id="_040e44c4-a464-4a8d-a2ce-29dd0b69fb96">The following shows AES-CBC AFT and MCT request vectors.</p>
+<sourcecode lang="json" id="_90d1485f-8ed2-4e6b-ae23-adea76d4f923">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2057,
+  "algorithm": "ACVP-AES-CBC",
+    "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+      "direction": "encrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 1,
+        "iv": "00C8F42C5B5...",
+        "key": "7F9863BCD5...",
+        "pt": "97549D671FA..."
+      }, {
+        "tcId": 2,
+        "iv": "CE6747E918F...",
+        "key": "25F73DBAF4...",
+        "pt": "D3A0AA732D7..."
+      }]
+    }, {
+      "tgId": 2,
+      "direction": "decrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 31,
+        "iv": "D498F4F8462...",
+        "key": "77D563ACE1...",
+        "ct": "78256FA155F..."
+      }, {
+        "tcId": 32,
+        "iv": "AB99A939B688...",
+        "key": "0569B0C6DB3...",
+        "ct": "EEBF23A65E83..."
+      }]
+    },
+    {
+      "tgId": 3,
+      "direction": "encrypt",
+      "testType": "MCT",
+      "keyLen": 256,
+      "tests": [{
+        "tcId": 63,
+        "iv": "057FB7EEDE1EBF40...",
+        "key": "E5E2E9F088E2C06...",
+        "pt": "6DA46A0AADB59615..."
+      }]
+    }, {
+      "tgId": 4,
+      "direction": "decrypt",
+      "testType": "MCT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 64,
+        "iv": "FD5EDEC164E504D6...",
+        "key": "F7439EAC671FC4B...",
+        "ct": "37ECE2FF3F391D8C..."
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_e8e4ae92-ab38-4ab9-b89d-d7a8b7f00b9e">The following shows AES-CBC AFT and MCT responses.</p>
+<sourcecode lang="json" id="_9aa45265-53ff-4644-b115-99300924a41d">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2057,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "DD95E867DFCFCC..."
+        },
+        {
+          "tcId": 2,
+          "ct": "540954F0016D40..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "F7251EA3C68FE..."
+        },
+        {
+          "tcId": 32,
+          "pt": "CEC14A7B465A3..."
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 63,
+        "resultsArray": [{
+            "key": "E5E2...",
+            "iv": "057FB...",
+            "pt": "6DA46...",
+            "ct": "3E794..."
+          },
+          {
+            "key": "DE31...",
+            "iv": "3E794...",
+            "pt": "3BD32...",
+            "ct": "9236D..."
+          }
+        ]
+      }]
+    },
+    {
+      "tgId": 1,
+      "tests": [{
+        "tcId": 64,
+        "resultsArray": [{
+            "key": "F743...",
+            "iv": "FD5ED...",
+            "ct": "37ECE...",
+            "pt": "52FC3..."
+          },
+          {
+            "key": "A5BF...",
+            "iv": "52FC3...",
+            "ct": "4400F...",
+            "pt": "66204..."
+          }
+        ]
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_044a4907-7721-4178-9563-c08c7de989b1">The following shows AES-CBC-CS1 AFT request vectors.</p>
+<sourcecode lang="json" id="_1a40e111-aad0-4c18-8e9b-6c9f65019f30">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2058,
+  "algorithm": "ACVP-AES-CBC-CS1",
+    "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+      "direction": "encrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 1,
+        "iv": "1216A541024...",
+        "key": "A6A8346C47...",
+        "pt": "71AC206DD0A...",
+        "payloadLen": 512
+      }, {
+        "tcId": 2,
+        "iv": "9A6A276AB96...",
+        "key": "7CDAE90854...",
+        "pt": "6D4AEE90179...",
+        "payloadLen": 178
+      }]
+    }, {
+      "tgId": 2,
+      "direction": "decrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 31,
+        "iv": "908543E2646...",
+        "key": "CB12AAFA25B...",
+        "ct": "AB99A939B688...",
+        "payloadLen": 378
+      }, {
+        "tcId": 32,
+        "iv": "AB99A939B688...",
+        "key": "0569B0C6DB3...",
+        "ct": "DD14A9A9A916A...",
+        "payloadLen": 471
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_90df3887-fb05-4102-bdea-cf7bc2ef8fc1">The following shows AES-CBC-CS1 AFT responses.</p>
+<sourcecode lang="json" id="_8a271e03-1b05-4906-93e5-78e4665fb022">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2057,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "E25DC48F39E4DA..."
+        },
+        {
+          "tcId": 2,
+          "ct": "360D25D820C3BA..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "33346D02A070A..."
+        },
+        {
+          "tcId": 32,
+          "pt": "8F52D6E73783A..."
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_970648fa-2d96-444c-8db7-dae85748644c">The following shows AES-CBC-CS2 AFT request vectors.</p>
+<sourcecode lang="json" id="_4d9c652d-c50d-48f8-8f88-b2eb3ce30ec1">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2058,
+  "algorithm": "ACVP-AES-CBC-CS2",
+    "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+      "direction": "encrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 1,
+        "iv": "1216A541024...",
+        "key": "A6A8346C47...",
+        "pt": "71AC206DD0A...",
+        "payloadLen": 512
+      }, {
+        "tcId": 2,
+        "iv": "9A6A276AB96...",
+        "key": "7CDAE90854...",
+        "pt": "6D4AEE90179...",
+        "payloadLen": 178
+      }]
+    }, {
+      "tgId": 2,
+      "direction": "decrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 31,
+        "iv": "908543E2646...",
+        "key": "CB12AAFA25B...",
+        "ct": "AB99A939B688...",
+        "payloadLen": 378
+      }, {
+        "tcId": 32,
+        "iv": "AB99A939B688...",
+        "key": "0569B0C6DB3...",
+        "ct": "DD14A9A9A916A...",
+        "payloadLen": 471
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_ba51de85-b986-4f8a-a001-b080ae1c3a51">The following shows AES-CBC-CS2 AFT  responses.</p>
+<sourcecode lang="json" id="_429ad1f7-42f2-4cda-bac8-fc2e59f29e7d">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2057,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "E25DC48F39E4DA..."
+        },
+        {
+          "tcId": 2,
+          "ct": "360D25D820C3BA..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "33346D02A070A..."
+        },
+        {
+          "tcId": 32,
+          "pt": "8F52D6E73783A..."
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_972ecc77-ab76-478b-8efe-a79012a89305">The following shows AES-CBC-CS3 AFT request vectors.</p>
+<sourcecode lang="json" id="_fcd7806b-4bbb-46e3-8cbb-1b84cbab24aa">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2058,
+  "algorithm": "ACVP-AES-CBC-CS3",
+    "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+      "direction": "encrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 1,
+        "iv": "1216A541024...",
+        "key": "A6A8346C47...",
+        "pt": "71AC206DD0A...",
+        "payloadLen": 512
+      }, {
+        "tcId": 2,
+        "iv": "9A6A276AB96...",
+        "key": "7CDAE90854...",
+        "pt": "6D4AEE90179...",
+        "payloadLen": 178
+      }]
+    }, {
+      "tgId": 2,
+      "direction": "decrypt",
+      "testType": "AFT",
+      "keyLen": 128,
+      "tests": [{
+        "tcId": 31,
+        "iv": "908543E2646...",
+        "key": "CB12AAFA25B...",
+        "ct": "AB99A939B688...",
+        "payloadLen": 378
+      }, {
+        "tcId": 32,
+        "iv": "AB99A939B688...",
+        "key": "0569B0C6DB3...",
+        "ct": "DD14A9A9A916A...",
+        "payloadLen": 471
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_2bdd9157-5f3e-4294-8d72-18dcd04df9c1">The following shows AES-CBC-CS3 AFT responses.</p>
+<sourcecode lang="json" id="_586792e3-580d-41a5-b967-8b998b8f6eff">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2057,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "E25DC48F39E4DA..."
+        },
+        {
+          "tcId": 2,
+          "ct": "360D25D820C3BA..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "33346D02A070A..."
+        },
+        {
+          "tcId": 32,
+          "pt": "8F52D6E73783A..."
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_77f416f2-14dd-41df-930c-011e1ec4b0d6">The following shows AES-ECB AFT and MCT request vectors.</p>
+<sourcecode lang="json" id="_4498ca2e-0eea-41f4-826c-bf12f61f66da">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2056,
+  "algorithm": "ACVP-AES-ECB",
+    "revision": "1.0",
+  "testGroups": [{
+      "tgId": 1,
+            "testType": "AFT",
+            "direction": "encrypt",
+            "keylen": 128,
+            "tests": [
+                {
+                    "tcId": 1,
+                    "plainText": "F34481E...",
+                    "key": "0000000000000..."
+                },
+                {
+                    "tcId": 2,
+                    "plainText": "9798C46...",
+                    "key": "0000000000000..."
+                }
+      ]
+    },
+    {
+            "tgId": 25,
+            "testType": "AFT",
+            "direction": "encrypt",
+            "keylen": 128,
+            "tests": [
+                {
+                    "tcId": 2079,
+                    "plainText": "1C46FA6...",
+                    "key": "18D3248D32630..."
+                },
+                {
+                    "tcId": 2080,
+                    "plainText": "5AC1B2D...",
+                    "key": "26007B74016FA..."
+                }
+      ]
+    },
+        {
+        "tgId": 31,
+        "testType": "MCT",
+        "direction": "encrypt",
+        "keylen": 128,
+        "tests": [
+                {
+                    "tcId": 2139,
+                    "key": "9489F6FFA4A74...",
+              "pt": "2D984D2F1FC178..."
+                }
+            ]
+        },
+        {
+        "tgId": 34,
+        "testType": "MCT",
+        "direction": "decrypt",
+        "keylen": 128,
+        "tests": [
+                {
+                    "tcId": 2142
+                    "key": "9489F6FFA4A74...",
+              "ct": "2D984D2F1FC178..."
+                }
+            ]
+        }
+  ]
+}]</sourcecode>
+
+<p id="_763cc6e4-5583-4716-abb7-3473ef1b816a">The following shows AES-ECB AFT and MCT responses.</p>
+<sourcecode lang="json" id="_53b71938-7b1a-4452-a1c5-8fbabc00897f">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2056,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "43FB8A36F168E3..."
+        },
+        {
+          "tcId": 2,
+          "ct": "27549D65BE8056..."
+        }
+      ]
+    },
+    {
+      "tgId": 1,
+      "tests": [{
+          "tcId": 31,
+          "pt": "F7F42B062BD643..."
+        },
+        {
+          "tcId": 32,
+          "pt": "EAF9AAA67B6C0E..."
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 61,
+        "resultsArray": [{
+            "key": "A4A8255E7...",
+            "pt": "B3B8F494D0...",
+            "ct": "619D5B0921..."
+          },
+          {
+            "key": "C5357E575...",
+            "pt": "619D5B0921...",
+            "ct": "28CF1C5DD2..."
+          }
+        ]
+      }]
+    },
+    {
+      "tgId": 4,
+      "tests": [{
+        "tcId": 64,
+        "resultsArray": [{
+            "key": "4D3BE577E...",
+            "ct": "0FE92E22BA...",
+            "pt": "73ED187BFE..."
+          },
+          {
+            "key": "3ED6FD0C1...",
+            "ct": "73ED187BFE...",
+            "pt": "59550A36E1..."
+          }
+        ]
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_bd9c848b-2e80-4825-b712-17062c826779">The following shows AES-OFB AFT and MCT request vectors.</p>
+<sourcecode lang="json" id="_a393ea6c-374a-4bcb-be18-3c68b7793852">[{
+    "acvVersion": "{acvp-version}",
+},{
+  "vsId": 2060,
+  "algorithm": "ACVP-AES-OFB",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "direction": "encrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 1,
+      "iv": "0F24B3F7808F292BC39128...",
+      "key": "8ECE26B1880C4B1F0A59E...",
+      "pt": "A8EF19C7182527C8CBBEE1..."
+    }, {
+      "tcId": 2,
+      "iv": "1D1CC64F9F004192B6BE35...",
+      "key": "054240C952C99D5B6E387224F...",
+      "pt": "EBFA3F5F990B678AA884FB..."
+    }]
+  }, {
+    "tgId": 2,
+    "direction": "decrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 31,
+      "iv": "A5F67A6CB0238A5DFB166...",
+      "key": "A3988AC61E9FB4820876...",
+      "ct": "CF6F24E68CEC8B97CB88D..."
+    }, {
+      "tcId": 32,
+      "iv": "4098786D4EF05639B5A20...",
+      "key": "5D22EAF883FB2B1847BF...",
+      "ct": "7203926F1210401F566E0..."
+    }]
+  }, {
+    "tgId": 3,
+    "direction": "encrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 61,
+      "iv": "39F33D19A09AAFD200D4C...",
+      "key": "190316BF21DE21E96FCF...",
+      "pt": "E4D7F490829710CADFD67..."
+    }]
+  }, {
+    "tgId": 4,
+    "direction": "decrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 64,
+      "iv": "1915C8A7AFEBB26AAE97C...",
+      "key": "9489F6FFA4A7480D5B34...",
+      "ct": "2D984D2F1FC178CAB247F..."
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_a1b4fea6-99f1-48e2-9c57-dd3fee9f2d79">The following shows AES-OFB AFT and MCT responses.</p>
+<sourcecode lang="json" id="_748ce17a-2c62-4f99-a861-d019d58ce2fc">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2060,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "B5D16C4219AC38..."
+        },
+        {
+          "tcId": 2,
+          "ct": "B85AF8646842A9..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "0863AB3A0CA17C..."
+        },
+        {
+          "tcId": 32,
+          "pt": "BF69D1BE04D013..."
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 61,
+        "resultsArray": [{
+            "key": "190316BF...",
+            "iv": "39F33D19A...",
+            "pt": "E4D7F4908...",
+            "ct": "F55626877..."
+          },
+          {
+            "key": "EC553038...",
+            "iv": "F55626877...",
+            "pt": "A04BCACFF...",
+            "ct": "1EAA7DE30..."
+          }
+        ]
+      }]
+    },
+    {
+      "tgId": 4,
+      "tests": [{
+        "tcId": 64,
+        "resultsArray": [{
+            "key": "9489F6FF...",
+            "iv": "1915C8A7A...",
+            "ct": "2D984D2F1...",
+            "pt": "0FE5765E5..."
+          },
+          {
+            "key": "9B6C80A1...",
+            "iv": "0FE5765E5...",
+            "ct": "F29F68E2E...",
+            "pt": "39AC0B63E..."
+          }
+        ]
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_a67f2cd3-bc80-4b93-8a3e-9276eced884f">The following shows AES-CFB1 AFT and MCT request vectors.</p>
+<sourcecode lang="json" id="_e85ceff9-5758-43c7-8453-c4e31c70b595">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2062,
+  "algorithm": "ACVP-AES-CFB1",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "direction": "encrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 67,
+      "iv": "F34481EC3CC627BACD5DC3...",
+      "key": "000000000000000000000...",
+      "pt": "00",
+      "payloadLen": 1
+    }, {
+      "tcId": 68,
+      "iv": "9798C4640BAD75C7C3227D...",
+      "key": "000000000000000000000...",
+      "pt": "00",
+      "payloadLen": 1
+    }]
+  }, {
+    "tgId": 2,
+    "direction": "decrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 31,
+      "iv": "C74388BA333118CDBDF578...",
+      "key": "8DE5E0586C4EA40FC36C0...",
+      "ct": "80",
+      "payloadLen": 1
+    }, {
+      "tcId": 32,
+      "iv": "0B1B558F3AF46F2E6AB29D...",
+      "key": "E52350E8E8EE950A3C2E3...",
+      "ct": "80",
+      "payloadLen": 1
+    }]
+  }, {
+    "tgId": 3,
+    "direction": "encrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 61,
+      "iv": "D4A4A028EEA3BCA708A31E...",
+      "key": "A3B254EAB3B0C8C60EF6A...",
+      "pt": "80",
+      "payloadLen": 1
+    }]
+  }, {
+    "tgId": 4,
+    "direction": "decrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 64,
+      "iv": "75BEE06DEC8A99EC0C7E7F...",
+      "key": "7C87174CB990272D0F2F2...",
+      "ct": "00",
+      "payloadLen": 1
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_ed8246da-e3bd-4ac6-bdc8-b671bdb2da9b">The following shows AES-CFB1 AFT and MCT responses.</p>
+<sourcecode lang="json" id="_dd2d9b7b-04a1-4eed-bd1c-3ed69c9c644d">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2062,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 67,
+          "ct": "00"
+        },
+        {
+          "tcId": 68,
+          "ct": "80"
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "00"
+        },
+        {
+          "tcId": 32,
+          "pt": "80"
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 61
+        "resultsArray": [{
+            "key": "A3B254EAB...",
+            "iv": "D4A4A028EE...",
+            "pt": "80",
+            "ct": "00"
+          },
+          {
+            "key": "8FFC23126...",
+            "iv": "2C4E77F8D0...",
+            "pt": "00",
+            "ct": "00"
+          }
+        ]
+      }]
+    }, {
+      "tgId": 4,
+      "tests": [{
+        "tcId": 64
+        "resultsArray": [{
+            "key": "7C87174CB...",
+            "iv": "75BEE06DEC...",
+            "ct": "00",
+            "pt": "00"
+          },
+          {
+            "key": "4B2492A3F...",
+            "iv": "37A385EF42...",
+            "ct": "80",
+            "pt": "80"
+          }
+        ]
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_6773e3e1-a098-40c1-947a-0f218496934b">The following shows AES-CFB8 AFT and MCT request vectors.</p>
+<sourcecode lang="json" id="_60271297-3307-491e-9b34-b6dd9a3c1170">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2058,
+  "algorithm": "ACVP-AES-CFB8",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "direction": "encrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 1,
+      "iv": "4EBD4CE189E6DA65026C2A...",
+      "key": "5FA02465F28B76C441C7B...",
+      "pt": "AF5E"
+    }, {
+      "tcId": 2,
+      "iv": "9A8017353E953B5AEC4D78...",
+      "key": "538EB5E1CBFEA61CC6B3D...",
+      "pt": "6ED3759B"
+    }]
+  }, {
+    "tgId": 2,
+    "direction": "decrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 31,
+      "iv": "1808A0F308838AA6F9F703...",
+      "key": "DB7FFD9166E4A5BACB022...",
+      "ct": "41DA"
+    }, {
+      "tcId": 32,
+      "iv": "4D75785D44B1B247788186...",
+      "key": "7201F5CC867A8DCE044DB...",
+      "ct": "E267BC1B"
+    }]
+  }, {
+    "tgId": 3,
+    "direction": "encrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 61,
+      "iv": "4B8F7DCCAD48776C746B79...",
+      "key": "FD0B5848870C7431179EB...",
+      "pt": "AD"
+    }]
+  }, {
+    "tgId": 4,
+    "direction": "decrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 64,
+      "iv": "5D2080050855970CE15DC1...",
+      "key": "EA378F16FF6144EF58E67...",
+      "ct": "83"
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_f3cddcae-82c4-455b-87fa-03bf4c18d768">The following shows AES-CFB8 AFT and MCT responses.</p>
+<sourcecode lang="json" id="_a6476798-df06-4a1b-9e0e-c523f41c0afd">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2058,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "181B"
+        },
+        {
+          "tcId": 2,
+          "ct": "DFF540F0"
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "DA19"
+        },
+        {
+          "tcId": 32,
+          "pt": "B2133D11"
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 61,
+        "resultsArray": [{
+            "key": "FD0B58488...",
+            "iv": "4B8F7DCCAD...",
+            "pt": "AD",
+            "ct": "3A"
+          },
+          {
+            "key": "6B96D9FD0...",
+            "iv": "969D81B585...",
+            "pt": "2F",
+            "ct": "BD"
+          }
+        ]
+      }]
+    },
+    {
+      "tgId": 4,
+      "tests": [{
+        "tcId": 64,
+        "resultsArray": [{
+            "key": "EA378F16F...",
+            "iv": "5D20800508...",
+            "ct": "83",
+            "pt": "E6"
+          },
+          {
+            "key": "31A0B0001A...",
+            "iv": "DB973F16E5D...",
+            "ct": "24",
+            "pt": "0A"
+          }
+        ]
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_767afb97-c73f-4952-90e6-cc94f446bec6">The following shows AES-CFB128 AFT and MCT request vectors.</p>
+<sourcecode lang="json" id="_d6827c86-86f0-42b5-8924-542429f70484">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2059,
+  "algorithm": "ACVP-AES-CFB128",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "direction": "encrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 1,
+      "iv": "24AD71C9734E64B8AC458...",
+      "key": "55B2490AD74A470F5CFE...",
+      "pt": "FE9C6B296C58324FE8B48..."
+    }, {
+      "tcId": 2,
+      "iv": "C0042889D189B508C5B88...",
+      "key": "AB383065E16B17306B50...",
+      "pt": "19F109316F7F740BD48FF..."
+    }]
+  }, {
+    "tgId": 2,
+    "direction": "decrypt",
+    "testType": "AFT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 31,
+      "iv": "40619E2F346B02D49BCEE...",
+      "key": "744F5B5D7813974E0DE2...",
+      "ct": "5B12E9B418F720C344698..."
+    }, {
+      "tcId": 32,
+      "iv": "D571797F5623F8442C2CE...",
+      "key": "6559CA840CF8360A8AF7...",
+      "ct": "0A17C2F7A82BBDE588262..."
+    }]
+  }, {
+    "tgId": 3,
+    "direction": "encrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 61,
+      "iv": "4AAF5D6F6E25B8A868D8D...",
+      "key": "0D0949FB32A2DC6BA267...",
+      "pt": "98EE9313512D5BEC19715..."
+    }]
+  }, {
+    "tgId": 4,
+    "direction": "decrypt",
+    "testType": "MCT",
+    "keyLen": 128,
+    "tests": [{
+      "tcId": 64,
+      "iv": "663D4E1B6F09FE1935E69...",
+      "key": "5924D41588E2DC657514...",
+      "ct": "83C1C3AF23A3F658DF142..."
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_b3d9ece6-ec18-4580-ae2d-518bbc24c44f">The following shows AES-CFB128 AFT and MCT responses.</p>
+<sourcecode lang="json" id="_fa2ff08f-7695-4aad-92f5-972808eafd33">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2059,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "1C9BF58FF640041F8E..."
+        },
+        {
+          "tcId": 2,
+          "ct": "2C822934B8D747336..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "4BC37D318900379CD75..."
+        },
+        {
+          "tcId": 32,
+          "pt": "523057EC2E120826..."
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 61,
+        "resultsArray": [{
+            "key": "0D0949FB32A...",
+            "iv": "4AAF5D6F6E25...",
+            "pt": "98EE9313512D...",
+            "ct": "7E94144C4DD4..."
+          },
+          {
+            "key": "739D5DB77F7...",
+            "iv": "7E94144C4DD4...",
+            "pt": "E93E4CCB2BD1...",
+            "ct": "050CE71D2451..."
+          }
+        ]
+      }]
+    },
+    {
+      "tgId": 4,
+      "tests": [{
+        "tcId": 64,
+        "resultsArray": [{
+            "key": "5924D41588E...",
+            "iv": "663D4E1B6F09...",
+            "ct": "83C1C3AF23A3...",
+            "pt": "32D4D152D488..."
+          },
+          {
+            "key": "6BF005475C6...",
+            "iv": "32D4D152D488...",
+            "ct": "3CC4191B8EBE...",
+            "pt": "BB97ADEF9F08..."
+          }
+        ]
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_e1819d48-e08c-4103-973a-3cb61118a89e">The following shows AES-CTR AFT and counter request vectors.</p>
+<sourcecode lang="json" id="_46b73035-c3fc-450a-9254-96a96dd32094">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2066,
+  "algorithm": "ACVP-AES-CTR",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "direction": "encrypt",
+    "keyLen": 128,
+    "testType": "AFT",
+    "tests": [{
+      "tcId": 1,
+      "key": "E870131CE703D6514E761F95E6EE9EFB",
+      "payloadLen": 128,
+      "iv": "53F225D8DE97F14BFE3EC65EC3FFF7D3",
+      "pt": "91074131F1F86CCD548D22A69340FF39"
+    }, {
+      "tcId": 2,
+      "key": "2C759788A49BF060353344413A1D0FFC",
+      "payloadLen": 128,
+      "iv": "A4DE6D846C3AE5D5FF78163FF209AFE4",
+      "pt": "BA37A61FD041F2881921D4705AD329DD"
+    }]
+  }, {
+    "tgId": 2,
+    "direction": "decrypt",
+    "keyLen": 128,
+    "testType": "AFT",
+    "tests": [{
+      "tcId": 31,
+      "key": "51B4375D6FB348A55477E3C3163F59C7",
+      "payloadLen": 128,
+      "iv": "93893A056C6C6F866A04D657A544F1F8",
+      "ct": "F2FF4B0C2E771A41525EA67AD036B459"
+    }, {
+      "tcId": 32,
+      "key": "6A4F0B775490D554F19B5A061A362666",
+      "payloadLen": 128,
+      "iv": "9877D2AB7568CEF28BA945B046BA20BE",
+      "ct": "09F4EEF2322BE13D75FF6DA86E8617B5"
+    }]
+  }, {
+    "tgId": 3,
+    "direction": "encrypt",
+    "keyLen": 128,
+    "testType": "CTR",
+    "tests": [{
+      "tcId": 829,
+      "key": "3A9A8485E1B7BA1987F88F8C095257C4",
+      "payloadLen": 12800,
+      "pt": "CE8E4B6F7C68DE5FDE3..."
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_c4cedc0c-f15e-4dc5-bb7f-5653afeb0933">The following shows AES-CTR AFT and counter responses.</p>
+<sourcecode lang="json" id="_72eee996-b997-4048-bec4-2b6d13979029">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2066,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "3AF64C7037EE4813D8..."
+        },
+        {
+          "tcId": 2,
+          "ct": "2DFDFCDDC4CFD3CBCE..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 31,
+          "pt": "349012E0807CA95CA5..."
+        },
+        {
+          "tcId": 32,
+          "pt": "2986D4B3FB208F0189..."
+        }
+      ]
+    },
+    {
+      "tgId": 3,
+      "tests": [{
+        "tcId": 829,
+        "ct": "676EC652D5B095136..."
+      }]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_56f3632f-70c6-44ef-9540-252bec59f861">The following shows AES-CTR RFC3686 request vectors with internal iv generation.</p>
+<sourcecode lang="json" id="_510ba5ff-a160-4e67-af1b-43d3b2e5c403">{
+	"vsId": 1,
+	"algorithm": "ACVP-AES-CTR",
+	"revision": "1.0",
+	"testGroups": [{
+			"tgId": 1,
+			"testType": "AFT",
+			"direction": "encrypt",
+			"keyLen": 128,
+			"tests": [{
+					"tcId": 12,
+					"pt": "3687D763A3EEC3E3099678068F3CDEB4C7B12BA83C50CCB744D8945C0DB0078E",
+					"payloadLen": 256,
+					"key": "208A474D7567BF87A1A62D0767724547"
+				},
+				{
+					"tcId": 13,
+					"pt": "F96CBC81F0B876A463FD467C5FBA19791A1BE394DF61C883BE7ECB67270846A1E345991F81DAAE4532DEFCFCCDC69BA0",
+					"payloadLen": 384,
+					"key": "629EFE9A344A081CD4E4D758C1E759BF"
+				}
+			]
+		},
+		{
+			"tgId": 3,
+			"testType": "AFT",
+			"direction": "decrypt",
+			"keyLen": 128,
+			"tests": [{
+					"tcId": 62,
+					"payloadLen": 256,
+					"ct": "0306E3B1F1719CD7C64296F52B06F246CAA463BE19309AC2CF842ADE0B0BCD21",
+					"iv": "14FD559C120735498CE09BA800000001",
+					"key": "4D94B2155A6322DB76878C71763EE544"
+				},
+				{
+					"tcId": 63,
+					"payloadLen": 384,
+					"ct": "474AB381112D9FB530BC2E0B2B7E6D139243BC6B1D23D21508E18E82D85218DB10C3C4DABE278B2D334860BEF96B619C",
+					"iv": "8E0759C1B24B8CCBDE7D51C100000001",
+					"key": "BE4AD76083C6A471803FFE704B6F194D"
+				}
+			]
+		}
+	]
+}</sourcecode>
+
+<p id="_d4003d62-7c51-4335-888c-54f60d042c61">The following shows AES-CTR RFC3686 with internal iv generation responses.</p>
+<sourcecode lang="json" id="_786c5137-5247-4b50-ad5b-edd1a656a849">{
+	"vsId": 0,
+	"algorithm": "ACVP-AES-CTR",
+	"mode": "",
+	"revision": "1.0",
+	"isSample": true,
+	"testGroups": [{
+			"tgId": 1,
+			"tests": [{
+					"tcId": 12,
+					"ct": "00F5E67B3C8C6038D907D5866866DDBE583CF90DD8AE37159D1CC0235EEA6175",
+					"iv": "992AA770156A7E1AB58BAFCA00000001"
+				},
+				{
+					"tcId": 13,
+					"ct": "7EA7DC8A993C1EBA61239CFBBBA4244DB185C4F8F248CCF1F1AF7DD7993B1AE5EE05D51AC58D453FE32EC59629F011EC",
+					"iv": "F083A4495B66E5DF0607BF9200000001"
+				}
+			]
+		},
+		{
+			"tgId": 3,
+			"tests": [{
+					"tcId": 62,
+					"pt": "0FC0CAF36921D2803DC9AEBFD5473124D77969BA9FF813861332A3E77E9265C1"
+				},
+				{
+					"tcId": 63,
+					"pt": "9C0DA9C01AEB0B4A42E99776A4E2DFE8E50A7A602E257C7D2EB3C79A529BAA4AC130ADBE6537CB39AA06850044D22547"
+				}
+			]
+		}
+	]
+}</sourcecode>
+
+<p id="_b42b6e47-3491-48c9-bf3f-e3dfe0b878ed">The following shows AES-CTR RFC3686 request vectors with external iv generation.</p>
+<sourcecode lang="json" id="_547dc825-2384-434e-837c-d311d2d1b7ec">{
+	"vsId": 1,
+	"algorithm": "ACVP-AES-CTR",
+	"revision": "1.0",
+	"testGroups": [{
+			"tgId": 1,
+			"testType": "AFT",
+			"direction": "encrypt",
+			"keyLen": 128,
+			"tests": [{
+					"tcId": 12,
+					"pt": "3687D763A3EEC3E3099678068F3CDEB4C7B12BA83C50CCB744D8945C0DB0078E",
+          "iv": "992AA770156A7E1AB58BAFCA00000001",
+					"payloadLen": 256,
+					"key": "208A474D7567BF87A1A62D0767724547"
+				},
+				{
+					"tcId": 13,
+					"pt": "F96CBC81F0B876A463FD467C5FBA19791A1BE394DF61C883BE7ECB67270846A1E345991F81DAAE4532DEFCFCCDC69BA0",
+          "iv": "F083A4495B66E5DF0607BF9200000001",
+					"payloadLen": 384,
+					"key": "629EFE9A344A081CD4E4D758C1E759BF"
+				}
+			]
+		},
+		{
+			"tgId": 3,
+			"testType": "AFT",
+			"direction": "decrypt",
+			"keyLen": 128,
+			"tests": [{
+					"tcId": 62,
+					"payloadLen": 256,
+					"ct": "0306E3B1F1719CD7C64296F52B06F246CAA463BE19309AC2CF842ADE0B0BCD21",
+					"iv": "14FD559C120735498CE09BA800000001",
+					"key": "4D94B2155A6322DB76878C71763EE544"
+				},
+				{
+					"tcId": 63,
+					"payloadLen": 384,
+					"ct": "474AB381112D9FB530BC2E0B2B7E6D139243BC6B1D23D21508E18E82D85218DB10C3C4DABE278B2D334860BEF96B619C",
+					"iv": "8E0759C1B24B8CCBDE7D51C100000001",
+					"key": "BE4AD76083C6A471803FFE704B6F194D"
+				}
+			]
+		}
+	]
+}</sourcecode>
+
+<p id="_11bbbb2b-f64e-4985-9304-66b771b6ada5">The following shows AES-CTR RFC3686 with external iv generation responses.</p>
+<sourcecode lang="json" id="_5c0be0b8-16c3-413b-8b49-801b6679e431">{
+	"vsId": 0,
+	"algorithm": "ACVP-AES-CTR",
+	"mode": "",
+	"revision": "1.0",
+	"isSample": true,
+	"testGroups": [{
+			"tgId": 1,
+			"tests": [{
+					"tcId": 12,
+					"ct": "00F5E67B3C8C6038D907D5866866DDBE583CF90DD8AE37159D1CC0235EEA6175"
+				},
+				{
+					"tcId": 13,
+					"ct": "7EA7DC8A993C1EBA61239CFBBBA4244DB185C4F8F248CCF1F1AF7DD7993B1AE5EE05D51AC58D453FE32EC59629F011EC"
+				}
+			]
+		},
+		{
+			"tgId": 3,
+			"tests": [{
+					"tcId": 62,
+					"pt": "0FC0CAF36921D2803DC9AEBFD5473124D77969BA9FF813861332A3E77E9265C1"
+				},
+				{
+					"tcId": 63,
+					"pt": "9C0DA9C01AEB0B4A42E99776A4E2DFE8E50A7A602E257C7D2EB3C79A529BAA4AC130ADBE6537CB39AA06850044D22547"
+				}
+			]
+		}
+	]
+}</sourcecode>
+
+<p id="_87272f62-22f0-4a3a-9e15-1c62a4b3efbe">The following shows AES-XPN AFT request vectors.</p>
+<sourcecode lang="json" id="_d0259bcc-5439-4e7d-8b32-11d5219ed71d">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "algorithm": "ACVP-AES-XPN",
+  "revision": "1.0",
+  "vsId": 1,
+  "testGroups": [
+    {
+      "tgId": 1,
+      "testType": "AFT",
+      "direction": "encrypt",
+      "keyLen": 128,
+      "ivLen": 96,
+      "ivGen": "external",
+      "ivGenMode": "8.2.2",
+      "saltLen": 96,
+      "saltGen": "external",
+      "payloadLen": 128,
+      "aadLen": 120,
+      "tagLen": 64,
+      "tests": [
+        {
+          "tcId": 1,
+          "plainText": "4849547C706231E248148...",
+          "key": "4A23FDD31C1B321C1D3E1A74ECA9585A",
+          "aad": "6B55B1B784180DE574F7709E480273",
+          "iv": "A05134709620EAB47DE77FCB",
+          "salt": "F0C77CB78D20BBDCF3A3C5EB"
+        },
+        {
+          "tcId": 2,
+          "plainText": "BF1D8173DA7F0273B7DA8...",
+          "key": "254E5AFE555D807E5ECC2FFAB2E3E107",
+          "aad": "304A2EC82959B419B8852F5C6A09D1",
+          "iv": "1BA39F6A71F075FEB72B91D6",
+          "salt": "AF44CD3E80088B8FD252AAB0"
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_bc050f3b-1e42-4261-a1dc-8651b5e25803">The following shows AES-XPN AFT responses.</p>
+<sourcecode lang="json" id="_bd9b9993-6838-4383-b6fa-1ba7460c3fd6">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 1,
+  "testGroups": [
+    {
+      "tgId": 1,
+      "tests": [
+        {
+          "tcId": 1,
+          "testPassed": false
+        },
+        {
+          "tcId": 2,
+          "cipherText": "D3104958599BE7BB9E672F...",
+          "tag": "48408062AA84718B"
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_94e8d7ce-6d23-4e03-aaa3-8ac3866d66ae">The following shows AES-XTS 1.0 AFT request vectors.</p>
+<sourcecode lang="json" id="_9428f106-3cef-4813-8d6b-4552c7adc401">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2065,
+  "algorithm": "ACVP-AES-XTS",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "testType": "AFT",
+    "direction": "encrypt",
+    "keyLen": 128,
+    "tweakMode": "hex",
+    "payloadLen": 65536,
+    "tests": [{
+      "tcId": 1,
+      "key": "2866E3659E11C7890313EDAC9...",
+      "tweakValue": "C7850E1C99DA28C5E7...",
+      "pt": "03F912D53EA625A7D206002864..."
+    }, {
+      "tcId": 2,
+      "key": "98B66C26FF9E4EF2BCBC3A212...",
+      "tweakValue": "57B127C8DAD60138C5...",
+      "pt": "20D7E083519F39DB185CDA2397..."
+    }]
+  }, {
+    "tgId": 2,
+    "testType": "AFT",
+    "direction": "decrypt",
+    "keyLen": 128,
+    "tweakMode": "hex",
+    "payloadLen": 65536,
+    "tests": [{
+      "tcId": 101,
+      "key": "BB626CADBBFB907AC5C795080...",
+      "tweakValue": "8B7E45A9200BDC72EB...",
+      "ct": "B85B91029478C3E02EBC619EC7..."
+    }, {
+      "tcId": 102,
+      "key": "9B859C56C1542C19F29AA7A4F...",
+      "tweakValue": "99FE35549768F476E2...",
+      "ct": "53CEE8379B03A38E33CCCC6EA0..."
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_a19f0db8-7502-4bee-b6f8-9ba4cd668560">The following shows AES-XTS 1.0 AFT responses.</p>
+<sourcecode lang="json" id="_c39cda58-607b-46fc-b2b7-8846b4f09bc1">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2065,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "97ED8057287E4FD0E1..."
+        },
+        {
+          "tcId": 2,
+          "ct": "BCACA25E6A625DB16..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 101,
+          "pt": "8AD40CBE09CD92FB0..."
+        },
+        {
+          "tcId": 102,
+          "pt": "07DD39402F4D427D7..."
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_06943d85-52f2-482e-9e3a-1691441478fe">The following shows AES-XTS 2.0 AFT request vectors.</p>
+<sourcecode lang="json" id="_7b97d181-9786-4618-9620-b5ea4711bb50">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2065,
+  "algorithm": "ACVP-AES-XTS",
+    "revision": "2.0",
+  "testGroups": [{
+    "tgId": 1,
+    "testType": "AFT",
+    "direction": "encrypt",
+    "keyLen": 128,
+    "tweakMode": "hex",
+    "tests": [{
+      "tcId": 1,
+      "key": "2866E3659E11C7890313EDAC9...",
+      "tweakValue": "C7850E1C99DA28C5E7...",
+      "pt": "03F912D53EA625A7D206002864...",
+      "payloadLen": 2048,
+      "dataUnitLen": 1024
+    }, {
+      "tcId": 2,
+      "key": "98B66C26FF9E4EF2BCBC3A212...",
+      "tweakValue": "57B127C8DAD60138C5...",
+      "pt": "20D7E083519F39DB185CDA2397...",
+      "payloadLen": 2048,
+      "dataUnitLen": 1024
+    }]
+  }, {
+    "tgId": 2,
+    "testType": "AFT",
+    "direction": "decrypt",
+    "keyLen": 128,
+    "tweakMode": "hex",
+    "tests": [{
+      "tcId": 101,
+      "key": "BB626CADBBFB907AC5C795080...",
+      "tweakValue": "8B7E45A9200BDC72EB...",
+      "ct": "B85B91029478C3E02EBC619EC7...",
+      "payloadLen": 2048,
+      "dataUnitLen": 1024
+    }, {
+      "tcId": 102,
+      "key": "9B859C56C1542C19F29AA7A4F...",
+      "tweakValue": "99FE35549768F476E2...",
+      "ct": "53CEE8379B03A38E33CCCC6EA0...",
+      "payloadLen": 2048,
+      "dataUnitLen": 1024
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_50205947-ee35-4a0f-822d-9029a716f677">The following shows AES-XTS 2.0 AFT responses.</p>
+<sourcecode lang="json" id="_2f50beca-9d77-4883-a90d-22fc62ab23f5">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2065,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "97ED8057287E4FD0E1..."
+        },
+        {
+          "tcId": 2,
+          "ct": "BCACA25E6A625DB16..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 101,
+          "pt": "8AD40CBE09CD92FB0..."
+        },
+        {
+          "tcId": 102,
+          "pt": "07DD39402F4D427D7..."
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_42c1b1d2-7dca-422c-9de5-9ba49451bd37">The following shows AES-KW request vectors.</p>
+<sourcecode lang="json" id="_7f2a107c-7f3b-4761-8ef2-6f27cac090f8">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2063,
+  "algorithm": "ACVP-AES-KW",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "testType": "AFT",
+    "direction": "encrypt",
+    "kwCipher": "cipher",
+    "keyLen": 128,
+    "payloadLen": 192,
+    "tests": [{
+      "tcId": 1,
+      "key": "71389B09A3EA1AAE1F265CD3DE8FABB7",
+      "pt": "3D90BE277A057C024A485F02486D733..."
+    }, {
+      "tcId": 2,
+      "key": "B75DB6D92A66A3E8E991FEDBA3DAACA7",
+      "pt": "3323EC2514C2902C424ABE968CA09FD..."
+    }]
+  }, {
+    "tgId": 2,
+    "testType": "AFT",
+    "direction": "decrypt",
+    "kwCipher": "cipher",
+    "keyLen": 128,
+    "payloadLen": 192,
+    "tests": [{
+      "tcId": 901,
+      "key": "E5319E0061F89DE08CB590EA...",
+      "ct": "1DE720863C759EC0682429AA4..."
+    }, {
+      "tcId": 902,
+      "key": "D16C5C5FDE26C1962342AACF...",
+      "ct": "F2EC43D61F2F356E1B2850D7C..."
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_071650ff-29d4-4688-a4b0-54687b950699">The following shows AES-KW responses.</p>
+<sourcecode lang="json" id="_82fedaea-0c4c-4db1-b9ea-3284a6a58380">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2063,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "BD009027DA8F4176B..."
+        },
+        {
+          "tcId": 2,
+          "ct": "B8BB3D3C76FDFD359..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 901,
+          "pt": "A6BA646D0D33808AB..."
+        },
+        {
+          "tcId": 902,
+          "pt": "B40AC5F6ED5A706CB..."
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_8185c035-a634-4948-8725-a36aafce2ce6">The following shows AES-KWP request vectors.</p>
+<sourcecode lang="json" id="_3db452ee-9196-4fba-a3f1-b521d403f591">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2064,
+  "algorithm": "ACVP-AES-KWP",
+    "revision": "1.0",
+  "testGroups": [{
+    "tgId": 1,
+    "testType": "AFT",
+    "direction": "encrypt",
+    "kwCipher": "cipher",
+    "keyLen": 128,
+    "payloadLen": 808,
+    "tests": [{
+      "tcId": 1,
+      "key": "EE3B424525EE1B2D0B8CDC4CCB15F018",
+      "pt": "269701A6DE9A2E8A8B2E28027..."
+    }, {
+      "tcId": 2,
+      "key": "579C5EBBD1D07F828251FE567326C5DD",
+      "pt": "634945E0FD1FA2E733CD60462..."
+    }]
+  }, {
+    "tgId": 2,
+    "testType": "AFT",
+    "direction": "decrypt",
+    "kwCipher": "cipher",
+    "keyLen": 128,
+    "payloadLen": 808,
+    "tests": [{
+      "tcId": 301,
+      "key": "0EB557E0F938E08662EB9EDAAE05725F",
+      "ct": "1BB87C360F2B644CD0BC75369..."
+    }, {
+      "tcId": 302,
+      "key": "644E2869C9698ADBB4417A8ED65748DC",
+      "ct": "583741B7624759F37EED76F76..."
+    }]
+  }]
+}]</sourcecode>
+
+<p id="_149291ce-d8c2-4b44-85b4-c27546f0cedb">The following shows AES-KWP responses.</p>
+<sourcecode lang="json" id="_9d94c306-1ede-4f60-8339-89f142660d23">[{
+  "acvVersion": "{acvp-version}"
+},{
+  "vsId": 2064,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "58385237F04FD67F0..."
+        },
+        {
+          "tcId": 2,
+          "ct": "0D6FE2D0A8605981E..."
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 300,
+          "ct": "D2A239230130B6077..."
+        },
+        {
+          "tcId": 301,
+          "testPassed": false
+        }
+      ]
+    }
+  ]
+}]</sourcecode>
+
+<p id="_7335caac-926a-4ec4-84fe-7d2e3bf7da1e">The following shows AES-FF1 request vectors.</p>
+<sourcecode lang="json" id="_86cad7bc-791c-4208-8d8b-9e6042371b6c">{
+  "vsId": 42,
+  "algorithm": "ACVP-AES-FF1",
+  "revision": "1.0",
+  "isSample": false,
+  "testGroups": [{
+      "tgId": 1,
+      "testType": "AFT",
+      "direction": "encrypt",
+      "keyLen": 128,
+      "alphabet": "0123456789",
+      "radix": 10,
+      "tests": [{
+          "tcId": 1,
+          "tweak": "",
+          "tweakLen": 0,
+          "pt": "5989891000",
+          "key": "FA407521178EDB931997C9EF5FF4F8BB"
+        },
+        {
+          "tcId": 2,
+          "tweak": "CB81CF732B22A983B2C6E584726C9F59",
+          "tweakLen": 128,
+          "pt": "60454384602180796680544707896451618557756152702734587161",
+          "key": "E3EFDAF1ABEA7863A0A95F833420D083"
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "testType": "AFT",
+      "direction": "encrypt",
+      "keyLen": 128,
+      "alphabet": "abcdefghijklmnopqrstuvwxyz",
+      "radix": 26,
+      "tests": [{
+          "tcId": 26,
+          "tweak": "",
+          "tweakLen": 0,
+          "pt": "zlwagydvpt",
+          "key": "D263686051802ECAE0217F4123000376"
+        },
+        {
+          "tcId": 27,
+          "tweak": "994C168B9F6225C4BC12A83561C0E1A6",
+          "tweakLen": 128,
+          "pt": "uxmdsdjbsywthsvzjlfcwlmpkarnaeoirtihgfuu",
+          "key": "53CA14AF6F97612C96FFAA2BA8D88C44"
+        }
+      ]
+    },
+    {
+      "tgId": 10,
+      "testType": "AFT",
+      "direction": "decrypt",
+      "keyLen": 128,
+      "alphabet": "0123456789",
+      "radix": 10,
+      "tests": [{
+          "tcId": 226,
+          "tweak": "",
+          "tweakLen": 0,
+          "key": "82DD08D210EB34C9743EC102E058CEE3",
+          "ct": "8416752187"
+        },
+        {
+          "tcId": 227,
+          "tweak": "03130ABD79425EEC806617434C60B2FE",
+          "tweakLen": 128,
+          "key": "E6265A6503AD2F4F13FCCF8B8AD64638",
+          "ct": "26379838628949309091263132236041132252667968597137110245"
+        }
+      ]
+    }
+  ]
+}</sourcecode>
+
+<p id="_23385ee8-1045-4dad-8fda-ced509f9b360">The following shows AES-FF1 responses.</p>
+<sourcecode lang="json" id="_9245a706-0809-457a-977d-7808019306f4">{
+  "vsId": 42,
+  "algorithm": "ACVP-AES-FF1",
+  "revision": "1.0",
+  "isSample": false,
+  "testGroups": [{
+      "tgId": 1,
+      "tests": [{
+          "tcId": 1,
+          "ct": "4896500946"
+        },
+        {
+          "tcId": 2,
+          "ct": "69747385701019112488208222409900597881359856066248208863"
+        }
+      ]
+    },
+    {
+      "tgId": 2,
+      "tests": [{
+          "tcId": 26,
+          "ct": "odmrhltvlj"
+        },
+        {
+          "tcId": 27,
+          "ct": "lifbvigwtcwmkiucogaztntcagaqqtoioagwsgef"
+        }
+      ]
+    },
+    {
+      "tgId": 18,
+      "tests": [{
+          "tcId": 426,
+          "pt": "/HN6wiTZoc"
+        },
+        {
+          "tcId": 427,
+          "pt": "NyFsYHaUg0000JcSKJhRvOe0000E"
+        }
+      ]
+    }
+  ]
+}</sourcecode>
+
+<p id="_e98a8fe5-f0c2-427d-bea5-0d2111536891">The following shows AES-FF3-1 request vectors.</p>
+<sourcecode lang="json" id="_2df9769b-fe84-4c1e-9b84-9dc95237e5f3">{
+  "vsId": 42,
+  "algorithm": "ACVP-AES-FF3-1",
+  "revision": "1.0",
+  "isSample": false,
+  "testGroups": [
+    {
+      "tgId": 1,
+      "testType": "AFT",
+      "direction": "encrypt",
+      "keyLen": 128,
+      "alphabet": "0123456789",
+      "radix": 10,
+      "tests": [
+        {
+          "tcId": 1,
+          "tweak": "9F6B7D43B3A552",
+          "tweakLen": 56,
+          "pt": "4312962667",
+          "key": "0D517EBC71852CBA6C7013C9DB9104D8"
+        },
+        {
+          "tcId": 2,
+          "tweak": "7ECCD5D62C8AA9",
+          "tweakLen": 56,
+          "pt": "42592972841413437983428634710481338922521696022233194252",
+          "key": "9BA74F3763BD93F8B59200D122F1C621"
+        }
+	  ]
+	}
+  ]
+}</sourcecode>
+
+<p id="_1b195854-d2d0-49a5-8bd4-5a7d11015325">The following shows AES-FF-31 responses.</p>
+<sourcecode lang="json" id="_92140b9b-b1b7-411d-89a1-ad44cf6c2302">{
+  "vsId": 42,
+  "algorithm": "ACVP-AES-FF3-1",
+  "revision": "1.0",
+  "isSample": false,
+  "testGroups": [
+    {
+      "tgId": 1,
+      "tests": [
+        {
+          "tcId": 1,
+          "ct": "9953909311"
+        },
+        {
+          "tcId": 2,
+          "ct": "28668408862620085501326992764022466222881643717215081258"
+        }
+	  ]
+	}
+  ]
+}</sourcecode>
+</annex><annex id="app-tdes1-results-ex" inline-header="false" obligation="normative"><title>Example TDES Test and Results JSON Object</title><p id="_79c0803e-5fa8-4f93-9ec4-8be571419f3b">The following is a example JSON object for test vectors sent from the ACVP server to the crypto module for an TDES-ECB algorithm functional test.</p>
+<sourcecode lang="json" id="_dbecb273-f1db-4de4-b757-02be6c0f1ed4">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 1564,
+    "algorithm": "ACVP-TDES-ECB",
+    "revision": "1.0",
+    "testGroups": [{
+        "tgId": 1,
+        "direction": "encrypt",
+        "testType": "AFT",
+        "tests": [{
+            "tcId": 236,
+            "key1": "5BE5B5FE9BB3E36D",
+            "key2": "26E92C6DD35D7AB3",
+            "key3": "4F89ADAD15D62FE3",
+            "pt": "7119CCA0648787AE"
+        }, {
+            "tcId": 237,
+            "key1": "2C7015EC2C044591",
+            "key2": "230D79A1D0F2469D",
+            "key3": "7A9EF7FDC4383131",
+            "pt": "772923F53BA2EA60E7AE232..."
+        }]
+    }]
+}]</sourcecode>
+
+<p id="_d54fcf44-f4e0-4f92-88f4-92dbcdd90972">The following is a example JSON object for test results sent from the crypto module to the ACVP server for an TDES-ECB algorithm functional test.</p>
+<sourcecode lang="json" id="_51359d71-a6b5-4205-a905-0cfd6befc6a4">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 1564,
+    "testGroups": [{
+        "tgId": 1,
+        "tests": [{
+                "tcId": 236,
+                "ct": "1E85F8256575B8B1"
+            },
+            {
+                "tcId": 237,
+                "ct": "BEFD0E02088D48648FEBAAF..."
+            }
+        ]
+    }]
+}]</sourcecode>
+
+<p id="_e927962d-4b28-4cea-9b5f-8daf7e6316f9">The following is a example JSON object for test vectors sent from the ACVP server to the crypto module for the TDES-CFB1 algorithm functional test.</p>
+<sourcecode lang="json" id="_1916287d-ae63-4110-92a8-daa05a6ccc09">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 1564,
+    "algorithm": "ACVP-TDES-CFB1",
+    "revision": "1.0",
+    "testGroups": [{
+            "tgId": 1,
+            "direction": "encrypt",
+            "testType": "AFT",
+            "keyingOption": 1,
+            "tests": [{
+                "tcId": 1,
+                "key1": "1046913489980131",
+                "key2": "1046913489980131",
+                "key3": "1046913489980131",
+                "pt": "00",
+                "payloadLen": 1,
+                "iv": "0000000000000000"
+            }]
+        },
+        {
+            "tgId": 2,
+            "direction": "encrypt",
+            "testType": "MCT",
+            "keyingOption": 1,
+            "tests": [{
+                "tcId": 961,
+                "key1": "337C857E01DE54B7",
+                "key2": "F106296828FCCA0D",
+                "key3": "2F65BF5A655FFFA3",
+                "pt": "80",
+                "payloadLen": 1,
+                "iv": "0C4CCC40D9C8C5D7"
+            }]
+        }
+    ]
+}]</sourcecode>
+
+<p id="_6d83f7cc-0fd0-4306-8a3b-453558fd24cc">The following is a example JSON object for test results sent from the crypto module to the ACVP server for an TDES-CFB1 algorithm functional test.</p>
+<sourcecode lang="json" id="_c74d84b8-1ad7-4155-9862-4ba6e6dab014">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 1564,
+    "testGroups": [{
+            "tgId": 1,
+            "tests": [{
+                "tcId": 1,
+                "ct": "00"
+            }]
+        },
+        {
+            "tgId": 2,
+            "tests": [{
+                "tcId": 961
+                "resultsArray": [{
+                        "key1": "337C857E01DE54B7",
+                        "key2": "F106296828FCCA0D",
+                        "key3": "2F65BF5A655FFFA3",
+                        "pt": "80",
+                        "ct": "00",
+                        "iv": "0C4CCC40D9C8C5D7"
+                    },
+                    {
+                        "key1": "290E7326C8833420",
+                        "key2": "8FE6BF67EF0B2325",
+                        "key3": "3E2976E05EB0646D",
+                        "pt": "80",
+                        "ct": "80",
+                        "iv": "1A73F758C95C6196"
+                    }
+                ]
+            }]
+        }
+    ]
+}]</sourcecode>
+</annex><annex id="app-tdes2-results-ex" inline-header="false" obligation="normative"><title>Example TDES MCT Test and Results JSON Object</title><p id="_406c3e8c-c9bb-42e1-ac8a-a91b16817ccc">The following is a example JSON object for test vectors sent from the ACVP server to the crypto module for an TDES-ECB Monte Carlo test.</p>
+<sourcecode lang="json" id="_22e8e75a-c99f-4f1f-b382-6fe68864f250">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 1564,
+    "algorithm": "ACVP-TDES-ECB",
+    "revision": "1.0",
+    "testGroups": [{
+        "tgId": 1,
+        "direction": "encrypt",
+        "testType": "MCT",
+        "tests": [{
+            "tcId": 492,
+            "key1": "0EABB0E6B0F129D5",
+            "key2": "DF61EAD07315DA37",
+            "key3": "EFA2B6A252A18694",
+            "ct": "2970B363C1461FAF"
+        }]
+    }]
+}]</sourcecode>
+
+<p id="_7a812a14-fc27-42e3-8709-86edac393edc">The following is a example JSON object for test results sent from the crypto module to the ACVP server for an TDES-ECB Monte Carlo test, only 2 iterations shown for brevity. For MCT results of each iteration are fed into the next iteration.  Therefore the results carry all fields to assist in any failure diagnosis.</p>
+<sourcecode lang="json" id="_cd7fc7b5-0663-4ec6-a4ce-1b370b2a74da">[{
+  "acvVersion": "{acvp-version}"
+},{
+    "vsId": 1564,
+    "testGroups": [{
+        "tgId": 1,
+        "tests": [{
+            "tcId": 492,
+            "resultsArray": [{
+                    "key1": "0EABB0E6B0F129D5",
+                    "key2": "DF61EAD07315DA37",
+                    "key3": "EFA2B6A252A18694",
+                    "ct": "2970B363C1461FAF",
+                    "pt": "40F806F9DE3466C0"
+                },
+                {
+                    "key1": "4F52B61F6EC4...",
+                    "key2": "2FEC373726FE...",
+                    "key3": "37B57029B65B...",
+                    "ct": "40F806F9DE3466C0",
+                    "pt": "A498B9748F2FB1E5"
+                }
+            ]
+        }]
+    }]
+}]</sourcecode>
+</annex><bibliography><references id="_references" normative="false" obligation="informative"><title>References</title><bibitem id="RFC2119" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Key words for use in RFCs to Indicate Requirement Levels</title>  <uri type="xml">https://raw.githubusercontent.com/relaton/relaton-data-ietf/master/data/reference.RFC.2119.xml</uri>  <uri type="src">https://www.rfc-editor.org/info/rfc2119</uri>  <docidentifier type="IETF">RFC 2119</docidentifier>  <docidentifier type="rfc-anchor">RFC2119</docidentifier>  <docidentifier type="DOI">10.17487/RFC2119</docidentifier>  <date type="published">    <on>1997-03</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en">S. Bradner</completename>      </name>      <affiliation>        <organization>          <name>Internet Engineering Task Force</name>          <abbreviation>IETF</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <contributor>    <role type="publisher"/>    <organization>      <name>Internet Engineering Task Force</name>      <abbreviation>IETF</abbreviation>    </organization>  </contributor>  <language>en</language>  <script>Latn</script>  <abstract format="text/plain" language="en" script="Latn">In many standards track documents several words are used to signify the requirements in the specification.  These words are often capitalized. This document defines these words as they should be interpreted in IETF documents.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</abstract>  <series type="main">    <title format="text/plain" language="en" script="Latn">BCP</title>    <number>14</number>  </series>  <series type="main">    <title format="text/plain" language="en" script="Latn">RFC</title>    <number>2119</number>  </series>  <place>Fremont, CA</place></bibitem><bibitem id="RFC8174" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</title>  <uri type="xml">https://raw.githubusercontent.com/relaton/relaton-data-ietf/master/data/reference.RFC.8174.xml</uri>  <uri type="src">https://www.rfc-editor.org/info/rfc8174</uri>  <docidentifier type="IETF">RFC 8174</docidentifier>  <docidentifier type="rfc-anchor">RFC8174</docidentifier>  <docidentifier type="DOI">10.17487/RFC8174</docidentifier>  <date type="published">    <on>2017-05</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en">B. Leiba</completename>      </name>      <affiliation>        <organization>          <name>Internet Engineering Task Force</name>          <abbreviation>IETF</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <contributor>    <role type="publisher"/>    <organization>      <name>Internet Engineering Task Force</name>      <abbreviation>IETF</abbreviation>    </organization>  </contributor>  <language>en</language>  <script>Latn</script>  <abstract format="text/plain" language="en" script="Latn">RFC 2119 specifies common key words that may be used in protocol  specifications.  This document aims to reduce the ambiguity by clarifying that only UPPERCASE usage of the key words have the  defined special meanings.</abstract>  <series type="main">    <title format="text/plain" language="en" script="Latn">BCP</title>    <number>14</number>  </series>  <series type="main">    <title format="text/plain" language="en" script="Latn">RFC</title>    <number>8174</number>  </series>  <place>Fremont, CA</place></bibitem><bibitem id="AES-XTS">  <fetched>2021-08-27</fetched>  <title type="main" format="text/plain" language="en" script="Latn">IEEE 1619-2007 — IEEE Standard for Cryptographic Protection of Data on Block-Oriented Storage Devices</title>  <uri type="src">https://standards.ieee.org/standard/1619-2007.html</uri>  <docidentifier type="IEEE">IEEE 1619-2007</docidentifier>  <date type="issued">    <on>2007-12-05</on>  </date>  <date type="published">    <on>2008-03-04</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename>Tom Thompson</completename>      </name>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <abstract format="text/plain" language="en" script="Latn">This standard specifies cryptographic transform and key archival methods for protection of data in sector-level storage devices.</abstract>  <status>    <stage>Superseded</stage>  </status></bibitem><bibitem id="FIPS-197" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Advanced Encryption Standard (AES)</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/fips/197/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.FIPS.197</uri>  <docidentifier type="NIST">FIPS 197</docidentifier>  <date type="published">    <on>2001-11</on>  </date>  <date type="issued">    <on>2001-11</on>  </date>  <contributor>    <role type="author"/>    <organization>      <name>National Institute of Standards and Technology</name>    </organization>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2001</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <place>Gaithersburg, MD</place>  <keyword>algorithm</keyword>  <keyword>block cipher</keyword>  <keyword>ciphertext</keyword>  <keyword>cryptographic algorithm</keyword>  <keyword>cryptographic keys</keyword>  <keyword>decryption</keyword>  <keyword>encryption</keyword></bibitem><bibitem id="SP800-38A" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Recommendation for Block Cipher Modes of Operation — Methods and Techniques</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/sp/800-38a/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.SP.800-38A</uri>  <docidentifier type="NIST">SP 800-38A</docidentifier>  <date type="published">    <on>2001-12</on>  </date>  <date type="issued">    <on>2001-12</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Morris J. Dworkin</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2001</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <place>Gaithersburg, MD</place>  <keyword>block cipher</keyword>  <keyword>cryptography</keyword>  <keyword>encryption</keyword>  <keyword>mode of operation</keyword></bibitem><bibitem id="SP800-38C" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Recommendation for Block Cipher Modes of Operation — the CCM Mode for Authentication and Confidentiality</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/sp/800-38c/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.SP.800-38C</uri>  <docidentifier type="NIST">SP 800-38C</docidentifier>  <date type="published">    <on>2007-07</on>  </date>  <date type="updated">    <on>2007-07</on>  </date>  <date type="issued">    <on>2004-05</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Morris J. Dworkin</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2007</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <relation type="supersedes">    <bibitem>      <formattedref format="text/plain" language="en" script="Latn">SP 800-38C</formattedref>      <uri type="src">https://csrc.nist.gov/publications/detail/sp/800-38c/archive/2004-05-12</uri>    </bibitem>  </relation>  <place>Gaithersburg, MD</place>  <keyword>authentication</keyword>  <keyword>block cipher</keyword>  <keyword>confidentiality</keyword>  <keyword>cryptography</keyword>  <keyword>encryption</keyword>  <keyword>information security</keyword>  <keyword>message authentication code</keyword>  <keyword>authenticated encryption</keyword>  <keyword>mode of operation</keyword></bibitem><bibitem id="SP800-38D" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Recommendation for Block Cipher Modes of Operation — Galois/Counter Mode (GCM) and GMAC</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/sp/800-38d/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.SP.800-38D</uri>  <docidentifier type="NIST">SP 800-38D</docidentifier>  <date type="published">    <on>2007-11</on>  </date>  <date type="issued">    <on>2007-11</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Morris J. Dworkin</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2007</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <place>Gaithersburg, MD</place>  <keyword>Authenticated encryption</keyword>  <keyword>authentication</keyword>  <keyword>block cipher</keyword>  <keyword>confidentiality</keyword>  <keyword>cryptography</keyword>  <keyword>encryption</keyword>  <keyword>information security</keyword>  <keyword>mode of operation.</keyword></bibitem><bibitem id="SP800-38E" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Recommendation for Block Cipher Modes of Operation — the XTS-AES Mode for Confidentiality on Storage Devices</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/sp/800-38e/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.SP.800-38E</uri>  <docidentifier type="NIST">SP 800-38E</docidentifier>  <date type="published">    <on>2010-01</on>  </date>  <date type="issued">    <on>2010-01</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Morris J. Dworkin</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2010</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <place>Gaithersburg, MD</place>  <keyword>Block cipher</keyword>  <keyword>ciphertext stealing</keyword>  <keyword>computer security</keyword>  <keyword>confidentiality</keyword>  <keyword>cryptography</keyword>  <keyword>encryption</keyword>  <keyword>information security mode of operation</keyword>  <keyword>tweakable block cipher.</keyword></bibitem><bibitem id="SP800-38F" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Recommendation for Block Cipher Modes of Operation — Methods for Key Wrapping</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/sp/800-38f/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.SP.800-38F</uri>  <docidentifier type="NIST">SP 800-38F</docidentifier>  <date type="published">    <on>2012-12</on>  </date>  <date type="issued">    <on>2012-12</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Morris J. Dworkin</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2012</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <place>Gaithersburg, MD</place>  <keyword>authenticated encryption</keyword>  <keyword>authentication</keyword>  <keyword>block cipher</keyword>  <keyword>computer security</keyword>  <keyword>confidentiality</keyword>  <keyword>cryptography</keyword>  <keyword>encryption</keyword>  <keyword>information security</keyword>  <keyword>key wrapping</keyword>  <keyword>mode of operation</keyword></bibitem><bibitem id="SP800-38Gr1">
+  <formattedref format="application/x-isodoc+xml"/>
+  <docidentifier type="NIST">NIST SP 800-38G Rev. 1</docidentifier>
+  <docnumber>800-38G Rev. 1</docnumber>
+</bibitem><bibitem id="SP800-67r2" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Recommendation for the Triple Data Encryption Algorithm (TDEA) Block Cipher</title>  <uri type="uri">https://csrc.nist.gov/publications/detail/sp/800-67/rev-2/final</uri>  <uri type="doi">https://doi.org/10.6028/NIST.SP.800-67r2</uri>  <docidentifier type="NIST">SP 800-67 Rev. 2</docidentifier>  <date type="published">    <on>2017-11</on>  </date>  <date type="issued">    <on>2017-11</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Elaine B. Barker</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en" script="Latn">Dr. Nicky Mouha</completename>      </name>      <affiliation>        <organization>          <name>National Institute of Standards and Technology</name>          <abbreviation>NIST</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <language>en</language>  <script>Latn</script>  <status>    <stage>final</stage>    <substage>active</substage>  </status>  <copyright>    <from>2017</from>    <owner>      <organization>        <name>National Institute of Standards and Technology</name>        <abbreviation>NIST</abbreviation>        <uri>www.nist.gov</uri>      </organization>    </owner>  </copyright>  <relation type="supersedes">    <bibitem>      <formattedref format="text/plain" language="en" script="Latn">SP 800-67 Rev. 1</formattedref>      <uri type="src">https://csrc.nist.gov/publications/detail/sp/800-67/rev-1/archive/2012-01-23</uri>    </bibitem>  </relation>  <place>Gaithersburg, MD</place>  <keyword>block cipher</keyword>  <keyword>computer security</keyword>  <keyword>cryptography</keyword>  <keyword>data encryption algorithm</keyword>  <keyword>security</keyword>  <keyword>triple data encryption algorithm</keyword></bibitem><bibitem id="RFC3686" type="standard">  <fetched>2021-08-27</fetched>  <title format="text/plain" language="en" script="Latn">Using Advanced Encryption Standard (AES) Counter Mode With IPsec Encapsulating Security Payload (ESP)</title>  <uri type="xml">https://raw.githubusercontent.com/relaton/relaton-data-ietf/master/data/reference.RFC.3686.xml</uri>  <uri type="src">https://www.rfc-editor.org/info/rfc3686</uri>  <docidentifier type="IETF">RFC 3686</docidentifier>  <docidentifier type="rfc-anchor">RFC3686</docidentifier>  <docidentifier type="DOI">10.17487/RFC3686</docidentifier>  <date type="published">    <on>2004-01</on>  </date>  <contributor>    <role type="author"/>    <person>      <name>        <completename language="en">R. Housley</completename>      </name>      <affiliation>        <organization>          <name>Internet Engineering Task Force</name>          <abbreviation>IETF</abbreviation>        </organization>      </affiliation>    </person>  </contributor>  <contributor>    <role type="publisher"/>    <organization>      <name>Internet Engineering Task Force</name>      <abbreviation>IETF</abbreviation>    </organization>  </contributor>  <language>en</language>  <script>Latn</script>  <abstract format="text/plain" language="en" script="Latn">This document describes the use of Advanced Encryption Standard (AES) Counter Mode, with an explicit initialization vector, as an IPsec Encapsulating Security Payload (ESP) confidentiality mechanism.</abstract>  <series type="main">    <title format="text/plain" language="en" script="Latn">RFC</title>    <number>3686</number>  </series>  <place>Fremont, CA</place></bibitem><bibitem id="ACVP">
+  <fetched>2021-08-27</fetched>
+  <title type="title-main" format="text/plain">Automatic Cryptographic Validation Protocol</title>
+  <title type="main" format="text/plain">Automatic Cryptographic Validation Protocol</title>
+  <docidentifier>ACVP</docidentifier>
+  <date type="published">
+    <on>2019-07-01</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>B.</initial>
+        <surname>Fussell</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>Cisco</name>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>A.</initial>
+        <surname>Vassilev</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>National Institute of Standards and Technology</name>
+          <abbreviation>NIST</abbreviation>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>H.</initial>
+        <surname>Booth</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>National Institute of Standards and Technology</name>
+          <abbreviation>NIST</abbreviation>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>National Institute of Standards and Technology</name>
+      <abbreviation>NIST</abbreviation>
+    </organization>
+  </contributor>
+</bibitem><bibitem id="AES-GCM-SIV">
+  <fetched>2021-08-27</fetched>
+  <title type="title-main" format="text/plain">AES-GCM-SIV Nonce Misuse-Resistant Authenticated Encryption</title>
+  <title type="main" format="text/plain">AES-GCM-SIV Nonce Misuse-Resistant Authenticated Encryption</title>
+  <docidentifier>AES-GCM-SIV</docidentifier>
+  <date type="published">
+    <on>2018</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>S.</initial>
+        <surname>Gueron</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>University of Haifa and Amazon Web Services</name>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>A.</initial>
+        <surname>Langley</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>Google LLC</name>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>Y.</initial>
+        <surname>Lindell</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>Bar Ilan University</name>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>University of Haifa and Amazon Web Services, Google LLC, and Bar Ilan University</name>
+      <abbreviation>UH-AWS-G-BIU</abbreviation>
+    </organization>
+  </contributor>
+</bibitem><bibitem id="SP800-38A-Add">
+  <fetched>2021-08-27</fetched>
+  <title type="title-main" format="text/plain">SP800-38A Addendum Recommendation for Block Cipher Modes of Operation: Three Variants of Ciphertext Stealing for CBC Mode</title>
+  <title type="main" format="text/plain">SP800-38A Addendum Recommendation for Block Cipher Modes of Operation: Three Variants of Ciphertext Stealing for CBC Mode</title>
+  <docidentifier>SP800-38A-Add</docidentifier>
+  <date type="published">
+    <on>2010</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      <name>
+        <initial>M.</initial>
+        <surname>Dworkin</surname>
+      </name>
+      <affiliation>
+        <organization>
+          <name>NIST</name>
+        </organization>
+      </affiliation>
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>National Institute of Standards and Technology</name>
+      <abbreviation>NIST</abbreviation>
+    </organization>
+  </contributor>
+</bibitem><bibitem id="ECMA">
+  <fetched>2021-08-27</fetched>
+  <title type="title-main" format="text/plain">ECMA-368 High Rate Ultra Wideband PHY and MAC Standard</title>
+  <title type="main" format="text/plain">ECMA-368 High Rate Ultra Wideband PHY and MAC Standard</title>
+  <uri type="src">https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-368.pdf</uri>
+  <docidentifier>ECMA</docidentifier>
+</bibitem>          
+
+
+
+</references></bibliography>
+</ietf-standard>

--- a/src/symmetric/sections/04-testtypes.adoc
+++ b/src/symmetric/sections/04-testtypes.adoc
@@ -20,10 +20,11 @@ See <<MC_test>> for implementation details.
 
 The MCTs start with an initial condition (plaintext/ciphertext, key, and optional, or maybe multiple IVs) and perform a series of chained computations. For modes that use an IV, the IV is used in the beginning of each pseudorandom process. The IV is implicitly advanced according to the block cipher mode in use. There are separate rounds of MCT for encryption and decryption. Because some block cipher modes rely on an IV and perform calculations differently from other modes, there are specific definitions of MCT for many of the block cipher modes.
 
-NOTE: For all the following, the pseudocode for decryption can be obtained by replacing all PT's with CT's and all CT's with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
-
 [[AES-ECB-MCT]]
 ===== AES Monte Carlo Test - ECB mode
+
+[[AES-ECB-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY, PT) set to some values.
 
@@ -46,8 +47,16 @@ For i = 0 to 99
     PT[0] = CT[j]
 ----
 
+[[AES-ECB-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[AES-CBC-MCT]]
 ===== AES Monte Carlo Test - CBC mode
+
+[[AES-CBC-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY, IV, PT) set to some values.
 
@@ -77,8 +86,16 @@ For i = 0 to 99
     PT[0] = CT[j-1]
 ----
 
+[[AES-CBC-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[AES-OFB-MCT]]
 ===== AES Monte Carlo Test - OFB mode
+
+[[AES-OFB-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY, IV, PT) set to some values.
 
@@ -108,8 +125,16 @@ For i = 0 to 99
     PT[0] = CT[j-1]
 ----
 
+[[AES-OFB-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[AES-CFB1-MCT]]
 ===== AES Monte Carlo Test - CFB1 mode
+
+[[AES-CFB1-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY, IV, PT) set to some values.
 
@@ -147,8 +172,16 @@ For i = 0 to 99
     PT[0] = CT[j-128]
 ----
 
+[[AES-CFB1-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[AES-CFB8-MCT]]
 ===== AES Monte Carlo Test - CFB8 mode
+
+[[AES-CFB8-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY, IV, PT) set to some values.
 
@@ -186,8 +219,16 @@ For i = 0 to 99
     PT[0] = CT[j-16]
 ----
 
+[[AES-CFB8-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[AES-CFB128-MCT]]
 ===== AES Monte Carlo Test - CFB128 mode
+
+[[AES-CFB128-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY, IV, PT) set to some values.
 
@@ -217,6 +258,11 @@ For i = 0 to 99
     PT[0] = CT[j-1]
 ----
 
+[[AES-CFB128-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[AES_KEY_SHUFFLE]]
 ===== AES Monte Carlo Key Shuffle
 
@@ -239,6 +285,8 @@ If ( keylen = 256 )
 [[TDES-ECB-MCT]]
 ===== TDES Monte Carlo Test - ECB mode
 
+[[TDES-ECB-MCT-ENC]]
+====== Encrypt
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, PT) set to some values.
 
 The algorithm is shown in <<xml_figureMCT_TDES_ECB>>.
@@ -269,8 +317,16 @@ For i = 0 to 399
     PT[0] = CT[j]
 ----
 
+[[TDES-ECB-MCT-DECR]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[TDES-CBC-MCT]]
 ===== TDES Monte Carlo Test - CBC mode
+
+[[TDES-CBC-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values.
 
@@ -309,8 +365,26 @@ For i = 0 to 399
     IV[0] = CT[j]
 ----
 
+[[TDES-CBC-MCT-DECR]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the inner loop in the pseudocode with the following:
+
+[[xml_figureMCT_TDES_CBC_DECR]]
+.TDES-CBC Monte Carlo Test Decrypt
+[source, code]
+----
+    For j = 0 to 9999
+        PT[j] = TDES_CBC_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV[j])
+        CT[j+1] = PT[j]
+        IV[j+1] = CT[j]
+----
+
 [[TDES-CBC-I-MCT]]
 ===== TDES Monte Carlo Test - CBC-I mode
+
+[[TDES-CBC-I-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT1, PT2, PT3) set to some values.
 
@@ -347,10 +421,10 @@ For i = 0 to 399
         IV2[j+1] = CT2[j]
         IV3[j+1] = CT3[j]
     Output CT1[j], CT2[j], CT3[j]
-    Key1[i+1] = Key1[i] xor CT[j]
-    Key2[i+1] = Key2[i] xor CT[j-1]
+    Key1[i+1] = Key1[i] xor CT1[j]
+    Key2[i+1] = Key2[i] xor CT2[j-1]
     If ( keyingOption = 1 )
-        Key3[i+1] = Key3[i] xor CT[j-2]
+        Key3[i+1] = Key3[i] xor CT3[j-2]
     Else
         Key3[i+1] = Key1[i+1]
     PT1[0] = CT1[j-1]
@@ -361,8 +435,58 @@ For i = 0 to 399
     IV3[0] = CT3[j]
 ----
 
+[[TDES-CBC-I-MCT-DECR]]
+====== Decrypt
+
+The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, CT1, CT2, CT3) set to some values.
+
+The algorithm is shown in <<xml_figureMCT_TDES_CBC_I_DECR>>.
+
+[[xml_figureMCT_TDES_CBC_I_DECR]]
+.TDES-CBC-I Monte Carlo Test Decrypt
+[source, code]
+----
+Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+CT1[0] = CT1
+CT2[0] = CT2
+CT3[0] = CT3
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0], IV2[0], IV3[0]
+    Output CT1[0], CT2[0], CT3[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CBC_I_DECRYPT(Key1[i], Key2[i], Key3[i], CT1[j], CT2[j], CT3[j], IV1[j], IV2[j], IV3[j])
+        CT1[j+1] = PT1[j]
+        CT2[j+1] = PT2[j]
+        CT3[j+1] = PT3[j]
+        IV1[j+1] = CT1[j]
+        IV2[j+1] = CT2[j]
+        IV3[j+1] = CT3[j]
+    Output PT1[j], PT2[j], PT3[j]
+    Key1[i+1] = Key1[i] xor PT1[j]
+    Key2[i+1] = Key2[i] xor PT2[j-1]
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor PT3[j-2]
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT1[0] = PT1[j]
+    CT2[0] = PT2[j]
+    CT3[0] = PT3[j]
+    IV1[0] = CT1[j]
+    IV2[0] = CT2[j]
+    IV3[0] = CT3[j]
+----
+
 [[TDES-CFB-MCT]]
 ===== TDES Monte Carlo Test - CFB1, CFB8, CFB64 modes
+
+[[TDES-CFB-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB1 has a feedback size of 1-bit.
 
@@ -399,8 +523,49 @@ For i = 0 to 399
     IV[0] = RightMost_64-K_Bits(IV[j]) || CT[j]
 ----
 
+[[TDES-CFB-MCT-DEC]]
+====== Decrypt
+
+The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, CT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB1 has a feedback size of 1-bit. O[j] is the O~j~ variable internal to the Triple DES operation described in Table 43 of SP 800-20.
+
+The algorithm is shown in <<xml_figureMCT_TDES_CFB_DEC>>.
+
+[[xml_figureMCT_TDES_CFB_DEC]]
+.TDES-CFB Monte Carlo Test Decrypt
+[source, code]
+----
+Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV[0] = IV
+CT[0] = CT
+For i = 0 to 399
+    Output Key1[i]
+    Output Key2[i]
+    Output Key3[i]
+    Output IV[0]
+    Output CT[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CFB_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV[j])
+        CT[j+1] = LeftMost_K_Bits(O[j])
+        IV[j+1] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    Output PT[j]
+    C = LeftMost_192_Bits(PT[j] || PT[j-1] || ... || PT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT[0] = LeftMost_K_Bits(O[j])
+    IV[0] = RightMost_64-K_Bits(IV[j]) || CT[j]
+----
+
 [[TDES-CFB-P-MCT]]
 ===== TDES Monte Carlo Test - CFB1-P, CFB8-P, CFB64-P modes
+
+[[TDES-CFB-P-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB8-P has a feedback size of 8-bits.
 
@@ -423,7 +588,7 @@ For i = 0 to 399
     Output PT[0]
     For j = 0 to 9999
         CT[j] = TDES_CFB_P_ENCRYPT(Key1[i], Key2[i], Key3[i], PT[j], IV1[j], IV2[j], IV3[j])
-        PT[j+1] = LeftMost_K_Bits(IV1[j])
+        PT[j+1] = LeftMost_K_Bits(IV1[j]) <-- This line may not be correct? Compare to SP 800-20 Table 49
     Output CT[j]
     C = LeftMost_192_Bits(CT[j] || CT[j-1] || ... || CT[0])
     Key1[i+1] = Key1[i] xor bits 129-192 of C
@@ -438,8 +603,50 @@ For i = 0 to 399
     IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64
 ----
 
+[[TDES-CFB-P-MCT-DEC]]
+====== Decrypt
+
+The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, CT) set to some values. PT and CT are k-bit where k is the feedback size, for example CFB8-P has a feedback size of 8-bits. O[j] is the O~j~ variable internal to the Triple DES operation described in Table 50 of SP 800-20.
+
+The algorithm is shown in <<xml_figureMCT_TDES_CFB-P-DEC>>.
+
+[[xml_figureMCT_TDES_CFB-P-DEC]]
+.TDES-CFB-P Monte Carlo Test Decrypt
+[source, code]
+----
+Key1[0] = KEY1
+Key2[0] = KEY2
+Key3[0] = KEY3
+IV1[0] = IV1
+IV2[0] = IV2
+IV3[0] = IV3
+CT[0] = CT
+For i = 0 to 399
+    Output Key1[i], Key2[i], Key3[i]
+    Output IV1[0]
+    Output CT[0]
+    For j = 0 to 9999
+        PT[j] = TDES_CFB_P_DECRYPT(Key1[i], Key2[i], Key3[i], CT[j], IV1[j], IV2[j], IV3[j])
+        CT[j+1] = LeftMost_K_Bits(O[j])
+    Output PT[j]
+    C = LeftMost_192_Bits(PT[j] || PT[j-1] || ... || PT[0])
+    Key1[i+1] = Key1[i] xor bits 129-192 of C
+    Key2[i+1] = Key2[i] xor bits 65-128 of C
+    If ( keyingOption = 1 )
+        Key3[i+1] = Key3[i] xor bits 1-64 of C
+    Else
+        Key3[i+1] = Key1[i+1]
+    CT[0] = LeftMost_K_Bits(O[j])
+    IV1[0] = RightMost_64-K_Bits(IV[j]) || CT[j]
+    IV2[0] = IV1[0] + "5555555555555555" mod 2^64
+    IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64
+----
+
 [[TDES-OFB-MCT]]
 ===== TDES Monte Carlo Test - OFB mode
+
+[[TDES-OFB-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV, PT) set to some values.
 
@@ -474,8 +681,16 @@ For i = 0 to 399
     IV[0] = CT[j]
 ----
 
+[[TDES-OFB-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
+
 [[TDES-OFB-I-MCT]]
 ===== TDES Monte Carlo Test - OFB-I mode
+
+[[TDES-OFB-I-MCT-ENC]]
+====== Encrypt
 
 The initial condition for the test is the tuple (KEY1, KEY2, KEY3, IV1, IV2, IV3, PT) set to some values.
 
@@ -511,6 +726,11 @@ For i = 0 to 399
     IV2[0] = IV1[0] + "5555555555555555" mod 2^64
     IV3[0] = IV1[0] + "AAAAAAAAAAAAAAAA" mod 2^64
 ----
+
+[[TDES-OFB-I-MCT-DEC]]
+====== Decrypt
+
+The pseudocode for decryption can be obtained by replacing all PT's in the encryption pseudocode with CT's and all CT's in the encryption pseudocode with PT's. As well, replace the encrypt operation with the corresponding decrypt operation.
 
 === Test Coverage
 


### PR DESCRIPTION
-added decrypt pseudo code for each MCT test
-added instructions to README.md for compiling files with metanorma that are referenced by other files
closes #1192 