### PR TITLE
Correct typo in 05-gmac-capabilities.adoc

### DIFF
--- a/src/mac/sections/05-gmac-capabilities.adoc
+++ b/src/mac/sections/05-gmac-capabilities.adoc
@@ -13,7 +13,7 @@ Each algorithm capability advertised is a self-contained JSON object using the f
 
 | algorithm | The MAC algorithm to be validated | string | "ACVP-AES-GMAC"
 | revision | The algorithm testing revision to use | string | "1.0"
-| prereqVals | Prerequistie algorithm validations | array of prereqAlgVal objects| See <<prereq_algs>>
+| prereqVals | Prerequisite algorithm validations | array of prereqAlgVal objects| See <<prereq_algs>>
 | direction | The GMAC direction(s) to test | array | "encrypt", "decrypt"
 | keyLen | The keyLen supported | array | 128, 192, 256
 | ivLen | The IV lengths supported in bits, values *MUST* be mod 8 | domain | Min: 8, Max: 1024, Inc: 8


### PR DESCRIPTION
Fix spelling of prerequisite.