### PR TITLE
KAS-ECC Sp800-56r3 KDF KC Updates

### DIFF
--- a/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
@@ -124,7 +124,7 @@ Note that AT LEAST one KDF Method is required for KAS schemes.  The following *M
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 
@@ -147,7 +147,7 @@ The one step no counter KDF is a special implementation of the one step KDF.  Th
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
+| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
 | l| The length of the keying material to derive (cannot exceed output length of aux function)| No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
@@ -254,6 +254,7 @@ Note that AT LEAST one mac method must be supplied when making use of Key Confir
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
 | CMAC| Utilizes CMAC as the MAC algorithm. | object| See <<supmacopt>>.  Note that the keyLen must be 128, 192, or 256 for this MAC.| Yes
+| HMAC-SHA-1| Utilizes HMAC-SHA-1 as the MAC algorithm. | object| See <<supmacopt>>| Yes
 | HMAC-SHA2-224| Utilizes HMAC-SHA2-224 as the MAC algorithm. | object| See <<supmacopt>>| Yes
 | HMAC-SHA2-256| Utilizes HMAC-SHA2-256 as the MAC algorithm. | object| See <<supmacopt>>| Yes
 | HMAC-SHA2-384| Utilizes HMAC-SHA2-384 as the MAC algorithm. | object| See <<supmacopt>>| Yes


### PR DESCRIPTION
-added SHA-1 and HMAC-SHA-1 as valid auxFunctions for the oneStep and oneStepNoCounter KDFs
-added HMAC-SHA-1 as a valid auxFunction for key confirmation