### PR TITLE
Update 06-test-vectors.adoc

### DIFF
--- a/src/kas/sp800-56c/twostep/sections/06-test-vectors.adoc
+++ b/src/kas/sp800-56c/twostep/sections/06-test-vectors.adoc
@@ -10,7 +10,6 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | tgId | Test group identifier | integer
 | testType | Describes the operation the client should perform on the tests data | string
 | tests | Array of individual test cases | See <<testCase>>
-| kdfConfiguration | Describes the KDA configuration values used for the group | See <<kdfconfig>>
 | kdfConfiguration | Describes the KDA configuration values used for single expansion groups. | See <<kdfconfig>>
 | kdfMultiExpansionConfiguration | Describes the KDA configuration values used for multi expansion groups. | See <<kdfmulticonfig>>
 |===
@@ -62,7 +61,8 @@ Each test group contains an array of one or more test cases. Each test case is a
 |===
 | JSON Value | Description | JSON Type
 
-| tcId | Numeric identifier for the test case, unique across the entire vector set.
+| tcId | Numeric identifier for the test case, unique across the entire vector set. | integer
+|dkm | Value for VAL tests. | hex
 | kdfParameter | Object representing inputs into the KDA for single expansion tests. | See <<kdfParameter>>.
 | fixedInfoPartyU | Fixed information specific to party U for single expansion tests. | See <<fixedInfo>>.
 | fixedInfoPartyV | Fixed information specific to party V for single expansion tests. | See <<fixedInfo>>.

--- a/src/kas/sp800-56c/twostep/sections/06-test-vectors.adoc
+++ b/src/kas/sp800-56c/twostep/sections/06-test-vectors.adoc
@@ -62,7 +62,7 @@ Each test group contains an array of one or more test cases. Each test case is a
 | JSON Value | Description | JSON Type
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set. | integer
-|dkm | Value for VAL tests. | hex
+|dkm | Derived keying material value for VAL tests. | hex
 | kdfParameter | Object representing inputs into the KDA for single expansion tests. | See <<kdfParameter>>.
 | fixedInfoPartyU | Fixed information specific to party U for single expansion tests. | See <<fixedInfo>>.
 | fixedInfoPartyV | Fixed information specific to party V for single expansion tests. | See <<fixedInfo>>.


### PR DESCRIPTION
Fixes Table 6 and Table 9 issues identified in Issues 1371 and 1369.