### PR TITLE
Updated KAS TwoStep SP800-56C to show properly required counterLength requirement

### DIFF
--- a/src/kas/sp800-56c/twostep/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56c/twostep/sections/05-capabilities.adoc
@@ -48,13 +48,19 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | kdfMode | The strategy for running the KDA. | string | counter, feedback, double pipeline iteration
 | macMode | The macMode supported by the KDA. | array of string | CMAC-AES128, CMAC-AES192, CMAC-AES256, HMAC-SHA-1, HMAC-SHA2-224, HMAC-SHA2-256, HMAC-SHA2-384, HMAC-SHA2-512, HMAC-SHA2-512/224, HMAC-SHA2-512/256, HMAC-SHA3-224, HMAC-SHA3-256, HMAC-SHA3-384, HMAC-SHA3-512
 | fixedDataOrder | The counter locations supported by the KDA. | array of string| none, before fixed data, after fixed data, before iterator
-| counterLength | The counter lengths supported for the KDA. | array of integer | 8, 16, 24, 32
+| counterLength | The counter lengths supported for the KDA. | array of integer | Any non-empty subset of {0, 8, 16, 24, 32}
 | supportedLengths | The supported derivation lengths. | domain| Registered value(s) must support the 'l' value provided.
 | supportsEmptyIv | The KDA supports an empty IV (feedback mode). | boolean | true, false
 | requiresEmptyIv | The KDA requires an empty IV (feedback mode). | boolean | true, false
 |===
 
-Note this capabilities object is very similar to the capability object from SP800-108.
+NOTE: The 'fixedDataOrder' options "none" and "before iterator" are not valid for "counter" KDF. The 'fixedDataOrder' option "middle fixed data" is not valid for "feedback" nor "double pipeline iteration" KDF.
+
+NOTE: A 'counterLength' of 0 describes that there is no counter used. The 0 option is not valid for "counter"  KDF.
+
+NOTE: When 'counterLength' contains a value of "0", 'fixedDataOrder' must contain a value of "none" and vice versus.
+
+NOTE: This capabilities object is very similar to the capability object from SP800-108.
 
 [[fixedinfopatcon]]
 ==== FixedInfoPatternConstruction


### PR DESCRIPTION
Updated KAS TwoStep SP800-56C to show properly required counterLength of 0 when fixedDataOrder contains none and kdfMode is not counter.