### PR TITLE
spec updates for ACVP-1246, acvp spec range update

### DIFF
--- a/src/protocol/sections/16-customspec.adoc
+++ b/src/protocol/sections/16-customspec.adoc
@@ -33,7 +33,7 @@ When a "value" is provided along with a "valueLen", the "valueLen" *MUST* be con
 
 === Range
 
-The Range object can be used to convey a range of values. It contains its own set of properties made up of "min", "max", and "increment".
+The Range object can be used to convey a range of values. It contains its own set of properties made up of "min", "max", and "increment". "inc" may be used as a shorthand for "increment." If the "increment" property is omitted, a default value of 1 *SHALL* be used.
 
 ==== Range JSON examples
 

--- a/src/xof/sections/04-testtypes.adoc
+++ b/src/xof/sections/04-testtypes.adoc
@@ -24,10 +24,10 @@ This section describes the design of the tests used to validate implementations 
 ----
 INPUT: The initial Msg is the length of the digest size
 
-MCT(Msg, MaxOutLen, MinOutLen)
+MCT(Msg, MaxOutLen, MinOutLen, OutLenIncrement)
 {
   Range = (MaxOutLen – MinOutLen + 1);
-  OutputLen = (floor(MaxOutLen/8)) * 8;
+  OutputLen = MaxOutLen;
   FunctionName = "";
   Customization = "";
 
@@ -39,7 +39,7 @@ MCT(Msg, MaxOutLen, MinOutLen)
       InnerMsg = Left(Output[i-1] || ZeroBits(128), 128);
       Output[i] = CSHAKE(InnerMsg, OutputLen, FunctionName, Customization);
       Rightmost_Output_bits = Right(Output[i], 16);
-      OutputLen = MinOutLen + (8 * Rightmost_Output_bits % Range);
+      OutputLen = MinOutLen + (floor((Rightmost_Output_bits % Range) / OutLenIncrement) * OutLenIncrement);
       Customization = BitsToString(InnerMsg || Rightmost_Output_bits);
     }
 
@@ -57,10 +57,10 @@ MCT(Msg, MaxOutLen, MinOutLen)
 ----
 INPUT: The initial Msg is the length of the digest size
 
-MCT(Msg, MaxOutLen, MinOutLen, MaxBlockSize, MinBlockSize)
+MCT(Msg, MaxOutLen, MinOutLen, OutLenIncrement, MaxBlockSize, MinBlockSize)
 {
   Range = (MaxOutLen – MinOutLen + 1);
-  OutputLen = (floor(MaxOutLen/8)) * 8;
+  OutputLen = MaxOutLen;
   BlockRange = (MaxBlockSize – MinBlockSize + 1);
   BlockSize = MinBlockSize;
   Customization = "";
@@ -73,7 +73,7 @@ MCT(Msg, MaxOutLen, MinOutLen, MaxBlockSize, MinBlockSize)
       InnerMsg = Left(Output[i-1] || ZeroBits(128), 128);
       Output[i] = ParallelHash(InnerMsg, OutputLen, BlockSize, FunctionName, Customization);
       Rightmost_Output_bits = Right(Output[i], 16);
-      OutputLen = MinOutLen + (8 * Rightmost_Output_bits % Range);
+      OutputLen = MinOutLen + (floor((Rightmost_Output_bits % Range) / OutLenIncrement) * OutLenIncrement);
       BlockSize = MinBlockSize + Right(Rightmost_Output_bits, 8) % BlockRange;
       Customization = BitsToString(InnerMsg || Rightmost_Output_bits);
     }
@@ -92,10 +92,10 @@ MCT(Msg, MaxOutLen, MinOutLen, MaxBlockSize, MinBlockSize)
 ----
 INPUT: The initial Single-Tuple of a random length between 0 and 65536 bits.
 
