### PR TITLE
KAS-ECC FFC 1.0 Component updates

### DIFF
--- a/src/kas/sp800-56ar2/ecc/sections/03-supported.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/03-supported.adoc
@@ -5,4 +5,5 @@
 The following key derivation functions *MAY* be advertised by the ACVP compliant cryptographic module:
 
 * KAS-ECC / null / 1.0
+* KAS-ECC / Component / 1.0
 * KAS-ECC / CDH-Component / 1.0

--- a/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
@@ -42,7 +42,7 @@ Each algorithm capability advertised is a self-contained JSON object using the f
 | JSON Value| Description| JSON type| Valid Values| Optional
 
 | algorithm| The algorithm under test| string | "KAS-ECC"| No
-| mode| The algorithm mode.| string | "CDH-Component"| Yes
+| mode | The algorithm mode.| string | null, "Component", or "CDH-Component"| Yes
 | revision| The algorithm testing revision to use.| string | "1.0"| No
 | prereqVals| Prerequisite algorithm validations| array of prereqAlgVal objects| See <<prereq_algs>>| No
 | function| Type of function supported| array| See <<supported_functions>>| No

--- a/src/kas/sp800-56ar2/ffc/sections/03-supported.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/03-supported.adoc
@@ -5,3 +5,4 @@
 The following key derivation functions *MAY* be advertised by the ACVP compliant cryptographic module:
 
 * KAS-FFC / null / 1.0
+* KAS-FFC / Component / 1.0


### PR DESCRIPTION
KAS-ECC 1.0:
-re-listed "Component" as an optional value for mode

KAS-FFC 1.0:
-listed KAS-FFC / Component / 1.0 in the Supported KAS-FFCs section