### PR TITLE
Updated documentation based on feedback from gh400.

### DIFF
--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -135,6 +135,10 @@ The following grid outlines which properties are *REQUIRED*, as well as the poss
 
 NOTE: The ivGenMode property is used for AES-GCM/AES-XPN algorithms to document which IV construction method the implementation conforms to: the deterministic construction defined in SP 800-38D section 8.2.1 or the RBG-based construction defined in SP 800-38D section 8.2.2.
 
+NOTE: For AES-CCM-ECMA, the IV/NONCE is used to create a pre-formatted "B_0 block" containing 16-bytes as defined by Fig 113 in ECMA-368 Sec 18.5.
+
+NOTE: The ivLen for AES-CCM-ECMA should always be 104-bits.
+
 The following grid outlines which properties are *REQUIRED*, as well as the possible values a server *MAY* support for the XTS block cipher algorithm:
 
 [[property_grid_xts]]

--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -137,7 +137,7 @@ NOTE: The ivGenMode property is used for AES-GCM/AES-XPN algorithms to document 
 
 NOTE: For AES-CCM-ECMA, the IV/NONCE is used to create a pre-formatted "B_0 block" containing 16-bytes as defined by Fig 113 in ECMA-368 Sec 18.5.
 
-NOTE: The ivLen for AES-CCM-ECMA should always be 104-bits.
+NOTE: The ivLen for AES-CCM-ECMA *SHALL* be 104-bits.
 
 The following grid outlines which properties are *REQUIRED*, as well as the possible values a server *MAY* support for the XTS block cipher algorithm:
 


### PR DESCRIPTION
Added clarification to Figure 7 of the documentation for AES-CCM-ECMA:

```
NOTE: For AES-CCM-ECMA, the IV/NONCE is used to create a pre-formatted "B_0 block" containing 16-bytes as defined by Fig 113 in ECMA-368 Sec 18.5.

NOTE: The ivLen for AES-CCM-ECMA should always be 104-bits.
```