### PR TITLE
updates to symmetric spec payloadLen descriptions

### DIFF
--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -34,8 +34,9 @@ Each algorithm capability advertised is a self-contained JSON object and *SHALL*
 | prereqVals| Prerequisite algorithm validations| array of prereqAlgVal objects described in <<prereqs_table>>
 | direction| The IUT processing direction| array of strings
 | keyLen| The supported key lengths in bits| array of integers
-| payloadLen| The supported plain and cipher text lengths in bits. This varies depending on the algorithm type, for additional details see
-<<property_grid_auth>> and <<property_grid_misc>>| domain
+| payloadLen| The supported plain and cipher text lengths in bits. This varies depending on the algorithm type; for 
+additional details see <<property_grid_kw>>, <<property_grid_auth>>, <<property_grid_xts>> and <<property_grid_misc>>. For AES-CTR, the values supplied for this parameter refer to the bit sizes supported in the last incomplete block (less than 128 bits) of the plain or cipher 
+text. | domain
 | ivLen| The supported IV/Nonce lengths in bits, see <<property_grid_auth>>| domain
 | ivGen| IV generation method for AES-GCM/AES-XPN algorithms| string
 | ivGenMode| IV generation mode for AES-GCM/AES-XPN algorithms| string
@@ -134,6 +135,7 @@ The following grid outlines which properties are *REQUIRED*, as well as the poss
 
 The following grid outlines which properties are *REQUIRED*, as well as the possible values a server *MAY* support for the XTS block cipher algorithm:
 
+[[property_grid_xts]]
 .XTS Block Cipher Algorithm Capabilities Applicability Grid
 
 |===
@@ -163,6 +165,7 @@ of capabilities is required. See <<property_grid_ff_capabilities>>
 |===
 
 NOTE: keyingOption 2 *SHALL* only be available for decrypt operations.
+
 NOTE: AES-CTR implementations must support a payloadLen of 128-bits. For AES-CTR, when values less than 128 are supplied for payloadLen, these lengths refer to the bit sizes supported in the last incomplete block (less than 128 bits) of the cipher or plain text.
 
 [[property_grid_ff_capabilities]]

--- a/src/symmetric/sections/06-test-vectors.adoc
+++ b/src/symmetric/sections/06-test-vectors.adoc
@@ -140,7 +140,7 @@ Each test group *SHALL* contain an array of one or more test cases. Each test ca
 | salt| The salt to use in AES-XPN (required for AES-XPN only)| string (hex)
 | pt| Plaintext to use| string (hex)
 | ct| Ciphertext to use| string (hex)
-| payloadLen| Plaintext or Ciphertext length to use in bits. Only the most significant 'payloadLen' bits will be used.| integer
+| payloadLen| The length of the provided Plaintext or Ciphertext in bits. Only the most significant 'payloadLen' bits will be used.| integer
 | dataUnitLen| Length of the data unit in bits for ACVP-AES-XTS| integer
 | aad| AAD to use for AEAD algorithms| string (hex)
 | tag| Tag to use for AEAD algorithms| string (hex)


### PR DESCRIPTION
-fixed an issue where a note in section 7.3 was not displaying
-slight update to the definition of payloadLen in section 8.2
-slight update to the definition of payloadLen in section 7.3
#1234 