### PR TITLE
Moved the TestVector Response documentation for multi expansion group…

### DIFF
--- a/src/kas/sp800-56c/onestep/sections/07-responses.adoc
+++ b/src/kas/sp800-56c/onestep/sections/07-responses.adoc
@@ -33,7 +33,6 @@ The following table describes the JSON object that represents a test case respon
 | tcId | The test case identifier | integer
 | testPassed | Was the provided `dkm` valid? Only valid for the "VAL" test type. | boolean
 | dkm | The derived keying material. Provided by the IUT for "AFT" test type test cases. For single expansion tests. | hex
-| dkms | The derived keying materials. Provided by the IUT for "AFT" test type test cases. For multi expansion groups. | array of hex
 
 |===
 

--- a/src/kas/sp800-56c/twostep/sections/07-responses.adoc
+++ b/src/kas/sp800-56c/twostep/sections/07-responses.adoc
@@ -33,6 +33,8 @@ The following table describes the JSON object that represents a test case respon
 | tcId | The test case identifier | integer
 | testPassed | Was the provided `dkm` valid? Only valid for the "VAL" test type. | boolean
 | dkm | The derived keying material. Provided by the IUT for "AFT" test type test cases. | hex
+| dkms | The derived keying materials. Provided by the IUT for "AFT" test type test cases. For multi expansion groups. | array of hex
+
 |===
 
 Here is an abbreviated example of the response


### PR DESCRIPTION
Fix for #1360 

Fixed the KSA SP800-56C documentation error for OneStep & TwoStep MultiExpansionGroups support. As reported, the Capabilities documentation files are correct, but the Responses documentation files do not. After checking the code, the Capabilities is correct, so I changed the Response files accordingly.
