### PR TITLE
updates for ACVP-Server 140

### DIFF
--- a/src/draft-celi-acvp-eddsa.adoc
+++ b/src/draft-celi-acvp-eddsa.adoc
@@ -54,7 +54,7 @@ include::eddsa/sections/05-eddsa-siggen-capabilities.adoc[]
 
 include::eddsa/sections/05-eddsa-sigver-capabilities.adoc[]
 
-include::common/common-sections/06-test-vector-intro.adoc[]
+//include::common/common-sections/06-test-vector-intro.adoc[]
 
 include::eddsa/sections/06-test-vectors.adoc[]
 

--- a/src/eddsa/sections/05-eddsa-siggen-capabilities.adoc
+++ b/src/eddsa/sections/05-eddsa-siggen-capabilities.adoc
@@ -14,8 +14,8 @@ The complete list of EDDSA signature generation capabilities may be advertised b
 | JSON Value | Description | JSON type | Valid Values
 
 | curve | The curve names supported for the IUT in sigGen | array | Any non-empty subset of {"ED-25519", "ED-448"}
-| pure | If the IUT supports normal 'pure' sigGen functionality | bool | true/false
-| preHash | If the IUT supports accepting a preHashed message to sign | bool | true/false
+| pure | If the IUT supports normal 'pure' EdDSA signature generation functionality | bool | true/false
+| preHash | If the IUT supports Prehash EdDSA, i.e., HashEdDSA, signature generation functionality | bool | true/false
 |===
 
 The following is an example

--- a/src/eddsa/sections/06-eddsa-keygen-test-vectors.adoc
+++ b/src/eddsa/sections/06-eddsa-keygen-test-vectors.adoc
@@ -1,7 +1,7 @@
 [[EDDSA_keyGen_tgjs]]
 === EDDSA keyGen Test Groups JSON Schema
 
-The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the JSON elements of the Test Group JSON object.
 
 The test group for EDDSA / keyGen / 1.0 is as follows:
 
@@ -47,6 +47,7 @@ The following is an example of a prompt for EDDSA / keyGen / 1.0
         "revision": "1.0",
         "testGroups": [
             {
+                "tgId": 1,
                 "curve": "ED-25519",
                 "secretGenerationMode": "extra bits",
                 "testType": "AFT",

--- a/src/eddsa/sections/06-eddsa-keyver-test-vectors.adoc
+++ b/src/eddsa/sections/06-eddsa-keyver-test-vectors.adoc
@@ -1,7 +1,7 @@
 [[EDDSA_keyVer_tgjs]]
 === EDDSA keyVer Test Groups JSON Schema
 
-The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the JSON elements of the Test Group JSON object.
 
 The test group for EDDSA / keyVer / 1.0 is as follows:
 

--- a/src/eddsa/sections/06-eddsa-siggen-test-vectors.adoc
+++ b/src/eddsa/sections/06-eddsa-siggen-test-vectors.adoc
@@ -1,7 +1,7 @@
 [[EDDSA_sigGen_tgjs]]
 === EDDSA sigGen Test Groups JSON Schema
 
-The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the JSON elements of the Test Group JSON object.
 
 The test group for EDDSA / sigGen / 1.0 is as follows:
 
@@ -12,7 +12,7 @@ The test group for EDDSA / sigGen / 1.0 is as follows:
 
 | tgId | The test group identifier | integer
 | curve | The curve type used for the test vectors | string
-| prehash | Whether or not the message is pre-hashed entering the signature function | boolean
+| prehash | Whether or not Prehash EdDSA/HashEdDSA (vs normal/'pure' EdDSA) should be used for the test vectors | boolean
 | testType | The testType for the group | string
 | tests | Array of individual test vector JSON objects, which are defined in <<EDDSA_sigGen_tvjs>> | array
 |===
@@ -29,10 +29,10 @@ Each test group contains an array of one or more test cases. Each test case is a
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set | integer
 | message | The message used to generate the signature | hex
-| context | The context used to generate the signature | hex
+| context | The context string defined in FIPS 186-5 sections 7.6 and 7.8 | hex
 |===
 
-NOTE: The 'context' property will only be present if the 'prehash' group property is set to true.
+NOTE: The 'context' property will only be present for 1) normal/'pure' EdDSA signature generation tests that use Ed448 and 2) Prehash EdDSA/HashEdDSA signature generation tests that use Ed448 or Ed25519.
 
 The following is an example of a prompt for EDDSA / sigGen / 1.0
 

