### PR TITLE
Updates information on XOF capability `hexCustomization`.

### DIFF
--- a/src/xof/sections/05-capabilities.adoc
+++ b/src/xof/sections/05-capabilities.adoc
@@ -19,7 +19,7 @@ Each algorithm capability advertised is a self-contained JSON object.  The follo
 | algorithm | The algorithm and mode to be validated. | string
 | revision | The algorithm testing revision to use. | string
 | xof | Implementation has the ability to act as an XOF or a non-XOF algorithm | array of boolean
-| hexCustomization | Implementation supports only hexadecimal customization strings (versus ASCII strings) | boolean
+| hexCustomization | An optional feature to the implementation.  When true, "hex" customization strings are supported, otherwise they aren't.  ASCII strings *SHALL* be tested regardless of the value within the `hexCustomization` property. | boolean
 | msgLen | Input length for the XOF | domain
 | outputLen | Output length for the XOF | domain
 | keyLen | Supported key lengths | domain


### PR DESCRIPTION
* Information updated to state that it is "an addon" capability not a "one or the other" as it relates to ASCII customization strings.
* Closes https://github.com/usnistgov/ACVP-Server/issues/141