### PR TITLE
Update 06-test-vectors.adoc

### DIFF
--- a/src/kas/sp800-56c/hkdf/sections/06-test-vectors.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/06-test-vectors.adoc
@@ -61,7 +61,7 @@ Each test group contains an array of one or more test cases. Each test case is a
 | JSON Value | Description | JSON Type
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set. | integer
-|dkm | Value for VAL tests. | hex
+| dkm | Derived keying material value for VAL tests. | hex
 | kdfParameter | Object representing inputs into the KDA for single expansion tests. | See <<kdfParameter>>.
 | fixedInfoPartyU | Fixed information specific to party U for single expansion tests. | See <<fixedInfo>>.
 | fixedInfoPartyV | Fixed information specific to party V for single expansion tests. | See <<fixedInfo>>.

--- a/src/kas/sp800-56c/hkdf/sections/06-test-vectors.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/06-test-vectors.adoc
@@ -11,6 +11,7 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | testType | Describes the operation the client should perform on the tests data | string
 | tests | Array of individual test cases | See <<testCase>>
 | kdfConfiguration | Describes the KDA configuration values used for single expansion groups. | See <<kdfconfig>>
+| multiExpansion | Should multi expansion tests be run (true or false)? | boolean
 | kdfMultiExpansionConfiguration | Describes the KDA configuration values used for multi expansion groups. | See <<kdfmulticonfig>>
 |===
 
@@ -59,7 +60,8 @@ Each test group contains an array of one or more test cases. Each test case is a
 |===
 | JSON Value | Description | JSON Type
 
-| tcId | Numeric identifier for the test case, unique across the entire vector set.
+| tcId | Numeric identifier for the test case, unique across the entire vector set. | integer
+|dkm | Value for VAL tests. | hex
 | kdfParameter | Object representing inputs into the KDA for single expansion tests. | See <<kdfParameter>>.
 | fixedInfoPartyU | Fixed information specific to party U for single expansion tests. | See <<fixedInfo>>.
 | fixedInfoPartyV | Fixed information specific to party V for single expansion tests. | See <<fixedInfo>>.


### PR DESCRIPTION
Fixes the Table 5 and Table 8 issues identified in Issues 1370 and 1369.