### PR TITLE
AES XTS Revision Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ The prod server (acvts.nist.gov) also supports ACVP version 1.0, with the same e
 * [AES-KWP](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)
 * [AES-OFB](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)
 * [AES-XPN](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)
-* [AES-XTS](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)
+* [AES-XTS 1.0](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html) - no longer supported by ACVTS
+* [AES-XTS 2.0](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)
 * [AES-FF1](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)
 * [AES-FF3-1](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html) - DEMO only
 * [TDES-CBC](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt) - [HTML](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html)

--- a/index.html
+++ b/index.html
@@ -164,7 +164,8 @@
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-KWP</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-OFB</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-XPN</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>
-					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-XTS</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>
+					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-XTS 1.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li> - no longer supported by ACVTS</li>
+					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-XTS 2.0</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-FF1</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">AES-FF3-1</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a> - DEMO only</li>
 					<li><a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.txt">TDES-CBC</a> - <a href="https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html">HTML</a></li>


### PR DESCRIPTION
When AES XTS 1.0 and SHA3 1.0 were deprecated, only SHA3 received a note in the documentation. This update adds the note to the AES XTS 1.0 revision so people know that only 2.0 is accepted by the server.