### PR TITLE
SHA3 1.0 no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ The prod server (acvts.nist.gov) also supports ACVP version 1.0, with the same e
 * [SHA-512](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html)
 * [SHA-512/224](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html)
 * [SHA-512/256](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html)
-* [SHA3-224 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)
-* [SHA3-256 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)
-* [SHA3-384 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)
-* [SHA3-512 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)
+* [SHA3-224 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html) - no longer supported by ACVTS
+* [SHA3-256 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html) - no longer supported by ACVTS
+* [SHA3-384 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html) - no longer supported by ACVTS
+* [SHA3-512 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html) - no longer supported by ACVTS
 * [SHA3-224 2.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)
 * [SHA3-256 2.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)
 * [SHA3-384 2.0](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html)

--- a/index.html
+++ b/index.html
@@ -191,10 +191,10 @@
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha.txt">SHA-512</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha.txt">SHA-512/224</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha.txt">SHA-512/256</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html">HTML</a></li>
-					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-224 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>
-					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-256 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>
-					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-384 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>
-					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-512 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>
+					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-224 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a> - no longer supported by ACVTS</li>
+					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-256 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a> - no longer supported by ACVTS</li>
+					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-384 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a> - no longer supported by ACVTS</li>
+					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-512 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a> - no longer supported by ACVTS</li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-224 2.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-256 2.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.txt">SHA3-384 2.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html">HTML</a></li>


### PR DESCRIPTION
Updates the list of supported algorithms to note that SHA3//1.0 is no longer supported by ACVTS.