### PR TITLE
uPartyInfo and vPartyInfo are not required for KTS

### DIFF
--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -238,7 +238,7 @@ Note that this method is *REQUIRED* when testing KTS schemes.
 [[fixedinfopatcon]]
 ===== FixedInfoPatternConstruction
 
-IUTs *MUST* be capable of specifying how the FixedInfo is constructed for the KAS/KTS negotiation. Note that for the purposes of testing against the ACVP system, both uPartyInfo and vPartyInfo are *REQUIRED* to be registered within the fixed info pattern.
+IUTs *MUST* be capable of specifying how the FixedInfo is constructed for the KAS/KTS negotiation. Note that for the purposes of testing a KAS against the ACVP system, both uPartyInfo and vPartyInfo are *REQUIRED* to be registered within the fixed info pattern.
 
 Pattern candidates:
 
@@ -250,7 +250,7 @@ substitutes "0123456789ABCDEF" in place of the field
 * uPartyInfo
   ** uPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
-    *** For the purposes of the testing defined in this specification, the uPartyInfo value
+    *** For the purposes of the testing a KAS defined in this specification, the uPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "uPartyId { || ephemeralKey } 
     { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the uPartyInfo
@@ -259,7 +259,7 @@ substitutes "0123456789ABCDEF" in place of the field
 * vPartyInfo
   ** vPartyId { || ephemeralKey } { || ephemeralNonce } { || dkmNonce }
     *** "optional" items such as ephemeralKey *MUST* be included when available for ACVP testing.
-    *** For the purposes of the testing defined in this specification, the vPartyInfo value
+    *** For the purposes of the testing a KAS defined in this specification, the vPartyInfo value
     used to create the fixedInfo that is input to the key derivation function *SHALL* take the form of "vPartyId { || ephemeralKey } 
     { || ephemeralNonce } { || dkmNonce }".
     *** Whether or not an "optional" item, e.g., ephemeralKey, will be included as part of the vPartyInfo


### PR DESCRIPTION
In the ACVP-Server source code, the validation of the "AssociatedDataPattern" (used in KTS) is separate from the validation of the "FixedInfoPattern" (used in KDA OneStep and TwoStep, also when part of a KAS):
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KAS_IFC/Sp800_56Br2/ParameterValidator.cs#L666
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KDA/Sp800_56Cr2/OneStepNoCounter/ParameterValidator.cs#L158
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KDA/Sp800_56Cr2/OneStep/ParameterValidator.cs#L168
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KDA/Sp800_56Cr2/TwoStep/ParameterValidator.cs#L130

Note that for OneStep and TwoStep, `uPartyInfo` and `vPartyInfo` are required:
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KDA/Sp800_56Cr2/OneStepNoCounter/ParameterValidator.cs#L70
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KDA/Sp800_56Cr2/OneStep/ParameterValidator.cs#L82
- https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/src/generation/src/NIST.CVP.ACVTS.Libraries.Generation/KDA/Sp800_56Cr2/TwoStep/ParameterValidator.cs#L30