### PR TITLE
Update SHA-MCT pseudocode

### DIFF
--- a/src/sha/sections/04-testtypes.adoc
+++ b/src/sha/sections/04-testtypes.adoc
@@ -23,12 +23,15 @@ The MCTs start with an initial condition (SEED which is a single message) and pe
 [source, code]
 ----
 For j = 0 to 99
-MD[0] = MD[1] = MD[2] = SEED
-	For i = 3 to 1003
-		MSG[i] = MD[i-3] || MD[i-2] || MD[i-1]
-		MD[i] = SHA(MSG[i])
-	Output MD[1002]
-    SEED = MD[1002]
+    A = B = C = SEED
+    For i = 0 to 999
+        MSG = A || B || C
+        MD = SHA(MSG)
+        A = B
+        B = C
+        C = MD
+    Output MD
+    SEED = MD
 ----
 
 [[LD_test]]


### PR DESCRIPTION
I found this code extremely difficult to read.
The Indentation was inconsistent.
Depending on the interpretation of the for loop semantics [0, 99) vs [0, 99],  the inner loop discards the MD[1003] product or the outer loop only produces 99 iterations.
