### PR TITLE
KAS/KDA fixedInfoConstructionPattern updates

### DIFF
--- a/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
@@ -89,8 +89,8 @@ All other scheme capabilities are advertised as a self-contained JSON object usi
 
 | kasRole| Roles supported for key agreement| array| initiator and/or responder| No
 | kdfMethods| The KDF methods to use when testing KAS schemes. | object| <<kdfmethods>>| No
-| keyConfirmationMethod| The KeyCnfirmation capabilities (when supported) for the scheme.| object| <<keyconfirmmethod>>| Yes
-| l| The length of the key to derive (using a KDF) or transport (using a KTS scheme).  This value should be large enough to
+| keyConfirmationMethod| The KeyConfirmation capabilities (when supported) for the scheme.| object| <<keyconfirmmethod>>| Yes
+| l | The length of the key to derive (using a KDF) or transport (using a KTS scheme).  This value should be large enough to
 accommodate the key length used for the mac algorithms in use for key confirmation, ideally the maximum value the IUT can support 
 with their KAS/KTS implementation.  Maximum value (for testing purposes) is 1024.| integer| 128 minimum without KC, 136 minimum with
 KC, maximum 1024.| No
@@ -150,8 +150,8 @@ The one step no counter KDF is a special implementation of the one step KDF.  Th
 |===
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
-| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
-| l| The length of the keying material to derive (cannot exceed output length of aux function)| No
+| auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No 
+| l | The length of the keying material to derive (cannot exceed output length of aux function)| integer | may not exceed output length of aux function  |No 
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 
@@ -215,12 +215,22 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
 
   ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** "Optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
+    { || ephemeralNonce } { || dkmNonce } { || c }".
+    *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
+    for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
 
 * vPartyInfo
 
   ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** "Optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
+    { || ephemeralNonce } { || dkmNonce } { || c }".
+    *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo
+    for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
 
 * context
 

--- a/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
@@ -89,7 +89,7 @@ All other scheme capabilities are advertised as a self-contained JSON object usi
 | kasRole| Roles supported for key agreement| array| initiator and/or responder| No
 | kdfMethods| The KDF methods to use when testing KAS schemes. | object| <<kdfmethods>>| No
 | keyConfirmationMethod| The KeyCnfirmation capabilities (when supported) for the scheme.| object| <<keyconfirmmethod>>| Yes
-| l| The length of the key to derive (using a KDF) or transport (using a KTS scheme).  This value should be large enough to accommodate the key length used for the mac algorithms in use for key confirmation, ideally the maximum value the IUT can support with their KAS/KTS implementation.  Maximum value (for testing purposes) is 1024.| integer| 128 minimum without KC, 136 minimum with KC, maximum 1024.| No
+| l | The length of the key to derive (using a KDF) or transport (using a KTS scheme).  This value should be large enough to accommodate the key length used for the mac algorithms in use for key confirmation, ideally the maximum value the IUT can support with their KAS/KTS implementation.  Maximum value (for testing purposes) is 1024.| integer| 128 minimum without KC, 136 minimum with KC, maximum 1024.| No
 |===
 
 [[kdfmethods]]
@@ -149,7 +149,7 @@ The one step no counter KDF is a special implementation of the one step KDF.  Th
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
 | auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
-| l| The length of the keying material to derive (cannot exceed output length of aux function)| No
+| l | The length of the keying material to derive (cannot exceed output length of aux function)| integer | may not exceed output length of aux function |No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 
@@ -208,10 +208,20 @@ Pattern candidates:
 * uPartyInfo
   ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
+    { || ephemeralNonce } { || dkmNonce } { || c }".
+    *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
+    for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
 
 * vPartyInfo
   ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
+    { || ephemeralNonce } { || dkmNonce } { || c }".
+    *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo
+    for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
 
 * context
   ** Random value chosen by ACVP server to represent the context.

--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -185,7 +185,7 @@ The one step no counter KDF is a special implementation of the one step KDF.  Th
 | JSON Value| Description| JSON Type| Valid Values| Optional
 
 | auxFunctionName| The auxiliary function to use. Note that a customization string of "KDF" is used for the function when KMAC is utilized.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 | No
-| l| The length of the keying material to derive (cannot exceed output length of aux function)| No
+|l |The length of the keying material to derive (cannot exceed output length of aux function)| integer | may not exceed output length of aux function  |No
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). | array of string| default, random| Not optional for mac based auxiliary functions.
 |===
 
@@ -250,10 +250,20 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
   ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
+    { || ephemeralNonce } { || dkmNonce } { || c }".
+    *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
+    for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
 
 * vPartyInfo
   ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
+    { || ephemeralNonce } { || dkmNonce } { || c }".
+    *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo
+    for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
     
 * context
   ** Random value chosen by ACVP server to represent the context.

--- a/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
@@ -51,12 +51,16 @@ Pattern candidates:
 substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** uPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** vPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context
   ** Random value chosen by ACVP server to represent the context.

--- a/src/kas/sp800-56c/onestep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/onestep/sections/05-capabilities.adoc
@@ -57,12 +57,16 @@ Pattern candidates:
 substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** uPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** vPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context
   ** Random value chosen by ACVP server to represent the context.

--- a/src/kas/sp800-56c/onestepnocounter/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/onestepnocounter/sections/05-capabilities.adoc
@@ -41,7 +41,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | JSON Value| Description| JSON Type| Valid Values
 
 | auxFunctionName| The auxiliary function to use.| string| SHA-1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512, KMAC-128, KMAC-256 
-| l | The length (in bits) of the keying material to derive (up to a max of 2048 for KMAC). The length may not exceed the output length of the auxiliary function. | number | 
+| l | The length (in bits) of the keying material to derive. | number | (up to a max of 2048 for KMAC). The length may not exceed the output length of the auxiliary function. 
 | macSaltMethods| How the salt is determined (default being all 00s, random being a random salt). Required for MAC based auxFunctions.| array of string| default, random
 |===
 
@@ -57,12 +57,16 @@ Pattern candidates:
 substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** uPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** vPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context
   ** Random value chosen by ACVP server to represent the context.

--- a/src/kas/sp800-56c/twostep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/twostep/sections/05-capabilities.adoc
@@ -68,12 +68,16 @@ Pattern candidates:
 substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** uPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
-    *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
+  ** vPartyId { || ephemeralData }
+    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context
   ** Random value chosen by ACVP server to represent the context.


### PR DESCRIPTION
Fixes misc. KAS-ECC Sp800-56Ar3, KAS-IFC spec formatting errors.

Adds additional information related to the construction of the uPartyInfo and vPartyInfo values used in testing to the KAS-ECC Sp800-56Ar3, KAS-FFC Sp800-56Ar3, KAS-IFC, and KDA specs.

See https://github.com/usnistgov/ACVP/issues/1395