### PR TITLE
ANSX963 updates

### DIFF
--- a/src/ans9.63/sections/03-supported.adoc
+++ b/src/ans9.63/sections/03-supported.adoc
@@ -4,4 +4,4 @@
 
 The following key derivation functions *MAY* be advertised by the ACVP compliant cryptographic module:
 
-* kdf-components / ansix9.42 / 1.0
+* kdf-components / ansix9.63 / 1.0

--- a/src/ans9.63/sections/05-capabilities.adoc
+++ b/src/ans9.63/sections/05-capabilities.adoc
@@ -17,10 +17,12 @@ A registration *SHALL* use these properties
 | revision | ACVP Test version | string | "1.0"
 | prereqVals | Prerequisites of the algorithm | object | See <<prerequisites>>
 | hashAlg | SHA functions supported. The digest size of at least one of the hash functions must be within the bounds of the fieldSize | array| See <<valid-sha>>
-| keyDataLength | Key length minimum and maximum | array | 128-4096
-| fieldSize | Minimum and Maximum field size in bits | array | Any non-empty subset of {224, 233, 256, 283, 384, 409, 521, 571}
-| sharedInfoLength | Minimum and Maximum sharedinfo size in bits | domain | Min: 0, Max: 1024
+| keyDataLength | Both the Minimum and the Maximum supported derived key lengths in bits | array | 128-4096
+| fieldSize | The Minimum and Maximum supported elliptic curve field sizes in bits | array | Any one or two element subset of {224, 233, 256, 283, 384, 409, 521, 571}
+| sharedInfoLength | Both the Minimum and Maximum sharedinfo sizes in bits | array | 0-1024
 |===
+
+NOTE: For the keyDataLength, fieldSize, and sharedInfoLength parameters, if the Minimum equals the Maximum, the array should only include the single value. Otherwise, the array should include two values, the one being the Minimum and the other being the Maximum.
 
 An example registration within an algorithm capability exchange looks like this
 


### PR DESCRIPTION
-corrected the "Supported KDFs" from "ansix9.42" to "ansix9.63"
-clarified what is expected for the keyDataLength, fieldSize, and sharedInfoLength parameters for capabilities registrations
closes #1271 