### PR TITLE
Updated RSA SigVer/Gen based on GH1562

### DIFF
--- a/src/rsa/sections/05-siggen-capabilities.adoc
+++ b/src/rsa/sections/05-siggen-capabilities.adoc
@@ -21,7 +21,7 @@ The following RSA / sigGen / FIPS186-4 capabilities *MAY* be advertised by the A
 | properties | RSA signature generation parameters  - see <<FIPS186-4>>, Section 5 | array | modulo, hashAlg, and saltLen (when sigType is "pss")
 | modulo | supported RSA modulo for signature generation - see <<FIPS186-4>>, Section 5 | integer | any one of the supported modulo sizes {2048, 3072, 4096}
 | hashPair | supported hash algorithms and optional salt length for signature generation for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
-| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
+| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | string | one of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
 | saltLen | supported salt lengths for PSS signature generation - see <<FIPS186-4>>, Section 5.5 | integer | See the note below
 |===
 
@@ -125,7 +125,7 @@ The following RSA / sigGen / FIPS186-5 capabilities *MAY* be advertised by the A
 | modulo | supported RSA modulo for signature generation - see <<FIPS186-5>>, Section 5 | integer | any one of the supported modulo sizes {2048, 3072, 4096}
 | maskFunction | the mask function used, only valid for PSS | array | any non-empty subset of {"mgf1", "shake-128", "shake-256"}
 | hashPair | supported hash algorithms and optional salt length for signature generation for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
-| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256", "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512", "SHAKE-128", "SHAKE-256"}
+| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | string | one of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256", "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512", "SHAKE-128", "SHAKE-256"}
 
 NOTE: SHAKE-128 and SHAKE-256 are only valid for pss.
 | saltLen | supported salt lengths for PSS signature generation - see <<FIPS186-5>>, Section 5.4 | integer | See the note below

--- a/src/rsa/sections/05-sigver-capabilities.adoc
+++ b/src/rsa/sections/05-sigver-capabilities.adoc
@@ -21,7 +21,7 @@ The following RSA / sigVer / FIPS186-2 capabilities *MAY* be advertised by the A
 | properties | RSA signature verification parameters  - see <<FIPS186-2>>, Section 5 | array | modulo, hashAlg, and saltLen (when sigType is "pss")
 | modulo | supported RSA modulo for signature verification | integer | any one of the supported modulo sizes {1024, 1536, 2048, 3072, 4096}
 | hashPair | supported hash algorithms and optional salt length for signature verification for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
-| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512"}
+| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | string | one of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512"}
 | saltLen | supported salt lengths for PSS signature verification - see <<FIPS186-4>>, Section 5.5 | integer | See the note below
 |===
 
@@ -43,7 +43,7 @@ The following RSA / sigVer / FIPS186-4 capabilities *MAY* be advertised by the A
 | properties | RSA signature verification parameters  - see <<FIPS186-4>>, Section 5 | array | modulo, hashAlg, and saltLen (when sigType is "pss")
 | modulo | supported RSA modulo for signature verification - see <<FIPS186-4>>, Section 5 | integer | any one of the supported modulo sizes {1024, 2048, 3072, 4096}
 | hashPair | supported hash algorithms and optional salt length for signature verification for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
-| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
+| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | string | one of {"SHA-1", "SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}
 | saltLen | supported salt lengths for PSS signature verification - see <<FIPS186-4>>, Section 5.5 | integer | See the note below
 |===
 
@@ -139,7 +139,7 @@ The following RSA / sigVer / FIPS186-5 capabilities *MAY* be advertised by the A
 | modulo | supported RSA modulo for signature verification - see <<FIPS186-5>>, Section 5 | integer | any one of the supported modulo sizes {2048, 3072, 4096}
 | maskFunction | the mask function used, only valid for PSS | array | any subset of {"mgf1", "shake-128", "shake-256"}
 | hashPair | supported hash algorithms and optional salt length for signature verification for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | an array of objects containing a hashAlg and an optional saltLen
-| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | array | any non-empty subset of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256", "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512", "SHAKE-128", "SHAKE-256"} NOTE: SHAKE-128 and SHAKE-256 are only valid for pss.
+| hashAlg | supported hash algorithms for this sigType and modulo - see <<SP800-131A>>, Section 9 | string | one of {"SHA2-224", "SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256", "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512", "SHAKE-128", "SHAKE-256"} NOTE: SHAKE-128 and SHAKE-256 are only valid for pss.
 | saltLen | supported salt lengths for PSS signature verification - see <<FIPS186-5>>, Section 5.5 | integer | See the note below
 |===
 


### PR DESCRIPTION
Updated document to reflect that hashAlg is a single string and not an array of strings, resolves #1562.