### PR TITLE
Case fixes for xof algo names

### DIFF
--- a/src/xof/sections/03-supported.adoc
+++ b/src/xof/sections/03-supported.adoc
@@ -4,12 +4,12 @@
 
 The following XOFs may be advertised by this ACVP compliant crypto module:
 
-* cSHAKE-128
-* cSHAKE-256
-* parallelHash-128
-* parallelHash-256
-* tupleHash-128
-* tupleHash-256
+* CSHAKE-128
+* CSHAKE-256
+* PARALLELHASH-128
+* PARALLELHASH-256
+* TUPLEHASH-128
+* TUPLEHASH-256
 * KMAC-128
 * KMAC-256
 

--- a/src/xof/sections/05-capabilities.adoc
+++ b/src/xof/sections/05-capabilities.adoc
@@ -24,7 +24,7 @@ Each algorithm capability advertised is a self-contained JSON object.  The follo
 | outputLen | Output length for the XOF | domain
 | keyLen | Supported key lengths | domain
 | macLen | Supported MAC lengths | domain
-| blockSize | blockSize (in bits) to be used with ParallelHash | domain
+| blockSize | blockSize (in bits) to be used with PARALLELHASH | domain
 |===
 
 The following grid outlines which properties are *REQUIRED*, as well as all the possible values a server *MAY* support for XOF algorithms:
@@ -35,14 +35,14 @@ The following grid outlines which properties are *REQUIRED*, as well as all the 
 |===
 | algorithm | xof | hexCustomization | msgLen | outputLen | keyLen | macLen | blockSize
 
-| cSHAKE-128 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
-| cSHAKE-256 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| CSHAKE-128 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| CSHAKE-256 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
 | KMAC-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
 | KMAC-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
-| ParallelHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
-| ParallelHash-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
-| TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
-| TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| PARALLELHASH-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
+| PARALLELHASH-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
+| TUPLEHASH-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
+| TUPLEHASH-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
 |===
 
-NOTE: For cSHAKE, ParallelHash, and TupleHash, the value for the outputLen property must consist either of a single range object or a single literal value. This restriction is made to simplify the implementation of the Monte Carlo Tests for these algorithms (see <<MC_test>>).
+NOTE: For CSHAKE, PARALLELHASH, and TUPLEHASH, the value for the outputLen property must consist either of a single range object or a single literal value. This restriction is made to simplify the implementation of the Monte Carlo Tests for these algorithms (see <<MC_test>>).

--- a/src/xof/sections/97-examples.adoc
+++ b/src/xof/sections/97-examples.adoc
@@ -3,7 +3,7 @@
 [[app-reg-ex]]
 == Example Capabilities JSON Objects
 
-The following is an example JSON object advertising support for cSHAKE-128.
+The following is an example JSON object advertising support for CSHAKE-128.
 
 [align=left,alt=,type=]
 [source, json]
@@ -64,13 +64,13 @@ The following is an example JSON object advertising support for KMAC-128.
 }
 ----
 
-The following is an example JSON object advertising support for ParallelHash-128.
+The following is an example JSON object advertising support for PARALLELHASH-128.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 {
-  "algorithm": "ParallelHash-128",
+  "algorithm": "PARALLELHASH-128",
   "revision": "1.0",
   "xof": [true, false],
   "hexCustomization": false,
@@ -98,13 +98,13 @@ The following is an example JSON object advertising support for ParallelHash-128
 }
 ----
 
-The following is an example JSON object advertising support for TupleHash-128.
+The following is an example JSON object advertising support for TUPLEHASH-128.
 
 [align=left,alt=,type=]
 [source, json]
 ----
 {
-  "algorithm": "TupleHash-128",
+  "algorithm": "TUPLEHASH-128",
   "revision": "1.0",
   "xof": [true, false],
   "hexCustomization": false,
@@ -129,7 +129,7 @@ The following is an example JSON object advertising support for TupleHash-128.
 [[app-vs-ex]]
 == Example Test Vectors JSON Objects
 
-The following is an example JSON object for cSHAKE test vectors sent from the ACVP server to the crypto module.
+The following is an example JSON object for CSHAKE test vectors sent from the ACVP server to the crypto module.
 
 [align=left,alt=,type=]
 [source, json]
@@ -253,7 +253,7 @@ The following is an example JSON object for KMAC test vectors sent from the ACVP
 ]
 ----
 
-The following is an example JSON object for ParallelHash test vectors sent from the ACVP server to the crypto module.
+The following is an example JSON object for PARALLELHASH test vectors sent from the ACVP server to the crypto module.
 
 [align=left,alt=,type=]
 [source, json]
@@ -262,7 +262,7 @@ The following is an example JSON object for ParallelHash test vectors sent from 
 { "acvVersion": <acvp-version> },
 {
   "vsId": 0,
-  "algorithm": "ParallelHash-128",
+  "algorithm": "PARALLELHASH-128",
   "revision": "1.0",
   "testGroups": [
     {
@@ -309,7 +309,7 @@ The following is an example JSON object for ParallelHash test vectors sent from 
 ]
 ----
 
-The following is an example JSON object for TupleHash test vectors sent from the ACVP server to the crypto module.
+The following is an example JSON object for TUPLEHASH test vectors sent from the ACVP server to the crypto module.
 
 [align=left,alt=,type=]
 [source, json]
@@ -318,7 +318,7 @@ The following is an example JSON object for TupleHash test vectors sent from the
 { "acvVersion": <acvp-version> },
 {
   "vsId": 0,
-  "algorithm": "TupleHash-128",
+  "algorithm": "TUPLEHASH-128",
   "revision": "1.0",
   "testGroups": [
     {
@@ -371,7 +371,7 @@ The following is an example JSON object for TupleHash test vectors sent from the
 [[app-results-ex]]
 == Example Test Results JSON Objects
 
-The following is an example JSON object for cSHAKE test results sent from the crypto module to the ACVP server. The JSON objects for ParallelHash and TupleHash match this schema.
+The following is an example JSON object for CSHAKE test results sent from the crypto module to the ACVP server. The JSON objects for PARALLELHASH and TUPLEHASH match this schema.
 
 [align=left,alt=,type=]
 [source, json]


### PR DESCRIPTION
Updates the casing for the TUPLEHASH, PARALLELHASH, and CSHAKE algorithm names to what is required by the server, i.e., the algorithm names must be uppercase.

Closes #1345 
