### PR TITLE
Corrects OI bitlen requirement

### DIFF
--- a/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ecc/sections/05-capabilities.adoc
@@ -263,7 +263,7 @@ The following MAC options are available for registration under a "kdfNoKc" and "
 [[oiPatternConstruction]]
 ==== Other Information Construction
 
-Some IUTs *MAY* require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength *MUST* be 240 for FFC, and 376 for ECC. The OI *SHALL* be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement 
+Some IUTs *MAY* require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength *MUST* be at least 240 for FFC, and at least 376 for ECC. The OI *SHALL* be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement 
 
 Pattern candidates:
                         
@@ -275,8 +275,8 @@ Pattern candidates:
     *** dkmNonce is provided by party u for static schemes
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
                             
-* vPartyInfo { || ephemeralKey } { || ephemeralNonce } 
-  ** vPartyId
+* vPartyInfo  
+  ** vPartyId { || ephemeralKey } { || ephemeralNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
                           
 * counter 

--- a/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar2/ffc/sections/05-capabilities.adoc
@@ -241,7 +241,7 @@ The following MAC options are available for registration under a "kdfNoKc" and "
 [[oiPatternConstruction]]
 ==== Other Information Construction
 
-Some IUTs *MAY* require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength *MUST* be 240 for FFC, and 376 for ECC. The OI will be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement 
+Some IUTs *MAY* require a specific pattern for the OtherInfo portion of the KDFs for KAS. An "oiPattern" is specified in the KDF registration to accommodate such requirements. Regardless of the oiPattern specified, the OI bitlength *MUST* be at least 240 for FFC, and at least 376 for ECC. The OI will be padded with random bits (or the most significant bits utilized) when the specified OI pattern does not meet the bitlength requirement 
 
 Pattern candidates:
 						
@@ -253,8 +253,8 @@ Pattern candidates:
     *** dkmNonce is provided by party u for static schemes
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
 
-* vPartyInfo { || ephemeralKey } { || ephemeralNonce } 
-  ** vPartyId
+* vPartyInfo  
+  ** vPartyId { || ephemeralKey } { || ephemeralNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
 							
 * counter 


### PR DESCRIPTION
Corrects the OI bitlen requirement to be "at least" 240 for FFC, and 376 for ECC.

closes https://github.com/usnistgov/ACVP/issues/1343