### PR TITLE
hexCustomization cSHAKE Fix

### DIFF
--- a/src/xof/sections/05-capabilities.adoc
+++ b/src/xof/sections/05-capabilities.adoc
@@ -35,8 +35,8 @@ The following grid outlines which properties are *REQUIRED*, as well as all the 
 |===
 | algorithm | xof | hexCustomization | msgLen | outputLen | keyLen | macLen | blockSize
 
-| cSHAKE-128 | | | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
-| cSHAKE-256 | | | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| cSHAKE-128 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| cSHAKE-256 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
 | KMAC-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
 | KMAC-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
 | ParallelHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}


### PR DESCRIPTION
Corrects XOF spec to indicate that the hexCustomization parameter is applicable to the cSHAKE algorithms.