### PR TITLE
Correct the 'keys' usage for the Block Cipher examples

### DIFF
--- a/src/conditioning-components/sections/05-capabilities.adoc
+++ b/src/conditioning-components/sections/05-capabilities.adoc
@@ -20,7 +20,7 @@ The following ConditioningComponent / AES-CBC-MAC / SP800-90B and ConditioningCo
 | mode | The specific conditioning component to be validated | string | "AES-CBC-MAC" or "BlockCipher_DF"
 | revision | The algorithm testing revision to use | string | "SP800-90B"
 | keyLen | The length of keys supported in bits | array | [128, 192, 256]
-| keys | User-defined keys used to generate, AES-CBC-MAC only | array | Must have matching keyLen support
+| keys | This property is *OPTIONAL*. User-defined keys used to generate, AES-CBC-MAC only | array | Must have matching keyLen support
 | payloadLen | The lengths in bits supported by the IUT | domain | [{"min": 8, "max": 65536, "inc": 8}]
 | outputLen | The lengths in bits supported by the IUT as output only for BlockCipher_DF | domain | [{"min": 128, "max": 512, "inc": 8}]
 |===


### PR DESCRIPTION
The last update to the Conditioning Components capabilities file had the example 'keys' object in the BlockCipher_DF example. Since BlockCipher_DF does not use that key, this update moves that information to the AES-CBC-MAC example and shows how to set it to have the keys for different keyLen values. I also put the keys in quotes since they are strings and fixed some typos. 