### PR TITLE
Updated 05-keygen-capabilities.adoc to remove 15360 modulo support temporarily

### DIFF
--- a/src/rsa/sections/05-keygen-capabilities.adoc
+++ b/src/rsa/sections/05-keygen-capabilities.adoc
@@ -111,7 +111,7 @@ A registration for RSA / keyGen / FIPS186-5 *SHALL* use these properties
 
 | randPQ | Key Generation mode to be validated. Random P and Q primes generated as (see <<FIPS186-5>>): provable primes; probable primes; provable primes with auxiliary provable primes; probable primes with auxiliary provable primes; probable primes with auxiliary probable primes | string | "provable", "probable", "provableWithProvableAux", "probableWithProvableAux", "probableWithProbableAux"
 | properties | An array of objects containing properties for all supported moduli, primality test, and hash algorithms for a single key generation mode | array |
-| modulo | supported RSA modulo for the randPQ mode - see <<FIPS186-5>> | integer | 2048, 3072, 4096, 6144, 8192
+| modulo | supported RSA modulo for the randPQ mode - see <<FIPS186-5>> | integer | 2048, 3072, 4096, 6144, or 8192
 | hashAlg | Supported hash algorithms for the randPQ mode - see <<FIPS186-5>>. Needed for any 'randPQ' with provable primes | array | any non-empty subset of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
 | primeTest | Primality test rounds of Miller-Rabin from <<FIPS186-5>>. Needed for any 'randPQ' with probable primes | array | any non-empty subset of {"2pow100", "2powSecStr"}
 | pMod8 | The result of the evaluation of the generated p prime, p % 8 | integer | 0, 1, 3, 5, 7

--- a/src/rsa/sections/05-keygen-capabilities.adoc
+++ b/src/rsa/sections/05-keygen-capabilities.adoc
@@ -111,12 +111,14 @@ A registration for RSA / keyGen / FIPS186-5 *SHALL* use these properties
 
 | randPQ | Key Generation mode to be validated. Random P and Q primes generated as (see <<FIPS186-5>>): provable primes; probable primes; provable primes with auxiliary provable primes; probable primes with auxiliary provable primes; probable primes with auxiliary probable primes | string | "provable", "probable", "provableWithProvableAux", "probableWithProvableAux", "probableWithProbableAux"
 | properties | An array of objects containing properties for all supported moduli, primality test, and hash algorithms for a single key generation mode | array |
-| modulo | supported RSA modulo for the randPQ mode - see <<FIPS186-5>> | integer | 2048, 3072, 4096, 6144, 8192, or 15360
+| modulo | supported RSA modulo for the randPQ mode - see <<FIPS186-5>> | integer | 2048, 3072, 4096, 6144, 8192
 | hashAlg | Supported hash algorithms for the randPQ mode - see <<FIPS186-5>>. Needed for any 'randPQ' with provable primes | array | any non-empty subset of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
 | primeTest | Primality test rounds of Miller-Rabin from <<FIPS186-5>>. Needed for any 'randPQ' with probable primes | array | any non-empty subset of {"2pow100", "2powSecStr"}
 | pMod8 | The result of the evaluation of the generated p prime, p % 8 | integer | 0, 1, 3, 5, 7
 | qMod8 | The result of the evaluation of the generated q prime, q % 8 | integer | 0, 1, 3, 5, 7
 |===
+
+NOTE: Support for modulo 15360 has been temporarily disabled while keys are generated for use, apologies for any inconvenience.
 
 NOTE: The properties 'pMod8' and 'qMod8' with a value of 0, means that no modulus check will be performed on the generated primes p and q.
 


### PR DESCRIPTION
Updated 05-keygen-capabilities.adoc to remove 15360 modulo support temporarily while we generate keys for customer use. 

This is a several month-long process.