--- a/src/eddsa/sections/06-eddsa-sigver-test-vectors.adoc
+++ b/src/eddsa/sections/06-eddsa-sigver-test-vectors.adoc
@@ -1,7 +1,7 @@
 [[EDDSA_sigVer_tgjs]]
 === EDDSA sigVer Test Groups JSON Schema
 
-The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the secure hash JSON elements of the Test Group JSON object.
+The testGroups element at the top level in the test vector JSON object is an array of test groups. Test vectors are grouped into similar test cases to reduce the amount of data transmitted in the vector set. For instance, all test vectors that use the same key size would be grouped together. The Test Group JSON object contains meta data that applies to all test vectors within the group. The following table describes the JSON elements of the Test Group JSON object.
 
 The test group for EDDSA / sigVer / 1.0 is as follows:
 
@@ -12,7 +12,7 @@ The test group for EDDSA / sigVer / 1.0 is as follows:
 
 | tgId | The test group identifier | integer
 | curve | The curve type used for the test vectors | string
-| prehash | Whether or not the message is pre-hashed entering the signature function | boolean
+| prehash | Whether or not Prehash EdDSA/HashEdDSA (vs normal/'pure' EdDSA) should be used for the test vectors | boolean
 | testType | The testType for the group | string
 | tests | Array of individual test vector JSON objects, which are defined in <<EDDSA_sigVer_tvjs>> | array
 |===

--- a/src/eddsa/sections/06-test-vectors.adoc
+++ b/src/eddsa/sections/06-test-vectors.adoc
@@ -1,7 +1,7 @@
 [[tgjs]]
 == Test Vectors
 
-The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual EDDSA function. This section describes the JSON schema for a test vector set used with EDDSA algorithms.
+The ACVP server provides test vectors to the ACVP client, which are then processed and returned to the ACVP server for validation. A typical ACVP validation session would require multiple test vector sets to be downloaded and processed by the ACVP client. Each test vector set represents an individual EdDSA function. This section describes the JSON schema for a test vector set used with EdDSA algorithms.
 
 The test vector set JSON schema is a multi-level hierarchy that contains meta data for the entire vector set as well as individual test vectors to be processed by the ACVP client.The following table describes the JSON elements at the top level of the hierarchy.
 
@@ -12,8 +12,22 @@ The test vector set JSON schema is a multi-level hierarchy that contains meta da
 
 | acvVersion | Protocol version identifier | string
 | vsId | Unique numeric identifier for the vector set | string
-| algorithm | EDDSA | string
-| mode | The EDDSA mode used for the test vectors | string
-| revision | The algorithm testing revision to use | string
+| algorithm | Algorithm defined in the capability exchange | string
+| mode | Mode defined in the capability exchange | string
+| revision | Protocol test revision selected | string
 | testGroups | Array of test group JSON objects, which are defined in <<EDDSA_keyGen_tgjs>>, <<EDDSA_keyVer_tgjs>>, <<EDDSA_sigGen_tgjs>>, and <<EDDSA_sigVer_tgjs>> | array
 |===
+
+An example of this would look like this
+
+[source,json]
+----
+{
+  "acvVersion": "version",
+  "vsId": 1,
+  "algorithm": "Alg1",
+  "mode": "Mode1",
+  "revision": "Revision1.0",
+  "testGroups": [ ... ]
+}
+----


### PR DESCRIPTION
-update the definitions for the "preHash" parameter
-corrected a note that states when the 'context' parameter appears in signature generation test vectors
-removed duplicate "Test Vectors" section
-small misc. wording changes