### PR TITLE
Fix swapped naming of test case fields

### DIFF
--- a/src/tls1.3/sections/06-test-vectors.adoc
+++ b/src/tls1.3/sections/06-test-vectors.adoc
@@ -28,10 +28,10 @@ Each test group contains an array of one or more test cases. Each test case is a
 | tcId | Test case identifier | integer
 | psk | Random pre-shared key, included for PSK and PSK-DHE running modes. | hex
 | dhe | Random Diffie-Hellman shared secret, included for DHE and PSK-DHE running modes. | hex
-| serverHelloRandom | Server hello random value | hex
-| clientHelloRandom | Client hello random value | hex
-| serverFinishedRandom | Server finished random value | hex
-| clientFinishedRandom | Client finished random value | hex
+| helloServerRandom | Server hello random value | hex
+| helloClientRandom | Client hello random value | hex
+| finishedServerRandom | Server finished random value | hex
+| finishedClientRandom | Client finished random value | hex
 |===
 
 Note that when the PSK or DHE are not included in the test case, it is assumed they are the digest size of the group's hash set to zero.  As an example, for a test group using SHA2-256, with a running mode of "DHE", the "PSK" would be represented by a BitString of 256 bits or 32 bytes, all being "0".


### PR DESCRIPTION
In the present version of the spec, table 5 names the fields of the ACVP
test cases. However, the order of the parts of the name (namely,
hello/finished and server/client) are swapped from the value given in
the example and by the Demo server. E.g., `serverHelloRandom` is in
practice called `helloServerRandom`. Fix the two to match.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Must confess this threw one for the better part of two days as I tried to figure out why HKDF was giving wrong answers in an otherwise working TLS implementation. :-) I had copied the JSON field names from the table, rather than look closely at the test vectors themselves, meaning all the `*Random` fields were empty. 