### PR TITLE
Fix/acvp1326 xof mct clarifications

### DIFF
--- a/src/xof/sections/04-testtypes.adoc
+++ b/src/xof/sections/04-testtypes.adoc
@@ -50,6 +50,8 @@ MCT(Msg, MaxOutLen, MinOutLen, OutLenIncrement)
 }
 ----
 
+NOTE: For the "Rightmost_Output_bits % Range" operation, the Rightmost_Output_bits bit string should be interpretted as a little endian-encoded number. 
+
 [[ParallelHash-MCT]]
 ==== ParallelHash Monte Carlo Test
 
@@ -84,6 +86,8 @@ MCT(Msg, MaxOutLen, MinOutLen, OutLenIncrement, MaxBlockSize, MinBlockSize)
   return OutputJ;
 }
 ----
+
+NOTE: For the "Rightmost_Output_bits % Range" operation, the Rightmost_Output_bits bit string should be interpretted as a little endian-encoded number. For "Right(Rightmost_Output_bits, 8) % BlockRange", the bit string resulting from the "Right(Rightmost_Output_bits, 8)" operation should be interpretted as a little endian-encoded number.
 
 [[TupleHash-MCT]]
 ==== TupleHash Monte Carlo Test
@@ -123,8 +127,13 @@ MCT(Tuple, MaxOutLen, MinOutLen, OutLenIncrement)
 }
 ----
 
+NOTE: For "Left(workingBits, 3) % 4", the bit string resulting from the "Left(workingBits, 3)" operation should be interpretted as a little endian-encoded number. For the "Rightmost_Output_bits % Range" operation, the Rightmost_Output_bits bit string should be interpretted as a little endian-encoded number.
+
+[xof-mct-functions]
+==== Functions Used in the Monte Carlo Tests for XOFs
+
 [bitsToString]
-==== BitsToString Function
+===== BitsToString Function
 
 [source, code]
 ----
@@ -137,6 +146,18 @@ BitsToString(bits)
   }
 }
 ----
+
+[left-mct-function]
+===== Left() Function
+The function Left(bitString, numberOfBits) returns the leftmost numberOfBits bits of bitString.
+
+[right-mct-function]
+===== Right() Function
+The function Right(bitString, numberOfBits) returns the rightmost numberOfBits bits of bitString.
+
+[zero-mct-function]
+===== ZeroBits() Function
+The function ZeroBits(numberOfBits) returns an all-zero bit string of length numberOfBits bits.
 
 === Test Coverage
 

--- a/src/xof/sections/06-test-vectors.adoc
+++ b/src/xof/sections/06-test-vectors.adoc
@@ -15,6 +15,11 @@ Test vector sets *MUST* contain one or many test groups, each sharing similar pr
 | xof | Whether or not the group uses the arbitrary output (XOF) version of the algorithm | boolean
 | hexCustomization | Whether or not the group uses customization strings in hex (true) or ASCII (false) | boolean
 | tests | Array of individual test case JSON objects, which are defined in <<tcjs>> | array of testCase objects
+| minOutLen | The minimum outputLen as specified in the capabilities registration (used in monte carlo tests). | integer
+| maxOutLen | The maximum outputLen as specified in the capabilities registration (used in monte carlo tests). | integer
+| outLenIncrement | The outputLen increment as specified in the capabilities registration (used in monte carlo tests). | integer
+| minBlockSize | The minimum blockSize as specified in the capabilities registration (used in ParallelHash monte carlo tests). | integer
+| maxBlockSize | The maximum blockSize as specified in the capabilities registration (used in ParallelHash monte carlo tests). | integer
 |===
 
 [[tcjs]]

--- a/src/xof/sections/97-examples.adoc
+++ b/src/xof/sections/97-examples.adoc
@@ -168,10 +168,13 @@ The following is an example JSON object for cSHAKE test vectors sent from the AC
       "tgId": 2,
       "testType": "MCT",
       "hexCustomization": false,
+      "minOutLen": 256,
+      "maxOutLen": 4096,
+      "outLenIncrement": 1,
       "tests": [
         {
-          "tcId": 251,
-          "msg": "5FB4BAE618DABE000B9FDAB178388671",
+          "tcId": 101,
+          "msg": "EDAF0D79E36F13461FE18B098F77A76B",
           "len": 128,
           "functionName": "",
           "customization": ""
@@ -295,12 +298,19 @@ The following is an example JSON object for ParallelHash test vectors sent from 
       "testType": "MCT",
       "function": "ParallelHash",
       "xof": true,
+      "minBlockSize": 1,
+      "maxBlockSize": 16,
       "hexCustomization": false,
+      "minOutLen": 256,
+      "maxOutLen": 4096,
+      "outLenIncrement": 1,
       "tests": [
         {
-          "tcId": 501,
-          "msg": "5ABA124055F84766A91603B7D1B57243",
-          "len": 128
+          "tcId": 201,
+          "msg": "8A4609316F3BCB102CBBD6428E7E1FC8",
+          "len": 128,
+          "blockSize": 256,
+          "customization": ""
         }
       ]
     }
@@ -350,15 +360,19 @@ The following is an example JSON object for TupleHash test vectors sent from the
       "tgId": 3,
       "testType": "MCT",
       "xof": true,
+      "minOutLen": 256,
+      "maxOutLen": 512,
+      "outLenIncrement": 8,
       "tests": [
         {
-          "tcId": 381,
+          "tcId": 201,
           "tuple": [
-            "B1D95CA98C5AB973C5BB25B1880A67EC1AA78582DBC7877EFDAC53EF31516E0ED0E125A5"
+            ""
           ],
           "len": [
-            288
-          ]
+            0
+          ],
+          "customization": ""
         }
       ]
     }


### PR DESCRIPTION
Defines the functions used in the cSHAKE, ParallelHash and TupleHash MCT tests. Clarifies that bit strings used in the MCT tests, when converted to a number, are considered little endian. Adds descriptions of several test group level properties used in MCT tests.