### PR TITLE
fix KAS-ECC 1.0 mode typo

### DIFF
--- a/src/kas/sp800-56ar2/ecc/sections/03-supported.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/03-supported.adoc
@@ -5,4 +5,4 @@
 The following key derivation functions *MAY* be advertised by the ACVP compliant cryptographic module:
 
 * KAS-ECC / null / 1.0
-* KAS-ECC / Component / 1.0
+* KAS-ECC / CDH-Component / 1.0

--- a/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
@@ -41,9 +41,9 @@ Each algorithm capability advertised is a self-contained JSON object using the f
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| algorithm| The algorithm under test| value| KAS-ECC| No
-| mode| The algorithm mode.| value| Component| Yes
-| revision| The algorithm testing revision to use.| value| "1.0"| No
+| algorithm| The algorithm under test| string | "KAS-ECC"| No
+| mode| The algorithm mode.| string | "CDH-Component"| Yes
+| revision| The algorithm testing revision to use.| string | "1.0"| No
 | prereqVals| Prerequisite algorithm validations| array of prereqAlgVal objects| See <<prereq_algs>>| No
 | function| Type of function supported| array| See <<supported_functions>>| No
 | scheme| Array of supported key agreement schemes each having their own capabilities| object| See <<supported_schemes>>| No


### PR DESCRIPTION
-fixed mode typos for KAS-ECC / CDH-Component / 1.0