### PR TITLE
Updated CMAC-AES/TDES and GMAC missing/extra fields.

### DIFF
--- a/src/mac/sections/05-gmac-capabilities.adoc
+++ b/src/mac/sections/05-gmac-capabilities.adoc
@@ -45,7 +45,7 @@ The following is an example JSON object advertising support for AES-GMAC.
        120
      ],
      "ivGen": "external",
-     ivGenMode": "8.2.2",
+     "ivGenMode": "8.2.2",
      "aadLen": [
        8,
        120

--- a/src/mac/sections/05-gmac-capabilities.adoc
+++ b/src/mac/sections/05-gmac-capabilities.adoc
@@ -45,6 +45,7 @@ The following is an example JSON object advertising support for AES-GMAC.
        120
      ],
      "ivGen": "external",
+     ivGenMode": "8.2.2",
      "aadLen": [
        8,
        120

--- a/src/mac/sections/06-cmac-aes-test-vectors.adoc
+++ b/src/mac/sections/06-cmac-aes-test-vectors.adoc
@@ -28,11 +28,11 @@ Each test group contains an array of one or more test cases. Each test case is a
 [[cmac_aes_vs_tc_table2]]
 .CMAC-AES Test Case JSON Object
 |===
-| JSON Value | Description | JSON type
+| JSON Value | Description | JSON tSype
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set | integer
 | key | Encryption key to use | hex
-| msg | Value of the message | hex
+| message | Value of the message | hex
 | mac | MAC value, for CMAC verify | hex
 |===
 

--- a/src/mac/sections/06-cmac-aes-test-vectors.adoc
+++ b/src/mac/sections/06-cmac-aes-test-vectors.adoc
@@ -28,7 +28,7 @@ Each test group contains an array of one or more test cases. Each test case is a
 [[cmac_aes_vs_tc_table2]]
 .CMAC-AES Test Case JSON Object
 |===
-| JSON Value | Description | JSON tSype
+| JSON Value | Description | JSON type
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set | integer
 | key | Encryption key to use | hex

--- a/src/mac/sections/06-cmac-tdes-test-vectors.adoc
+++ b/src/mac/sections/06-cmac-tdes-test-vectors.adoc
@@ -14,9 +14,10 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | tgId | Numeric identifier for the test group, unique across the entire vector set | integer
 | testType | Test category type | string
 | direction | The direction of the tests - gen or ver | string
-| keyLen | Length of key in bits to use | integer
+| keyLen | Length of key in bits to use, AES only| integer
 | msgLen | Length of message in bits | integer
 | macLen | Length of MAC in bits to generate/verify | integer
+| keyingOption | The Keying Option used in TDES. Keying option 1 (1) is 3 distinct keys (K1, K2, K3). Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1). Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1). | array | 1, 2
 | tests | Array of individual test vector JSON objects, which are defined in <<cmac_tdes_tvjs>> | array
 |===
 
@@ -31,9 +32,9 @@ Each test group contains an array of one or more test cases. Each test case is a
 | JSON Value | Description | JSON type
 
 | tcId | Numeric identifier for the test case, unique across the entire vector set | integer
-| key1, key2, key3 | Encryption keys to use for TDES | hex
-| msg | Value of the message | hex
+| message | Value of the message | hex
 | mac | MAC value, for CMAC verify | hex
+| key1, key2, key3 | Encryption keys to use for TDES | hex
 |===
 
 [[cmac_tdes_test_vector_json]]
@@ -51,7 +52,6 @@ The following is an example JSON test vector object for CMAC-TDES, truncated for
             "tgId": 4,
             "testType": "AFT",
             "direction": "gen",
-            "keyLen": 192,
             "msgLen": 752,
             "macLen": 32,
             "keyingOption": 1,
@@ -82,7 +82,6 @@ The following is an example JSON test vector object for CMAC-TDES, truncated for
             "tgId": 10,
             "testType": "AFT",
             "direction": "ver",
-            "keyLen": 192,
             "msgLen": 0,
             "macLen": 32,
             "keyingOption": 1,

--- a/src/mac/sections/06-cmac-tdes-test-vectors.adoc
+++ b/src/mac/sections/06-cmac-tdes-test-vectors.adoc
@@ -14,7 +14,6 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | tgId | Numeric identifier for the test group, unique across the entire vector set | integer
 | testType | Test category type | string
 | direction | The direction of the tests - gen or ver | string
-| keyLen | Length of key in bits to use, AES only| integer
 | msgLen | Length of message in bits | integer
 | macLen | Length of MAC in bits to generate/verify | integer
 | keyingOption | The Keying Option used in TDES. Keying option 1 (1) is 3 distinct keys (K1, K2, K3). Keying Option 2 (2) is 2 distinct only suitable for decrypt (K1, K2, K1). Keying option 3 (No longer valid for testing, save TDES KATs) is a single key, now deprecated (K1, K1, K1). | array | 1, 2

--- a/src/mac/sections/06-gmac-test-vectors.adoc
+++ b/src/mac/sections/06-gmac-test-vectors.adoc
@@ -60,6 +60,7 @@ The following is an example JSON test vector object for AES-GMAC, truncated for 
          "keyLen": 128,
          "ivLen": 96,
          "ivGen": "external",
+         ivGenMode": "8.2.2",
          "aadLen": 0,
          "tagLen": 32,
          "tests": [{
@@ -76,6 +77,7 @@ The following is an example JSON test vector object for AES-GMAC, truncated for 
          "keyLen": 128,
          "ivLen": 96,
          "ivGen": "external",
+         ivGenMode": "8.2.2",
          "aadLen": 0,
          "tagLen": 32,
          "tests": [{

--- a/src/mac/sections/06-gmac-test-vectors.adoc
+++ b/src/mac/sections/06-gmac-test-vectors.adoc
@@ -23,6 +23,9 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | tests | Array of individual test vector JSON objects, which are defined in <<gmac_tcjs>> | array
 |===
 
+  |  NOTE: PayloadLength is not supported for GMAC, and a value of 0 is assigned 
+  |  and printed to the TestGroup's for clarity.
+
 [[gmac_tcjs]]
 ==== AES-GMAC Test Case JSON Schema
 

--- a/src/mac/sections/06-gmac-test-vectors.adoc
+++ b/src/mac/sections/06-gmac-test-vectors.adoc
@@ -23,8 +23,7 @@ The testGroups element at the top level in the test vector JSON object is an arr
 | tests | Array of individual test vector JSON objects, which are defined in <<gmac_tcjs>> | array
 |===
 
-  |  NOTE: PayloadLength is not supported for GMAC, and a value of 0 is assigned 
-  |  and printed to the TestGroup's for clarity.
+  |  NOTE: PayloadLength is not supported for GMAC which defaults to 0, and is printed to the Test Group for clarity.
 
 [[gmac_tcjs]]
 ==== AES-GMAC Test Case JSON Schema


### PR DESCRIPTION
1. Edited docs for CMAC-AES Test Case where message was labeled as msg. 
2. For TDES I removed KeyLen, and added a description for KeyingOption. Renamed msg to message.
4. PayloadLength's not in documentation for GMAC - this is due to PayloadLength being defaulted to 0 if run for GMAC rather than GCM. Added a note to the docs for the PayloadLength explanation.
5. Updated AES-GMAC documentation to include ivGenMode within the vector examples and capabilities, to match examples.