### PR TITLE
Update docker image to known working version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-docker:
     runs-on: ubuntu-latest
-    container: docker://metanorma/mn
+    container: docker://metanorma/mn:1.4.12
     steps:
       - uses: actions/checkout@v2
       - name: Install gems from local Gemfile


### PR DESCRIPTION
seems like a recent change to mn docker container broke builds - rather than using latest docker tag, build against known working version