### PR TITLE
Updated SHA to detail support for the updated MCT algorithm.

### DIFF
--- a/src/sha/sections/04-testtypes.adoc
+++ b/src/sha/sections/04-testtypes.adoc
@@ -49,8 +49,8 @@ if SupportedMessageLengths.Contains(3*digestSize):
             A = B
             B = C
             C = MD
-       Output MD
-       SEED = MD
+        Output MD
+        SEED = MD
  else 
     SEED = GetRandomBitsOfLength(SmallestSupportedMessageLengthGreaterThanZero)
     For j = 0 to 99

--- a/src/sha/sections/04-testtypes.adoc
+++ b/src/sha/sections/04-testtypes.adoc
@@ -18,8 +18,9 @@ There are two types of tests for SHA-1 and SHA-2: functional tests and Monte Car
 === Monte Carlo tests for SHA-1 and SHA-2
 
 The MCTs start with an initial condition (SEED which is a single message) and perform a series of chained computations. The algorithm is shown below.
+Note: The algorithm was updated, 3/2023, to support SmallestSupportedMessageLengthGreaterThanZero's less than 3*digestSize, a limitation from the original implementation.
 
-.SHA-1 and SHA-2 Monte Carlo Test
+.SHA-1 and SHA-2 Monte Carlo Test (Original)
 [source, code]
 ----
 For j = 0 to 99
@@ -32,6 +33,40 @@ For j = 0 to 99
         C = MD
     Output MD
     SEED = MD
+----
+
+.SHA-1 and SHA-2 Monte Carlo Test (Updated)
+[source, code]
+----
+if SupportedMessageLengths.Contains(3*digestSize):
+    SEED = GetRandomBitsOfLength(digestSize)
+    For j = 0 to 99
+        A = B = C = SEED
+        For i = 0 to 999
+            MSG = A || B || C
+            MD = SHA(MSG)
+            A = B
+            B = C
+            C = MD
+       Output MD
+       SEED = MD
+ else 
+    SEED = GetRandomBitsOfLength(SmallestSupportedMessageLengthGreaterThanZero)
+    For j = 0 to 99
+        A = B = C = SEED
+        For i = 0 to 999
+            MSG = A || B || C
+            If  !SupportedMessageLengths.Contains(LEN(MSG)):
+                MSG = TruncateToSize(MSG, SmallestSupportedMessageLengthGreaterThanZero)
+            MD = SHA(MSG)
+            A = B
+            B = C
+            If SmallestSupportedMessageLengthGreaterThanZero >= digestSize:
+                C = MD || CreateZeroBitStringOfLength(SmallestSupportedMessageLengthGreaterThanZero - digestSize)
+            Else:
+                C = TruncateToSize(MD, SmallestSupportedMessageLengthGreaterThanZero)
+        Output MD
+        SEED = C
 ----
 
 [[LD_test]]

--- a/src/sha/sections/05-capabilities.adoc
+++ b/src/sha/sections/05-capabilities.adoc
@@ -13,13 +13,13 @@ This section describes the constructs for advertising support of hash algorithms
 
 | algorithm | The hash algorithm and mode to be validated. | string
 | revision | The algorithm testing revision to use. | string
-| messageLength | The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65536. | domain
+| messageLength | The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535. | domain
 | performLargeDataTest | Determines if the server should include the large data test group defined in <<LD_test>>. This property is *OPTIONAL*, and shall include the lengths in GiB being tested. Valid options are {1, 2, 4, 8}. | integer array
 |===
 
 The value of the algorithm property *MUST* be one of the elements from the list in <<supported_algs>>.
 
-NOTE: The IUT must support at least one 'messageLength > 0'. The lengths provided in the 'performLargeDataTest' property are in gibibytes. 1GiB is equivalent to 2^30 bytes. 
+NOTE: The lengths provided in the 'performLargeDataTest' property are in gibibytes. 1GiB is equivalent to 2^30 bytes. 
 
 NOTE: At least one messageLength > 0 must be supported by an IUT in order to accommodate MCT testing.
 

--- a/src/sha/sections/05-capabilities.adoc
+++ b/src/sha/sections/05-capabilities.adoc
@@ -13,7 +13,7 @@ This section describes the constructs for advertising support of hash algorithms
 
 | algorithm | The hash algorithm and mode to be validated. | string
 | revision | The algorithm testing revision to use. | string
-| messageLength | The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535. | domain
+| messageLength | The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65536. | domain
 | performLargeDataTest | Determines if the server should include the large data test group defined in <<LD_test>>. This property is *OPTIONAL*, and shall include the lengths in GiB being tested. Valid options are {1, 2, 4, 8}. | integer array
 |===
 

--- a/src/sha/sections/05-capabilities.adoc
+++ b/src/sha/sections/05-capabilities.adoc
@@ -13,13 +13,13 @@ This section describes the constructs for advertising support of hash algorithms
 
 | algorithm | The hash algorithm and mode to be validated. | string
 | revision | The algorithm testing revision to use. | string
-| messageLength | The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65535. | domain
+| messageLength | The message lengths in bits supported by the IUT. Minimum allowed is 0, maximum allowed is 65536. | domain
 | performLargeDataTest | Determines if the server should include the large data test group defined in <<LD_test>>. This property is *OPTIONAL*, and shall include the lengths in GiB being tested. Valid options are {1, 2, 4, 8}. | integer array
 |===
 
 The value of the algorithm property *MUST* be one of the elements from the list in <<supported_algs>>.
 
-NOTE: The lengths provided in the 'performLargeDataTest' property are in gibibytes. 1GiB is equivalent to 2^30 bytes. 
+NOTE: The IUT must support at least one 'messageLength > 0'. The lengths provided in the 'performLargeDataTest' property are in gibibytes. 1GiB is equivalent to 2^30 bytes. 
 
 The following is a example JSON object advertising support for SHA-256.
 

--- a/src/xof/sections/05-capabilities.adoc
+++ b/src/xof/sections/05-capabilities.adoc
@@ -37,8 +37,8 @@ The following grid outlines which properties are *REQUIRED*, as well as all the 
 
 | cSHAKE-128 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
 | cSHAKE-256 | | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |
-| KMAC-128 | [true, false] | true, false | | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
-| KMAC-256 | [true, false] | true, false | | {Min: 0, Max: 65536, Increment: any} | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
+| KMAC-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
+| KMAC-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | | {Min: 128, Max: 524288, Increment: 8} | {Min: 32, Max: 65536, Increment: 8} |
 | ParallelHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
 | ParallelHash-256 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | | {Min: 1, Max: 128, Increment: 1}
 | TupleHash-128 | [true, false] | true, false | {Min: 0, Max: 65536, Increment: any} | {Min: 16, Max: 65536, Increment: any} | | |


### PR DESCRIPTION
This enables users to submit min lengths less than 3*digestSize, a limitation carried over from CMVP.