### PR TITLE
Fix KBKDF Capabilities mode name typo

### DIFF
--- a/src/kdf/sections/05-capabilities.adoc
+++ b/src/kdf/sections/05-capabilities.adoc
@@ -63,7 +63,7 @@ The complete list of KDF key generation capabilities may be advertised by the AC
 | customKeyInLength | Optional value used to control the length of the keyIn produced by the ACVP server for the capability.  This field cannot be used to alter the keyIn length for AES/TDES based macModes, as the keyIns expected by those algorithms is fixed. | integer | 112-4096
 |===
 
-NOTE: The 'fixedDataOrder' options "none" and "before iterator" are not valid for "counter" KDF. The 'fixedDataOrder' option "middle fixed data" is not valid for "feedback" nor "double pipeline iterator" KDF.
+NOTE: The 'fixedDataOrder' options "none" and "before iterator" are not valid for "counter" KDF. The 'fixedDataOrder' option "middle fixed data" is not valid for "feedback" nor "double pipeline iteration" KDF.
 
 NOTE: A 'counterLength' of 0 describes that there is no counter used. The 0 option is not valid for "counter"  KDF.
 


### PR DESCRIPTION
In footnote 1 of table 4 under Section 7.3.2. "Supported KDF Modes
Capabilities", Double Pipeline mode is incorrectly referred to as an
"iterator" KDF and not an "iteration" KDF, as in the rest of the
specification.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`