### PR TITLE
Try fix Metanorma IEEE reference glitch

### DIFF
--- a/src/symmetric/sections/98-references.adoc
+++ b/src/symmetric/sections/98-references.adoc
@@ -4,7 +4,6 @@
 * [[[RFC2119,RFC 2119]]]
 * [[[RFC8174,RFC 8174]]]
 
-* [[[AES-XTS,IEEE 1619-2007]]]
 * [[[FIPS-197,NIST FIPS 197]]]
 * [[[SP800-38A,NIST SP 800-38A]]]
 
@@ -102,3 +101,19 @@ docid::
 link::
 link.type:: src
 link.content:: https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-368.pdf
+
+[%bibitem]
+=== IEEE 1619-2007 — IEEE Standard for Cryptographic Protection of Data on Block-Oriented Storage Devices
+id:: AES-XTS
+docid::
+  id::: IEEE 1619-2007
+contributor::
+contributor.role:: author
+contributor.person.name.initial:: T.
+contributor.person.name.surname:: Thompson
+date::
+date.type:: published
+date.value:: 4 March 2008
+link::
+link.type:: src
+link.content:: https://standards.ieee.org/standard/1619-2007.html


### PR DESCRIPTION
Try entering the IEEE AES-XTS reference by hand to try to get past the metanorma build failure that occurs when metanorma tries to resolve this reference.