### PR TITLE
Fix kdf macmode

### DIFF
--- a/src/kdf/sections/05-capabilities.adoc
+++ b/src/kdf/sections/05-capabilities.adoc
@@ -55,7 +55,7 @@ The following table describes the capabilities that may be advertised by the ACV
 | JSON Value | Description | JSON Type | Valid Values
 
 | kdfMode | The type of SP800-108r1 KDF or "mode of iteration" | string | See <<kdfmodes>>
-| macMode | The MAC or PRF algorithm used | string | See <<valid-mac>>
+| macMode | The MAC or PRF algorithm used | array of string | See <<valid-mac>>
 | supportedLengths | The supported derived keying material lengths in bits | domain | Min: 1, Max: 4096
 | fixedDataOrder | Describes where the counter appears in the fixed data | array | Any non-empty subset of {"none", "after fixed data", "before fixed  data", "middle fixed data", "before iterator"}
 | counterLength | The length of the counter in bits | array | Any non-empty subset of {0, 8, 16, 24, 32}
@@ -76,7 +76,7 @@ The following table describes the capabilities that may be advertisd by the ACVP
 |===
 | JSON Value | Description | JSON Type | Valid Values
 
-| macMode | The MAC or PRF algorithm used | string | See <<valid-mac>>
+| macMode | The MAC or PRF algorithm used | array of string | See <<valid-mac>>
 | keyDerivationKeyLength | The lengths of the key derivation key in bits | domain | Min: 8, Max: 4096, Inc: 8
 | contextLength | The lengths of the context field in bits | domain | Min: 8, Max: 4096, Inc: 8
 | labelLength | The lengths of the label field in bits. This field can be excluded if no label is used. | domain | Min: 8, Max: 4096, Inc: 8

--- a/src/kdf/sections/05-capabilities.adoc
+++ b/src/kdf/sections/05-capabilities.adoc
@@ -77,7 +77,7 @@ The following table describes the capabilities that may be advertisd by the ACVP
 | JSON Value | Description | JSON Type | Valid Values
 
 | macMode | The MAC or PRF algorithm used | array of string | See <<valid-mac>>
-| keyDerivationKeyLength | The lengths of the key derivation key in bits | domain | Min: 8, Max: 4096, Inc: 8
+| keyDerivationKeyLength | The lengths of the key derivation key in bits | domain | Min: 112, Max: 4096, Inc: 8
 | contextLength | The lengths of the context field in bits | domain | Min: 8, Max: 4096, Inc: 8
 | labelLength | The lengths of the label field in bits. This field can be excluded if no label is used. | domain | Min: 8, Max: 4096, Inc: 8
 | derivedKeyLength | The lengths of the derived keys in bits | domain | Min: 112, Max: 4096, Inc: 8


### PR DESCRIPTION
After reviewing the algo, fixed macMode for KDF/KMAC to be arrays of strings and not strings, also updated the keyDerivationKeyLength min to be 112 instead of 8.