### PR TITLE
Clarifies TLS 1.3 KDF hello / finished values

### DIFF
--- a/src/tls1.3/sections/06-test-vectors.adoc
+++ b/src/tls1.3/sections/06-test-vectors.adoc
@@ -28,10 +28,10 @@ Each test group contains an array of one or more test cases. Each test case is a
 | tcId | Test case identifier | integer
 | psk | Random pre-shared key, included for PSK and PSK-DHE running modes. | hex
 | dhe | Random Diffie-Hellman shared secret, included for DHE and PSK-DHE running modes. | hex
-| helloServerRandom | Server hello random value | hex
-| helloClientRandom | Client hello random value | hex
-| finishedServerRandom | Server finished random value | hex
-| finishedClientRandom | Client finished random value | hex
+| helloClientRandom | Randomly generated Client Hello message | hex
+| helloServerRandom | Randomly generated Server Hello message | hex
+| finishedClientRandom | Randomly generated Client Finished message | hex
+| finishedServerRandom | Randomly generated Server Finished message | hex
 |===
 
 Note that when the PSK or DHE are not included in the test case, it is assumed they are the digest size of the group's hash set to zero.  As an example, for a test group using SHA2-256, with a running mode of "DHE", the "PSK" would be represented by a BitString of 256 bits or 32 bytes, all being "0".


### PR DESCRIPTION
Clarifies that the hello*Random finished*Random test case elements are random Hello/Finished messages.

closes #1306