### PR TITLE
Adds keyBlockLength Property to TLS KDF

### DIFF
--- a/src/tls/sections/05-capabilities.adoc
+++ b/src/tls/sections/05-capabilities.adoc
@@ -15,9 +15,10 @@ A registration *SHALL* use these properties
 | revision | ACVP Test version | string | "1.0", "RFC7627"
 | tlsVersion | The version of TLS supported | array | "v1.0/1.1", "v1.2".  Note TLS v1.2 w/ extended master secret testing, i.e., TLS-v1.2 / KDF / RFC7627, does not use this property.
 | hashAlg | SHA functions supported if TLS Version "v1.2" is included in the registration | array | See <<valid-sha>>
+| keyBlockLength | The length of the key block in bits. This registration property is only valid for TLS v1.2 w/ extended master secret testing, i.e., TLS-v1.2 / KDF / RFC7627; if ommitted from the registration, a default value of 1024 will be used. | domain | {"Min": 512, "Max": 1024, "Increment": 8}
 |===
 
-Note that the "hashAlg" field is *REQUIRED* when "v1.2" is present within the "tlsVersion" array.
+NOTE: the "hashAlg" field is *REQUIRED* when "v1.2" is present within the "tlsVersion" array.
 
 [#valid-sha]
 ==== Valid Hash Functions


### PR DESCRIPTION
Adds the keyBlockLength registration property for TLS-v1.2 / KDF / RFC7627