### PR TITLE
fix SP800-106 formatting issue in dsa spec

### DIFF
--- a/src/dsa/sections/06-siggen-test-vectors.adoc
+++ b/src/dsa/sections/06-siggen-test-vectors.adoc
@@ -18,7 +18,7 @@ The test group for DSA / sigGen / * is as follows:
 | l | Length in bits of prime modulus p | integer
 | n | Length in bits of prime divisor q | integer
 | hashAlg | The hash algorithm used in the test group | string
-| conformance | Signifies all test cases within the group should utilize random message hashing as described in <SP800-106>>. | string
+| conformance | Signifies all test cases within the group should utilize random message hashing as described in <<SP800-106>>. | string
 | tests | Array of individual test vector JSON objects, which are defined in <<dsa_sigGen_tvjs>> | array
 |===
 

--- a/src/dsa/sections/06-sigver-test-vectors.adoc
+++ b/src/dsa/sections/06-sigver-test-vectors.adoc
@@ -21,7 +21,7 @@ The test group for DSA / sigVer / * is as follows:
 | q | Domain parameter Q | hex
 | g | Domain parameter G | hex
 | hashAlg | The hash algorithm used in the test group | string
-| conformance | Signifies all test cases within the group should utilize random message hashing as described in <SP800-106>>. | string
+| conformance | Signifies all test cases within the group should utilize random message hashing as described in <<SP800-106>>. | string
 | tests | Array of individual test vector JSON objects, which are defined in <<dsa_sigVer_tvjs>> | array
 |===
 
@@ -37,7 +37,7 @@ Each test group contains an array of one or more test cases. Each test case is a
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set | integer
 | message | The message used to generate signature or verify signature | hex
-| randomValue | The random value to be used as an input into the message randomization function as described in <SP800-106>>. | hex
+| randomValue | The random value to be used as an input into the message randomization function as described in <<SP800-106>>. | hex
 | randomValueLen | The random value's bit length. | integer
 | r | The signature component R | hex
 | s | The signature component S | hex

--- a/src/dsa/sections/07-siggen-responses.adoc
+++ b/src/dsa/sections/07-siggen-responses.adoc
@@ -26,7 +26,7 @@ Each test group contains an array of one or more test cases. Each test case is a
 | tcId | The test case identifier | integer
 | r | The signature component R | hex
 | s | The signature component S | hex
-| randomValue | The random value to be used as an input into the message randomization function as described in <SP800-106>>. | hex
+| randomValue | The random value to be used as an input into the message randomization function as described in <<SP800-106>>. | hex
 | randomValueLen | The random value's bit length. | integer
 |===
 


### PR DESCRIPTION
fixed formatting of SP800-106 references in the dsa spec that were causing the metanorma build process to fail