### PR TITLE
ACVP 1217 XTS tweakMode Updates

### DIFF
--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -44,7 +44,7 @@ text. | domain
 | aadLen| The supported AAD lengths in bits for AEAD algorithms| domain
 | tagLen| The supported Tag lengths in bits for AEAD algorithms, see <<property_grid_auth>>| array of integers
 | kwCipher| The cipher as defined in SP800-38F for key wrap mode| array of strings
-| tweakMode| The format of tweak value input for AES-XTS. Hex refers to the tweakValue being a literal hex string. Number refers to the tweakValue being an integer number represented as a hex string.| array of strings
+| tweakMode| Indicates the format(s) of the tweak value input for AES-XTS. A value of "hex" indicates that the IUT expects the tweak value input as a hexadecimal string. A value of "number" indicates that the IUT expects to receive a Data Unit Sequence Number.| array of strings
 | keyingOption| The Keying Option used in TDES.  Keying option 1 (1) is 3 distinct keys (K1, K2, K3).  Keying Option 2 (2) is 2 distinct keys only suitable for decrypt (K1, K2, K1). | array of integers
 | overflowCounter| Indicates if the implementation can handle a counter exceeding the maximum value| boolean
 | incrementalCounter| Indicates if the implementation increments the counter (versus decrementing the counter)| boolean

--- a/src/symmetric/sections/06-test-vectors.adoc
+++ b/src/symmetric/sections/06-test-vectors.adoc
@@ -12,6 +12,7 @@ Test vector sets *MUST* contain one or more test groups, each sharing similar pr
 | JSON Value| Description| JSON type
 
 | tgId| Numeric identifier for the test group, unique across the entire vector set.| integer
+| testType| The test category type (AFT, MCT or counter). See <<testtypes>> for more information about what these tests do, and how to implement them. | string
 | direction| The IUT processing direction: encrypt or decrypt| string
 | ivGen| IV generation method| string
 | ivGenMode| IV generation method| string
@@ -24,7 +25,7 @@ Test vector sets *MUST* contain one or more test groups, each sharing similar pr
 | tagLen| Length of AEAD tag in bits to use| integer
 | alphabet | Characters representing the alphabet in use for the group. ACVP-AES-FF1 and ACVP-AES-FF3-1 only. | string
 | radix | The number base in use for the group (should match the number of characters from the alphabet. ACVP-AES-FF1 and ACVP-AES-FF3-1 only. | integer
-| testType| The test category type (AFT, MCT or counter). See <<testtypes>> for more information about what these tests do, and how to implement them. | string
+| tweakMode | Indicates the format of the tweak value input for AES-XTS. A value of 'hex' indicates that the test cases in the test group will contain a 'tweakValue' element with a 32-character hexadecimal string for a value. A value of 'number' indicates that the test cases in the test group will contain a 'sequenceNumber' (Data Unit Sequence Number) element with an integer value between 0 and 255.| string
 | tests| Array of individual test case JSON objects, which are defined in <<tcjs>>| array of testCase objects
 |===
 
@@ -136,10 +137,10 @@ Each test group *SHALL* contain an array of one or more test cases. Each test ca
 | key| Encryption key to use for AES| string (hex)
 | key1, key2, key3| Encryption keys to use for TDES| string (hex)
 | iv| IV to use| string (hex)
-| tweak| tweak used to form an IV for AES-FF1 and AES-FF3-1 | string (hex)
-| tweakLen| length of the tweak for AES-FF1 and AES-FF3-1 | integer
-| tweakValue| tweakValue used to form an IV for AES-XTS when the tweakMode for the group is 'hex'| string (hex)
-| sequenceNumber| integer used to form an IV for AES-XTS when the tweakMode for the group is 'number'| integer
+| tweak| Tweak used to form an IV for AES-FF1 and AES-FF3-1 | string (hex)
+| tweakLen| Length of the tweak for AES-FF1 and AES-FF3-1 | integer
+| tweakValue| Tweak value used to form an IV for AES-XTS when the tweakMode for the group is 'hex'. A 32-character hexadecimal string. | string (hex)
+| sequenceNumber| (Data Unit Sequence Number) Integer used to form an IV for AES-XTS when the tweakMode for the group is 'number'. An integer between 0 and 255.| integer
 | salt| The salt to use in AES-XPN (required for AES-XPN only)| string (hex)
 | pt| Plaintext to use| string (hex)
 | ct| Ciphertext to use| string (hex)


### PR DESCRIPTION
Updated the descriptions of the tweakMode capability registration property and test group element to clarify their meanings. Also updated the tweakValue and sequenceNumber descriptions to include their ranges.

#1217 