### PR TITLE
Fix DSA sigGen capabilities example

### DIFF
--- a/src/dsa/sections/05-siggen-capabilities.adoc
+++ b/src/dsa/sections/05-siggen-capabilities.adoc
@@ -40,7 +40,6 @@ An example of this is the following
       "n": 224,
       "l": 2048,
       "hashAlg": [
-        "SHA-1",
         "SHA2-224",
         "SHA2-256",
         "SHA2-384",
@@ -53,7 +52,6 @@ An example of this is the following
       "n": 256,
       "l": 2048,
       "hashAlg": [
-        "SHA-1",
         "SHA2-224",
         "SHA2-256",
         "SHA2-384",
@@ -66,7 +64,6 @@ An example of this is the following
       "n": 256,
       "l": 3072,
       "hashAlg": [
-        "SHA-1",
         "SHA2-224",
         "SHA2-256",
         "SHA2-384",


### PR DESCRIPTION
Table 7: DSA sigGen Capabilities JSON values states that `hashAlg` must be _Any non-empty subset of {"SHA2-224","SHA2-256", "SHA2-384", "SHA2-512", "SHA2-512/224", "SHA2-512/256"}_, but the example registration includes `"SHA-1"` in the `hashAlg` arrays.

Remove SHA-1 from the `hashAlg` arrays in the example to align with the stated specification.

See:

* https://pages.nist.gov/ACVP/draft-fussell-acvp-dsa.html#name-dsa-siggen-capabilities-jso
* https://pages.nist.gov/ACVP/draft-fussell-acvp-dsa.html#section-7.5.2-6