### PR TITLE
misc ifc, RSA spec fixes

### DIFF
--- a/src/kas/sp800-56br2/sections/03-supported.adoc
+++ b/src/kas/sp800-56br2/sections/03-supported.adoc
@@ -1,7 +1,8 @@
 
 [#supported]
-== Supported KAS-IFC-SSC
+== Supported KAS-IFC and KTS-IFC
 
-The following key derivation functions *MAY* be advertised by the ACVP compliant cryptographic module:
+The following key agreement / key transport scheme and test revision pairs *MAY* be advertised by the ACVP compliant cryptographic module:
 
-* KAS-IFC-SSC / null / SP800-56Br2
+* KAS-IFC / SP800-56Br2
+* KTS-IFC / SP800-56Br2

--- a/src/kas/sp800-56br2/sections/04-testtypes.adoc
+++ b/src/kas/sp800-56br2/sections/04-testtypes.adoc
@@ -11,7 +11,7 @@ There are two test types for KAS testing:
  
 * "AFT" - Algorithm Function Test. In the AFT test mode, the IUT *SHALL* act as a party in the Key Agreement with the ACVP server. The server *SHALL* generate and provide all necessary information for the IUT to perform a successful key agreement; both the server and IUT *MAY* act as party U/V, as well as recipient/provider to key confirmation.
 
-* "VAL" - Validation Test (KAS only). In the VAL test mode, The ACVP server *MUST* generate a complete (from both party U and party V's perspectives) key agreement, and expects the IUT to be able to determine if that agreement is valid. Various types of errors *MSUT* be introduced in varying portions of the key agreement process (changed DKM, changed key, changed hash digest, etc), that the IUT *MUST* be able to detect and report on.
+* "VAL" - Validation Test (KAS only). In the VAL test mode, The ACVP server *MUST* generate a complete (from both party U and party V's perspectives) key agreement, and expects the IUT to be able to determine if that agreement is valid. Various types of errors *MUST* be introduced in varying portions of the key agreement process (changed DKM, changed key, changed hash digest, etc), that the IUT *MUST* be able to detect and report on.
 
 === Test Coverage
 

--- a/src/kas/sp800-56br2/ssc/sections/03-supported.adoc
+++ b/src/kas/sp800-56br2/ssc/sections/03-supported.adoc
@@ -1,7 +1,7 @@
 
 [#supported]
-== Supported KAS-IFCs
+== Supported KAS-IFC-SSC
 
-The following key derivation functions *MAY* be advertised by the ACVP compliant cryptographic module:
+The following shared secret computation and test revision pair *MAY* be advertised by the ACVP compliant cryptographic module:
 
-* KAS-IFC-SSC / null / SP800-56Br2
+* KAS-IFC-SSC / SP800-56Br2

--- a/src/rsa/sections/05-siggen-capabilities.adoc
+++ b/src/rsa/sections/05-siggen-capabilities.adoc
@@ -25,7 +25,7 @@ The following RSA / sigGen / FIPS186-4 capabilities *MAY* be advertised by the A
 | saltLen | supported salt lengths for PSS signature generation - see <<FIPS186-4>>, Section 5.5 | integer | See the note below
 |===
 
-NOTE: The 'saltLen' property for each hash algorithm *SHALL* only be present of the 'sigType' is "pss". The values allowed in PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.
+NOTE: The 'saltLen' property for each hash algorithm *SHALL* only be present if the 'sigType' is "pss". The values allowed in PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.
 
 The following is an example of a registration for RSA / sigGen / FIPS186-4
 
@@ -126,10 +126,10 @@ The following RSA / sigGen / FIPS186-5 capabilities *MAY* be advertised by the A
 | maskFunction | the mask function used, only valid for PSS | array | any non-empty subset of {"mgf1", "shake-128", "shake-256"}
 | hashPair | supported hash algorithms and optional salt length for signature generation for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
 | hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
-| saltLen | supported salt lengths for PSS signature generation - see <<FIPS186-5>>, Section 5.5 | integer | See the note below
+| saltLen | supported salt lengths for PSS signature generation - see <<FIPS186-5>>, Section 5.4 | integer | See the note below
 |===
 
-NOTE: The 'saltLen' property for each hash algorithm *SHALL* only be present of the 'sigType' is "pss". The values allowed in PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.
+NOTE: The 'saltLen' property for each hash algorithm *SHALL* only be present if the 'sigType' is "pss". The values allowed in PSS signature generation is between 0 and the length of the corresponding hash function output block (in bytes), the end points included.
 
 For an example of the RSA / sigGen / FIPS186-5 registration see the following abbreviated example for PSS
 


### PR DESCRIPTION
Clarifies which algorithms are supported by the KAS/KTS-IFC and KAS-IFC-SSC specs.
Corrects several RSA spec typos.