### PR TITLE
first round of updates

### DIFF
--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -159,9 +159,9 @@ The following grid outlines which properties are *REQUIRED*, as well as the poss
 | AES-CBC-CS3| "1.0"| ["encrypt", "decrypt"]| [128, 192, 256]| {"Min": 128, "Max": 65536, "Inc": any}| | | | | | 
 | AES-CTR| "1.0"| ["encrypt", "decrypt"]| [128, 192, 256]| {"Min": 1, "Max": 128, "Inc": any}| | true, false| true, false | true, false | |
 | TDES-CTR| "1.0"| ["encrypt", "decrypt"]| | {"Min": 1, "Max": 64, "Inc": any}| [1, 2] Note: 2 is only available for decrypt operations| true, false| true, false| true, false | |
-| AES-FF1| "1.0"| ["encrypt", "decrypt"]| [128, 192, 256]| {"Min": 128, "Max": 65536, "Inc": any}| | | | | Domain 0-128 bits, mod 8. | At least one set
+| AES-FF1| "1.0"| ["encrypt", "decrypt"]| [128, 192, 256]| | | | | | Domain 0-128 bits, mod 8. | At least one set
 of capabilities is required. See <<property_grid_ff_capabilities>> 
-| AES-FF3-1| "1.0"| ["encrypt", "decrypt"]| [128, 192, 256]| {"Min": 128, "Max": 65536, "Inc": any}| | | | | | At least one set of capabilities is required. See <<property_grid_ff_capabilities>> 
+| AES-FF3-1| "1.0"| ["encrypt", "decrypt"]| [128, 192, 256]| | | | | | | At least one set of capabilities is required. See <<property_grid_ff_capabilities>> 
 |===
 
 NOTE: keyingOption 2 *SHALL* only be available for decrypt operations.

--- a/src/symmetric/sections/06-test-vectors.adoc
+++ b/src/symmetric/sections/06-test-vectors.adoc
@@ -2,7 +2,7 @@
 [[tgjs]]
 === Test Groups
 
-Test vector sets *MUST* contain one or many test groups, each sharing similar properties.  For instance, all test vectors that use the same key size would be grouped together. The testGroups element at the top level of the test vector JSON object *SHALL* be the array of test groups. The Test Group JSON object *MUST* contain meta-data that applies to all test cases within the group.  The following table describes the JSON elements that *MAY* appear from the server in the Test Group JSON object:
+Test vector sets *MUST* contain one or more test groups, each sharing similar properties.  For instance, all test vectors that use the same key size would be grouped together. The testGroups element at the top level of the test vector JSON object *SHALL* be the array of test groups. The Test Group JSON object *MUST* contain meta-data that applies to all test cases within the group.  The following table describes the JSON elements that *MAY* appear from the server in the Test Group JSON object:
 
 [cols="<,<,<"]
 [[vs_tg_table]]
@@ -32,7 +32,6 @@ Some properties *MUST* appear in the prompt file from the server for every testG
 
 * tgId
 * direction
-* payloadLen
 * testType
 * tests
 
@@ -108,11 +107,15 @@ The following grid defines when each property is *REQUIRED* from a server for th
 |===
 | algorithm| revision| keyLen| keyingOption| incremental| overflow| tweakMode| payloadLen
 
-| ACVP-AES-CBC-CS1| "1.0"| 128, 192, 256| | | | | within domain
+| ACVP-AES-CBC-CS1| "1.0"| 128, 192, 256| | | | | 
+| ACVP-AES-CBC-CS2| "1.0"| 128, 192, 256| | | | | 
+| ACVP-AES-CBC-CS3| "1.0"| 128, 192, 256| | | | | 
 | ACVP-AES-CTR| "1.0"| 128, 192, 256| | true, false| true, false| |
 | ACVP-AES-XTS| "1.0"| 128, 256| | | | "hex", "number"| within domain
-| ACVP-AES-XTS| "2.0"| 128, 256| | | | "hex", "number"|
+| ACVP-AES-XTS| "2.0"| 128, 256| | | | "hex", "number"| 
 | ACVP-TDES-CTR| "1.0"| | 1, 2| true, false| true, false| |
+| ACVP-AES-FF1| "1.0"| 128, 192, 256| | | | | 
+| ACVP-AES-FF3-1| "1.0"| 128, 192, 256| | | | | 
 |===
 
 NOTE: The particular values of a domain are *REQUIRED* to be an integer element of the domain present in the registration used. The ACVP server *MAY* select predetermined or random values with particular features (ex. on a block boundary, or not on a block boundary) within the domain the client provided in the registration.


### PR DESCRIPTION
Table 9
-updated table to indicate that the 'payloadLen' parameter is not applicable to FF1 and FF3-1
Test Groups section
-small wording updates
-Table 16
-added entries  for AES-CBC-CS2, AES-CBC-CS3, AES-FF1 and AES-FF3-1
-updated table to indicate that the 'payloadLen' parameter is not required for CS1-CS3