### PR TITLE
Acvp1302KasStaticUnifiedFixes

### DIFF
--- a/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
@@ -112,7 +112,7 @@ Contains properties *REQUIRED* for "noKdfNoKc" registration.
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| parameterSet| The parameterSet options for "noKdfNoKc"| object| <<parameter_set>>| No
+| parameterSet| The parameter sets supported| object| <<parameter_set>>| No
 |===
 
 [[kdfNoKc]]
@@ -125,9 +125,9 @@ Contains properties *REQUIRED* for "kdfNoKc" registration.
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| kdfOption| The kdf options for "kdfNoKc"| object| <<supported_kdfOption>>| No
-| dkmNonceTypes | the dkmNonceTypes supported | array of string | randomNonce, timestamp, sequence, timestampSequence | Required for staticUnified scheme
-| parameterSet| The parameterSet options for "kdfNoKc"| object| <<parameter_set>>| No
+| kdfOption| The kdf options supported| object| <<supported_kdfOption>>| No
+| dkmNonceTypes | The dkmNonceTypes supported | array of string | randomNonce, timestamp, sequence, timestampSequence | Required for staticUnified scheme
+| parameterSet| The parameter sets supported| object| <<parameter_set>>| No
 |===
 
 [[kdfKc]]
@@ -141,9 +141,10 @@ Contains properties *REQUIRED* for "kdfKc" registration.
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| kdfOption| The kdf options for "kdfNoKc"| object| <<supported_kdfOption>>| No
-| kcOption| The kc options for "kdfNoKc"| object| <<supported_kcOption>>| No
-| parameterSet| The parameterSet options for "kdfNoKc"| object| <<parameter_set>>| No
+| kdfOption| The kdf options supported| object| <<supported_kdfOption>>| No
+| dkmNonceTypes | The dkmNonceTypes supported | array of string | randomNonce, timestamp, sequence, timestampSequence | Required for staticUnified scheme
+| kcOption| The kc options supported| object| <<supported_kcOption>>| No
+| parameterSet| The parameter sets supported| object| <<parameter_set>>| No
 |===
 
 [[parameterSet]]
@@ -262,7 +263,7 @@ The following MAC options are available for registration under a "kdfNoKc" and "
 [[oiPatternConstruction]]
 ==== Other Information Construction
 
- Some IUTs *MAY* require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength *MUST* be 240 for FFC, and 376 for ECC. The OI *SHALL* be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement 
+Some IUTs *MAY* require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength *MUST* be 240 for FFC, and 376 for ECC. The OI *SHALL* be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement 
 
 Pattern candidates:
                         

--- a/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
@@ -110,7 +110,7 @@ Contains properties *REQUIRED* for "noKdfNoKc" registration.
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| parameterSet| The parameterSet options for "noKdfNoKc"| object| <<parameter_set>>| No
+| parameterSet| The parameter sets supported| object| <<parameter_set>>| No
 |===
 
 [[kdfNoKc]]
@@ -123,9 +123,9 @@ Contains properties *REQUIRED* for "kdfNoKc" registration.
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| kdfOption| The kdf options for "kdfNoKc"| object| <<supported_kdfOption>>| No
-| dkmNonceTypes | the dkmNonceTypes supported | array of string | randomNonce, timestamp, sequence, timestampSequence | Required for dhStatic scheme
-| parameterSet| The parameterSet options for "kdfNoKc"| object| <<parameter_set>>| No
+| kdfOption| The kdf options supported| object| <<supported_kdfOption>>| No
+| dkmNonceTypes | The dkmNonceTypes supported | array of string | randomNonce, timestamp, sequence, timestampSequence | Required for dhStatic scheme
+| parameterSet| The parameter sets supported| object| <<parameter_set>>| No
 |===
 
 [[kdfKc]]
@@ -139,9 +139,10 @@ Contains properties *REQUIRED* for "kdfKc" registration.
 |===
 | JSON Value| Description| JSON type| Valid Values| Optional
 
-| kdfOption| The kdf options for "kdfNoKc"| object| <<supported_kdfOption>>| No
-| kcOption| The kc options for "kdfNoKc"| object| <<supported_kcOption>>| No
-| parameterSet| The parameterSet options for "kdfNoKc"| object| <<parameter_set>>| No
+| kdfOption| The kdf options supported| object| <<supported_kdfOption>>| No
+| dkmNonceTypes | The dkmNonceTypes supported | array of string | randomNonce, timestamp, sequence, timestampSequence | Required for dhStatic scheme
+| kcOption| The kc options supported| object| <<supported_kcOption>>| No
+| parameterSet| The parameter sets supported| object| <<parameter_set>>| No
 |===
 
 [[parameterSet]]


### PR DESCRIPTION
-added missing "dkmNoncesTypes" entry to KAS ECC/FFC  1.0 kdfKc Capabilities table
-clarified the descriptions of several KAS ECC/FFC mode properties

closes #1302 