### PR TITLE
Correct KAS-FFC-SSC prerequisites

### DIFF
--- a/src/kas/sp800-56ar3/ssc/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ssc/ffc/sections/05-capabilities.adoc
@@ -26,7 +26,7 @@ KAS has conditional prerequisite algorithms, depending on the capabilities regis
 | DRBG | Always *REQUIRED*
 | SHA | Always *REQUIRED*
 | DSA | DSA KeyGen validation *REQUIRED* when IUT makes use of the "FB" or "FB" (legacy) domain parameters for the generation/validation of keys within the module boundary.
-| SafePrimes | SafePrimes KeyGen/KeyVer validation *REQUIRED* when IUT makes use of the "FB" or "FB" (legacy) domain parameters for the generation/validation of keys within the module boundary.
+| SafePrimes | SafePrimes KeyGen/KeyVer validation *REQUIRED* when IUT makes use of the safe-prime groups for the generation/validation of keys within the module boundary.
 |===
 
 [#properties]


### PR DESCRIPTION
SafePrimes KeyGen/KeyVer testing is required when the IUT makes use of the safe-prime groups for generation/validation of keys

closes #1313