### PR TITLE
Updates KAS and KAS SSC prerequisites

### DIFF
--- a/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
@@ -15,7 +15,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal| prerequistie algorithm validation| object with algorithm and valValue properties| see above| Yes
 |===
 
-Required prerequisite algorithms for KAS can be found here: https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
+Required prerequisite algorithms for KAS can be found at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [[cap_ex]]
 === Algorithm Capabilities JSON Values

--- a/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ecc/sections/05-capabilities.adoc
@@ -1,6 +1,6 @@
 
 [[prereq_algs]]
-=== Prerequisite Algorithms
+=== Required Prerequisite Algorithms
 
 Some algorithm implementations rely on other cryptographic primitives. For example, IKEv2 uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same 	submission. ACVP provides a mechanism for specifying the required prerequisites:
 
@@ -15,22 +15,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal| prerequistie algorithm validation| object with algorithm and valValue properties| see above| Yes
 |===
 
-KAS has conditional prerequisite algorithms, depending on the capabilities registered:
-
-[[prereqs_requirements_table]]
-
-.Prerequisite requirement conditions
-|===
-| Prerequisite Algorithm| Condition
-
-| DRBG | Always *REQUIRED*
-| SHA | Always *REQUIRED*
-| ECDSA | If the implementation supports fullVal (see <<supported_functions>>), then ECDSA keyVer validation is *REQUIRED*. If the implementation supports keyPairGen (see <<supported_functions>>), then ECDSA keyGen and ECDSA keyVer validation are *REQUIRED*.
-| CMAC | CMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing CMAC.
-| HMAC | HMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing HMAC.
-| KMAC | KMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing KMAC.
-|===
-
+Required prerequisite algorithms for KAS can be found here: https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [[cap_ex]]
 === Algorithm Capabilities JSON Values

--- a/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ffc/sections/05-capabilities.adoc
@@ -1,6 +1,6 @@
 
 [[prereq_algs]]
-=== Prerequisite Algorithms for KAS FFC Validations
+=== Required Prerequisite Algorithms for KAS FFC Validations
 
 Some algorithm implementations rely on other cryptographic primitives. For example, IKEv2 uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same 	submission. ACVP provides a mechanism for specifying the required prerequisites:
 
@@ -15,22 +15,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal| prerequistie algorithm validation| object with algorithm and valValue properties| see above| Yes
 |===
 
-KAS has conditional prerequisite algorithms, depending on the capabilities registered:
-
-[[prereqs_requirements_table]]
-
-.Prerequisite requirement conditions
-|===
-| Prerequisite Algorithm| Condition
-
-| DRBG | Always *REQUIRED*
-| SHA | Always *REQUIRED*
-| DSA | DSA KeyGen validation *REQUIRED* when IUT makes use of the "FB" or "FB" (legacy) domain parameters for the generation/validation of keys within the module boundary.
-| CMAC | CMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing CMAC.
-| HMAC | HMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing HMAC.
-| KMAC | KMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing KMAC.
-|===
-
+Required prerequisite algorithms for KAS can be found at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [[cap_ex]]
 === KAS FFC Algorithm Capabilities JSON Values

--- a/src/kas/sp800-56ar3/ssc/ecc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ssc/ecc/sections/05-capabilities.adoc
@@ -1,6 +1,6 @@
 
 [[prereq_algs]]
-=== Prerequisite Algorithms for KAS FFC Validations
+=== Required Prerequisite Algorithms for KAS FFC Validations
 
 Some algorithm implementations rely on other cryptographic primitives. For example, IKEv2 uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same 	submission. ACVP provides a mechanism for specifying the required prerequisites:
 
@@ -15,18 +15,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal| prerequisite algorithm validation| object with algorithm and valValue properties| see above| Yes
 |===
 