-MCT(Tuple, MaxOutLen, MinOutLen)
+MCT(Tuple, MaxOutLen, MinOutLen, OutLenIncrement)
 {
   Range = (MaxOutLen – MinOutLen + 1);
-  OutputLen = (floor(MaxOutLen/8)) * 8;
+  OutputLen = MaxOutLen;
   Customization = "";
 
   T[0][0] = Tuple;
@@ -112,7 +112,7 @@ MCT(Tuple, MaxOutLen, MinOutLen)
       }
       Output[i] = TupleHash(T[i], OutputLen, Customization);
       Rightmost_Output_bits = Right(Output[i], 16);
-      OutputLen = MinOutLen + (8 * Rightmost_Output_bits % Range);
+      OutputLen = MinOutLen + (floor((Rightmost_Output_bits % Range) / OutLenIncrement) * OutLenIncrement);
       Customization = BitsToString(T[i][0] || Rightmost_Output_bits);
     }
   

--- a/src/xof/sections/05-capabilities.adoc
+++ b/src/xof/sections/05-capabilities.adoc
@@ -8,7 +8,7 @@ The XOF capabilities *MUST* be advertised as JSON objects within the 'algorithms
 
 Each XOF algorithm capability advertised *SHALL* be a self-contained JSON object.
 
-Each algorithm capability advertised is a self-contained JSON object.  The following JSON values are used for hash algorithm capabilities:
+Each algorithm capability advertised is a self-contained JSON object.  The following JSON values are used for XOF algorithm capabilities:
 
 [cols="<,<,<"]
 [[caps_table]]
@@ -35,12 +35,14 @@ The following grid outlines which properties are *REQUIRED*, as well as all the 
 |===
 | algorithm | xof | hexCustomization | msgLen | outputLen | keyLen | macLen | blockSize
 
-| cSHAKE-128 | | | {Min: 0, Max: 65536} | {Min: 16, Max: 65536} | | |
-| cSHAKE-256 | | | {Min: 0, Max: 65536} | {Min: 16, Max: 65536} | | |
-| KMAC-128 | [true, false] | true, false | {Min: 0, Max: 65536} | {Min: 0, Max: 65536} | {Min: 128, Max: 524288, Inc: 8} | {Min: 32, Max: 65536, Inc: 8} |
-| KMAC-256 | [true, false] | true, false | {Min: 0, Max: 65536} | {Min: 0, Max: 65536} | {Min: 128, Max: 524288, Inc: 8} | {Min: 32, Max: 65536, Inc: 8} |
-| ParallelHash-128 | [true, false] | true, false | {Min: 0, Max: 65536} | {Min: 16, Max: 65536} | | | {Min: 1, Max: 128, Inc: 1}
-| ParallelHash-256 | [true, false] | true, false | {Min: 0, Max: 65536} | {Min: 16, Max: 65536} | | | {Min: 1, Max: 128, Inc: 1}
-| TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536} | {Min: 16, Max: 65536} | | |
-| TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536} | {Min: 16, Max: 65536} | | |
+| cSHAKE-128 | | | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| cSHAKE-256 | | | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| KMAC-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
+| KMAC-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
+| ParallelHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
+| ParallelHash-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
+| TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
 |===
+
+NOTE: For cSHAKE, ParallelHash, and TupleHash, the value for the outputLen property must consist of a single range object. This restriction is made to simplify the implementation of the Monte Carlo Tests for these algorithms (see <<MC_test>>).


### PR DESCRIPTION
ACVP Spec Update:
-updated the description of the range data type to include the "inc" shorthand for "increment" and the default value of 1 that is used when no increment is specified.

ACVP-1246 Updates:
-updated the MCT pseudo code for cSHAKE, ParallelHash, and TupleHash to ensure that the OutputLen values generated honor the OutLenIncrement provided by the tester.
-added information for valid values for Increment for msgLen and outputLen for Table 3.

see https://github.com/usnistgov/ACVP/issues/1246