### PR TITLE
BlockCipher_DF OutputLen

### DIFF
--- a/src/conditioning-components/sections/05-capabilities.adoc
+++ b/src/conditioning-components/sections/05-capabilities.adoc
@@ -21,6 +21,7 @@ The following ConditioningComponent / AES-CBC-MAC / SP800-90B and ConditioningCo
 | revision | The algorithm testing revision to use | string | "SP800-90B"
 | keyLen | The length of keys supported in bits | array | [128, 192, 256]
 | payloadLen | The lengths in bits supported by the IUT | domain | [{"min": 8, "max": 65536, "inc": 8}]
+| outputLen | The lengths in bits suppoerted by the IUT as output only for BlockCipher_DF | domain | [{"min": 128, "max": 512, "inc": 8}]
 |===
 
 NOTE: For ConditioningComponent / AES-CBC-MAC / SP800-90B, the payload itself is processed through the encryption engine. Therefore the minimum 'payloadLen' is 128 bits and the minimum increment is 128 bits. In other words, all values within the 'payloadLen' must correspond to complete AES blocks in bits (a multiple of 128).
@@ -65,6 +66,13 @@ The following is an example of a registration for ConditioningComponents / Block
     {
       "min": 8,
       "max": 65536,
+      "increment": 8
+    }
+  ],
+  "outputLen": [
+    {
+      "min": 128,
+      "max": 512,
       "increment": 8
     }
   ]

--- a/src/conditioning-components/sections/06-blockcipher-df-test-vectors.adoc
+++ b/src/conditioning-components/sections/06-blockcipher-df-test-vectors.adoc
@@ -12,6 +12,7 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | tgId | The unique group identifier | integer
 | testType | Describes the operation the client should perform on the test data | string
 | keyLen | The length of the key used in the group | integer
+| outputLen | The expected length of the output | integer
 | tests | Array of individual test cases, see <<bc_df_tvjs>> | array
 |===
 
@@ -45,6 +46,7 @@ Here is an abbreviated yet fully constructed example of the prompt for Condition
       "tgId": 1,
       "keyLen": 128,
       "testType": "AFT",
+      "outputLen": 128,
       "tests": [
         {
           "tcId": 1,

--- a/src/conditioning-components/sections/07-blockcipher-df-responses.adoc
+++ b/src/conditioning-components/sections/07-blockcipher-df-responses.adoc
@@ -14,8 +14,6 @@ The following table describes the JSON elements for the test case responses for 
 | requestedBits | The output of the derivation function | hex
 |===
 
-NOTE: In the case of BlockCipher_DF, the output is always 128-bits regardless of the size of the input.
-
 The following is an example of the response for ConditioningComponent / BlockCipher_DF / SP800-90B .
 
 [source, json]


### PR DESCRIPTION
Adds the `outputLen` property to `BlockCipher_DF`. 