### PR TITLE
[shake-mct] Fix typo

### DIFF
--- a/src/sha3/sections/04-testtypes.adoc
+++ b/src/sha3/sections/04-testtypes.adoc
@@ -57,7 +57,7 @@ For j = 0 to 99
         MSG[i] = 128 leftmost bits of MD[i-1]
         if (MSG[i] < 128 bits)
             Append 0 bits on rightmost side of MSG[i] til MSG[i] is 128 bits
-        MD[i] = SHAKE(M[i], OutputLen * 8)
+        MD[i] = SHAKE(MSG[i], OutputLen * 8)
 
         if (i != 1000)
             RightmostOutputBits = 16 rightmost bits of MD[i] as an integer


### PR DESCRIPTION
I think SHAKE takes ``MSG`` as an input. Otherwise ``M`` is not defined.