-KAS has conditional prerequisite algorithms, depending on the capabilities registered:
-
-[[prereqs_requirements_table]]
-
-.Prerequisite requirement conditions
-|===
-| Prerequisite Algorithm| Condition
-
-| DRBG | Always *REQUIRED*
-| SHA | Always *REQUIRED*
-| ECDSA | ECDSA KeyGen/KeyVer validation *REQUIRED* when IUT makes use of the generation/validation of keys within the module boundary.|===
-|===
+Required prerequisite algorithms for KAS-SSC can be found at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [#properties]
 === Property Registration

--- a/src/kas/sp800-56ar3/ssc/ffc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56ar3/ssc/ffc/sections/05-capabilities.adoc
@@ -1,6 +1,6 @@
 
 [[prereq_algs]]
-=== Prerequisite Algorithms for KAS FFC Validations
+=== Required Prerequisite Algorithms for KAS FFC SSC Validations
 
 Some algorithm implementations rely on other cryptographic primitives. For example, IKEv2 uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same 	submission. ACVP provides a mechanism for specifying the required prerequisites:
 
@@ -15,19 +15,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal| prerequistie algorithm validation| object with algorithm and valValue properties| see above| Yes
 |===
 
-KAS has conditional prerequisite algorithms, depending on the capabilities registered:
-
-[[prereqs_requirements_table]]
-
-.Prerequisite requirement conditions
-|===
-| Prerequisite Algorithm| Condition
-
-| DRBG | Always *REQUIRED*
-| SHA | Always *REQUIRED*
-| DSA | DSA KeyGen validation *REQUIRED* when IUT makes use of the "FB" or "FB" (legacy) domain parameters for the generation/validation of keys within the module boundary.
-| SafePrimes | SafePrimes KeyGen/KeyVer validation *REQUIRED* when IUT makes use of the safe-prime groups for the generation/validation of keys within the module boundary.
-|===
+Required prerequisite algorithms for KAS FFC SSC can be found at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [#properties]
 === Property Registration

--- a/src/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -1,6 +1,6 @@
 
 [[prereq_algs]]
-=== Prerequisite Algorithms for KAS IFC Validations
+=== Required Prerequisite Algorithms for KAS IFC Validations
 
 Some algorithm implementations rely on other cryptographic primitives. For example, IKEv2 uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:
 
@@ -16,22 +16,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal| prerequisite algorithm validation| object with algorithm and valValue properties| see above| Yes
 |===
 
-KAS has conditional prerequisite algorithms, depending on the capabilities registered:
-
-[[prereqs_requirements_table]]
-
-.Prerequisite requirement conditions
-|===
-| Prerequisite Algorithm| Condition
-
-| DRBG | Always *REQUIRED*
-| SHA | Always *REQUIRED*
-| RSA | RSA KeyGen validation *REQUIRED* when IUT makes use of the generation/validation of keys within the module boundary.
-| CMAC | CMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing CMAC.
-| HMAC | HMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing HMAC.
-| KMAC | KMAC validation *REQUIRED* when IUT is performing KeyConfirmation (KC) or a KDF and utilizing KMAC.
-|===
-
+Required prerequisite algorithms for KAS can be found at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [[cap_ex]]
 === KAS IFC Algorithm Capabilities JSON Values

--- a/src/kas/sp800-56br2/ssc/sections/05-capabilities.adoc
+++ b/src/kas/sp800-56br2/ssc/sections/05-capabilities.adoc
@@ -1,6 +1,6 @@
 
 [[prereq_algs]]
-=== Prerequisite Algorithms
+=== Required Prerequisite Algorithms for KAS IFC SSC
 
 Some algorithm implementations rely on other cryptographic primitives. For example, IKEv2 uses an underlying SHA algorithm. Each of these underlying algorithm primitives must be validated, either separately or as part of the same submission. ACVP provides a mechanism for specifying the required prerequisites:
 
@@ -16,19 +16,7 @@ Some algorithm implementations rely on other cryptographic primitives. For examp
 | prereqAlgVal | prerequisite algorithm validation | object with algorithm and valValue properties | see above | Yes
 |===
 
-KAS has conditional prerequisite algorithms, depending on the capabilities registered:
-
-[[prereqs_requirements_table]]
-
-.Prerequisite requirement conditions
-|===
-| Prerequisite Algorithm| Condition
-
-| DRBG | Always *REQUIRED*
-| SHA | Always *REQUIRED*
-| RSA | RSA KeyGen validation *REQUIRED* when IUT makes use of the generation/validation of keys within the module boundary.
-|===
-
+Required prerequisite algorithms for KAS IFC SSC can be found at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.
 
 [[cap_ex]]
 === Algorithm Capabilities JSON Values


### PR DESCRIPTION
Updates KAS and KAS SSC specifications to point to the required algorithms prerequisites listed at https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/prerequisites.