### PR TITLE
Removed ||c from KAS FixedInfoPattern documentation.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-docker:
     runs-on: ubuntu-latest
-    container: docker://metanorma/mn:1.4.12
+    container: docker://metanorma/mn
     steps:
       - uses: actions/checkout@v2
       - name: Install gems from local Gemfile

--- a/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
@@ -214,22 +214,22 @@ substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
 
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
+  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "Optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
-    { || ephemeralNonce } { || dkmNonce } { || c }".
+    { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
     for a given test case is dependant on the scheme and party being tested. Please consult Section 6 of SP 800-56Ar3 to determine whether or not an "optional" item is applicable to the scheme being tested and must be included as part of the uPartyInfo for a given test case. 
     *** uPartyId is the identifier of Party U, i.e., the IDu from Sections 5.8 and 6 of SP 800-56Ar3.
 
 * vPartyInfo
 
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
+  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "Optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
-    { || ephemeralNonce } { || dkmNonce } { || c }".
+    { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo
     for a given test case is dependant on the scheme and party being tested. Please consult Section 6 of SP 800-56Ar3 to determine whether or not an "optional" item is applicable to the scheme being tested and must be included as part of the vPartyInfo for a given test case.
      *** vPartyId is the identifier of Party V, i.e., the IDv from Sections 5.8 and 6 of SP 800-56Ar3.

--- a/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
@@ -206,21 +206,21 @@ Pattern candidates:
   ** uses the specified hex within "[]". literal[0123456789ABCDEF] substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
+  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
-    { || ephemeralNonce } { || dkmNonce } { || c }".
+    { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
     for a given test case is dependant on the scheme and party being tested. Please consult Section 6 of SP 800-56Ar3 to determine whether or not an "optional" item is applicable to the scheme being tested and must be included as part of the uPartyInfo for a given test case.
     *** uPartyId is the identifier of Party U, i.e., the IDu from Sections 5.8 and 6 of SP 800-56Ar3.
 
 * vPartyInfo
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
+  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
-    { || ephemeralNonce } { || dkmNonce } { || c }".
+    { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo
     for a given test case is dependant on the scheme and party being tested. Please consult Section 6 of SP 800-56Ar3 to determine whether or not an "optional" item is applicable to the scheme being tested and must be included as part of the vPartyInfo for a given test case.
     *** vPartyId is the identifier of Party V, i.e., the IDv from Sections 5.8 and 6 of SP 800-56Ar3.

--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -248,20 +248,20 @@ Pattern candidates:
 substitutes "0123456789ABCDEF" in place of the field
 
 * uPartyInfo
-  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
+  ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
-    { || ephemeralNonce } { || dkmNonce } { || c }".
+    { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
     for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
 
 * vPartyInfo
-  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }
+  ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
-    { || ephemeralNonce } { || dkmNonce } { || c }".
+    { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo
     for a given test case is dependant on the scheme and party being tested. Please consult <<scheme_generation_requirements>> for more information.
     

--- a/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/hkdf/sections/05-capabilities.adoc
@@ -53,13 +53,13 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
   ** uPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
   ** vPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context

--- a/src/kas/sp800-56c/onestep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/onestep/sections/05-capabilities.adoc
@@ -59,13 +59,13 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
   ** uPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
   ** vPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context

--- a/src/kas/sp800-56c/onestepnocounter/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/onestepnocounter/sections/05-capabilities.adoc
@@ -59,13 +59,13 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
   ** uPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
   ** vPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context

--- a/src/kas/sp800-56c/twostep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/twostep/sections/05-capabilities.adoc
@@ -70,13 +70,13 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
   ** uPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the uPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * vPartyInfo
   ** vPartyId { || ephemeralData }
     *** For the purposes of the testing defined in this specification, the vPartyInfo value
-    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce } { || c }"
+    used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralData }". Because the KDA is being tested in isolation of the specific schemes it may be used with, ephemeralData is used in place of "{ || ephemeralKey } { || ephemeralNonce } { || dkmNonce }"
     *** For a given test case, a partyId value (see <<fixedInfo>>) *SHALL* always be given. ephemeralData values (see <<fixedInfo>>) may be provided or omitted.
 
 * context

--- a/src/rsa/sections/05-sigver-capabilities.adoc
+++ b/src/rsa/sections/05-sigver-capabilities.adoc
@@ -21,7 +21,7 @@ The following RSA / sigVer / FIPS186-2 capabilities *MAY* be advertised by the A
 | properties | RSA signature verification parameters  - see <<FIPS186-2>>, Section 5 | array | modulo, hashAlg, and saltLen (when sigType is "pss")
 | modulo | supported RSA modulo for signature verification | integer | any one of the supported modulo sizes {1024, 1536, 2048, 3072, 4096}
 | hashPair | supported hash algorithms and optional salt length for signature verification for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
-| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
+| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512"}
 | saltLen | supported salt lengths for PSS signature verification - see <<FIPS186-4>>, Section 5.5 | integer | See the note below
 |===
 


### PR DESCRIPTION
After looking through the code and the documentation, this seems to just be a copy/paste error.