### PR TITLE
removes deferred from test case JSON schema

### DIFF
--- a/src/kdf/sections/06-test-vectors.adoc
+++ b/src/kdf/sections/06-test-vectors.adoc
@@ -34,12 +34,8 @@ Each test group contains an array of one or more test cases. Each test case is a
 | tcId | Test case idenfitier | integer
 | keyIn | Input key | hex
 | iv | The initialization vector used only for feedback KDFs | hex
-| deferred | Indicates the client is required to provide additional input values to complete the test case | boolean
 |===
 
-NOTE: If the "middle fixed data" option is used for the 'counterLocation', then the test case is deferred from the server. In this case, the client *MUST* provide a 'breakLocation' integer value which is the length of the fixed data before the counter is inserted.
-
-NOTE: If the 'deferred' property is not present, it *MAY* be assumed to be 'false'.
 
 === Example Test Vector JSON Object
 

--- a/src/kdf/sections/07-responses.adoc
+++ b/src/kdf/sections/07-responses.adoc
@@ -53,7 +53,8 @@ The following table describes the JSON properties that represent a test case res
 | JSON Property | Description | JSON Type
 
 | tcId | The test case identifier | integer
-| breakLocation | The bit location in the fixed data where the counter is placed | integer
+| breakLocation | The bit location in the fixed data where the counter is placed. breakLocation is only applicable 
+and *SHALL* be included for test cases where counterLocation is "middle fixed data". | integer
 | fixedData | The fixed input data used by the IUT | hex
 | keyOut | The outputted keying material or key | hex
 |===


### PR DESCRIPTION
Clarifies when breakLocation is required in a test vector response.
Removes "deferred" from the Test Case JSON Schema. Considering ACVTS' notion of a "deferred" test case, all SP800-108 test cases would be considered "deferred". However,  including the deferred designation in the test case JSON doesn't provide any additional value to a client and so it is being removed.

Addresses https://github.com/usnistgov/ACVP-Server/issues/182