### PR TITLE
Update the documentation for AES-GCM

### DIFF
--- a/src/symmetric/sections/05-capabilities.adoc
+++ b/src/symmetric/sections/05-capabilities.adoc
@@ -57,7 +57,7 @@ text. | domain
 
 NOTE: The 'conformances' property is only valid for algorithms listed in <<conformances>>. The valid values in the array are also listed in that section. The array is always optional.
 
-NOTE: Some optional values are required depending on the algorithm. For example, AES-GCM requires ivLen, ivGen, ivGenMode, aadLen and tagLen. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.
+NOTE: Some optional values are required depending on the algorithm. For example, AES-GCM requires ivLen, ivGen, aadLen, and tagLen. Failure to provide these values will result in the ACVP server returning an error to the ACVP client during registration.
 
 NOTE: The 'performCounterTests' option is provided for counter implementations such as linear-feedback shift registers which may not present an always increasing or decreasing counter while still ensuring the IV is unique. This value defaults to true if not present. If it is set to false, the 'overflowCounter' and 'incrementalCounter' values will not be used.
 


### PR DESCRIPTION
Removes the requirement of ivGenMode from the Note.

Resolves Issue [#424](https://github.com/usnistgov/ACVP-Server/issues/424) from ACVP-Server.