### PR TITLE
Clarify RSA signature primitive response signature format

### DIFF
--- a/src/rsa/sections/07-sigprim-responses.adoc
+++ b/src/rsa/sections/07-sigprim-responses.adoc
@@ -11,7 +11,7 @@ The following table describes the JSON elements for the test case responses for 
 | JSON Value | Description | JSON type
 
 | tcId | Numeric identifier for the test case | integer
-| signature | If the message can be signed, the signature | hex
+| signature | If the message can be signed, the signature. If the encoded value is shorter than the key modulus it should be padded at the front with zero bytes. | hex
 | testPassed | If the message could not be signed | boolean
 |===
 


### PR DESCRIPTION
Test failures were seen with the production ACVP test server when calculated RSA primitive signatures values happened to be shorter than the signing key modulus.
These were avoided by zero padding the result to the size of the modulus.