### PR TITLE
Fix typos in the Ascon AEAD128 capabilities section

### DIFF
--- a/src/ascon/sections/05-ascon-aead128-capabilities.adoc
+++ b/src/ascon/sections/05-ascon-aead128-capabilities.adoc
@@ -12,9 +12,9 @@ Each Ascon AEAD128 algorithm capability advertised is a self-contained JSON obje
 | algorithm | The algorithm to be validated | string | "Ascon"
 | mode | The Ascon mode to be validated | string | "AEAD128"
 | revision | The algorithm testing revision to use | string | "SP800-232"
-| directions | The directions for AEAD to be tested | array of strings | "encrypt", "decrypt"
+| direction | The direction for AEAD to be tested | array of strings | "encrypt", "decrypt"
 | payloadLen | The supported plaintext lengths in bits | Domain | {"Min": 0, "Max": 65536, "Inc": any}
-| adLen | The supported associated data lengths in bits | Domain | {"Min": 0, "Max": 65536, "Inc": any}
+| aadLen | The supported associated data lengths in bits | Domain | {"Min": 0, "Max": 65536, "Inc": any}
 | tagLen | The supported tag lengths in bits | Domain | {"Min": 32, "Max": 128, "Inc": any}
 | supportsNonceMasking | The support for nonce masking (second key) mode | array of booleans | true, false
 |===
@@ -30,7 +30,7 @@ Below is an example of the registration for Ascon / AEAD128 / SP800-232
   "algorithm": "Ascon",
   "mode": "AEAD128",
   "revision": "SP800-232",
-  "directions": [
+  "direction": [
     "encrypt",
     "decrypt"
   ],
@@ -41,7 +41,7 @@ Below is an example of the registration for Ascon / AEAD128 / SP800-232
       "increment": 1
     }
   ],
-  "adLen": [
+  "aadLen": [
     {
       "min": 0,
       "max": 65536,


### PR DESCRIPTION
The capabilities section for Ascon AEAD128 had two typos that do not follow the naming that the ACVP Server is looking for when registering for vectors. The reference JSON is here: https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/Ascon-AEAD128-SP800-232/registration.json.

Note that the adLen was updated to aadLen because the server is looking for that key. AD means Associated Data and AAD means Additional Authenticated Data. I am not sure if the server should be changed to look for AD instead of AAD details, but the references I have seen in both projects use AAD for Ascon and call it Associated Data.

The details in `Test Case JSON Schema` do not have these typos. 